### PR TITLE
Enable functional tests in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: scala
 scala:
   - 2.12.6
 
+python:
+  - 2.7
+
 sudo: false
 
 jdk:
@@ -10,7 +13,6 @@ jdk:
   
 services:
   - docker
-  - docker-compose
 
 cache:
   directories:
@@ -21,7 +23,7 @@ cache:
 install:
   - wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
   - tar -xzvf protobuf-2.6.1.tar.gz
-  - pushd protobuf-2.6.1 && ./configure --prefix=/usr && make && sudo make install && popd    
+  - pushd protobuf-2.6.1 && ./configure --prefix=/usr && make && sudo make install && popd
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates (https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html)
@@ -33,6 +35,8 @@ jobs:
     - stage: "Verify"
       script: sbt ++$TRAVIS_SCALA_VERSION ";validate-api; validate-core; verify-api"
       name: "Validate and verify API"
+    - script: ./bin/func-test-api-travis.sh
+      name: "Run API functional tests"
     - script: sbt ++$TRAVIS_SCALA_VERSION ";validate-portal; verify-portal"
       name: "Validate and verify portal"
     - script: ./bin/func-test-portal.sh

--- a/bin/func-test-api-travis.sh
+++ b/bin/func-test-api-travis.sh
@@ -33,11 +33,11 @@ fi
 cp -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar $WORK_DIR/docker/api
 
 echo "Starting docker environment and running func tests..."
-docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker --log-level ERROR up --build --exit-code-from functest
+docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker up --exit-code-from functest
 test_result=$?
 
 echo "Grabbing the logs..."
-
+docker logs vinyldns-functest
 docker logs vinyldns-api > $DIR/../target/vinyldns-api.log 2>/dev/null
 docker logs vinyldns-bind9 > $DIR/../target/vinyldns-bind9.log 2>/dev/null
 docker logs vinyldns-mysql > $DIR/../target/vinyldns-mysql.log 2>/dev/null

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -7,7 +7,7 @@ services:
       - MYSQL_ROOT_PASSWORD=pass # do not use quotes around the environment variables!!!
       - MYSQL_ROOT_HOST=% # this is required as mysql is currently locked down to localhost
     ports:
-      - "3306:3306"
+      - "19002:3306"
 
   dynamodb:
     image: "cnadiminti/dynamodb-local:2017-02-16"

--- a/docker/docker-compose-func-test.yml
+++ b/docker/docker-compose-func-test.yml
@@ -7,7 +7,7 @@ services:
       - MYSQL_ROOT_PASSWORD=pass # do not use quotes around the environment variables!!!
       - MYSQL_ROOT_HOST=% # this is required as mysql is currently locked down to localhost
     ports:
-      - "3306:3306"
+      - "19002:3306"
 
   dynamodb:
     image: "cnadiminti/dynamodb-local:2017-02-16"

--- a/modules/api/functional_test/conftest.py
+++ b/modules/api/functional_test/conftest.py
@@ -74,4 +74,5 @@ def pytest_report_header(config):
     header += "\r\nURL: " + config.getoption("url")
     header += "\r\nRunning from directory " + os.getcwd()
     header += '\r\nTest shim directory ' + os.path.dirname(__file__)
+    header += "\r\nDNS IP: " + config.getoption("dns_ip")
     return header

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -156,7 +156,12 @@ trait DnsJsonProtocol extends JsonValidation {
       val recordSetResult = (
         (js \ "zoneId").required[String]("Missing RecordSet.zoneId"),
         (js \ "name")
-          .required[String]("Missing RecordSet.name"),
+          .required[String]("Missing RecordSet.name")
+          .check("Record name must not exceed 255 characters" -> checkDomainNameLen)
+          .checkIf(recordType.isValid)(
+            "Record name cannot contain '.' with given type" ->
+              ((s: String) => !((recordTypeGet == CNAME) && nameContainsDots(s)))
+          ),
         recordType,
         (js \ "ttl")
           .required[Long]("Missing RecordSet.ttl")


### PR DESCRIPTION
- `travis.yml`: Add `python` support,  removed non-existent `docker-compose` service and added functional test task.
- `func-test-api-travis.sh`: Create Travis-friendly version of `func-test-api.sh` with supported `docker-compose` parameters.
- `docker-compose-build.yml`/`docker-compose-func-test.yml`: Update MySQL port to `19001`
- `conftest.py`: Add DNS IP to logging
- `DnsJsonProtocol.scala`: Add back JSON validations prior to `scalaz` → `cats` conversion.