### PR TITLE
Enable code coverage and gh-pages publish on merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,17 @@ before_cache:
   
 jobs:  
   include:
-    - stage: "Verify"
-      script: sbt ++$TRAVIS_SCALA_VERSION ";validate-api; validate-core; verify-api"
+    - stage: "Verify core and API modules"
+      script: sbt ++$TRAVIS_SCALA_VERSION ";validate-api; validate-core"
       name: "Validate and verify API"
     - script: ./bin/func-test-api-travis.sh
       name: "Run API functional tests"
-    - script: sbt ++$TRAVIS_SCALA_VERSION ";validate-portal; verify-portal"
-      name: "Validate and verify portal"
+    - script: sbt ++$TRAVIS_SCALA_VERSION "validate-portal"
+      name: "Validate portal"
     - script: ./bin/func-test-portal.sh
       name: "Run portal functional tests"
+    - script: sbt ++$TRAVIS_SCALA_VERSION "verify"
+      name: "Verify and run coverage on API and portal"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -296,6 +296,8 @@ lazy val docSettings = Seq(
       Map("title" -> "Contributing", "section" -> "contributing", "position" -> "2")
     )
   ),
+  micrositePushSiteWith := GitHub4s,
+  micrositeGithubToken := sys.env.get("SBT_MICROSITES_PUBLISH_TOKEN"),
   ghpagesNoJekyll := false,
   fork in tut := true
 )

--- a/build.sbt
+++ b/build.sbt
@@ -314,8 +314,6 @@ addCommandAlias("validate-portal",
 addCommandAlias("validate", ";validate-core;validate-api;validate-portal")
 
 // Verify runs all tests and code coverage
-addCommandAlias("verify-api", ";project api; dockerComposeUp; test; it:test; dockerComposeStop")
-addCommandAlias("verify-portal", ";project portal; test")
 addCommandAlias("verify",
   ";project api;dockerComposeUp;project root;coverage;test;it:test;coverageReport;coverageAggregate;project api;dockerComposeStop")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,8 @@ object Dependencies {
     "io.prometheus"             % "simpleclient_dropwizard"         % prometheusV,
     "io.prometheus"             % "simpleclient_common"             % prometheusV,
     "com.typesafe"              % "config"                          % configV,
-    "org.typelevel"             %% "cats-effect"                    % catsEffectV
+    "org.typelevel"             %% "cats-effect"                    % catsEffectV,
+    "com.47deg"                 %% "github4s"                       % "0.18.6"
   )
 
   lazy val coreDependencies = Seq(


### PR DESCRIPTION
- Consolidate verify step for API and portal to generate code coverage, removing deprecated `verify-api` and `verify-portal` `sbt` commands. Finish successful build by uploading to CodeCov.
- Add `47deg/Github4s` dependency and configure travis environment variable to publish Github pages on merge (see: https://47deg.github.io/sbt-microsites/docs/publish-with-travis.html#publish-using-github4s).

Notes:
- I needed to create a personal token since we need to give Travis read/write repo access. There are currently two Travis builds that run - one from the organizational `vinyldns/vinyldns` repo, and one from the Travis CI checks. Once this gets merged, The simpler CI build will get removed (as it's a duplicate).