### PR TITLE
make publishing microsites work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,6 @@ jobs:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - if ["$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false"]; then
+      sbt ";project docs ;publishMicrosite";
+    fi


### PR DESCRIPTION
I looked at the sbt-microsites docs and the only difference i noticed between what they suggest and what we have set up is the value for micrositeGithubToken is `getEnvVar("GITHUB_TOKEN")`. We have `sys.env.get("GITHUB_TOKEN")`. So changing to match what they have. If that doesn't work we can dig deeper. for #73 