### PR TITLE
Implement JavaCrypto

### DIFF
--- a/bin/generate-aes-256-hex-key.sh
+++ b/bin/generate-aes-256-hex-key.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Generate 256-bit AES key.
+#
+# Usage:
+#  $ ./generate-aes-256-hex-key.sh [passphrase]
+# * passphrase: Optional passphrase used to generate secret key. A pseudo-random passphrase will be used if
+#               one is not provided.
+
+if [[ ! -z "$1" ]]
+then
+    echo "Using user-provided passphrase."
+fi
+
+PASSPHRASE=${1:-$(openssl rand 32)}
+
+KEY=$(openssl enc -aes-256-cbc -k "$PASSPHRASE" -P -md sha1 | awk -F'=' 'NR == 2 {print $2}')
+echo "Your 256-bit AES hex key: $KEY"

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -52,7 +52,8 @@ vinyldns {
   # this key is used in order to encrypt/decrypt DNS TSIG keys.  We use this dummy one for test purposes, this
   # should be overridden with a real value that is hidden for production deployment
   crypto {
-    type = "vinyldns.core.crypto.NoOpCrypto"
+    type = "vinyldns.core.crypto.JavaCrypto"
+    secret = "8B06A7F3BC8A2497736F1916A123AA40E88217BE9264D8872597EF7A6E5DCE61"
   }
 
   monitoring {

--- a/modules/core/src/main/scala/vinyldns/core/crypto/JavaCrypto.scala
+++ b/modules/core/src/main/scala/vinyldns/core/crypto/JavaCrypto.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.crypto
+
+import java.nio.charset.StandardCharsets
+import java.security.{GeneralSecurityException, SecureRandom, Security}
+
+import com.typesafe.config.Config
+import javax.crypto.Cipher
+import javax.crypto.spec.{IvParameterSpec, SecretKeySpec}
+import javax.xml.bind.DatatypeConverter
+import scodec.bits.ByteVector
+
+/**
+  * Provides functions for encrypting and decrypting data using a user-defined secret stored in the configuration.
+  *
+  * Uses 256-bit AES key with CBC/PKCS5Padding algorithm.
+  */
+class JavaCrypto(cryptoConfig: Config) extends CryptoAlgebra {
+
+  private val zeroByte = 0.toByte
+  private val zeroChar = 0.toChar
+
+  // Assumes that secret is stored as 64-char hex string (32 bytes)
+  private val secret = DatatypeConverter.parseHexBinary(cryptoConfig.getString("secret"))
+  private val ivLength = 16 // Java AES has a fixed block size of 16 bytes, regardless of key size
+
+  private val encryptedPrefix = "ENC:" // Prefix used to indicate encrypted strings
+
+  // Enables Java Cryptography Extension (JCE) Unlimited Strength Policy Jurisdiction for the application.
+  // Required for 256-bit keys and padding cryptography mode.
+  // TODO: Remove once Java is updated to version 9, where it is enabled by default.
+  Security.setProperty("crypto.policy", "unlimited")
+
+  /*
+   * Attempt to encrypt a string. If the string is already encrypted, do not double encrypt.
+   */
+  @throws(classOf[GeneralSecurityException])
+  def encrypt(value: String): String =
+    if (value.startsWith(encryptedPrefix)) {
+      // Return already encrypted string
+      value
+    } else {
+      // Encode
+      val inBytes = StandardCharsets.UTF_8.encode(value)
+
+      // Generate a new initialization vector (IV)
+      val iv = new Array[Byte](ivLength)
+      new SecureRandom().nextBytes(iv)
+
+      // Generate the key with secret
+      val secretKeySpec = new SecretKeySpec(secret, "AES")
+
+      // Perform encryption
+      val encryptedBytes = cipher(secretKeySpec, iv, encryptMode = true).doFinal(inBytes.array)
+
+      // Convert cipher text string and pre-pend IV
+      try {
+        encryptedPrefix + (ByteVector(iv) ++ ByteVector(encryptedBytes)).toBase64
+      } finally {
+        // Clean up memory
+        nullByteArray(inBytes.array)
+        nullByteArray(iv)
+        nullByteArray(encryptedBytes)
+      }
+    }
+
+  /*
+   * Attempt to decrypt a string. If the string is not prefixed with our encrypted prefix, don't attempt to decrypt.
+   */
+  @throws(classOf[GeneralSecurityException])
+  def decrypt(base64EncryptedData: String): String =
+    if (!base64EncryptedData.startsWith(encryptedPrefix)) {
+      // Don't attempt to decrypt data that hasn't been encrypted with our encrypted prefix;
+      // simply return passed-in string
+      base64EncryptedData
+    } else {
+      // Remove the encrypted prefix
+      val actualString = base64EncryptedData.substring(encryptedPrefix.length)
+
+      // Decode bytes from String
+      val inBytes = ByteVector
+        .fromBase64(actualString)
+        .getOrElse(throw new GeneralSecurityException("Base-64 decoding failed!"))
+
+      // Extract IV
+      val decryptIv = inBytes.take(ivLength.toLong)
+
+      // Extract cipher text
+      val cipherText = inBytes.drop(ivLength.toLong)
+
+      // Decrypt cipher text with IV and key
+      val plainTextBytes =
+        cipher(new SecretKeySpec(secret, "AES"), decryptIv.toArray, encryptMode = false)
+          .doFinal(cipherText.toArray)
+
+      try {
+        // Need to trim string since decrypted padded data can result in longer lengths despite same data
+        new String(plainTextBytes, "UTF-8").trim
+      } finally {
+        // Clean up memory
+        nullCharArray(actualString.toCharArray)
+        nullByteArray(inBytes.toArray)
+        nullByteArray(decryptIv.toArray)
+        nullByteArray(cipherText.toArray)
+        nullByteArray(plainTextBytes)
+      }
+    }
+
+  /*
+   * Helper to instantiate a cipher
+   */
+  private def cipher(keySpec: SecretKeySpec, iv: Array[Byte], encryptMode: Boolean): Cipher = {
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+    val mode = if (encryptMode) Cipher.ENCRYPT_MODE else Cipher.DECRYPT_MODE
+    cipher.init(mode, keySpec, new IvParameterSpec(iv))
+    cipher
+  }
+
+  // Helpers to clean up sensitive data in memory
+  private def nullCharArray(arr: Array[Char]): Unit =
+    for (i <- arr.indices) arr(i) = zeroChar
+  private def nullByteArray(arr: Array[Byte]): Unit =
+    for (i <- arr.indices) arr(i) = zeroByte
+}

--- a/modules/core/src/test/scala/vinyldns/core/crypto/JavaCryptoSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/crypto/JavaCryptoSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.crypto
+
+import com.typesafe.config._
+import org.scalatest.{Matchers, WordSpec}
+
+class JavaCryptoSpec extends WordSpec with Matchers {
+
+  val unencryptedString =
+    s"""Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."""
+
+  private val conf =
+    """
+      | type = "com.comcast.denis.crypto.JavaCrypto"
+      | secret = "8B06A7F3BC8A2497736F1916A123AA40E88217BE9264D8872597EF7A6E5DCE61"
+    """.stripMargin
+
+  private val cryptoConf = ConfigFactory.parseString(conf)
+  private val javaCrypto = new JavaCrypto(cryptoConf)
+
+  "JavaCrypto" should {
+    "round trip successfully" in {
+      val hidden = javaCrypto.encrypt(unencryptedString)
+      hidden should not be unencryptedString
+
+      val roundTripped = javaCrypto.decrypt(hidden)
+      roundTripped shouldBe unencryptedString
+
+      javaCrypto.decrypt(javaCrypto.encrypt(roundTripped)) shouldBe unencryptedString
+    }
+
+    "be thread safe" in {
+      (1 to 100).par.foreach { i =>
+        val e = unencryptedString
+        val h = javaCrypto.encrypt(e)
+        val r = javaCrypto.decrypt(h)
+
+        e shouldBe r
+      }
+    }
+
+    "not double encrypt" in {
+      val base = unencryptedString
+      val encryptedOnce = javaCrypto.encrypt(base)
+      val encryptedTwice = javaCrypto.encrypt(encryptedOnce)
+
+      encryptedOnce shouldBe encryptedTwice
+    }
+
+    "not decrypt text that doesn't have encrypted prefix" in {
+      val base = unencryptedString
+      val decryptAttempt = javaCrypto.decrypt(base)
+
+      decryptAttempt shouldBe base
+    }
+
+    "work successfully for different instances encrypting and decrypting a message" in {
+      val hidden = javaCrypto.encrypt(unencryptedString)
+
+      val secondCrypto = new JavaCrypto(cryptoConf)
+      secondCrypto.decrypt(hidden) shouldBe unencryptedString
+    }
+  }
+}


### PR DESCRIPTION
Implement a symmetric cryptography mechanism that uses AES-CBC padding with support for 256-bit keys, which doesn't double-encrypt or double-decrypt.

`JavaCrypto.scala` provides the implementation and `JavaCryptoSpec.scala` tests the functionality. `generate-aes-256-hex-key.sh` is a script that utilizes `openssl` to generate a 256-bit key that can be used with the cryptography mechanism.

Note for reviewers:
- To test this, I replaced updated the `crypto` object in `application.conf` to point to the new `JavaCrypto` mechanism with the appropriate key and ran unit and integration tests.
- Usage information will be added later in the operator guide.