### PR TITLE
tweak publishMicrosite command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ jobs:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - if ["$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false"]; then
-      sbt ";project docs ;publishMicrosite";
+      sbt 'project docs' 'publishMicrosite'
     fi


### PR DESCRIPTION
the command I attempted didn't work, but I'm hopeful this one does.

According to this site http://www.onegeek.com.au/scala/setting-up-travis-ci-for-scala to specify the module you do `sbt 'project module-name' 'whateverCommand'`. Locally that seemed to work when i did `sbt 'project docs' 'makeMicrosite'`