### PR TITLE
add CNAME file to docs module

### DIFF
--- a/modules/docs/src/main/tut/CNAME
+++ b/modules/docs/src/main/tut/CNAME
@@ -1,0 +1,1 @@
+www.vinyldns.io


### PR DESCRIPTION
previously added the domain for our doc site through GIthub settings and that make a CNAME file, but then it's deleted when running the publishMicrosite command, so needed to add the CNAME file in the docs module so it's included in publishMicrosite.