### PR TITLE
add scalac option for fatal warnings (#24)

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeInterfaces.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeInterfaces.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain.batch
 
 import cats.data.Validated.{Invalid, Valid}
-import cats.data.{NonEmptyList, _}
+import cats.data._
 import cats.implicits._
 import vinyldns.api.domain.DomainValidationError
 

--- a/modules/core/src/main/scala/vinyldns/core/crypto/NoOpCrypto.scala
+++ b/modules/core/src/main/scala/vinyldns/core/crypto/NoOpCrypto.scala
@@ -26,7 +26,7 @@ import com.typesafe.config.Config
   * @param config - [[com.typesafe.config.Config]] that holds the no-op configuration.  This is required in order
   *               to dynamically load this Crypto implementation.  However, it is not used.
   */
-class NoOpCrypto(config: Config) extends CryptoAlgebra {
+class NoOpCrypto(val config: Config) extends CryptoAlgebra {
   def encrypt(value: String): String = value
   def decrypt(value: String): String = value
 }

--- a/project/CompilerOptions.scala
+++ b/project/CompilerOptions.scala
@@ -16,6 +16,7 @@ object CompilerOptions {
     "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field
     "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
     "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+    "-Xfatal-warnings",                  // Enable failure of compilation when warnings exist.
     "-Ypartial-unification",             // Enable partial unification in type constructor inference
     "-Ywarn-dead-code",                  // Warn when dead code is identified.
     "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.


### PR DESCRIPTION
The `NoOpCrypto` failed due to an unused `config` in the constructor. I left it there because the scaladoc for the class mentions it specifically. To fix I just added a `val` unless there is a more desired approach.