### PR TITLE
WIP Publish documentation once on successful PR merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,20 +36,20 @@ before_cache:
 
 jobs:
   include:
-    - stage: "Verify core and API modules"
-      script: sbt ++$TRAVIS_SCALA_VERSION ";validate-api; validate-core"
+    - stage: "Validate and verify modules"
       name: "Validate and verify API"
-    - script: ./bin/func-test-api-travis.sh
-      name: "Run API functional tests"
-    - script: sbt ++$TRAVIS_SCALA_VERSION "validate-portal"
-      name: "Validate portal"
-    - script: ./bin/func-test-portal.sh
-      name: "Run portal functional tests"
-    - script: sbt ++$TRAVIS_SCALA_VERSION "verify"
-      name: "Verify and run coverage on API and portal"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-      sbt 'project docs' 'publishMicrosite';
-    fi
+      script: sbt ++$TRAVIS_SCALA_VERSION ";validate-api; validate-core"
+    - name: "Run API functional tests"
+      script: ./bin/func-test-api-travis.sh
+    - name: "Validate portal"
+      script: sbt ++$TRAVIS_SCALA_VERSION "validate-portal"
+    - name: "Run portal functional tests"
+      script: ./bin/func-test-portal.sh
+    - name: "Verify and run coverage on API and portal"
+      script: sbt ++$TRAVIS_SCALA_VERSION "verify" && bash <(curl -s https://codecov.io/bash)
+    - stage: "Post-validate/verify tasks"
+      name: "Publish documentation changes (gh-pages)"
+      script: if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+                sbt 'project docs' 'publishMicrosite';
+              fi
+      install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ install:
   - wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
   - tar -xzvf protobuf-2.6.1.tar.gz
   - pushd protobuf-2.6.1 && ./configure --prefix=/usr && make && sudo make install && popd
-  - rvm use 2.2.8 --install --fuzzy
-  - gem update --system
-  - gem install sass
-  - gem install jekyll -v 3.2.1
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates (https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html)
@@ -49,7 +45,6 @@ jobs:
       script: sbt ++$TRAVIS_SCALA_VERSION "verify" && bash <(curl -s https://codecov.io/bash)
     - stage: "Post-validate/verify tasks"
       name: "Publish documentation changes (gh-pages)"
-      script: if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-                sbt 'project docs' 'publishMicrosite';
-              fi
-      install: skip
+      script: rvm use 2.2.8 --install --fuzzy;
+              gem install sass jekyll:3.2.1;
+              sbt ";project docs; publishMicrosite";

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
   - wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
   - tar -xzvf protobuf-2.6.1.tar.gz
   - pushd protobuf-2.6.1 && ./configure --prefix=/usr && make && sudo make install && popd
+  - rvm use 2.2.8 --install --fuzzy
+  - gem install sass jekyll:3.2.1
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates (https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html)
@@ -45,6 +47,4 @@ jobs:
       script: sbt ++$TRAVIS_SCALA_VERSION "verify" && bash <(curl -s https://codecov.io/bash)
     - stage: "Post-validate/verify tasks"
       name: "Publish documentation changes (gh-pages)"
-      script: rvm use 2.2.8 --install --fuzzy;
-              gem install sass jekyll:3.2.1;
-              sbt ";project docs; publishMicrosite";
+      script: sbt ";project docs; publishMicrosite"


### PR DESCRIPTION
Using `after_success` causes a publish on each task success, so moving to a build stage will resolve this issue. Since code coverage is only being generated in one task, moving CodeCov upload to the appropriate task.