### PR TITLE
Suppress error thrown from scaladoc compilation 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val sharedSettings = Seq(
   licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
   scalacOptions += "-target:jvm-1.8",
   scalacOptions ++= scalacOptionsByV(scalaVersion.value),
+  scalacOptions in (Compile, doc) += "-no-link-warnings",
   // Use wart remover to eliminate code badness
   wartremoverErrors ++= Seq(
     Wart.ArrayEquals,


### PR DESCRIPTION
Adding fatal warnings in this pr https://github.com/vinyldns/vinyldns/pull/90 caused errors when compiling scaladocs. Followed this thread to resolve the error: https://issues.scala-lang.org/browse/SI-9311. This is necessary because sbt docker builds scaladocs and will error out 