### PR TITLE
reduce travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: false
 
 jdk:
   - oraclejdk8
-  
+
 services:
   - docker
 
@@ -26,30 +26,21 @@ install:
   - pushd protobuf-2.6.1 && ./configure --prefix=/usr && make && sudo make install && popd
   - rvm use 2.2.8 --install --fuzzy
   - gem update --system
-  - gem install sass
-  - gem install jekyll -v 3.2.1
+  - gem install sass jekyll:3.2.1
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates (https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html)
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 
+after_success:
+  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+      sbt ";project docs; publishMicrosite";
+    fi
+
 jobs:
   include:
-    - stage: "Verify core and API modules"
-      script: sbt ++$TRAVIS_SCALA_VERSION ";validate-api; validate-core"
-      name: "Validate and verify API"
-    - script: ./bin/func-test-api-travis.sh
-      name: "Run API functional tests"
-    - script: sbt ++$TRAVIS_SCALA_VERSION "validate-portal"
-      name: "Validate portal"
-    - script: ./bin/func-test-portal.sh
-      name: "Run portal functional tests"
-    - script: sbt ++$TRAVIS_SCALA_VERSION "verify"
-      name: "Verify and run coverage on API and portal"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-      sbt 'project docs' 'publishMicrosite';
-    fi
+    - name: "Validate and verify modules"
+      script: sbt ++$TRAVIS_SCALA_VERSION ";validate; verify" && bash <(curl -s https://codecov.io/bash)
+    - name: "Run API and portal functional tests"
+      script: ./bin/func-test-portal.sh && ./bin/func-test-api-travis.sh


### PR DESCRIPTION
Combining jobs to reduce the number of concurrent jobs from 5 to 2. This will allow us to run more builds in parallel.