### PR TITLE
Update to sbt-protoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,8 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
-    - $HOME/.protobuf-2.6.1/src
 
 install:
-  - wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
-  - tar -xzvf protobuf-2.6.1.tar.gz
-  - pushd protobuf-2.6.1 && ./configure --prefix=/usr && make && sudo make install && popd
   - rvm use 2.2.8 --install --fuzzy
   - gem update --system
   - gem install sass jekyll:3.2.1

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -81,25 +81,6 @@ database with their LDAP information.
 - virtualenv
 - docker
 - wget
-- Protobuf 2.6.1
-
-### Installing Protobuf on a Mac
-The protocol buffer library is located at `https://github.com/sbt/sbt-protobuf`, we currently have it set to v0.5.2, which can only support up to protobuf v2.6.1
-
-Run `protoc --version`, if it is not 2.6.1, then
-
-1. Note that on Mac OS, `brew install protobuf` will install a version too new to use with this project, if you have protobuf installed through brew, then run `brew uninstall protobuf`
-1. To install protobuf v2.6.1, go to https://github.com/google/protobuf/releases/tag/v2.6.1, and download `protobuf-2.6.1.tar.gz`
-1. Run the following commands to extract the tar, cd into it, and configure/install:
- ```
- $ cd ~/Downloads; tar -zxvf protobuf-2.6.1.tar.gz; cd protobuf-2.6.1
- $ ./configure
- $ make
- $ make check
- $ sudo make install
-
- ```
-1. Finally, run `protoc --version` to confirm you are on v2.6.1
 
 ## Docker
 Be sure to install the latest version of [docker](https://docs.docker.com/).  You must have docker running in order to work with VinylDNS on your machine.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ participating, you agree to this Code.  Please report any violations to the code
 - virtualenv
 - docker
 - wget
-- Protobuf 2.6.1
 
 See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for instructions on setting up VinylDNS locally.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import sbtprotobuf.{ProtobufPlugin => PB}
 import Resolvers._
 import Dependencies._
 import CompilerOptions._
@@ -169,7 +168,10 @@ lazy val portalPublishSettings = Seq(
 )
 
 lazy val pbSettings = Seq(
-  version in ProtobufConfig := "2.6.1"
+  PB.targets in Compile := Seq(
+    PB.gens.java("2.6.1") -> (sourceManaged in Compile).value
+  ),
+  PB.protocVersion := "-v261"
 )
 
 lazy val allApiSettings = Revolver.settings ++ Defaults.itSettings ++
@@ -183,14 +185,14 @@ lazy val allApiSettings = Revolver.settings ++ Defaults.itSettings ++
   scalaStyleSettings
 
 lazy val api = (project in file("modules/api"))
-  .enablePlugins(JavaAppPackaging, DockerComposePlugin, AutomateHeaderPlugin, ProtobufPlugin)
+  .enablePlugins(JavaAppPackaging, DockerComposePlugin, AutomateHeaderPlugin, ProtocPlugin)
   .configs(IntegrationTest)
   .settings(allApiSettings)
   .settings(headerSettings(IntegrationTest))
   .settings(inConfig(IntegrationTest)(scalafmtConfigSettings))
   .dependsOn(core)
 
-lazy val root = (project in file(".")).enablePlugins(AutomateHeaderPlugin, ProtobufPlugin)
+lazy val root = (project in file(".")).enablePlugins(AutomateHeaderPlugin)
   .configs(IntegrationTest)
   .settings(headerSettings(IntegrationTest))
   .settings(sharedSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val allApiSettings = Revolver.settings ++ Defaults.itSettings ++
   scalaStyleSettings
 
 lazy val api = (project in file("modules/api"))
-  .enablePlugins(JavaAppPackaging, DockerComposePlugin, AutomateHeaderPlugin, ProtocPlugin)
+  .enablePlugins(JavaAppPackaging, DockerComposePlugin, AutomateHeaderPlugin)
   .configs(IntegrationTest)
   .settings(allApiSettings)
   .settings(headerSettings(IntegrationTest))

--- a/modules/api/src/main/protobuf/VinylDNSProto.proto
+++ b/modules/api/src/main/protobuf/VinylDNSProto.proto
@@ -1,4 +1,5 @@
 // VinylDNSProto.proto
+syntax = "proto2";
 option java_package = "vinyldns.proto";
 option optimize_for = SPEED;
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,6 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
-
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "5.0.0")

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
-
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"


### PR DESCRIPTION
The sbt protobuf plugin we were using forced developers to install
protoc version 2.6.1 on their local.  That makes it difficult
to onboard new developers.

sbt-protoc is an alternative plugin.  It has a lot of features we
are presently not using.  The biggest feature it brings is to
not require developers to install protoc.

* build.sbt - use the new protoc plugin
* VinylDNSProto.proto - add syntax = proto2 to ensure compile
to compatible protobuf version
* plugins.sbt - remove the old protobuf plugin
* protoc.sbt - add the new protoc plugin