### PR TITLE
Replace wget with curl

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -80,7 +80,6 @@ database with their LDAP information.
 - Python 2.7
 - virtualenv
 - docker
-- wget
 
 ## Docker
 Be sure to install the latest version of [docker](https://docs.docker.com/).  You must have docker running in order to work with VinylDNS on your machine.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -80,6 +80,7 @@ database with their LDAP information.
 - Python 2.7
 - virtualenv
 - docker
+- curl
 
 ## Docker
 Be sure to install the latest version of [docker](https://docs.docker.com/).  You must have docker running in order to work with VinylDNS on your machine.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ participating, you agree to this Code.  Please report any violations to the code
 - Python 2.7
 - virtualenv
 - docker
-- wget
 
 See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for instructions on setting up VinylDNS locally.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ participating, you agree to this Code.  Please report any violations to the code
 - Python 2.7
 - virtualenv
 - docker
+- curl
 
 See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for instructions on setting up VinylDNS locally.
 

--- a/bin/docker-up-api-server.sh
+++ b/bin/docker-up-api-server.sh
@@ -16,7 +16,7 @@ cp -af "$DIR"/../docker "$WORK_DIR"/
 
 echo "Copy the vinyldns.jar to the API Docker folder so it is in context..."
 if [[ ! -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
-    echo "vinyldns jar not found, building..."
+    echo "vinyldns.jar not found, building..."
     cd "$DIR"/../
     sbt api/clean api/assembly
     cd "$DIR"

--- a/bin/docker-up-api-server.sh
+++ b/bin/docker-up-api-server.sh
@@ -11,10 +11,10 @@ DIR=$( cd $(dirname $0) ; pwd -P )
 WORK_DIR="$DIR"/../target/scala-2.12
 mkdir -p "$WORK_DIR"
 
-echo "Copy all docker to the target directory so we can start up properly and the docker context is small..."
+echo "Copy all Docker to the target directory so we can start up properly and the Docker context is small..."
 cp -af "$DIR"/../docker "$WORK_DIR"/
 
-echo "Copy the vinyldns.jar to the api docker folder so it is in context..."
+echo "Copy the vinyldns.jar to the API Docker folder so it is in context..."
 if [[ ! -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
     echo "vinyldns jar not found, building..."
     cd "$DIR"/../
@@ -23,7 +23,7 @@ if [[ ! -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
 fi
 cp -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar "$WORK_DIR"/docker/api
 
-echo "Starting api server and all dependencies in the background..."
+echo "Starting API server and all dependencies in the background..."
 docker-compose -f "$WORK_DIR"/docker/docker-compose-func-test.yml --project-directory "$WORK_DIR"/docker up --build -d api
 
 VINYLDNS_URL="http://localhost:9000"
@@ -35,7 +35,7 @@ do
     DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
-        echo "Succeeded in connecting to VINYLDNS!"
+        echo "Succeeded in connecting to VinylDNS API!"
         break
     else
         echo "Retrying Again" >&2
@@ -45,7 +45,7 @@ do
 
         if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYLDNS to be ready, failing"
+          echo "Exceeded retries waiting for VinylDNS API to be ready, failing"
           exit 1
         fi
     fi

--- a/bin/docker-up-api-server.sh
+++ b/bin/docker-up-api-server.sh
@@ -8,34 +8,34 @@
 ######################################################################
 
 DIR=$( cd $(dirname $0) ; pwd -P )
-WORK_DIR=$DIR/../target/scala-2.12
-mkdir -p $WORK_DIR
+WORK_DIR="$DIR"/../target/scala-2.12
+mkdir -p "$WORK_DIR"
 
 echo "Copy all docker to the target directory so we can start up properly and the docker context is small..."
-cp -af $DIR/../docker $WORK_DIR/
+cp -af "$DIR"/../docker "$WORK_DIR"/
 
 echo "Copy the vinyldns.jar to the api docker folder so it is in context..."
-if [[ ! -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
+if [[ ! -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
     echo "vinyldns jar not found, building..."
-    cd $DIR/../
+    cd "$DIR"/../
     sbt api/clean api/assembly
-    cd $DIR
+    cd "$DIR"
 fi
-cp -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar $WORK_DIR/docker/api
+cp -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar "$WORK_DIR"/docker/api
 
 echo "Starting api server and all dependencies in the background..."
-docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker up --build -d api
+docker-compose -f "$WORK_DIR"/docker/docker-compose-func-test.yml --project-directory "$WORK_DIR"/docker up --build -d api
 
-VINYL_URL="http://localhost:9000"
-echo "Waiting for API to be ready at ${VINYL_URL} ..."
+VINYLDNS_URL="http://localhost:9000"
+echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=40
-while [ $RETRY -gt 0 ]
+while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(wget -O - -q -t 1 "${VINYL_URL}/ping")
+    DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
-        echo "Succeeded in connecting to VINYL!"
+        echo "Succeeded in connecting to VINYLDNS!"
         break
     else
         echo "Retrying Again" >&2
@@ -43,9 +43,9 @@ do
         let RETRY-=1
         sleep 1
 
-        if [ $RETRY -eq 0 ]
+        if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYL to be ready, failing"
+          echo "Exceeded retries waiting for VINYLDNS to be ready, failing"
           exit 1
         fi
     fi

--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -8,7 +8,7 @@
 DIR=$( cd $(dirname $0) ; pwd -P )
 
 echo "Starting portal server and all dependencies in the background..."
-docker-compose -f $DIR/../docker/docker-compose-build.yml up -d
+docker-compose -f "$DIR"/../docker/docker-compose-build.yml up -d
 
 VINYLDNS_URL="http://localhost:9000"
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
@@ -19,7 +19,7 @@ do
     DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
-        echo "Succeeded in connecting to VINYL API!"
+        echo "Succeeded in connecting to VinylDNS API!"
         break
     else
         echo "Retrying Again" >&2
@@ -29,14 +29,14 @@ do
 
         if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYLDNS API to be ready, failing"
+          echo "Exceeded retries waiting for VinylDNS API to be ready, failing"
           exit 1
         fi
     fi
 done
 
 VINYLDNS_URL="http://localhost:9001"
-echo "Waiting for PORTAL to be ready at ${VINYLDNS_URL} ..."
+echo "Waiting for portal to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=40
 while [ "$RETRY" -gt 0 ]
@@ -44,7 +44,7 @@ do
     DATA=$(curl -I -s "${VINYLDNS_URL}" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
-        echo "Succeeded in connecting to VINYL PORTAL!"
+        echo "Succeeded in connecting to VinylDNS portal!"
         break
     else
         echo "Retrying Again" >&2
@@ -54,7 +54,7 @@ do
 
         if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYLDNS PORTAL to be ready, failing"
+          echo "Exceeded retries waiting for VinylDNS portal to be ready, failing"
           exit 1
         fi
     fi

--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -10,13 +10,13 @@ DIR=$( cd $(dirname $0) ; pwd -P )
 echo "Starting portal server and all dependencies in the background..."
 docker-compose -f $DIR/../docker/docker-compose-build.yml up -d
 
-VINYL_URL="http://localhost:9000"
-echo "Waiting for API to be ready at ${VINYL_URL} ..."
+VINYLDNS_URL="http://localhost:9000"
+echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=40
-while [ $RETRY -gt 0 ]
+while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(wget -O - -q -t 1 "${VINYL_URL}/ping")
+    DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
         echo "Succeeded in connecting to VINYL API!"
@@ -27,21 +27,21 @@ do
         let RETRY-=1
         sleep 1
 
-        if [ $RETRY -eq 0 ]
+        if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYL API to be ready, failing"
+          echo "Exceeded retries waiting for VINYLDNS API to be ready, failing"
           exit 1
         fi
     fi
 done
 
-VINYL_URL="http://localhost:9001"
-echo "Waiting for PORTAL to be ready at ${VINYL_URL} ..."
+VINYLDNS_URL="http://localhost:9001"
+echo "Waiting for PORTAL to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=40
-while [ $RETRY -gt 0 ]
+while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(wget -O - -q -t 1 "${VINYL_URL}")
+    DATA=$(curl -I -s "${VINYLDNS_URL}" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
         echo "Succeeded in connecting to VINYL PORTAL!"
@@ -52,9 +52,9 @@ do
         let RETRY-=1
         sleep 1
 
-        if [ $RETRY -eq 0 ]
+        if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYL PORTAL to be ready, failing"
+          echo "Exceeded retries waiting for VINYLDNS PORTAL to be ready, failing"
           exit 1
         fi
     fi

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -18,7 +18,7 @@ do
 
         if [ "$RETRY" -eq 0 ]
         then
-          echo "Exceeded retries waiting for VINYLDNS to be ready, failing"
+          echo "Exceeded retries waiting for VinylDNS API to be ready, failing"
           exit 1
         fi
     fi

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -4,9 +4,9 @@ VINYLDNS_URL="http://vinyldns-api:9000"
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=40
-while [ $RETRY -gt 0 ]
+while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(wget -O - -q -t 1 "${VINYLDNS_URL}/ping")
+    DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
         break
@@ -16,7 +16,7 @@ do
         let RETRY-=1
         sleep 1
 
-        if [ $RETRY -eq 0 ]
+        if [ "$RETRY" -eq 0 ]
         then
           echo "Exceeded retries waiting for VINYLDNS to be ready, failing"
           exit 1


### PR DESCRIPTION
`wget` is currently a VinylDNS installation dependency that is not available by default on Windows (and possibly other operating systems as well).

Note to reviewers: Tested both `docker-up-api-server.sh` and `docker-up-vinyldns.sh` locally.