### PR TITLE
change api docker entrypoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val apiDockerSettings = Seq(
   packageName in Docker := "api",
   dockerUpdateLatest := true,
   dockerExposedPorts := Seq(9000),
-  dockerEntrypoint := Seq("/opt/docker/bin/boot"),
+  dockerEntrypoint := Seq("/opt/docker/bin/api"),
   dockerExposedVolumes := Seq("/opt/docker/lib_extra"), // mount extra libs to the classpath
   dockerExposedVolumes := Seq("/opt/docker/conf"), // mount extra config to the classpath
 


### PR DESCRIPTION
## This changed recently, think since we got rid of the other main method in the api module? 

### steps to reproduce error:
`bin/remove-vinyl-containers.sh`
`docker images`
`docker rmi -f` all images ids for the api
change version in build.sbt to 0.8.0
`sbt ";project api ;docker:publishLocal"`
This makes it so it doesnt pull the current 0.8.0 from docker hub and uses your local
run `bin/docker-up-vinyldns.sh`

### steps to test fix:
repeat above but with this change 