### PR TITLE
Travis configuration - conditionally deploy docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,6 @@ jobs:
     - name: "Run API and portal functional tests"
       script: ./bin/func-test-portal.sh && ./bin/func-test-api-travis.sh
     - stage: Deploy
+      if: branch = master AND type = push
       name: "Deploy doc site"
       script: sbt ";project docs; publishMicrosite";

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,12 @@ before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 
-after_success:
-  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-      sbt ";project docs; publishMicrosite";
-    fi
-
 jobs:
   include:
     - name: "Validate and verify modules"
       script: sbt ++$TRAVIS_SCALA_VERSION ";validate; verify" && bash <(curl -s https://codecov.io/bash)
     - name: "Run API and portal functional tests"
       script: ./bin/func-test-portal.sh && ./bin/func-test-api-travis.sh
+    - stage: Deploy
+      name: "Deploy doc site"
+      script: sbt ";project docs; publishMicrosite";


### PR DESCRIPTION
Conditionally publish docs after the test stages pass.
- Only runs on the master build.
- Deploys the docs once (instead of once per job in the same stage).

I was hoping there was a way to also move the doc related installs to that stage also, but that doesn't seem possible. closes #73 