### PR TITLE
WIP: Adding publishing to sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,6 +211,7 @@ lazy val coreBuildSettings = Seq(
   scalacOptions ++= scalacOptionsByV(scalaVersion.value).filterNot(_ == "-Ywarn-unused:params")
 )
 
+import xerial.sbt.Sonatype._
 lazy val corePublishSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
@@ -218,7 +219,33 @@ lazy val corePublishSettings = Seq(
   autoAPIMappings := true,
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
   publish in Docker := {},
-  mainClass := None
+  mainClass := None,
+  publishTo := {
+    val nexus = "https://oss.sonatype.org/"
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    else
+      Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+  },
+  homepage := Some(url("http://vinyldns.io")),
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/vinyldns/vinyldns"),
+      "scm:git@github.com:vinyldns/vinyldns.git"
+    )
+  ),
+  developers := List(
+    Developer(id="pauljamescleary", name="Paul James Cleary", email="pauljamescleary@gmail.com", url=url("https://github.com/pauljamescleary")),
+    Developer(id="rebstar6", name="Rebecca Star", email="rebstar6@gmail.com", url=url("https://github.com/rebstar6")),
+    Developer(id="nimaeskandary", name="Nima Eskandary", email="nimaesk1@gmail.com", url=url("https://github.com/nimaeskandary")),
+    Developer(id="mitruly", name="Michael Ly", email="michaeltrulyng@gmail.com", url=url("https://github.com/mitruly")),
+    Developer(id="britneywright", name="Britney Wright", email="blw06g@gmail.com", url=url("https://github.com/britneywright")),
+  ),
+  sonatypeProfileName := "io.vinyldns",
+
+  // gpg credentials are used to sign sonatype artifacts
+  // sonatype credentials live in ~/.sbt/1.0/sonatype.sbt
+  credentials += Credentials(Path.userHome / ".iv2" / ".gpgCredentials")
 )
 
 lazy val core = (project in file("modules/core")).enablePlugins(AutomateHeaderPlugin)
@@ -229,6 +256,7 @@ lazy val core = (project in file("modules/core")).enablePlugins(AutomateHeaderPl
   .settings(libraryDependencies ++= coreDependencies)
   .settings(scalaStyleCompile ++ scalaStyleTest)
   .settings(
+    organization := "io.vinyldns",
     coverageMinimum := 85,
     coverageFailOnMinimum := true,
     coverageHighlighting := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,3 +33,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
 
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.22")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+
+addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")


### PR DESCRIPTION
Tested deploying core to snapshots and it worked

* Updated plugins.sbt to include the sonatype plugin as well as
the pgp plugin.  The pgp plugin is new, and simply pulls gpg keys
from your default keyring
* Updated build.sbt to publish to sonatype.

You need to have a file ~/.sbt/1.0/sonatype.sbt that has credentials
to publish to sonatype.

You also need to have a file ~/.ivy2/.gpgCredentials that has
the gpg credentials used to load the key to sign artifacts with.