### PR TITLE
WIP lock users and check user lock status

### DIFF
--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -171,6 +171,8 @@ object LdapAuthenticator {
 }
 
 class UserDoesNotExistException(message: String) extends Exception(message: String)
+class UserIsNotAnAdminException(message: String) extends Exception(message: String)
+class UserAccountIsLockedException(message: String) extends Exception(message: String)
 
 /**
   * Top level ldap authenticator that tries authenticating on both the cable and corphq domains. Authentication is

--- a/modules/portal/app/models/UserAccount.scala
+++ b/modules/portal/app/models/UserAccount.scala
@@ -30,7 +30,8 @@ case class UserAccount(
     created: DateTime,
     accessKey: String,
     accessSecret: String,
-    isSuper: Boolean = false) {
+    isSuper: Boolean = false,
+    isLocked: Boolean = false) {
 
   private def generateKey: String = RandomStringUtils.randomAlphanumeric(20)
 
@@ -49,6 +50,9 @@ case class UserAccount(
 
   def regenerateCredentials(): UserAccount =
     copy(accessKey = generateKey, accessSecret = generateKey)
+
+  def lockUser(lockedStatus: Boolean): UserAccount =
+    copy(isLocked = lockedStatus)
 }
 
 object UserAccount {
@@ -64,6 +68,16 @@ object UserAccount {
     val key = generateKey
     val secret = generateKey
 
-    UserAccount(userId, username, firstName, lastName, email, createdTime, key, secret, false)
+    UserAccount(
+      userId,
+      username,
+      firstName,
+      lastName,
+      email,
+      createdTime,
+      key,
+      secret,
+      false,
+      false)
   }
 }

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -45,6 +45,8 @@ GET           /api/groups/:gid/members           @controllers.VinylDNS.getMember
 
 GET           /api/users/currentuser             @controllers.VinylDNS.getAuthenticatedUserData
 GET           /api/users/lookupuser/:uname       @controllers.VinylDNS.getUserDataByUsername(uname: String)
+PUT           /api/users/:uid/lock               @controllers.VinylDNS.updateUser(uid: String, locked: Boolean = true)
+PUT           /api/users/:uid/unlock             @controllers.VinylDNS.updateUser(uid: String, locked: Boolean = false)
 
 GET           /api/batchchanges/:id              @controllers.VinylDNS.getBatchChange(id: String)
 GET           /api/batchchanges                  @controllers.VinylDNS.listBatchChanges

--- a/modules/portal/test/models/UserAccountSpec.scala
+++ b/modules/portal/test/models/UserAccountSpec.scala
@@ -39,6 +39,8 @@ class UserAccountSpec extends Specification with Mockito {
       result.email must beEqualTo(email)
       result.accessKey.length must beEqualTo(20)
       result.accessSecret.length must beEqualTo(20)
+      result.isSuper must beEqualTo(false)
+      result.isLocked must beEqualTo(false)
     }
 
     "Copy an existing UserAccount with different accessKey and accessSecret" in {
@@ -60,6 +62,31 @@ class UserAccountSpec extends Specification with Mockito {
       newResult.accessSecret.length must beEqualTo(20)
       newResult.accessKey mustNotEqual result.accessKey
       newResult.accessSecret mustNotEqual result.accessSecret
+      newResult.isSuper must beEqualTo(false)
+      newResult.isLocked must beEqualTo(false)
+    }
+
+    "Lock a UserAccount" in {
+      val username = "fbaggins"
+      val fname = Some("Frodo")
+      val lname = Some("Baggins")
+      val email = Some("fb@hobbitmail.me")
+
+      val result = UserAccount(username, fname, lname, email)
+      val updatedResult = result.lockUser(true)
+
+      result must beAnInstanceOf[UserAccount]
+      result.isLocked must beEqualTo(false)
+      updatedResult must beAnInstanceOf[UserAccount]
+      UUID.fromString(updatedResult.userId) must beEqualTo(UUID.fromString(result.userId))
+      updatedResult.username must beEqualTo(username)
+      updatedResult.firstName must beEqualTo(fname)
+      updatedResult.lastName must beEqualTo(lname)
+      updatedResult.email must beEqualTo(email)
+      updatedResult.accessKey.length must beEqualTo(20)
+      updatedResult.accessSecret.length must beEqualTo(20)
+      updatedResult.isSuper must beEqualTo(false)
+      updatedResult.isLocked must beEqualTo(true)
     }
   }
 }


### PR DESCRIPTION
closes #142 

This adds the ability for super users to lock user accounts and also adds a check of the user lock status in each API call and the portal credential requests.

This doesn't actually provide the ability to change user lock status, it just creates the endpoint, so there isn't a way to test that yet. We have to decide if we want to add that functionality to the portal or one of the tools, or both. 

To test the experience of being locked out go to the UserAccount.scala file in the portal module (https://github.com/vinyldns/vinyldns/blob/d303c5ea593aa4a24499ea7aa7828a568e3d374b/modules/portal/app/models/UserAccount.scala#L34) and change false to true.