### PR TITLE
add locked account check to api authentication

### DIFF
--- a/modules/api/functional_test/live_tests/authentication_test.py
+++ b/modules/api/functional_test/live_tests/authentication_test.py
@@ -19,3 +19,11 @@ def test_request_fails_when_user_is_not_found():
     client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'unknownAccessKey', 'anyAccessSecretKey')
 
     client.list_batch_change_summaries(status=401)
+
+def test_request_succeeds_when_user_is_found_and_not_locked():
+    """
+    Test request success with Success (200) when user account is found and not locked
+    """
+    client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'okAccessKey', 'okSecretKey')
+
+    client.list_batch_change_summaries(status=200)

--- a/modules/api/functional_test/live_tests/authentication_test.py
+++ b/modules/api/functional_test/live_tests/authentication_test.py
@@ -1,0 +1,27 @@
+import pytest
+import sys
+import dns.query
+import dns.tsigkeyring
+import dns.update
+
+from utils import *
+from hamcrest import *
+from vinyldns_python import VinylDNSClient
+from dns.resolver import *
+from vinyldns_context import VinylDNSTestContext
+
+
+def test_request_fails_when_user_account_is_locked():
+    """
+    Test request fails with Forbidden (403) when user account is locked
+    """
+    client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'lockedAccessKey', 'lockedSecretKey')
+    client.list_batch_change_summaries(status=403)
+
+def test_request_fails_when_user_is_not_found():
+    """
+    Test request fails with Unauthorized (401) when user account is not found
+    """
+    client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'unknownAccessKey', 'anyAccessSecretKey')
+
+    client.list_batch_change_summaries(status=401)

--- a/modules/api/functional_test/live_tests/authentication_test.py
+++ b/modules/api/functional_test/live_tests/authentication_test.py
@@ -1,9 +1,3 @@
-import pytest
-import sys
-import dns.query
-import dns.tsigkeyring
-import dns.update
-
 from utils import *
 from hamcrest import *
 from vinyldns_python import VinylDNSClient

--- a/modules/api/functional_test/live_tests/membership/list_group_members_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_group_members_test.py
@@ -93,7 +93,7 @@ def test_list_group_members_start_from(shared_zone_test_context):
 
         # members has one more because admins are added as members
         assert_that(result['members'], has_length(len(members) + 1))
-        assert_that(result['members'], has_item({ 'id': 'ok'}))
+        assert_that(result['members'], has_item({ 'isLocked': False, 'id': 'ok'}))
         result_member_ids = map(lambda member: member['id'], result['members'])
         for user in members:
             assert_that(result_member_ids, has_item(user['id']))

--- a/modules/api/functional_test/live_tests/membership/list_group_members_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_group_members_test.py
@@ -93,7 +93,7 @@ def test_list_group_members_start_from(shared_zone_test_context):
 
         # members has one more because admins are added as members
         assert_that(result['members'], has_length(len(members) + 1))
-        assert_that(result['members'], has_item({ 'isLocked': False, 'id': 'ok'}))
+        assert_that(result['members'], has_item({ 'lockStatus': 'Unlocked', 'id': 'ok'}))
         result_member_ids = map(lambda member: member['id'], result['members'])
         for user in members:
             assert_that(result_member_ids, has_item(user['id']))

--- a/modules/api/src/it/scala/vinyldns/api/repository/mysql/JdbcZoneRepositoryIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/repository/mysql/JdbcZoneRepositoryIntegrationSpec.scala
@@ -101,7 +101,7 @@ class JdbcZoneRepositoryIntegrationSpec
     if (num == 1) z.addACLRule(dummyAclRule) else z
   }
 
-  private val superUserAuth = AuthPrincipal(dummyUser.copy(isSuper = true), Seq())
+  private val jdbcSuperUserAuth = AuthPrincipal(dummyUser.copy(isSuper = true), Seq())
 
   private def testZone(name: String, adminGroupId: String = testZoneAdminGroupId) =
     okZone.copy(name = name, id = UUID.randomUUID().toString, adminGroupId = adminGroupId)
@@ -410,7 +410,7 @@ class JdbcZoneRepositoryIntegrationSpec
       val f =
         for {
           _ <- saveZones(testZones)
-          retrieved <- repo.listZones(superUserAuth)
+          retrieved <- repo.listZones(jdbcSuperUserAuth)
         } yield retrieved
 
       whenReady(f.unsafeToFuture(), timeout) { retrieved =>
@@ -431,7 +431,7 @@ class JdbcZoneRepositoryIntegrationSpec
       val f =
         for {
           _ <- saveZones(testZones)
-          retrieved <- repo.listZones(superUserAuth, zoneNameFilter = Some("system"))
+          retrieved <- repo.listZones(jdbcSuperUserAuth, zoneNameFilter = Some("system"))
         } yield retrieved
 
       whenReady(f.unsafeToFuture(), timeout) { retrieved =>
@@ -471,19 +471,19 @@ class JdbcZoneRepositoryIntegrationSpec
 
       whenReady(saveZones(testZones).unsafeToFuture(), timeout) { _ =>
         whenReady(
-          repo.listZones(superUserAuth, offset = None, pageSize = 4).unsafeToFuture(),
+          repo.listZones(jdbcSuperUserAuth, offset = None, pageSize = 4).unsafeToFuture(),
           timeout) { firstPage =>
           (firstPage should contain).theSameElementsInOrderAs(expectedFirstPage)
         }
 
         whenReady(
-          repo.listZones(superUserAuth, offset = Some(4), pageSize = 4).unsafeToFuture(),
+          repo.listZones(jdbcSuperUserAuth, offset = Some(4), pageSize = 4).unsafeToFuture(),
           timeout) { secondPage =>
           (secondPage should contain).theSameElementsInOrderAs(expectedSecondPage)
         }
 
         whenReady(
-          repo.listZones(superUserAuth, offset = Some(8), pageSize = 4).unsafeToFuture(),
+          repo.listZones(jdbcSuperUserAuth, offset = Some(8), pageSize = 4).unsafeToFuture(),
           timeout) { thirdPage =>
           (thirdPage should contain).theSameElementsInOrderAs(expectedThirdPage)
         }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -73,7 +73,8 @@ case class UserInfo(
     firstName: Option[String] = None,
     lastName: Option[String] = None,
     email: Option[String] = None,
-    created: Option[DateTime] = None
+    created: Option[DateTime] = None,
+    isLocked: Boolean = false
 )
 object UserInfo {
   def apply(user: User): UserInfo =
@@ -83,7 +84,8 @@ object UserInfo {
       firstName = user.firstName,
       lastName = user.lastName,
       email = user.email,
-      created = Some(user.created)
+      created = Some(user.created),
+      isLocked = user.isLocked
     )
 }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import org.joda.time.DateTime
 import vinyldns.core.domain.membership.GroupChangeType.GroupChangeType
 import vinyldns.core.domain.membership.GroupStatus.GroupStatus
+import vinyldns.core.domain.membership.LockStatus.LockStatus
 import vinyldns.core.domain.membership._
 
 /* This is the new View model for Groups, do not surface the Group model directly any more */
@@ -74,7 +75,7 @@ case class UserInfo(
     lastName: Option[String] = None,
     email: Option[String] = None,
     created: Option[DateTime] = None,
-    isLocked: Boolean = false
+    lockStatus: LockStatus = LockStatus.Unlocked
 )
 object UserInfo {
   def apply(user: User): UserInfo =
@@ -85,7 +86,7 @@ object UserInfo {
       lastName = user.lastName,
       email = user.email,
       created = Some(user.created),
-      isLocked = user.isLocked
+      lockStatus = user.lockStatus
     )
 }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -232,12 +232,12 @@ class MembershipService(
 
   def updateUserLockStatus(
       userId: String,
-      setLockedTo: LockStatus,
+      lockStatus: LockStatus,
       authPrincipal: AuthPrincipal): Result[User] =
     for {
       _ <- isSuperAdmin(authPrincipal).toResult
       existingUser <- getExistingUser(userId)
-      newUser = existingUser.updateUserLockStatus(setLockedTo)
+      newUser = existingUser.updateUserLockStatus(lockStatus)
       _ <- userRepo.save(newUser).toResult[User]
     } yield newUser
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -55,7 +55,7 @@ class MembershipService(
     for {
       existingGroup <- getExistingGroup(groupId)
       newGroup = existingGroup.withUpdates(name, email, description, memberIds, adminUserIds)
-      _ <- isAdmin(existingGroup, authPrincipal).toResult
+      _ <- isGroupAdmin(existingGroup, authPrincipal).toResult
       addedMembers = newGroup.memberIds.diff(existingGroup.memberIds)
       removedMembers = existingGroup.memberIds.diff(newGroup.memberIds)
       _ <- hasMembersAndAdmins(newGroup).toResult
@@ -72,7 +72,7 @@ class MembershipService(
   def deleteGroup(groupId: String, authPrincipal: AuthPrincipal): Result[Group] =
     for {
       existingGroup <- getExistingGroup(groupId)
-      _ <- isAdmin(existingGroup, authPrincipal).toResult
+      _ <- isGroupAdmin(existingGroup, authPrincipal).toResult
       _ <- groupCanBeDeleted(existingGroup)
       _ <- groupChangeRepo
         .save(GroupChange.forDelete(existingGroup, authPrincipal))

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -19,6 +19,7 @@ package vinyldns.api.domain.membership
 import cats.implicits._
 import vinyldns.api.Interfaces._
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.LockStatus.LockStatus
 import vinyldns.core.domain.zone.ZoneRepository
 import vinyldns.core.domain.membership._
 
@@ -231,7 +232,7 @@ class MembershipService(
 
   def updateUserLockStatus(
       userId: String,
-      setLockedTo: Boolean,
+      setLockedTo: LockStatus,
       authPrincipal: AuthPrincipal): Result[User] =
     for {
       _ <- isSuperAdmin(authPrincipal).toResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
@@ -56,4 +56,9 @@ trait MembershipServiceAlgebra {
       startFrom: Option[String],
       maxItems: Int,
       authPrincipal: AuthPrincipal): Result[ListGroupChangesResponse]
+
+  def updateUserLockStatus(
+      userId: String,
+      setLockedTo: Boolean,
+      authPrincipal: AuthPrincipal): Result[User]
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
@@ -60,6 +60,6 @@ trait MembershipServiceAlgebra {
 
   def updateUserLockStatus(
       userId: String,
-      setLockedTo: LockStatus,
+      lockStatus: LockStatus,
       authPrincipal: AuthPrincipal): Result[User]
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
@@ -18,6 +18,7 @@ package vinyldns.api.domain.membership
 
 import vinyldns.api.Interfaces.Result
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.LockStatus.LockStatus
 import vinyldns.core.domain.membership._
 
 trait MembershipServiceAlgebra {
@@ -59,6 +60,6 @@ trait MembershipServiceAlgebra {
 
   def updateUserLockStatus(
       userId: String,
-      setLockedTo: Boolean,
+      setLockedTo: LockStatus,
       authPrincipal: AuthPrincipal): Result[User]
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -28,7 +28,7 @@ object MembershipValidations {
       group.memberIds.nonEmpty && group.adminUserIds.nonEmpty
     }
 
-  def isAdmin(group: Group, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
+  def isGroupAdmin(group: Group, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
       group.adminUserIds.contains(authPrincipal.userId) || authPrincipal.signedInUser.isSuper
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -33,6 +33,11 @@ object MembershipValidations {
       group.adminUserIds.contains(authPrincipal.userId) || authPrincipal.signedInUser.isSuper
     }
 
+  def isSuperAdmin(authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
+    ensuring(NotAuthorizedError("Not authorized")) {
+      authPrincipal.signedInUser.isSuper
+    }
+
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
       authPrincipal.isAuthorized(groupId)

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -65,6 +65,18 @@ object TestDataLoader {
     isSuper = false,
     isLocked = true
   )
+  final val superUser = User(
+    userName = "super",
+    id = "super",
+    created = DateTime.now.secondOfDay().roundFloorCopy(),
+    accessKey = "superAccessKey",
+    secretKey = "superSecretKey",
+    firstName = Some("Super"),
+    lastName = Some("User"),
+    email = Some("super@test.com"),
+    isSuper = true,
+    isLocked = false
+  )
   final val listOfDummyUsers: List[User] = List.range(0, 200).map { runner =>
     User(
       userName = "name-dummy%03d".format(runner),

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -140,7 +140,7 @@ object TestDataLoader {
     lastName = Some("list-zero-summaries"),
     email = Some("test@test.com")
   )
-  
+
   def loadTestData(repository: UserRepository): IO[List[User]] =
     (testUser :: okUser :: dummyUser :: lockedUser :: listGroupUser :: listZonesUser :: listBatchChangeSummariesUser ::
       listZeroBatchChangeSummariesUser :: zoneHistoryUser :: listOfDummyUsers).map { user =>

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -63,7 +63,7 @@ object TestDataLoader {
     lastName = Some("User"),
     email = Some("testlocked@test.com"),
     isSuper = false,
-    isLocked = true
+    lockStatus = LockStatus.Locked
   )
   final val listOfDummyUsers: List[User] = List.range(0, 200).map { runner =>
     User(

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -51,7 +51,20 @@ object TestDataLoader {
     id = "dummy",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "dummyAccessKey",
-    secretKey = "dummySecretKey")
+    secretKey = "dummySecretKey"
+  )
+  final val lockedUser = User(
+    userName = "locked",
+    id = "locked",
+    created = DateTime.now.secondOfDay().roundFloorCopy(),
+    accessKey = "lockedAccessKey",
+    secretKey = "lockedSecretKey",
+    firstName = Some("Locked"),
+    lastName = Some("User"),
+    email = Some("testlocked@test.com"),
+    isSuper = false,
+    isLocked = true
+  )
   final val listOfDummyUsers: List[User] = List.range(0, 200).map { runner =>
     User(
       userName = "name-dummy%03d".format(runner),
@@ -115,9 +128,9 @@ object TestDataLoader {
     lastName = Some("list-zero-summaries"),
     email = Some("test@test.com")
   )
-
+  
   def loadTestData(repository: UserRepository): IO[List[User]] =
-    (testUser :: okUser :: dummyUser :: listGroupUser :: listZonesUser :: listBatchChangeSummariesUser ::
+    (testUser :: okUser :: dummyUser :: lockedUser :: listGroupUser :: listZonesUser :: listBatchChangeSummariesUser ::
       listZeroBatchChangeSummariesUser :: zoneHistoryUser :: listOfDummyUsers).map { user =>
       val encrypted =
         if (VinylDNSConfig.encryptUserSecrets)

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -65,18 +65,6 @@ object TestDataLoader {
     isSuper = false,
     isLocked = true
   )
-  final val superUser = User(
-    userName = "super",
-    id = "super",
-    created = DateTime.now.secondOfDay().roundFloorCopy(),
-    accessKey = "superAccessKey",
-    secretKey = "superSecretKey",
-    firstName = Some("Super"),
-    lastName = Some("User"),
-    email = Some("super@test.com"),
-    isSuper = true,
-    isLocked = false
-  )
   final val listOfDummyUsers: List[User] = List.range(0, 200).map { runner =>
     User(
       userName = "name-dummy%03d".format(runner),

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -23,7 +23,6 @@ import cats.implicits._
 import org.joda.time.DateTime
 import org.json4s._
 import vinyldns.api.domain.membership._
-import vinyldns.core.domain.membership.LockStatus.LockStatus
 import vinyldns.core.domain.membership.{Group, GroupChangeType, GroupStatus, LockStatus}
 
 object MembershipJsonProtocol {
@@ -40,7 +39,6 @@ object MembershipJsonProtocol {
       description: Option[String],
       members: Set[UserInfo],
       admins: Set[UserInfo])
-  final case class UpdateUserInput(id: String, lockStatus: LockStatus)
 }
 
 /* Defines the JSON serialization to support the Membership Routes */

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -39,6 +39,7 @@ object MembershipJsonProtocol {
       description: Option[String],
       members: Set[UserInfo],
       admins: Set[UserInfo])
+  final case class UpdateUserInput(id: String, isLocked: Boolean)
 }
 
 /* Defines the JSON serialization to support the Membership Routes */

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -23,7 +23,8 @@ import cats.implicits._
 import org.joda.time.DateTime
 import org.json4s._
 import vinyldns.api.domain.membership._
-import vinyldns.core.domain.membership.{Group, GroupChangeType, GroupStatus}
+import vinyldns.core.domain.membership.LockStatus.LockStatus
+import vinyldns.core.domain.membership.{Group, GroupChangeType, GroupStatus, LockStatus}
 
 object MembershipJsonProtocol {
   final case class CreateGroupInput(
@@ -39,7 +40,7 @@ object MembershipJsonProtocol {
       description: Option[String],
       members: Set[UserInfo],
       admins: Set[UserInfo])
-  final case class UpdateUserInput(id: String, isLocked: Boolean)
+  final case class UpdateUserInput(id: String, lockStatus: LockStatus)
 }
 
 /* Defines the JSON serialization to support the Membership Routes */
@@ -53,6 +54,7 @@ trait MembershipJsonProtocol extends JsonValidation {
     GroupChangeInfoSerializer,
     CreateGroupInputSerializer,
     UpdateGroupInputSerializer,
+    JsonEnumV(LockStatus),
     JsonEnumV(GroupStatus),
     JsonEnumV(GroupChangeType)
   )

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
@@ -23,7 +23,7 @@ import vinyldns.api.domain.membership._
 import vinyldns.api.domain.zone.NotAuthorizedError
 import vinyldns.api.route.MembershipJsonProtocol.{CreateGroupInput, UpdateGroupInput}
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.membership.Group
+import vinyldns.core.domain.membership.{Group, LockStatus}
 
 trait MembershipRoute extends Directives {
   this: VinylDNSJsonProtocol with VinylDNSDirectives with JsonValidationRejection =>
@@ -170,13 +170,15 @@ trait MembershipRoute extends Directives {
         }
       } ~
       (put & path("users" / Segment / "lock") & monitor("Endpoint.lockUser")) { id =>
-        execute(membershipService.updateUserLockStatus(id, true, authPrincipal)) { user =>
-          complete(StatusCodes.OK, UserInfo(user))
+        execute(membershipService.updateUserLockStatus(id, LockStatus.Locked, authPrincipal)) {
+          user =>
+            complete(StatusCodes.OK, UserInfo(user))
         }
       } ~
       (put & path("users" / Segment / "unlock") & monitor("Endpoint.unlockUser")) { id =>
-        execute(membershipService.updateUserLockStatus(id, false, authPrincipal)) { user =>
-          complete(StatusCodes.OK, UserInfo(user))
+        execute(membershipService.updateUserLockStatus(id, LockStatus.Unlocked, authPrincipal)) {
+          user =>
+            complete(StatusCodes.OK, UserInfo(user))
         }
       }
   }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
@@ -168,6 +168,16 @@ trait MembershipRoute extends Directives {
             }
           }
         }
+      } ~
+      (put & path("users" / Segment / "lock") & monitor("Endpoint.lockUser")) { id =>
+        execute(membershipService.updateUserLockStatus(id, true, authPrincipal)) { user =>
+          complete(StatusCodes.OK, UserInfo(user))
+        }
+      } ~
+      (put & path("users" / Segment / "unlock") & monitor("Endpoint.unlockUser")) { id =>
+        execute(membershipService.updateUserLockStatus(id, false, authPrincipal)) { user =>
+          complete(StatusCodes.OK, UserInfo(user))
+        }
       }
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
@@ -26,6 +26,7 @@ import vinyldns.api.domain.auth.{AuthPrincipalProvider, MembershipAuthPrincipalP
 import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.route.Monitored
+import vinyldns.core.domain.membership.LockStatus
 
 import scala.util.matching.Regex
 
@@ -133,7 +134,7 @@ trait VinylDNSAuthentication extends Monitored {
   def getAuthPrincipal(accessKey: String): IO[AuthPrincipal] =
     authPrincipalProvider.getAuthPrincipal(accessKey).flatMap {
       case Some(ok) =>
-        if (ok.signedInUser.isLocked) {
+        if (ok.signedInUser.lockStatus == LockStatus.Locked) {
           IO.raiseError(
             AccountLocked(s"Account with username ${ok.signedInUser.userName} is locked"))
         } else IO.pure(ok)

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSDirectives.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSDirectives.scala
@@ -52,21 +52,25 @@ trait VinylDNSDirectives extends Directives {
             .flatMap {
               case Right(authPrincipal) ⇒
                 provide(authPrincipal)
-              case Left(AccountLocked(err)) ⇒
-                complete(
-                  HttpResponse(
-                    status = StatusCodes.Forbidden,
-                    entity = HttpEntity(s"Authentication Failed: $err")
-                  ))
               case Left(e) ⇒
-                complete(
-                  HttpResponse(
-                    status = StatusCodes.Unauthorized,
-                    entity = HttpEntity(s"Authentication Failed: $e")
-                  ))
+                complete(handleAuthenticateError(e))
             }
         }
       }
+    }
+
+  def handleAuthenticateError(error: VinylDNSAuthenticationError): HttpResponse =
+    error match {
+      case AccountLocked(err) =>
+        HttpResponse(
+          status = StatusCodes.Forbidden,
+          entity = HttpEntity(s"Authentication Failed: $err")
+        )
+      case e =>
+        HttpResponse(
+          status = StatusCodes.Unauthorized,
+          entity = HttpEntity(s"Authentication Failed: ${e.getMessage}")
+        )
     }
 
   /* Adds monitoring to an Endpoint.  The name will be surfaced in JMX */

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSDirectives.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSDirectives.scala
@@ -17,7 +17,6 @@
 package vinyldns.api.route
 
 import akka.http.scaladsl.model.{HttpEntity, HttpResponse, StatusCodes}
-import akka.http.javadsl.server.CustomRejection
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.BasicDirectives
@@ -42,7 +41,7 @@ trait VinylDNSDirectives extends Directives {
     */
   def vinyldnsAuthenticator(
       ctx: RequestContext,
-      content: String): IO[Either[CustomRejection, AuthPrincipal]] =
+      content: String): IO[Either[VinylDNSAuthenticationError, AuthPrincipal]] =
     VinylDNSAuthenticator(ctx, content)
 
   def authenticate: Directive1[AuthPrincipal] =
@@ -53,7 +52,7 @@ trait VinylDNSDirectives extends Directives {
             .flatMap {
               case Right(authPrincipal) ⇒
                 provide(authPrincipal)
-              case Left(VinylDNSAccountLocked(err)) ⇒
+              case Left(AccountLocked(err)) ⇒
                 complete(
                   HttpResponse(
                     status = StatusCodes.Forbidden,

--- a/modules/api/src/test/scala/vinyldns/api/GroupTestData.scala
+++ b/modules/api/src/test/scala/vinyldns/api/GroupTestData.scala
@@ -31,6 +31,7 @@ trait GroupTestData { this: Matchers =>
   val okUser: User = TestDataLoader.okUser
   val dummyUser: User = TestDataLoader.dummyUser
   val lockedUser: User = TestDataLoader.lockedUser
+  val superUser: User = TestDataLoader.superUser
   val listOfDummyUsers: List[User] = TestDataLoader.listOfDummyUsers
 
   val okUserInfo: UserInfo = UserInfo(okUser)
@@ -93,6 +94,7 @@ trait GroupTestData { this: Matchers =>
   val deletedGroupAuth: AuthPrincipal = AuthPrincipal(okUser, Seq(deletedGroup.id))
   val dummyUserAuth: AuthPrincipal = AuthPrincipal(dummyUser, Seq(dummyGroup.id))
   val lockedUserAuth: AuthPrincipal = AuthPrincipal(lockedUser, Seq())
+  val superUserAuth: AuthPrincipal = AuthPrincipal(superUser, Seq())
   val listOfDummyGroupsAuth: AuthPrincipal = AuthPrincipal(dummyUser, listOfDummyGroups.map(_.id))
 
   val memberOkZoneAuthorized: Zone = Zone(

--- a/modules/api/src/test/scala/vinyldns/api/GroupTestData.scala
+++ b/modules/api/src/test/scala/vinyldns/api/GroupTestData.scala
@@ -30,6 +30,7 @@ trait GroupTestData { this: Matchers =>
 
   val okUser: User = TestDataLoader.okUser
   val dummyUser: User = TestDataLoader.dummyUser
+  val lockedUser: User = TestDataLoader.lockedUser
   val listOfDummyUsers: List[User] = TestDataLoader.listOfDummyUsers
 
   val okUserInfo: UserInfo = UserInfo(okUser)
@@ -91,6 +92,7 @@ trait GroupTestData { this: Matchers =>
   val noGroupsUserAuth: AuthPrincipal = AuthPrincipal(okUser, Seq())
   val deletedGroupAuth: AuthPrincipal = AuthPrincipal(okUser, Seq(deletedGroup.id))
   val dummyUserAuth: AuthPrincipal = AuthPrincipal(dummyUser, Seq(dummyGroup.id))
+  val lockedUserAuth: AuthPrincipal = AuthPrincipal(lockedUser, Seq())
   val listOfDummyGroupsAuth: AuthPrincipal = AuthPrincipal(dummyUser, listOfDummyGroups.map(_.id))
 
   val memberOkZoneAuthorized: Zone = Zone(

--- a/modules/api/src/test/scala/vinyldns/api/GroupTestData.scala
+++ b/modules/api/src/test/scala/vinyldns/api/GroupTestData.scala
@@ -31,9 +31,8 @@ trait GroupTestData { this: Matchers =>
   val okUser: User = TestDataLoader.okUser
   val dummyUser: User = TestDataLoader.dummyUser
   val lockedUser: User = TestDataLoader.lockedUser
-  val superUser: User = TestDataLoader.superUser
-  val listOfDummyUsers: List[User] = TestDataLoader.listOfDummyUsers
 
+  val listOfDummyUsers: List[User] = TestDataLoader.listOfDummyUsers
   val okUserInfo: UserInfo = UserInfo(okUser)
   val dummyUserInfo: UserInfo = UserInfo(dummyUser)
 
@@ -94,7 +93,6 @@ trait GroupTestData { this: Matchers =>
   val deletedGroupAuth: AuthPrincipal = AuthPrincipal(okUser, Seq(deletedGroup.id))
   val dummyUserAuth: AuthPrincipal = AuthPrincipal(dummyUser, Seq(dummyGroup.id))
   val lockedUserAuth: AuthPrincipal = AuthPrincipal(lockedUser, Seq())
-  val superUserAuth: AuthPrincipal = AuthPrincipal(superUser, Seq())
   val listOfDummyGroupsAuth: AuthPrincipal = AuthPrincipal(dummyUser, listOfDummyGroups.map(_.id))
 
   val memberOkZoneAuthorized: Zone = Zone(

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestData.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestData.scala
@@ -39,6 +39,7 @@ trait VinylDNSTestData {
     created = DateTime.now.secondOfDay().roundFloorCopy())
   val okAuth: AuthPrincipal = AuthPrincipal(TestDataLoader.okUser, Seq(grp.id))
   val notAuth: AuthPrincipal = AuthPrincipal(TestDataLoader.dummyUser, Seq.empty)
+  val lockedAuth: AuthPrincipal = AuthPrincipal(TestDataLoader.lockedUser, Seq.empty)
 
   val testConnection: Option[ZoneConnection] = Some(
     ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1"))

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -781,11 +781,10 @@ class MembershipServiceSpec
         doReturn(IO.pure(Some(lockedUser))).when(mockUserRepo).getUser(lockedUser.id)
         doReturn(IO.pure(okUser)).when(mockUserRepo).save(any[User])
 
-        val something = underTest
+        underTest
           .updateUserLockStatus(lockedUser.id, LockStatus.Unlocked, superUserAuth)
           .value
-
-        something.unsafeRunSync()
+          .unsafeRunSync()
 
         val userCaptor = ArgumentCaptor.forClass(classOf[User])
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -761,7 +761,7 @@ class MembershipServiceSpec
 
         awaitResultOf(
           underTest
-            .updateUserLockStatus(okUser.id, true, superUserAuth)
+            .updateUserLockStatus(okUser.id, LockStatus.Locked, superUserAuth)
             .value)
 
         val userCaptor = ArgumentCaptor.forClass(classOf[User])
@@ -769,7 +769,7 @@ class MembershipServiceSpec
         verify(mockUserRepo).save(userCaptor.capture())
 
         val savedUser = userCaptor.getValue
-        savedUser.isLocked shouldBe true
+        savedUser.lockStatus shouldBe LockStatus.Locked
         savedUser.id shouldBe okUser.id
       }
 
@@ -781,7 +781,7 @@ class MembershipServiceSpec
 
         awaitResultOf(
           underTest
-            .updateUserLockStatus(lockedUser.id, false, superUserAuth)
+            .updateUserLockStatus(lockedUser.id, LockStatus.Unlocked, superUserAuth)
             .value)
 
         val userCaptor = ArgumentCaptor.forClass(classOf[User])
@@ -789,14 +789,14 @@ class MembershipServiceSpec
         verify(mockUserRepo).save(userCaptor.capture())
 
         val savedUser = userCaptor.getValue
-        savedUser.isLocked shouldBe false
+        savedUser.lockStatus shouldBe LockStatus.Unlocked
         savedUser.id shouldBe lockedUser.id
       }
 
       "return an error if the signed in user is not a super user" in {
         val error = leftResultOf(
           underTest
-            .updateUserLockStatus(okUser.id, true, dummyUserAuth)
+            .updateUserLockStatus(okUser.id, LockStatus.Locked, dummyUserAuth)
             .value)
 
         error shouldBe a[NotAuthorizedError]
@@ -810,7 +810,7 @@ class MembershipServiceSpec
 
         val error = leftResultOf(
           underTest
-            .updateUserLockStatus(okUser.id, true, superUserAuth)
+            .updateUserLockStatus(okUser.id, LockStatus.Locked, superUserAuth)
             .value)
 
         error shouldBe a[UserNotFoundError]

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -758,11 +758,12 @@ class MembershipServiceSpec
           signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
           memberGroupIds = Seq.empty)
         doReturn(IO.pure(Some(okUser))).when(mockUserRepo).getUser(okUser.id)
+        doReturn(IO.pure(okUser)).when(mockUserRepo).save(any[User])
 
-        awaitResultOf(
-          underTest
-            .updateUserLockStatus(okUser.id, LockStatus.Locked, superUserAuth)
-            .value)
+        underTest
+          .updateUserLockStatus(okUser.id, LockStatus.Locked, superUserAuth)
+          .value
+          .unsafeRunSync()
 
         val userCaptor = ArgumentCaptor.forClass(classOf[User])
 
@@ -778,11 +779,13 @@ class MembershipServiceSpec
           signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
           memberGroupIds = Seq.empty)
         doReturn(IO.pure(Some(lockedUser))).when(mockUserRepo).getUser(lockedUser.id)
+        doReturn(IO.pure(okUser)).when(mockUserRepo).save(any[User])
 
-        awaitResultOf(
-          underTest
-            .updateUserLockStatus(lockedUser.id, LockStatus.Unlocked, superUserAuth)
-            .value)
+        val something = underTest
+          .updateUserLockStatus(lockedUser.id, LockStatus.Unlocked, superUserAuth)
+          .value
+
+        something.unsafeRunSync()
 
         val userCaptor = ArgumentCaptor.forClass(classOf[User])
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -85,16 +85,6 @@ class MembershipServiceSpec
     adminUserIds = existingGroup.adminUserIds ++ updatedInfo.memberIds
   )
 
-  // the update will set isLocked to true
-  private val updatedToLockUserInfo = okUser.copy(
-    isLocked = true
-  )
-
-  // the update will set isLocked to false
-  private val updatedToUnlockUserInfo = lockedUser.copy(
-    isLocked = true
-  )
-
   override protected def beforeEach(): Unit =
     reset(mockGroupRepo, mockUserRepo, mockMembershipRepo, mockGroupChangeRepo, underTest)
 
@@ -764,7 +754,6 @@ class MembershipServiceSpec
     "updateUserLockStatus" should {
       "save the update and lock the user account" in {
         doReturn(IO.pure(Some(okUser))).when(mockUserRepo).getUser(okUser.id)
-        doReturn(IO.pure(updatedToLockUserInfo)).when(mockUserRepo).save(any[User])
 
         awaitResultOf(
           underTest
@@ -782,7 +771,6 @@ class MembershipServiceSpec
 
       "save the update and unlock the user account" in {
         doReturn(IO.pure(Some(lockedUser))).when(mockUserRepo).getUser(lockedUser.id)
-        doReturn(IO.pure(updatedToUnlockUserInfo)).when(mockUserRepo).save(any[User])
 
         awaitResultOf(
           underTest
@@ -799,8 +787,6 @@ class MembershipServiceSpec
       }
 
       "return an error if the signed in user is not a super user" in {
-        doReturn(IO.pure(Some(okUser))).when(mockUserRepo).getUser(okUser.id)
-
         val error = leftResultOf(
           underTest
             .updateUserLockStatus(okUser.id, true, dummyUserAuth)

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -23,7 +23,7 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import vinyldns.api.Interfaces._
-import vinyldns.api.{GroupTestData, ResultHelpers}
+import vinyldns.api.{GroupTestData, ResultHelpers, VinylDNSTestData}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.zone.{ZoneRepository, _}
 import cats.effect._
@@ -37,6 +37,7 @@ class MembershipServiceSpec
     with BeforeAndAfterEach
     with ResultHelpers
     with GroupTestData
+    with VinylDNSTestData
     with EitherMatchers {
 
   private val mockGroupRepo = mock[GroupRepository]
@@ -753,6 +754,9 @@ class MembershipServiceSpec
 
     "updateUserLockStatus" should {
       "save the update and lock the user account" in {
+        val superUserAuth = okAuth.copy(
+          signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
+          memberGroupIds = Seq.empty)
         doReturn(IO.pure(Some(okUser))).when(mockUserRepo).getUser(okUser.id)
 
         awaitResultOf(
@@ -770,6 +774,9 @@ class MembershipServiceSpec
       }
 
       "save the update and unlock the user account" in {
+        val superUserAuth = okAuth.copy(
+          signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
+          memberGroupIds = Seq.empty)
         doReturn(IO.pure(Some(lockedUser))).when(mockUserRepo).getUser(lockedUser.id)
 
         awaitResultOf(
@@ -796,6 +803,9 @@ class MembershipServiceSpec
       }
 
       "return an error if the requested user is not found" in {
+        val superUserAuth = okAuth.copy(
+          signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
+          memberGroupIds = Seq.empty)
         doReturn(IO.pure(None)).when(mockUserRepo).getUser(okUser.id)
 
         val error = leftResultOf(

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -56,17 +56,17 @@ class MembershipValidationsSpec
 
     "isAdmin" should {
       "return true when the user is in admin group" in {
-        isAdmin(okGroup, okUserAuth) should be(right)
+        isGroupAdmin(okGroup, okUserAuth) should be(right)
       }
       "return true when the user is a super user" in {
         val user = User("some", "new", "user", isSuper = true)
         val superAuth = AuthPrincipal(user, Seq())
-        isAdmin(okGroup, superAuth) should be(right)
+        isGroupAdmin(okGroup, superAuth) should be(right)
       }
       "return an error when the user has no access and is not super" in {
         val user = User("some", "new", "user")
         val nonSuperAuth = AuthPrincipal(user, Seq())
-        val error = leftValue(isAdmin(okGroup, nonSuperAuth))
+        val error = leftValue(isGroupAdmin(okGroup, nonSuperAuth))
         error shouldBe an[NotAuthorizedError]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -30,10 +30,11 @@ import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import vinyldns.api.Interfaces._
 import vinyldns.api.domain.membership._
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.membership.Group
+import vinyldns.core.domain.membership.{Group, LockStatus}
 import vinyldns.api.domain.zone.NotAuthorizedError
 import vinyldns.api.route.MembershipJsonProtocol.{CreateGroupInput, UpdateGroupInput}
 import vinyldns.api.{GroupTestData, VinylDNSTestData}
+import vinyldns.core.domain.membership.LockStatus.LockStatus
 
 class MembershipRoutingSpec
     extends WordSpec
@@ -673,13 +674,13 @@ class MembershipRoutingSpec
   }
   "PUT update user lock status" should {
     "return a 200 response with the user locked" in {
-      val updatedUser = okUser.copy(isLocked = true)
+      val updatedUser = okUser.copy(lockStatus = LockStatus.Locked)
       val superUserAuth = okAuth.copy(
         signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
         memberGroupIds = Seq.empty)
       doReturn(result(updatedUser))
         .when(membershipService)
-        .updateUserLockStatus("ok", true, superUserAuth)
+        .updateUserLockStatus("ok", LockStatus.Locked, superUserAuth)
 
       Put("/users/ok/lock") ~> membershipRoute(superUserAuth) ~> check {
         status shouldBe StatusCodes.OK
@@ -687,18 +688,18 @@ class MembershipRoutingSpec
         val result = responseAs[UserInfo]
 
         result.id shouldBe okUser.id
-        result.isLocked shouldEqual true
+        result.lockStatus shouldBe LockStatus.Locked
       }
     }
 
     "return a 200 response with the user unlocked" in {
-      val updatedUser = lockedUser.copy(isLocked = false)
+      val updatedUser = lockedUser.copy(lockStatus = LockStatus.Unlocked)
       val superUserAuth = okAuth.copy(
         signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
         memberGroupIds = Seq.empty)
       doReturn(result(updatedUser))
         .when(membershipService)
-        .updateUserLockStatus("locked", false, superUserAuth)
+        .updateUserLockStatus("locked", LockStatus.Unlocked, superUserAuth)
 
       Put("/users/locked/unlock") ~> membershipRoute(superUserAuth) ~> check {
         status shouldBe StatusCodes.OK
@@ -706,7 +707,7 @@ class MembershipRoutingSpec
         val result = responseAs[UserInfo]
 
         result.id shouldBe lockedUser.id
-        result.isLocked shouldEqual false
+        result.lockStatus shouldBe LockStatus.Unlocked
       }
     }
 
@@ -716,7 +717,7 @@ class MembershipRoutingSpec
         memberGroupIds = Seq.empty)
       doReturn(result(UserNotFoundError("fail")))
         .when(membershipService)
-        .updateUserLockStatus(anyString, anyBoolean, any[AuthPrincipal])
+        .updateUserLockStatus(anyString, any[LockStatus], any[AuthPrincipal])
       Put("/users/notFound/lock") ~> membershipRoute(superUserAuth) ~> check {
         status shouldBe StatusCodes.NotFound
       }
@@ -725,7 +726,7 @@ class MembershipRoutingSpec
     "return a 403 Forbidden when not authorized" in {
       doReturn(result(NotAuthorizedError("fail")))
         .when(membershipService)
-        .updateUserLockStatus(anyString, anyBoolean, any[AuthPrincipal])
+        .updateUserLockStatus(anyString, any[LockStatus], any[AuthPrincipal])
       Put("/users/forbidden/lock") ~> membershipRoute(okGroupAuth) ~> check {
         status shouldBe StatusCodes.Forbidden
       }

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -674,6 +674,9 @@ class MembershipRoutingSpec
   "PUT update user lock status" should {
     "return a 200 response with the user locked" in {
       val updatedUser = okUser.copy(isLocked = true)
+      val superUserAuth = okAuth.copy(
+        signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
+        memberGroupIds = Seq.empty)
       doReturn(result(updatedUser))
         .when(membershipService)
         .updateUserLockStatus("ok", true, superUserAuth)
@@ -690,6 +693,9 @@ class MembershipRoutingSpec
 
     "return a 200 response with the user unlocked" in {
       val updatedUser = lockedUser.copy(isLocked = false)
+      val superUserAuth = okAuth.copy(
+        signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
+        memberGroupIds = Seq.empty)
       doReturn(result(updatedUser))
         .when(membershipService)
         .updateUserLockStatus("locked", false, superUserAuth)
@@ -705,6 +711,9 @@ class MembershipRoutingSpec
     }
 
     "return a 404 Not Found when the user is not found" in {
+      val superUserAuth = okAuth.copy(
+        signedInUser = dummyUserAuth.signedInUser.copy(isSuper = true),
+        memberGroupIds = Seq.empty)
       doReturn(result(UserNotFoundError("fail")))
         .when(membershipService)
         .updateUserLockStatus(anyString, anyBoolean, any[AuthPrincipal])

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -16,8 +16,8 @@
 
 package vinyldns.api.route
 
+import akka.http.javadsl.server.CustomRejection
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, StatusCodes}
-import akka.http.scaladsl.server.AuthenticationFailedRejection.Cause
 import akka.http.scaladsl.server.{Directives, RequestContext, Route}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect._
@@ -485,7 +485,7 @@ class RecordSetRoutingSpec
 
   override def vinyldnsAuthenticator(
       ctx: RequestContext,
-      content: String): IO[Either[Cause, AuthPrincipal]] =
+      content: String): IO[Either[CustomRejection, AuthPrincipal]] =
     IO.pure(Right(okAuth))
 
   private def rsJson(recordSet: RecordSet): String =

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -16,7 +16,6 @@
 
 package vinyldns.api.route
 
-import akka.http.javadsl.server.CustomRejection
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, StatusCodes}
 import akka.http.scaladsl.server.{Directives, RequestContext, Route}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -485,7 +484,7 @@ class RecordSetRoutingSpec
 
   override def vinyldnsAuthenticator(
       ctx: RequestContext,
-      content: String): IO[Either[CustomRejection, AuthPrincipal]] =
+      content: String): IO[Either[VinylDNSAuthenticationError, AuthPrincipal]] =
     IO.pure(Right(okAuth))
 
   private def rsJson(recordSet: RecordSet): String =

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSAuthenticatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSAuthenticatorSpec.scala
@@ -191,7 +191,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthenticator)
         .extractAccessKey(any[String])
 
-      doReturn(IO.raiseError(AccountLocked("Account with username locked is locked")))
+      doReturn(IO.pure(Some(lockedUserAuth)))
         .when(mockAuthPrincipalProvider)
         .getAuthPrincipal(any[String])
 
@@ -214,18 +214,18 @@ class VinylDNSAuthenticatorSpec
       val context: RequestContext = mock[RequestContext]
       doReturn(httpRequest).when(context).request
 
-      doReturn(okUser.accessKey)
+      doReturn("fakeKey")
         .when(mockAuthenticator)
         .extractAccessKey(any[String])
 
       // No User found
-      doReturn(IO.raiseError(AuthRejected("Authorization header could not be parsed")))
+      doReturn(IO.pure(None))
         .when(mockAuthPrincipalProvider)
         .getAuthPrincipal(any[String])
 
       val result =
         await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
-      result shouldBe Left(AuthRejected("Authorization header could not be parsed"))
+      result shouldBe Left(AuthRejected("Account with accessKey fakeKey specified was not found"))
     }
     "fail if signatures can not be validated" in {
       val fakeHttpHeader = mock[HttpHeader]

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSAuthenticatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSAuthenticatorSpec.scala
@@ -24,15 +24,13 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.api.domain.auth.AuthPrincipalProvider
-import vinyldns.api.{GroupTestData, ResultHelpers}
+import vinyldns.api.{GroupTestData}
 import vinyldns.core.crypto.CryptoAlgebra
-import vinyldns.core.domain.auth.AuthPrincipal
 
 class VinylDNSAuthenticatorSpec
     extends WordSpec
     with Matchers
     with MockitoSugar
-    with ResultHelpers
     with GroupTestData {
   private val mockAuthenticator = mock[Aws4Authenticator]
   private val mockAuthPrincipalProvider = mock[AuthPrincipalProvider]
@@ -82,8 +80,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthenticator)
         .authenticateReq(any[HttpRequest], any[List[String]], any[String], any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Right(okUserAuth)
     }
     "fail if missing Authorization header" in {
@@ -104,8 +101,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthenticator)
         .authenticateReq(any[HttpRequest], any[List[String]], any[String], any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AuthMissing("Authorization header not found"))
     }
     "fail if Authorization header can not be parsed" in {
@@ -120,8 +116,7 @@ class VinylDNSAuthenticatorSpec
       val context: RequestContext = mock[RequestContext]
       doReturn(httpRequest).when(context).request
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AuthRejected("Authorization header could not be parsed"))
     }
     "fail if the access key is missing" in {
@@ -144,8 +139,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthenticator)
         .extractAccessKey(any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AuthMissing("accessKey not found"))
     }
     "fail if the access key can not be retrieved" in {
@@ -168,8 +162,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthenticator)
         .extractAccessKey(any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AuthRejected("Invalid authorization header"))
     }
     "fail if the user is locked" in {
@@ -195,8 +188,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthPrincipalProvider)
         .getAuthPrincipal(any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AccountLocked("Account with username locked is locked"))
     }
     "fail if the user can not be found" in {
@@ -223,8 +215,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthPrincipalProvider)
         .getAuthPrincipal(any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AuthRejected("Account with accessKey fakeKey specified was not found"))
     }
     "fail if signatures can not be validated" in {
@@ -255,8 +246,7 @@ class VinylDNSAuthenticatorSpec
         .when(mockAuthenticator)
         .authenticateReq(any[HttpRequest], any[List[String]], any[String], any[String])
 
-      val result =
-        await[Either[VinylDNSAuthenticationError, AuthPrincipal]](underTest.apply(context, ""))
+      val result = underTest.apply(context, "").unsafeRunSync()
       result shouldBe Left(AuthRejected("Request signature could not be validated"))
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSDirectivesSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSDirectivesSpec.scala
@@ -18,7 +18,7 @@ package vinyldns.api.route
 
 import java.io.IOException
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import nl.grons.metrics.scala.{Histogram, Meter}
@@ -65,6 +65,26 @@ class VinylDNSDirectivesSpec
 
   override def beforeEach(): Unit =
     reset(mockLatency, mockErrors)
+
+  ".handleAuthenticateError" should {
+    "respond with Forbidden status if account is locked" in {
+      val trythis = handleAuthenticateError(AccountLocked("error"))
+
+      trythis shouldBe HttpResponse(
+        status = StatusCodes.Forbidden,
+        entity = HttpEntity(s"Authentication Failed: error")
+      )
+    }
+
+    "respond with Unauthorized status for other authentication errors" in {
+      val trythis = handleAuthenticateError(AuthRejected("error"))
+
+      trythis shouldBe HttpResponse(
+        status = StatusCodes.Unauthorized,
+        entity = HttpEntity(s"Authentication Failed: error")
+      )
+    }
+  }
 
   "The monitor directive" should {
     "record when completing an HttpResponse normally" in {

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -17,7 +17,6 @@
 package vinyldns.api.route
 
 import akka.actor.ActorSystem
-import akka.http.javadsl.server.CustomRejection
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest}
 import akka.http.scaladsl.server.{Directives, RequestContext, Route}
@@ -332,7 +331,7 @@ class ZoneRoutingSpec
 
   override def vinyldnsAuthenticator(
       ctx: RequestContext,
-      content: String): IO[Either[CustomRejection, AuthPrincipal]] =
+      content: String): IO[Either[VinylDNSAuthenticationError, AuthPrincipal]] =
     IO.pure(Right(okAuth))
 
   def zoneJson(name: String, email: String): String =

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -17,9 +17,9 @@
 package vinyldns.api.route
 
 import akka.actor.ActorSystem
+import akka.http.javadsl.server.CustomRejection
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest}
-import akka.http.scaladsl.server.AuthenticationFailedRejection.Cause
 import akka.http.scaladsl.server.{Directives, RequestContext, Route}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect._
@@ -332,7 +332,7 @@ class ZoneRoutingSpec
 
   override def vinyldnsAuthenticator(
       ctx: RequestContext,
-      content: String): IO[Either[Cause, AuthPrincipal]] =
+      content: String): IO[Either[CustomRejection, AuthPrincipal]] =
     IO.pure(Right(okAuth))
 
   def zoneJson(name: String, email: String): String =

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -19,6 +19,12 @@ package vinyldns.core.domain.membership
 import java.util.UUID
 
 import org.joda.time.DateTime
+import vinyldns.core.domain.membership.LockStatus.LockStatus
+
+object LockStatus extends Enumeration {
+  type LockStatus = Value
+  val Locked, Unlocked = Value
+}
 
 case class User(
     userName: String,
@@ -30,9 +36,9 @@ case class User(
     created: DateTime = DateTime.now,
     id: String = UUID.randomUUID().toString,
     isSuper: Boolean = false,
-    isLocked: Boolean = false
+    lockStatus: LockStatus = LockStatus.Unlocked
 ) {
 
-  def updateUserLockStatus(lockStatus: Boolean): User =
-    this.copy(isLocked = lockStatus)
+  def updateUserLockStatus(lockStatus: LockStatus): User =
+    this.copy(lockStatus = lockStatus)
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -29,5 +29,6 @@ case class User(
     email: Option[String] = None,
     created: DateTime = DateTime.now,
     id: String = UUID.randomUUID().toString,
-    isSuper: Boolean = false
+    isSuper: Boolean = false,
+    isLocked: Boolean = false
 )

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -31,4 +31,8 @@ case class User(
     id: String = UUID.randomUUID().toString,
     isSuper: Boolean = false,
     isLocked: Boolean = false
-)
+) {
+
+  def updateUserLockStatus(lockStatus: Boolean): User =
+    this.copy(isLocked = lockStatus)
+}

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -149,12 +149,9 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
       result.get.isLocked shouldBe true
     }
     "returns the locked flag when false" in {
-      val testUser = User(userName = "testSuper", accessKey = "testSuper", secretKey = "testUser")
+      val result = repo.getUser(testUserIds.head).unsafeRunSync()
 
-      val saved = repo.save(testUser).unsafeRunSync()
-      val result = repo.getUser(saved.id).unsafeRunSync()
-
-      result shouldBe Some(testUser)
+      result shouldBe Some(testUserIds.head)
       result.get.isLocked shouldBe false
     }
   }

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -135,5 +135,37 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
       result shouldBe Some(testUser)
       result.get.isSuper shouldBe false
     }
+    "returns the locked flag when true" in {
+      val testUser = User(
+        userName = "testSuper",
+        accessKey = "testSuper",
+        secretKey = "testUser",
+        isLocked = true)
+
+      val f =
+        for {
+          saved <- repo.save(testUser)
+          result <- repo.getUser(saved.id)
+        } yield result
+
+      whenReady(f.unsafeToFuture(), timeout) { saved =>
+        saved shouldBe Some(testUser)
+        saved.get.isLocked shouldBe true
+      }
+    }
+    "returns the locked flag when false" in {
+      val testUser = User(userName = "testSuper", accessKey = "testSuper", secretKey = "testUser")
+
+      val f =
+        for {
+          saved <- repo.save(testUser)
+          result <- repo.getUser(saved.id)
+        } yield result
+
+      whenReady(f.unsafeToFuture(), timeout) { saved =>
+        saved shouldBe Some(testUser)
+        saved.get.isLocked shouldBe false
+      }
+    }
   }
 }

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -142,30 +142,20 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
         secretKey = "testUser",
         isLocked = true)
 
-      val f =
-        for {
-          saved <- repo.save(testUser)
-          result <- repo.getUser(saved.id)
-        } yield result
+      val saved = repo.save(testUser).unsafeRunSync()
+      val result = repo.getUser(saved.id).unsafeRunSync()
 
-      whenReady(f.unsafeToFuture(), timeout) { saved =>
-        saved shouldBe Some(testUser)
-        saved.get.isLocked shouldBe true
-      }
+      result shouldBe Some(testUser)
+      result.get.isLocked shouldBe true
     }
     "returns the locked flag when false" in {
       val testUser = User(userName = "testSuper", accessKey = "testSuper", secretKey = "testUser")
 
-      val f =
-        for {
-          saved <- repo.save(testUser)
-          result <- repo.getUser(saved.id)
-        } yield result
+      val saved = repo.save(testUser).unsafeRunSync()
+      val result = repo.getUser(saved.id).unsafeRunSync()
 
-      whenReady(f.unsafeToFuture(), timeout) { saved =>
-        saved shouldBe Some(testUser)
-        saved.get.isLocked shouldBe false
-      }
+      result shouldBe Some(testUser)
+      result.get.isLocked shouldBe false
     }
   }
 }

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -20,8 +20,7 @@ import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
 import com.typesafe.config.ConfigFactory
 import vinyldns.core.crypto.NoOpCrypto
-import vinyldns.core.domain.membership.User
-
+import vinyldns.core.domain.membership.{User, LockStatus}
 import scala.concurrent.duration._
 
 class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
@@ -140,19 +139,19 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
         userName = "testSuper",
         accessKey = "testSuper",
         secretKey = "testUser",
-        isLocked = true)
+        lockStatus = LockStatus.Locked)
 
       val saved = repo.save(testUser).unsafeRunSync()
       val result = repo.getUser(saved.id).unsafeRunSync()
 
       result shouldBe Some(testUser)
-      result.get.isLocked shouldBe true
+      result.get.lockStatus shouldBe LockStatus.Locked
     }
     "returns the locked flag when false" in {
       val f = repo.getUserByAccessKey(users.head.accessKey).unsafeRunSync()
 
       f shouldBe Some(users.head)
-      f.get.isLocked shouldBe false
+      f.get.lockStatus shouldBe LockStatus.Unlocked
     }
   }
 }

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -149,10 +149,10 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
       result.get.isLocked shouldBe true
     }
     "returns the locked flag when false" in {
-      val result = repo.getUser(testUserIds.head).unsafeRunSync()
+      val f = repo.getUserByAccessKey(users.head.accessKey).unsafeRunSync()
 
-      result shouldBe Some(testUserIds.head)
-      result.get.isLocked shouldBe false
+      f shouldBe Some(users.head)
+      f.get.isLocked shouldBe false
     }
   }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -44,9 +44,9 @@ object DynamoDBUserRepository {
   private[repository] val ACCESS_KEY = "accesskey"
   private[repository] val SECRET_KEY = "secretkey"
   private[repository] val IS_SUPER = "super"
+  private[repository] val LOCK_STATUS = "lockstatus"
   private[repository] val USER_NAME_INDEX_NAME = "username_index"
   private[repository] val ACCESS_KEY_INDEX_NAME = "access_key_index"
-  private[repository] val LOCK_STATUS = "lock_status"
 
   def apply(
       config: DynamoDBRepositorySettings,

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -26,10 +26,12 @@ import com.amazonaws.services.dynamodbv2.model._
 import org.joda.time.DateTime
 import org.slf4j.{Logger, LoggerFactory}
 import vinyldns.core.crypto.CryptoAlgebra
-import vinyldns.core.domain.membership.{ListUsersResults, User, UserRepository}
+import vinyldns.core.domain.membership.LockStatus.LockStatus
+import vinyldns.core.domain.membership.{ListUsersResults, LockStatus, User, UserRepository}
 import vinyldns.core.route.Monitored
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 object DynamoDBUserRepository {
 
@@ -44,7 +46,7 @@ object DynamoDBUserRepository {
   private[repository] val IS_SUPER = "super"
   private[repository] val USER_NAME_INDEX_NAME = "username_index"
   private[repository] val ACCESS_KEY_INDEX_NAME = "access_key_index"
-  private[repository] val IS_LOCKED = "locked"
+  private[repository] val LOCK_STATUS = "lock_status"
 
   def apply(
       config: DynamoDBRepositorySettings,
@@ -98,7 +100,7 @@ object DynamoDBUserRepository {
     item.put(ACCESS_KEY, new AttributeValue(user.accessKey))
     item.put(SECRET_KEY, new AttributeValue(crypto.encrypt(user.secretKey)))
     item.put(IS_SUPER, new AttributeValue().withBOOL(user.isSuper))
-    item.put(IS_LOCKED, new AttributeValue().withBOOL(user.isLocked))
+    item.put(LOCK_STATUS, new AttributeValue(user.lockStatus.toString))
 
     val firstName =
       user.firstName.map(new AttributeValue(_)).getOrElse(new AttributeValue().withNULL(true))
@@ -112,6 +114,12 @@ object DynamoDBUserRepository {
   }
 
   def fromItem(item: java.util.Map[String, AttributeValue]): IO[User] = IO {
+    def userStatus(str: String): LockStatus = Try(LockStatus.withName(str)).getOrElse {
+      val log: Logger = LoggerFactory.getLogger(classOf[DynamoDBUserRepository])
+      log.error(s"Invalid locked status value '$str'; defaulting to unlocked")
+      LockStatus.Unlocked
+    }
+
     User(
       id = item.get(USER_ID).getS,
       userName = item.get(USER_NAME).getS,
@@ -122,7 +130,7 @@ object DynamoDBUserRepository {
       lastName = Option(item.get(LAST_NAME)).flatMap(ln => Option(ln.getS)),
       email = Option(item.get(EMAIL)).flatMap(e => Option(e.getS)),
       isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL,
-      isLocked = if (item.get(IS_LOCKED) == null) false else item.get(IS_LOCKED).getBOOL
+      lockStatus = userStatus(item.get(LOCK_STATUS).getS)
     )
   }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -44,6 +44,7 @@ object DynamoDBUserRepository {
   private[repository] val IS_SUPER = "super"
   private[repository] val USER_NAME_INDEX_NAME = "username_index"
   private[repository] val ACCESS_KEY_INDEX_NAME = "access_key_index"
+  private[repository] val IS_LOCKED = "locked"
 
   def apply(
       config: DynamoDBRepositorySettings,
@@ -97,6 +98,7 @@ object DynamoDBUserRepository {
     item.put(ACCESS_KEY, new AttributeValue(user.accessKey))
     item.put(SECRET_KEY, new AttributeValue(crypto.encrypt(user.secretKey)))
     item.put(IS_SUPER, new AttributeValue().withBOOL(user.isSuper))
+    item.put(IS_LOCKED, new AttributeValue().withBOOL(user.isLocked))
 
     val firstName =
       user.firstName.map(new AttributeValue(_)).getOrElse(new AttributeValue().withNULL(true))
@@ -119,7 +121,8 @@ object DynamoDBUserRepository {
       firstName = Option(item.get(FIRST_NAME)).flatMap(fn => Option(fn.getS)),
       lastName = Option(item.get(LAST_NAME)).flatMap(ln => Option(ln.getS)),
       email = Option(item.get(EMAIL)).flatMap(e => Option(e.getS)),
-      isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL
+      isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL,
+      isLocked = if (item.get(IS_LOCKED) == null) false else item.get(IS_LOCKED).getBOOL
     )
   }
 }

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositorySpec.scala
@@ -31,6 +31,7 @@ import scala.collection.JavaConverters._
 import cats.effect._
 import com.typesafe.config.ConfigFactory
 import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
+import vinyldns.core.domain.membership.LockStatus
 import vinyldns.dynamodb.DynamoTestConfig
 
 class DynamoDBUserRepositorySpec
@@ -72,6 +73,7 @@ class DynamoDBUserRepositorySpec
       items.get(LAST_NAME).getS shouldBe okUser.lastName.get
       items.get(EMAIL).getS shouldBe okUser.email.get
       items.get(CREATED).getN shouldBe okUser.created.getMillis.toString
+      items.get(LOCK_STATUS).getS shouldBe okUser.lockStatus.toString
     }
     "set the first name to null if it is not present" in {
       val emptyFirstName = okUser.copy(firstName = None)
@@ -131,6 +133,7 @@ class DynamoDBUserRepositorySpec
       item.put(CREATED, new AttributeValue().withN("0"))
       item.put(ACCESS_KEY, new AttributeValue("accessKey"))
       item.put(SECRET_KEY, new AttributeValue("secretkey"))
+      item.put(LOCK_STATUS, new AttributeValue("lock_status"))
       val user = fromItem(item).unsafeRunSync()
 
       user.firstName shouldBe None
@@ -151,9 +154,23 @@ class DynamoDBUserRepositorySpec
       item.put(CREATED, new AttributeValue().withN("0"))
       item.put(ACCESS_KEY, new AttributeValue("accesskey"))
       item.put(SECRET_KEY, new AttributeValue("secretkey"))
+      item.put(LOCK_STATUS, new AttributeValue("Locked"))
       val user = fromItem(item).unsafeRunSync()
 
       user.isSuper shouldBe false
+    }
+
+    "sets the lockStatus to Unlocked if the given value is invalid" in {
+      val item = new java.util.HashMap[String, AttributeValue]()
+      item.put(USER_ID, new AttributeValue("ok"))
+      item.put(USER_NAME, new AttributeValue("ok"))
+      item.put(CREATED, new AttributeValue().withN("0"))
+      item.put(ACCESS_KEY, new AttributeValue("accesskey"))
+      item.put(SECRET_KEY, new AttributeValue("secretkey"))
+      item.put(LOCK_STATUS, new AttributeValue("lock_status"))
+      val user = fromItem(item).unsafeRunSync()
+
+      user.lockStatus shouldBe LockStatus.Unlocked
     }
   }
 

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositorySpec.scala
@@ -133,7 +133,7 @@ class DynamoDBUserRepositorySpec
       item.put(CREATED, new AttributeValue().withN("0"))
       item.put(ACCESS_KEY, new AttributeValue("accessKey"))
       item.put(SECRET_KEY, new AttributeValue("secretkey"))
-      item.put(LOCK_STATUS, new AttributeValue("lock_status"))
+      item.put(LOCK_STATUS, new AttributeValue("lockstatus"))
       val user = fromItem(item).unsafeRunSync()
 
       user.firstName shouldBe None


### PR DESCRIPTION
This is part of #142 for the API side. Adds the "lockStatus" attribute to the the User class and database. The attribute is a custom type `LockStatus`, the value is either LockStatus.Locked or LockStatus.Unlocked.  Also adds a check of the attribute in the authentication.