### PR TITLE
Create UserChangeRepository

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/repository/mysql/TestMySqlInstance.scala
+++ b/modules/api/src/it/scala/vinyldns/api/repository/mysql/TestMySqlInstance.scala
@@ -17,13 +17,14 @@
 package vinyldns.api.repository.mysql
 
 import vinyldns.api.VinylDNSConfig
+import vinyldns.api.crypto.Crypto
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.zone.ZoneRepository
 import vinyldns.core.repository.{DataStore, RepositoryName}
 
 object TestMySqlInstance {
   lazy val instance: DataStore =
-    new MySqlDataStoreProvider().load(VinylDNSConfig.mySqlConfig).unsafeRunSync()
+    new MySqlDataStoreProvider().load(VinylDNSConfig.mySqlConfig, Crypto.instance).unsafeRunSync()
 
   lazy val zoneRepository: ZoneRepository =
     instance.get[ZoneRepository](RepositoryName.zone).get

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -64,7 +64,7 @@ object Boot extends App {
     // that if anything fails, the app does not start!
     for {
       banner <- vinyldnsBanner()
-      crypto <- Crypto.loadCrypto(VinylDNSConfig.cryptoConfig) // load crypto
+      crypto <- IO(Crypto.instance) // load crypto
       // TODO datastore loading will not be hardcoded by type here
       mySqlDataStore <- new MySqlDataStoreProvider().load(VinylDNSConfig.mySqlConfig)
       zoneRepo <- IO.fromEither(

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -66,7 +66,7 @@ object Boot extends App {
       banner <- vinyldnsBanner()
       crypto <- IO(Crypto.instance) // load crypto
       // TODO datastore loading will not be hardcoded by type here
-      mySqlDataStore <- new MySqlDataStoreProvider().load(VinylDNSConfig.mySqlConfig)
+      mySqlDataStore <- new MySqlDataStoreProvider().load(VinylDNSConfig.mySqlConfig, crypto)
       zoneRepo <- IO.fromEither(
         mySqlDataStore
           .get[ZoneRepository](RepositoryName.zone)

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -64,7 +64,7 @@ object Boot extends App {
     // that if anything fails, the app does not start!
     for {
       banner <- vinyldnsBanner()
-      _ <- Crypto.loadCrypto(VinylDNSConfig.cryptoConfig) // load crypto
+      crypto <- Crypto.loadCrypto(VinylDNSConfig.cryptoConfig) // load crypto
       // TODO datastore loading will not be hardcoded by type here
       mySqlDataStore <- new MySqlDataStoreProvider().load(VinylDNSConfig.mySqlConfig)
       zoneRepo <- IO.fromEither(
@@ -78,7 +78,9 @@ object Boot extends App {
       // TODO this also will all be removed with dynamic loading
       userRepo <- DynamoDBUserRepository(
         VinylDNSConfig.usersStoreConfig,
-        VinylDNSConfig.dynamoConfig)
+        VinylDNSConfig.dynamoConfig,
+        crypto
+      )
       groupRepo <- DynamoDBGroupRepository(
         VinylDNSConfig.groupsStoreConfig,
         VinylDNSConfig.dynamoConfig)

--- a/modules/api/src/main/scala/vinyldns/api/domain/auth/AuthPrincipalProvider.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/auth/AuthPrincipalProvider.scala
@@ -18,6 +18,7 @@ package vinyldns.api.domain.auth
 
 import cats.effect._
 import vinyldns.api.VinylDNSConfig
+import vinyldns.api.crypto.Crypto
 import vinyldns.core.domain.membership.{MembershipRepository, User, UserRepository}
 import vinyldns.dynamodb.repository.{DynamoDBMembershipRepository, DynamoDBUserRepository}
 import vinyldns.core.domain.auth.AuthPrincipal
@@ -55,7 +56,10 @@ class MembershipAuthPrincipalProvider(
 object MembershipAuthPrincipalProvider {
   // TODO this has to be dynamic!!!
   val userRepository: UserRepository =
-    DynamoDBUserRepository(VinylDNSConfig.usersStoreConfig, VinylDNSConfig.dynamoConfig)
+    DynamoDBUserRepository(
+      VinylDNSConfig.usersStoreConfig,
+      VinylDNSConfig.dynamoConfig,
+      Crypto.instance)
       .unsafeRunSync()
   val membershipRepository: MembershipRepository =
     DynamoDBMembershipRepository(VinylDNSConfig.membershipStoreConfig, VinylDNSConfig.dynamoConfig)

--- a/modules/api/src/main/scala/vinyldns/api/repository/DataStoreLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/DataStoreLoader.scala
@@ -21,7 +21,12 @@ import cats.effect.IO
 import cats.implicits._
 import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.batch.BatchChangeRepository
-import vinyldns.core.domain.membership.{GroupChangeRepository, GroupRepository, MembershipRepository, UserRepository}
+import vinyldns.core.domain.membership.{
+  GroupChangeRepository,
+  GroupRepository,
+  MembershipRepository,
+  UserRepository
+}
 import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetRepository}
 import vinyldns.core.domain.zone.{ZoneChangeRepository, ZoneRepository}
 import vinyldns.core.repository._

--- a/modules/api/src/main/scala/vinyldns/api/repository/mysql/MySqlDataStoreProvider.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/mysql/MySqlDataStoreProvider.scala
@@ -26,6 +26,7 @@ import pureconfig.module.catseffect.loadConfigF
 import scala.collection.JavaConverters._
 import scalikejdbc.config.DBs
 import scalikejdbc.{ConnectionPool, DataSourceConnectionPool}
+import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.repository._
 
 class MySqlDataStoreProvider extends DataStoreProvider {
@@ -33,7 +34,7 @@ class MySqlDataStoreProvider extends DataStoreProvider {
   private val logger = LoggerFactory.getLogger("MySqlDataStoreProvider")
   private val implementedRepositories = Set(RepositoryName.zone, RepositoryName.batchChange)
 
-  def load(config: DataStoreConfig): IO[DataStore] =
+  def load(config: DataStoreConfig, cryptoAlgebra: CryptoAlgebra): IO[DataStore] =
     for {
       settingsConfig <- loadConfigF[IO, MySqlDataStoreSettings](config.settings)
       _ <- validateRepos(config.repositories)

--- a/modules/api/src/test/scala/vinyldns/api/repository/DataStoreLoaderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/DataStoreLoaderSpec.scala
@@ -21,7 +21,12 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.mockito.MockitoSugar
 import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
-import vinyldns.core.domain.membership.{GroupChangeRepository, GroupRepository, MembershipRepository, UserRepository}
+import vinyldns.core.domain.membership.{
+  GroupChangeRepository,
+  GroupRepository,
+  MembershipRepository,
+  UserRepository
+}
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetRepository}
 import vinyldns.core.domain.zone.{ZoneChangeRepository, ZoneRepository}
@@ -92,14 +97,17 @@ class DataStoreLoaderSpec
 
     "throw an exception if getValidatedConfigs fails" in {
       val loadCall =
-        DataStoreLoader.loadAll(List(goodConfig.copy(repositories = allDisabledReposConfig)), crypto)
+        DataStoreLoader.loadAll(
+          List(goodConfig.copy(repositories = allDisabledReposConfig)),
+          crypto)
       val thrown = the[DataStoreStartupError] thrownBy loadCall.unsafeRunSync()
       thrown.msg should include("Config validation error")
     }
 
     "throw an exception if load fails" in {
       val loadCall = DataStoreLoader.loadAll(
-        List(goodConfig.copy(className = "vinyldns.api.repository.FailDataStoreProvider")), crypto)
+        List(goodConfig.copy(className = "vinyldns.api.repository.FailDataStoreProvider")),
+        crypto)
       val thrown = the[RuntimeException] thrownBy loadCall.unsafeRunSync()
       thrown.getMessage should include("ruh roh")
     }

--- a/modules/api/src/test/scala/vinyldns/api/repository/MockDataStoreProvider.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/MockDataStoreProvider.scala
@@ -17,6 +17,7 @@
 package vinyldns.api.repository
 import cats.effect.IO
 import org.scalatest.mockito.MockitoSugar
+import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.membership.{
   GroupChangeRepository,
@@ -30,7 +31,7 @@ import vinyldns.core.repository.{DataStore, DataStoreConfig, DataStoreProvider}
 
 class MockDataStoreProvider extends DataStoreProvider with MockitoSugar {
 
-  def load(config: DataStoreConfig): IO[DataStore] = {
+  def load(config: DataStoreConfig, crypto: CryptoAlgebra): IO[DataStore] = {
     val repoConfig = config.repositories
 
     val user = repoConfig.user.map(_ => mock[UserRepository])
@@ -62,6 +63,6 @@ class MockDataStoreProvider extends DataStoreProvider with MockitoSugar {
 class AlternateMockDataStoreProvider extends MockDataStoreProvider
 
 class FailDataStoreProvider extends DataStoreProvider {
-  def load(config: DataStoreConfig): IO[DataStore] =
+  def load(config: DataStoreConfig, crypto: CryptoAlgebra): IO[DataStore] =
     IO.raiseError(new RuntimeException("ruh roh"))
 }

--- a/modules/api/src/test/scala/vinyldns/api/repository/mysql/MySqlDataStoreProviderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/mysql/MySqlDataStoreProviderSpec.scala
@@ -18,10 +18,10 @@ package vinyldns.api.repository.mysql
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{Matchers, WordSpec}
+import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
 import vinyldns.core.repository.{DataStoreConfig, DataStoreStartupError}
 
 class MySqlDataStoreProviderSpec extends WordSpec with Matchers {
-
   val mySqlConfig: Config = ConfigFactory.parseString(
     """
       |    class-name = "vinyldns.api.repository.mysql.MySqlDataStoreProvider"
@@ -49,6 +49,8 @@ class MySqlDataStoreProviderSpec extends WordSpec with Matchers {
     pureconfig.loadConfigOrThrow[DataStoreConfig](mySqlConfig)
 
   val underTest = new MySqlDataStoreProvider()
+
+  val crypto: CryptoAlgebra = new NoOpCrypto()
 
   "validateRepos" should {
     "Return successfully if all configured repos are implemented" in {
@@ -94,7 +96,7 @@ class MySqlDataStoreProviderSpec extends WordSpec with Matchers {
       val badSettings = pureconfig.loadConfigOrThrow[DataStoreConfig](badConfig)
 
       a[pureconfig.error.ConfigReaderException[MySqlDataStoreSettings]] should be thrownBy underTest
-        .load(badSettings)
+        .load(badSettings, crypto)
         .unsafeRunSync()
     }
     "Fail if validateRepos fails" in {
@@ -103,7 +105,7 @@ class MySqlDataStoreProviderSpec extends WordSpec with Matchers {
       val badSettings = dataStoreSettings.copy(repositories = badRepos)
 
       a[DataStoreStartupError] should be thrownBy underTest
-        .load(badSettings)
+        .load(badSettings, crypto)
         .unsafeRunSync()
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/crypto/NoOpCrypto.scala
+++ b/modules/core/src/main/scala/vinyldns/core/crypto/NoOpCrypto.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.core.crypto
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 
 /**
   * Provides a no op implementation of Crypto.  Does not actually do any encryption.
@@ -27,6 +27,9 @@ import com.typesafe.config.Config
   *               to dynamically load this Crypto implementation.  However, it is not used.
   */
 class NoOpCrypto(val config: Config) extends CryptoAlgebra {
+  def this() {
+    this(ConfigFactory.load())
+  }
   def encrypt(value: String): String = value
   def decrypt(value: String): String = value
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChange.scala
@@ -32,8 +32,8 @@ object UserChangeType {
     }
 
   def fromChange[A <: UserChange](change: A): UserChangeType = change match {
-    case CreateUser(_, _, _, _) => Create
-    case UpdateUser(_, _, _, _, _) => Update
+    case UserChange.CreateUser(_, _, _, _) => Create
+    case UserChange.UpdateUser(_, _, _, _, _) => Update
   }
 }
 
@@ -47,18 +47,16 @@ sealed trait UserChange {
   def madeByUserId: String
   def created: DateTime
 }
-final case class CreateUser(id: String, newUser: User, madeByUserId: String, created: DateTime)
-    extends UserChange
-
-final case class UpdateUser(
-    id: String,
-    newUser: User,
-    madeByUserId: String,
-    created: DateTime,
-    oldUser: User)
-    extends UserChange
-
 object UserChange {
+  final case class CreateUser(id: String, newUser: User, madeByUserId: String, created: DateTime)
+      extends UserChange
+  final case class UpdateUser(
+      id: String,
+      newUser: User,
+      madeByUserId: String,
+      created: DateTime,
+      oldUser: User)
+      extends UserChange
 
   def apply(
       id: String,

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChange.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain.membership
+import java.util.UUID
+
+import org.joda.time.DateTime
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.UserChangeType.UserChangeType
+
+object UserChangeType extends Enumeration {
+  type UserChangeType = Value
+
+  // Note: we do not have Delete yet, Update would be for locking and unlocking users
+  val Create, Update = Value
+}
+
+final case class UserChange(
+    newUser: User,
+    changeType: UserChangeType,
+    madeByUserId: String,
+    oldUser: Option[User],
+    id: String,
+    created: DateTime)
+
+object UserChange {
+  def forAdd(user: User, authPrincipal: AuthPrincipal): UserChange =
+    UserChange(
+      user,
+      UserChangeType.Create,
+      authPrincipal.userId,
+      None,
+      UUID.randomUUID().toString,
+      DateTime.now)
+
+  def forUpdate(newUser: User, oldUser: User, authPrincipal: AuthPrincipal): UserChange =
+    UserChange(
+      newUser,
+      UserChangeType.Update,
+      authPrincipal.userId,
+      Some(oldUser),
+      UUID.randomUUID().toString,
+      DateTime.now)
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChange.scala
@@ -20,7 +20,7 @@ import org.joda.time.DateTime
 sealed abstract class UserChangeType(val value: String)
 object UserChangeType {
   case object Create extends UserChangeType("create")
-  case object Update extends UserChangeType("delete")
+  case object Update extends UserChangeType("update")
 
   case class UnknownUserChangeType(value: String) extends Throwable(s"Unknown change type $value")
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChangeRepository.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain.membership
+import cats.effect.IO
+
+trait UserChangeRepository {
+
+  def save(change: UserChange): IO[UserChange]
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/UserChangeRepository.scala
@@ -18,6 +18,6 @@ package vinyldns.core.domain.membership
 import cats.effect.IO
 
 trait UserChangeRepository {
-
   def save(change: UserChange): IO[UserChange]
+  def get(changeId: String): IO[Option[UserChange]]
 }

--- a/modules/core/src/main/scala/vinyldns/core/repository/DataStoreProvider.scala
+++ b/modules/core/src/main/scala/vinyldns/core/repository/DataStoreProvider.scala
@@ -17,7 +17,8 @@
 package vinyldns.core.repository
 
 import cats.effect.IO
+import vinyldns.core.crypto.CryptoAlgebra
 
 trait DataStoreProvider {
-  def load(config: DataStoreConfig): IO[DataStore]
+  def load(config: DataStoreConfig, crypto: CryptoAlgebra): IO[DataStore]
 }

--- a/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeSpec.scala
@@ -27,12 +27,12 @@ class UserChangeSpec extends WordSpec with Matchers with EitherMatchers with Eit
   "apply" should {
     "succeed for CreateUser" in {
       val result = UserChange("foo", newUser, "bar", currentDate, None, UserChangeType.Create)
-      result shouldBe Right(CreateUser("foo", newUser, "bar", currentDate))
+      result shouldBe Right(UserChange.CreateUser("foo", newUser, "bar", currentDate))
     }
     "succeed for UpdateUser" in {
       val result =
         UserChange("foo", newUser, "bar", currentDate, Some(newUser), UserChangeType.Update)
-      result shouldBe Right(UpdateUser("foo", newUser, "bar", currentDate, newUser))
+      result shouldBe Right(UserChange.UpdateUser("foo", newUser, "bar", currentDate, newUser))
     }
     "fail for invalid parameters" in {
       val result = UserChange("foo", newUser, "bar", currentDate, None, UserChangeType.Update)

--- a/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain.membership
+import cats.scalatest.EitherMatchers
+import org.joda.time.DateTime
+import org.scalatest.{EitherValues, Matchers, WordSpec}
+
+class UserChangeSpec extends WordSpec with Matchers with EitherMatchers with EitherValues {
+
+  private val newUser = User("foo", "key", "secret")
+  private val currentDate = DateTime.now
+
+  "apply" should {
+    "succeed for CreateUser" in {
+      val result = UserChange("foo", newUser, "bar", currentDate, None, UserChangeType.Create)
+      result shouldBe Right(CreateUser("foo", newUser, "bar", currentDate))
+    }
+    "succeed for UpdateUser" in {
+      val result =
+        UserChange("foo", newUser, "bar", currentDate, Some(newUser), UserChangeType.Update)
+      result shouldBe Right(UpdateUser("foo", newUser, "bar", currentDate, newUser))
+    }
+    "fail for invalid parameters" in {
+      val result = UserChange("foo", newUser, "bar", currentDate, None, UserChangeType.Update)
+      result shouldBe left
+      result.left.value shouldBe an[IllegalArgumentException]
+    }
+  }
+}

--- a/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeTypeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeTypeSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain.membership
+import org.scalatest.{Matchers, WordSpec}
+import vinyldns.core.domain.membership.UserChangeType.UnknownUserChangeType
+
+class UserChangeTypeSpec extends WordSpec with Matchers {
+  "fromString" should {
+    "succeed for Create" in {
+      UserChangeType.fromString("create") shouldBe Right(UserChangeType.Create)
+    }
+    "succeed for Update" in {
+      UserChangeType.fromString("update") shouldBe Right(UserChangeType.Update)
+    }
+    "fail for unknown string" in {
+      UserChangeType.fromString("badness") shouldBe Left(UnknownUserChangeType("badness"))
+    }
+  }
+}

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderIntegrationSpec.scala
@@ -19,6 +19,7 @@ package vinyldns.dynamodb.repository
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
 import com.typesafe.config.{Config, ConfigFactory}
+import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.membership._
 import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetRepository}
@@ -33,9 +34,10 @@ class DynamoDBDataStoreProviderIntegrationSpec extends DynamoDBIntegrationSpec {
   val dynamoDBConfig: DataStoreConfig =
     pureconfig.loadConfigOrThrow[DataStoreConfig](config, "dynamodb")
   val provider: DynamoDBDataStoreProvider = new DynamoDBDataStoreProvider()
+  val crypto: CryptoAlgebra = new NoOpCrypto()
 
   logger.info("Loading all dynamodb tables in DynamoDBDataStoreProviderSpec")
-  val dataStore: DataStore = provider.load(dynamoDBConfig).unsafeRunSync()
+  val dataStore: DataStore = provider.load(dynamoDBConfig, crypto).unsafeRunSync()
   logger.info("DynamoDBDataStoreProviderSpec load complete")
 
   def setup(): Unit = ()

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
@@ -7,13 +7,13 @@ import vinyldns.core.domain.membership.{User, UserChange, UserChangeType}
 
 class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
 
-  private val USER_CHANGE_TABLE = "groups-live"
+  private val USER_CHANGE_TABLE = "user-changes"
 
   private val tableConfig = ConfigFactory.parseString(s"""
                                                          | dynamo {
-                                                         |   tableName = "$USER_CHANGE_TABLE"
-                                                         |   provisionedReads=30
-                                                         |   provisionedWrites=30
+                                                         |   table-name = "$USER_CHANGE_TABLE"
+                                                         |   provisioned-reads=30
+                                                         |   provisioned-writes=30
                                                          | }
     """.stripMargin).withFallback(ConfigFactory.load())
 
@@ -29,12 +29,10 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
     secretKey = "user"
   )
 
-  private var repo: DynamoDBUserChangeRepository = _
+  private val repo: DynamoDBUserChangeRepository =
+    DynamoDBUserChangeRepository(dynamoDBHelper, tableConfig, new NoOpCrypto(tableConfig)).unsafeRunSync()
 
-  def setup(): Unit = {
-    repo = new DynamoDBUserChangeRepository(tableConfig, dynamoDBHelper, new NoOpCrypto(tableConfig))
-    waitForRepo(repo.get("any"))
-  }
+  def setup(): Unit = ()
 
   def tearDown(): Unit = {
     val request = new DeleteTableRequest().withTableName(USER_CHANGE_TABLE)

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
@@ -1,0 +1,64 @@
+package vinyldns.dynamodb.repository
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
+import com.typesafe.config.ConfigFactory
+import org.joda.time.DateTime
+import vinyldns.core.crypto.NoOpCrypto
+import vinyldns.core.domain.membership.{User, UserChange, UserChangeType}
+
+class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
+
+  private val USER_CHANGE_TABLE = "groups-live"
+
+  private val tableConfig = ConfigFactory.parseString(s"""
+                                                         | dynamo {
+                                                         |   tableName = "$USER_CHANGE_TABLE"
+                                                         |   provisionedReads=30
+                                                         |   provisionedWrites=30
+                                                         | }
+    """.stripMargin).withFallback(ConfigFactory.load())
+
+  private val testUser = User(
+    id = "test-user",
+    userName = "testUser",
+    firstName = Some("Test"),
+    lastName = Some("User"),
+    email = Some("test@user.com"),
+    created = DateTime.now,
+    isSuper = false,
+    accessKey = "test",
+    secretKey = "user"
+  )
+
+  private var repo: DynamoDBUserChangeRepository = _
+
+  def setup(): Unit = {
+    repo = new DynamoDBUserChangeRepository(tableConfig, dynamoDBHelper, new NoOpCrypto(tableConfig))
+    waitForRepo(repo.get("any"))
+  }
+
+  def tearDown(): Unit = {
+    val request = new DeleteTableRequest().withTableName(USER_CHANGE_TABLE)
+    val deleteTables = dynamoDBHelper.deleteTable(request)
+    deleteTables.unsafeRunSync()
+  }
+
+  "DynamoDBUserChangeRepository" should {
+    "save a user change" in {
+      val c = UserChange(
+        newUser = testUser,
+        changeType = UserChangeType.Create,
+        madeByUserId = "me",
+        oldUser = None,
+        created = DateTime.now,
+        id = "test-create"
+      )
+
+      val t = for {
+        _ <- repo.save(c)
+        retrieved <- repo.get(c.id)
+      } yield retrieved
+
+      t.unsafeRunSync() shouldBe Some(c)
+    }
+  }
+}

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import vinyldns.core.crypto.NoOpCrypto
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.membership.{CreateUser, UpdateUser, User}
+import vinyldns.core.domain.membership.{User, UserChange}
 
 class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
 
@@ -54,7 +54,7 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
   "DynamoDBUserChangeRepository" should {
     "save a user change" in {
       val auth = AuthPrincipal(testUser, Seq.empty)
-      val c = CreateUser("foo", testUser, auth.userId, DateTime.now)
+      val c = UserChange.CreateUser("foo", testUser, auth.userId, DateTime.now)
 
       val t = for {
         _ <- repo.save(c)
@@ -67,7 +67,7 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
     "save a change for a modified user" in {
       val auth = AuthPrincipal(testUser, Seq.empty)
       val updated = testUser.copy(userName = testUser.userName + "-updated")
-      val c = UpdateUser("foo", updated, auth.userId, DateTime.now, testUser)
+      val c = UserChange.UpdateUser("foo", updated, auth.userId, DateTime.now, testUser)
 
       val t = for {
         _ <- repo.save(c)

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import vinyldns.core.crypto.NoOpCrypto
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.membership.{User, UserChange}
+import vinyldns.core.domain.membership.{CreateUser, UpdateUser, User}
 
 class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
 
@@ -54,7 +54,7 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
   "DynamoDBUserChangeRepository" should {
     "save a user change" in {
       val auth = AuthPrincipal(testUser, Seq.empty)
-      val c = UserChange.forAdd(testUser, auth)
+      val c = CreateUser("foo", testUser, auth.userId, DateTime.now)
 
       val t = for {
         _ <- repo.save(c)
@@ -67,7 +67,7 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
     "save a change for a modified user" in {
       val auth = AuthPrincipal(testUser, Seq.empty)
       val updated = testUser.copy(userName = testUser.userName + "-updated")
-      val c = UserChange.forUpdate(testUser, updated, auth)
+      val c = UpdateUser("foo", updated, auth.userId, DateTime.now, testUser)
 
       val t = for {
         _ <- repo.save(c)

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package vinyldns.dynamodb.repository
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
 import com.typesafe.config.ConfigFactory

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepositoryIntegrationSpec.scala
@@ -10,13 +10,7 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
 
   private val USER_CHANGE_TABLE = "user-changes"
 
-  private val tableConfig = ConfigFactory.parseString(s"""
-                                                         | dynamo {
-                                                         |   table-name = "$USER_CHANGE_TABLE"
-                                                         |   provisioned-reads=30
-                                                         |   provisioned-writes=30
-                                                         | }
-    """.stripMargin).withFallback(ConfigFactory.load())
+  private val tableConfig = DynamoDBRepositorySettings(s"$USER_CHANGE_TABLE", 30, 30)
 
   private val testUser = User(
     id = "test-user",
@@ -31,13 +25,13 @@ class DynamoDBUserChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
   )
 
   private val repo: DynamoDBUserChangeRepository =
-    DynamoDBUserChangeRepository(dynamoDBHelper, tableConfig, new NoOpCrypto(tableConfig)).unsafeRunSync()
+    DynamoDBUserChangeRepository(tableConfig, dynamoIntegrationConfig, new NoOpCrypto(ConfigFactory.load())).unsafeRunSync()
 
   def setup(): Unit = ()
 
   def tearDown(): Unit = {
     val request = new DeleteTableRequest().withTableName(USER_CHANGE_TABLE)
-    val deleteTables = dynamoDBHelper.deleteTable(request)
+    val deleteTables = repo.dynamoDBHelper.deleteTable(request)
     deleteTables.unsafeRunSync()
   }
 

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -18,6 +18,8 @@ package vinyldns.dynamodb.repository
 
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
+import com.typesafe.config.ConfigFactory
+import vinyldns.core.crypto.NoOpCrypto
 import vinyldns.core.domain.membership.User
 
 import scala.concurrent.duration._
@@ -36,7 +38,7 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
   }
 
   def setup(): Unit = {
-    repo = DynamoDBUserRepository(tableConfig, dynamoIntegrationConfig).unsafeRunSync()
+    repo = DynamoDBUserRepository(tableConfig, dynamoIntegrationConfig, new NoOpCrypto(ConfigFactory.load())).unsafeRunSync()
 
     // Create all the items
     val results = users.map(repo.save(_)).parSequence

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
@@ -72,7 +72,7 @@ object DynamoDBUserChangeRepository {
       new AttributeValue().withM(DynamoDBUserRepository.toItem(crypto, change.newUser)))
 
     change match {
-      case UpdateUser(_, _, _, _, oldUser) =>
+      case UserChange.UpdateUser(_, _, _, _, oldUser) =>
         item.put(
           OLD_USER,
           new AttributeValue().withM(DynamoDBUserRepository.toItem(crypto, oldUser)))

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
@@ -49,7 +49,8 @@ object DynamoDBUserChangeRepository {
       c <- IO(item.get(CHANGE_TYPE).getS)
       changeType <- IO.fromEither(UserChangeType.fromString(c))
       newUser <- IO(item.get(NEW_USER).getM).flatMap(m => DynamoDBUserRepository.fromItem(m))
-      oldUser <- OptionT(IO(Option(item.get(OLD_USER)).flatMap(i => Option(i.getM))))
+      oldUser <- OptionT(IO(Option(item.get(OLD_USER))))
+        .subflatMap(av => Option(av.getM))
         .semiflatMap(DynamoDBUserRepository.fromItem)
         .value
       madeByUserId <- IO(item.get(MADE_BY_ID).getS)

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
@@ -37,7 +37,6 @@ class DynamoDBUserChangeRepository(
   import DynamoDBUserRepository._
 
   private val logger = LoggerFactory.getLogger(classOf[DynamoDBUserChangeRepository])
-  private[repository] val USER_CHANGE_TABLE = "user-change"
   private[repository] val USER_CHANGE_ID = "change_id"
   private[repository] val USER_ID = "user_id"
   private[repository] val MADE_BY_ID = "made_by_id"
@@ -50,6 +49,7 @@ class DynamoDBUserChangeRepository(
   private[repository] val tableAttributes = Seq(
     new AttributeDefinition(USER_CHANGE_ID, "S")
   )
+  private[repository] val USER_CHANGE_TABLE = config.getString("dynamo.tableName")
   private val dynamoReads = config.getLong("dynamo.provisionedReads")
   private val dynamoWrites = config.getLong("dynamo.provisionedWrites")
 

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
@@ -44,7 +44,7 @@ object DynamoDBUserChangeRepository {
   )
 
   // Note: This should be an Either; however pulling everything into an Either is a big refactoring
-  def fromItem(item: java.util.Map[String, AttributeValue]): IO[UserChange] = {
+  def fromItem(item: java.util.Map[String, AttributeValue]): IO[UserChange] =
     for {
       c <- IO(item.get(CHANGE_TYPE).getS)
       changeType <- IO.fromEither(UserChangeType.fromString(c))
@@ -58,7 +58,6 @@ object DynamoDBUserChangeRepository {
       created <- IO(new DateTime(item.get(CREATED).getN.toLong))
       change <- IO.fromEither(UserChange(id, newUser, madeByUserId, created, oldUser, changeType))
     } yield change
-  }
 
   def toItem(crypto: CryptoAlgebra, change: UserChange): java.util.Map[String, AttributeValue] = {
     val item = new util.HashMap[String, AttributeValue]()

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserChangeRepository.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.dynamodb.repository
+import java.util
+import java.util.HashMap
+
+import cats.effect.IO
+import cats.implicits._
+import com.amazonaws.services.dynamodbv2.model._
+import com.typesafe.config.Config
+import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
+import vinyldns.core.crypto.CryptoAlgebra
+import vinyldns.core.domain.membership.{UserChange, UserChangeRepository, UserChangeType}
+import vinyldns.core.route.Monitored
+
+class DynamoDBUserChangeRepository(
+    config: Config,
+    dynamoDBHelper: DynamoDBHelper,
+    crypto: CryptoAlgebra)
+    extends UserChangeRepository
+    with Monitored {
+  import DynamoDBUserRepository._
+
+  private val logger = LoggerFactory.getLogger(classOf[DynamoDBUserChangeRepository])
+  private[repository] val USER_CHANGE_TABLE = "user-change"
+  private[repository] val USER_CHANGE_ID = "change_id"
+  private[repository] val USER_ID = "user_id"
+  private[repository] val MADE_BY_ID = "made_by_id"
+  private[repository] val TIMESTAMP = "created"
+  private[repository] val USER_NAME = "username"
+  private[repository] val CHANGE_TYPE = "change_type"
+  private[repository] val NEW_USER = "new_user"
+  private[repository] val OLD_USER = "old_user"
+
+  private[repository] val tableAttributes = Seq(
+    new AttributeDefinition(USER_CHANGE_ID, "S")
+  )
+  private val dynamoReads = config.getLong("dynamo.provisionedReads")
+  private val dynamoWrites = config.getLong("dynamo.provisionedWrites")
+
+  dynamoDBHelper.setupTable(
+    new CreateTableRequest()
+      .withTableName(USER_CHANGE_TABLE)
+      .withAttributeDefinitions(tableAttributes: _*)
+      .withKeySchema(new KeySchemaElement(USER_CHANGE_ID, KeyType.HASH))
+      .withProvisionedThroughput(new ProvisionedThroughput(dynamoReads, dynamoWrites))
+  )
+
+  def save(change: UserChange): IO[UserChange] =
+    monitor("repo.UserChange.save") {
+      logger.info(s"Saving user change ${change.id}")
+      val item = toItem(change)
+      val request = new PutItemRequest().withTableName(USER_CHANGE_TABLE).withItem(item)
+      dynamoDBHelper.putItem(request).as(change)
+    }
+
+  def get(changeId: String): IO[Option[UserChange]] =
+    monitor("repo.UserChange.get") {
+      val key = new HashMap[String, AttributeValue]()
+      key.put(USER_CHANGE_ID, new AttributeValue(changeId))
+      val request = new GetItemRequest().withTableName(USER_CHANGE_TABLE).withKey(key)
+
+      dynamoDBHelper.getItem(request).map { result =>
+        Option(result.getItem).map(attrs => fromItem(attrs))
+      }
+    }
+
+  def fromItem(item: java.util.Map[String, AttributeValue]): UserChange =
+    UserChange(
+      newUser = DynamoDBUserRepository.fromItem(item.get(NEW_USER).getM),
+      changeType = UserChangeType.withName(item.get(CHANGE_TYPE).getS),
+      madeByUserId = item.get(MADE_BY_ID).getS,
+      oldUser = Option(item.get(OLD_USER))
+        .map(av => av.getM)
+        .map(attrs => DynamoDBUserRepository.fromItem(attrs)),
+      id = item.get(USER_CHANGE_ID).getS,
+      created = new DateTime(item.get(CREATED).getN.toLong)
+    )
+
+  def toItem(change: UserChange): java.util.Map[String, AttributeValue] = {
+    val item = new util.HashMap[String, AttributeValue]()
+    item.put(USER_CHANGE_ID, new AttributeValue(change.id))
+    item.put(USER_ID, new AttributeValue(change.newUser.id))
+    item.put(USER_NAME, new AttributeValue(change.newUser.userName))
+    item.put(CHANGE_TYPE, new AttributeValue(change.changeType.toString))
+    item.put(CREATED, new AttributeValue().withN(change.created.getMillis.toString))
+    item.put(
+      NEW_USER,
+      new AttributeValue().withM(DynamoDBUserRepository.toItem(crypto, change.newUser)))
+    change.oldUser.foreach { user =>
+      item.put(OLD_USER, new AttributeValue().withM(DynamoDBUserRepository.toItem(crypto, user)))
+    }
+    item
+  }
+}

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -116,9 +116,9 @@ object DynamoDBUserRepository {
       created = new DateTime(item.get(CREATED).getN.toLong),
       accessKey = item.get(ACCESS_KEY).getS,
       secretKey = item.get(SECRET_KEY).getS,
-      firstName = Option(item.get(FIRST_NAME)).map(_.getS),
-      lastName = Option(item.get(LAST_NAME)).map(_.getS),
-      email = Option(item.get(EMAIL)).map(_.getS),
+      firstName = Option(item.get(FIRST_NAME)).flatMap(fn => Option(fn.getS)),
+      lastName = Option(item.get(LAST_NAME)).flatMap(ln => Option(ln.getS)),
+      email = Option(item.get(EMAIL)).flatMap(e => Option(e.getS)),
       isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL
     )
   }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -19,6 +19,7 @@ package vinyldns.dynamodb.repository
 import java.util
 import java.util.HashMap
 
+import cats.data.OptionT
 import cats.effect._
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model._
@@ -85,7 +86,7 @@ object DynamoDBUserRepository {
         .withGlobalSecondaryIndexes(secondaryIndexes: _*)
     )
 
-    setup.as(new DynamoDBUserRepository(tableName, dynamoDBHelper, crypto))
+    setup.as(new DynamoDBUserRepository(tableName, dynamoDBHelper, toItem(crypto, _), fromItem))
   }
 
   def toItem(crypto: CryptoAlgebra, user: User): java.util.Map[String, AttributeValue] = {
@@ -108,7 +109,7 @@ object DynamoDBUserRepository {
     item
   }
 
-  def fromItem(item: java.util.Map[String, AttributeValue]): User =
+  def fromItem(item: java.util.Map[String, AttributeValue]): IO[User] = IO {
     User(
       id = item.get(USER_ID).getS,
       userName = item.get(USER_NAME).getS,
@@ -120,12 +121,14 @@ object DynamoDBUserRepository {
       email = if (item.get(EMAIL) == null) None else Option(item.get(EMAIL).getS),
       isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL
     )
+  }
 }
 
 class DynamoDBUserRepository private[repository] (
     userTableName: String,
     val dynamoDBHelper: DynamoDBHelper,
-    crypto: CryptoAlgebra)
+    serialize: User => java.util.Map[String, AttributeValue],
+    deserialize: java.util.Map[String, AttributeValue] => IO[User])
     extends UserRepository
     with Monitored {
 
@@ -140,7 +143,11 @@ class DynamoDBUserRepository private[repository] (
       key.put(USER_ID, new AttributeValue(userId))
       val request = new GetItemRequest().withTableName(userTableName).withKey(key)
 
-      dynamoDBHelper.getItem(request).map(result => Option(result.getItem).map(fromItem))
+      OptionT
+        .liftF(dynamoDBHelper.getItem(request))
+        .subflatMap(r => Option(r.getItem))
+        .semiflatMap(item => deserialize(item))
+        .value
     }
 
   def getUsers(
@@ -165,13 +172,13 @@ class DynamoDBUserRepository private[repository] (
       new BatchGetItemRequest().withRequestItems(request)
     }
 
-    def parseUsers(result: BatchGetItemResult): List[User] = {
+    def parseUsers(result: BatchGetItemResult): IO[List[User]] = {
       val userAttributes = result.getResponses.asScala.get(userTableName)
       userAttributes match {
         case None =>
-          List()
+          IO.pure(List())
         case Some(items) =>
-          items.asScala.toList.map(fromItem)
+          items.asScala.toList.map(fromItem).sequence
       }
     }
 
@@ -195,14 +202,20 @@ class DynamoDBUserRepository private[repository] (
 
       val batchGets = batches.map(toBatchGetItemRequest)
 
-      // run the batches in parallel
       val batchGetIo = batchGets.map(dynamoDBHelper.batchGetItem)
 
-      val allBatches: IO[List[BatchGetItemResult]] = batchGetIo.sequence
+      // run the batches in parallel
+      val allBatches: IO[List[BatchGetItemResult]] = batchGetIo.parSequence
 
-      val allUsers = allBatches.map { batchGetItemResults =>
-        batchGetItemResults.flatMap(parseUsers)
-      }
+      val allUsers = for {
+        batches <- allBatches
+        x <- batches.foldLeft(IO(List.empty[User])) { (acc, cur) =>
+          for {
+            u <- parseUsers(cur)
+            a <- acc
+          } yield u ++ a
+        }
+      } yield x
 
       allUsers.map { list =>
         val lastEvaluatedId =
@@ -230,17 +243,15 @@ class DynamoDBUserRepository private[repository] (
         .withExpressionAttributeValues(expressionAttributeValues)
         .withKeyConditionExpression(keyConditionExpression)
 
-      dynamoDBHelper.query(queryRequest).map { results =>
-        results.getItems.asScala.headOption.map(fromItem)
+      dynamoDBHelper.query(queryRequest).flatMap { results =>
+        results.getItems.asScala.headOption.map(deserialize).sequence
       }
     }
 
   def save(user: User): IO[User] = //For testing purposes
     monitor("repo.User.save") {
       log.info(s"Saving user id: ${user.id} name: ${user.userName}.")
-
-      val item = toItem(crypto, user)
-      val request = new PutItemRequest().withTableName(userTableName).withItem(item)
+      val request = new PutItemRequest().withTableName(userTableName).withItem(serialize(user))
       dynamoDBHelper.putItem(request).map(_ => user)
     }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -116,9 +116,9 @@ object DynamoDBUserRepository {
       created = new DateTime(item.get(CREATED).getN.toLong),
       accessKey = item.get(ACCESS_KEY).getS,
       secretKey = item.get(SECRET_KEY).getS,
-      firstName = if (item.get(FIRST_NAME) == null) None else Option(item.get(FIRST_NAME).getS),
-      lastName = if (item.get(LAST_NAME) == null) None else Option(item.get(LAST_NAME).getS),
-      email = if (item.get(EMAIL) == null) None else Option(item.get(EMAIL).getS),
+      firstName = Option(item.get(FIRST_NAME)).map(_.getS),
+      lastName = Option(item.get(LAST_NAME)).map(_.getS),
+      email = Option(item.get(EMAIL)).map(_.getS),
       isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL
     )
   }
@@ -211,9 +211,9 @@ class DynamoDBUserRepository private[repository] (
         batches <- allBatches
         x <- batches.foldLeft(IO(List.empty[User])) { (acc, cur) =>
           for {
-            u <- parseUsers(cur)
-            a <- acc
-          } yield u ++ a
+            users <- parseUsers(cur)
+            accumulated <- acc
+          } yield users ++ accumulated
         }
       } yield x
 

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderSpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderSpec.scala
@@ -19,7 +19,12 @@ package vinyldns.dynamodb.repository
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.crypto.NoOpCrypto
-import vinyldns.core.repository.{DataStoreConfig, DataStoreStartupError, RepositoriesConfig, RepositoryName}
+import vinyldns.core.repository.{
+  DataStoreConfig,
+  DataStoreStartupError,
+  RepositoriesConfig,
+  RepositoryName
+}
 import vinyldns.dynamodb.DynamoTestConfig
 
 class DynamoDBDataStoreProviderSpec extends WordSpec with Matchers {

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderSpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderSpec.scala
@@ -18,17 +18,14 @@ package vinyldns.dynamodb.repository
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{Matchers, WordSpec}
-import vinyldns.core.repository.{
-  DataStoreConfig,
-  DataStoreStartupError,
-  RepositoriesConfig,
-  RepositoryName
-}
+import vinyldns.core.crypto.NoOpCrypto
+import vinyldns.core.repository.{DataStoreConfig, DataStoreStartupError, RepositoriesConfig, RepositoryName}
 import vinyldns.dynamodb.DynamoTestConfig
 
 class DynamoDBDataStoreProviderSpec extends WordSpec with Matchers {
 
-  val underTest = new DynamoDBDataStoreProvider()
+  private val underTest = new DynamoDBDataStoreProvider()
+  private val crypto = new NoOpCrypto()
 
   "load" should {
     // Note: success here will actually startup the repos, just testing failure in unit tests
@@ -54,7 +51,7 @@ class DynamoDBDataStoreProviderSpec extends WordSpec with Matchers {
       val badSettings = pureconfig.loadConfigOrThrow[DataStoreConfig](badConfig)
 
       a[pureconfig.error.ConfigReaderException[DynamoDBDataStoreSettings]] should be thrownBy underTest
-        .load(badSettings)
+        .load(badSettings, crypto)
         .unsafeRunSync()
     }
   }

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositorySpec.scala
@@ -29,6 +29,8 @@ import vinyldns.core.TestMembershipData._
 
 import scala.collection.JavaConverters._
 import cats.effect._
+import com.typesafe.config.ConfigFactory
+import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
 import vinyldns.dynamodb.DynamoTestConfig
 
 class DynamoDBUserRepositorySpec
@@ -43,10 +45,11 @@ class DynamoDBUserRepositorySpec
   doReturn(IO.pure(mockPutItemResult)).when(dynamoDBHelper).putItem(any[PutItemRequest])
   private val usersStoreConfig = DynamoTestConfig.usersStoreConfig
   private val userTable = usersStoreConfig.tableName
+  private val crypto = new NoOpCrypto(ConfigFactory.load())
 
-  class TestDynamoDBUserRepository extends DynamoDBUserRepository(userTable, dynamoDBHelper)
+  class TestDynamoDBUserRepository extends DynamoDBUserRepository(userTable, dynamoDBHelper, crypto)
 
-  private val underTest = new DynamoDBUserRepository(userTable, dynamoDBHelper)
+  private val underTest = new DynamoDBUserRepository(userTable, dynamoDBHelper, crypto)
 
   override def beforeEach(): Unit =
     reset(dynamoDBHelper)
@@ -55,11 +58,15 @@ class DynamoDBUserRepositorySpec
 
   "DynamoDBUserRepository.toItem" should {
     "set all values correctly" in {
-      val items = underTest.toItem(okUser)
+      val crypt = new CryptoAlgebra {
+        def encrypt(value: String): String = "encrypted"
+        def decrypt(value: String): String = "decrypted"
+      }
+      val items = toItem(crypt, okUser)
       items.get(USER_ID).getS shouldBe okUser.id
       items.get(USER_NAME).getS shouldBe okUser.userName
       items.get(ACCESS_KEY).getS shouldBe okUser.accessKey
-      items.get(SECRET_KEY).getS shouldBe okUser.secretKey
+      items.get(SECRET_KEY).getS shouldBe "encrypted"
       items.get(FIRST_NAME).getS shouldBe okUser.firstName.get
       items.get(LAST_NAME).getS shouldBe okUser.lastName.get
       items.get(EMAIL).getS shouldBe okUser.email.get
@@ -68,21 +75,21 @@ class DynamoDBUserRepositorySpec
     "set the first name to null if it is not present" in {
       val emptyFirstName = okUser.copy(firstName = None)
 
-      val items = underTest.toItem(emptyFirstName)
+      val items = toItem(crypto, emptyFirstName)
       Option(items.get(DynamoDBUserRepository.FIRST_NAME).getS) shouldBe None
       items.get(DynamoDBUserRepository.FIRST_NAME).getNULL shouldBe true
     }
     "set the last name to null if it is not present" in {
       val emptyLastName = okUser.copy(lastName = None)
 
-      val items = underTest.toItem(emptyLastName)
+      val items = toItem(crypto, emptyLastName)
       Option(items.get(LAST_NAME).getS) shouldBe None
       items.get(LAST_NAME).getNULL shouldBe true
     }
     "set the email to null if it is not present" in {
       val emptyEmail = okUser.copy(email = None)
 
-      val items = underTest.toItem(emptyEmail)
+      val items = toItem(crypto, emptyEmail)
       Option(items.get(EMAIL).getS) shouldBe None
       items.get(EMAIL).getNULL shouldBe true
     }
@@ -90,29 +97,29 @@ class DynamoDBUserRepositorySpec
 
   "DynamoDBUserRepository.fromItem" should {
     "set all the values correctly" in {
-      val items = underTest.toItem(okUser)
-      val user = underTest.fromItem(items)
+      val items = toItem(crypto, okUser)
+      val user = fromItem(items)
 
       user shouldBe okUser
     }
     "set all the values correctly if first name is not present" in {
       val emptyFirstName = okUser.copy(firstName = None)
-      val items = underTest.toItem(emptyFirstName)
-      val user = underTest.fromItem(items)
+      val items = toItem(crypto, emptyFirstName)
+      val user = fromItem(items)
 
       user shouldBe emptyFirstName
     }
     "set all the values correctly if last name is not present" in {
       val emptyLastName = okUser.copy(lastName = None)
-      val items = underTest.toItem(emptyLastName)
-      val user = underTest.fromItem(items)
+      val items = toItem(crypto, emptyLastName)
+      val user = fromItem(items)
 
       user shouldBe emptyLastName
     }
     "set all the values correctly if email is not present" in {
       val emptyEmail = okUser.copy(email = None)
-      val items = underTest.toItem(emptyEmail)
-      val user = underTest.fromItem(items)
+      val items = toItem(crypto, emptyEmail)
+      val user = fromItem(items)
 
       user shouldBe emptyEmail
     }
@@ -123,7 +130,7 @@ class DynamoDBUserRepositorySpec
       item.put(CREATED, new AttributeValue().withN("0"))
       item.put(ACCESS_KEY, new AttributeValue("accessKey"))
       item.put(SECRET_KEY, new AttributeValue("secretkey"))
-      val user = underTest.fromItem(item)
+      val user = fromItem(item)
 
       user.firstName shouldBe None
       user.lastName shouldBe None
@@ -131,8 +138,8 @@ class DynamoDBUserRepositorySpec
     }
     "sets the isSuper flag correctly" in {
       val superUser = okUser.copy(isSuper = true)
-      val items = underTest.toItem(superUser)
-      val user = underTest.fromItem(items)
+      val items = toItem(crypto, superUser)
+      val user = fromItem(items)
 
       user shouldBe superUser
     }
@@ -143,7 +150,7 @@ class DynamoDBUserRepositorySpec
       item.put(CREATED, new AttributeValue().withN("0"))
       item.put(ACCESS_KEY, new AttributeValue("accesskey"))
       item.put(SECRET_KEY, new AttributeValue("secretkey"))
-      val user = underTest.fromItem(item)
+      val user = fromItem(item)
 
       user.isSuper shouldBe false
     }
@@ -153,7 +160,7 @@ class DynamoDBUserRepositorySpec
     "return the user if the id is found" in {
       val dynamoResponse = mock[GetItemResult]
 
-      val expected = underTest.toItem(okUser)
+      val expected = toItem(crypto, okUser)
       doReturn(expected).when(dynamoResponse).getItem
       doReturn(IO.pure(dynamoResponse)).when(dynamoDBHelper).getItem(any[GetItemRequest])
 
@@ -188,14 +195,14 @@ class DynamoDBUserRepositorySpec
     "return the users if the id is found" in {
       val firstResponse = mock[BatchGetItemResult]
       val firstPage =
-        Map(userTable -> listOfDummyUsers.slice(0, 100).map(underTest.toItem).asJava).asJava
+        Map(userTable -> listOfDummyUsers.slice(0, 100).map(toItem(crypto, _)).asJava).asJava
       doReturn(firstPage).when(firstResponse).getResponses
 
       val secondResponse = mock[BatchGetItemResult]
       val secondPage = Map(
         userTable -> listOfDummyUsers
           .slice(100, 200)
-          .map(underTest.toItem)
+          .map(toItem(crypto, _))
           .asJava).asJava
       doReturn(secondPage).when(secondResponse).getResponses
 
@@ -266,7 +273,7 @@ class DynamoDBUserRepositorySpec
       val firstPage = Map(
         userTable -> listOfDummyUsers
           .slice(151, 200)
-          .map(underTest.toItem)
+          .map(toItem(crypto, _))
           .asJava).asJava
       doReturn(firstPage).when(firstResponse).getResponses
 
@@ -292,7 +299,7 @@ class DynamoDBUserRepositorySpec
     "truncates the response to only return limit items" in {
       val firstResponse = mock[BatchGetItemResult]
       val firstPage =
-        Map(userTable -> listOfDummyUsers.slice(0, 50).map(underTest.toItem).asJava).asJava
+        Map(userTable -> listOfDummyUsers.slice(0, 50).map(toItem(crypto, _)).asJava).asJava
       doReturn(firstPage).when(firstResponse).getResponses
 
       doReturn(IO.pure(firstResponse))
@@ -321,7 +328,7 @@ class DynamoDBUserRepositorySpec
     "return the user if the access key is found" in {
       val dynamoResponse = mock[QueryResult]
 
-      val expected = List(underTest.toItem(okUser)).asJava
+      val expected = List(toItem(crypto, okUser)).asJava
       doReturn(expected).when(dynamoResponse).getItems
       doReturn(IO.pure(dynamoResponse)).when(dynamoDBHelper).query(any[QueryRequest])
 


### PR DESCRIPTION
Interim step to pull the repos out of the portal.  This PR does not address strongly typed secrets covered in #193 .

Following PRs will pull the user repository _and_ the user change repository into the portal.

**Changes**

* Created a UserChangeRepository trait that will eventually replace
the DynamoDBChangeLogStore in the portal
* Created a DynamoDBUserChangeRepository implementation in the
dynamodb module
* Externalized the fromItem and toItem in the DynamoDBUserRepository
as those are needed by the DynamoDBUserChangeRepository to serialize
the new and old versions of the user
* Added CryptoAlgebra to the DynamoDBUserRepository as we need to
encrypt the secret when it is stored.

Note: users do not have protobufs like the other repositories, rather it saves things as attributes and attribute maps (getM).  Rather than re-writing both the user repository AND the user change repository, we are going to stay with plain old dynamo attributes here.

Also, the **existing** UserChangeLog from the portal uses `timestamp` as the `HASH` key in the table.  This is undesireable / terribly inconsistent.  To make it more consistent, we will store the UUID for user changes.  This will force the creation of a new table when this is merged, an update to our deployment, and eventually a migration of the change log data.  