### PR TITLE
Docker Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,40 +46,40 @@ Docker images for VinylDNS live on Docker Hub at https://hub.docker.com/u/vinyld
 To start up a local instance of VinylDNS on your machine with docker:
 
 1. Ensure that you have [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/)
-2. Clone the repo: `git clone https://github.com/vinyldns/vinyldns.git`
-3. Navigate to repo: `cd vinyldns`
-4. Run `bin/docker-up-vinyldns.sh`. This will start up the api at `localhost:9000` and the portal at `localhost:9001` along with their 
+1. Clone the repo: `git clone https://github.com/vinyldns/vinyldns.git`
+1. Navigate to repo: `cd vinyldns`
+1. Run `bin/docker-up-vinyldns.sh`. This will start up the api at `localhost:9000` and the portal at `localhost:9001` along with their 
 dependencies, ping the API on `http://localhost:9000/ping` and the portal on `http://localhost:9001`, and notify you if either failed to start.
-5. To stop the local setup, run `./bin/remove-vinyl-containers.sh` from the project root.
+1. To stop the local setup, run `./bin/remove-vinyl-containers.sh` from the project root.
 
 Things to try after VinylDNS is running:
 
 1. View the portal at <http://localhost:9001> in a web browser
-2. Login with the credentials ***testuser*** and ***testpassword***
-3. Navigate to the `groups` tab: <http://localhost:9001/groups>
-4. Click on the **New Group** button and create a new group
-5. Navigate to the `zones` tab: <http://localhost:9001/zones>
-6. Click on the **Connect** button to connect to zone, the `bin/docker-up-vinyldns.sh` started up a local bind9 DNS server 
+1. Login with the credentials ***testuser*** and ***testpassword***
+1. Navigate to the `groups` tab: <http://localhost:9001/groups>
+1. Click on the **New Group** button and create a new group
+1. Navigate to the `zones` tab: <http://localhost:9001/zones>
+1. Click on the **Connect** button to connect to zone, the `bin/docker-up-vinyldns.sh` started up a local bind9 DNS server 
 with a few test zones preloaded, 
 connect to `Zone Name = dummy.`, `Email = sometest@vinyldns.com`, `Admin Group = the group you just created`. The DNS
 Server and Zone Transfer Server can be left blank as the test zones use the defaults 
-7. This is async, so refresh the zones page to view the newly created zone
-8. Click the **View** button under the **Actions** column for the `dummy.` zone
-9. You will see that some records are preloaded already, this is because these records existed in the bind9 server 
+1. This is async, so refresh the zones page to view the newly created zone
+1. Click the **View** button under the **Actions** column for the `dummy.` zone
+1. You will see that some records are preloaded already, this is because these records existed in the bind9 server 
 and VinylDNS automatically syncs records with the backend DNS server upon zone connection
-10. From here, you can create DNS record sets in the **Manage Records** tab, and manage zone settings and ***ACL rules***
+1. From here, you can create DNS record sets in the **Manage Records** tab, and manage zone settings and ***ACL rules***
 in the **Manage Zone** tab
-11. To try creating a DNS record, click on the **Create Record Set** button under Records, `Record Type = A, Record Name = my-test-a,
+1. To try creating a DNS record, click on the **Create Record Set** button under Records, `Record Type = A, Record Name = my-test-a,
 TTL = 300, IP Addressess = 1.1.1.1`
-12. Click on the **Refresh** button under Records, you should see your new record created
+1. Click on the **Refresh** button under Records, you should see your new record created
 
 Things to note: 
 
 1. Upon connecting to a zone for the first time, a zone sync is ran to provide VinylDNS a copy of the records in the zone
-2. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
-3. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
-4. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution. You'll need to also modify your application.conf and uncomment the `play.filters.disabled` line. You can read more about this at https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter
-5. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
+1. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
+1. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
+1. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution. You'll need to also modify your application.conf and uncomment the `play.filters.disabled` line. You can read more about this at https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter
+1. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
 
 For details regarding setup and configuration of the dev environment, see the [Developer Guide](DEVELOPER_GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Things to note:
 
 ### Docker Customization
 1. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution.
-2. A similar docker/.env can be modified to change the default ports for the Portal and API.
+2. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
 
 For details regarding setup and configuration of the dev environment, see the [Developer Guide](DEVELOPER_GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,8 @@ Things to note:
 1. Upon connecting to a zone for the first time, a zone sync is ran to provide VinylDNS a copy of the records in the zone
 2. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
 3. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
-
-### Docker Customization
-1. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution.
-2. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
+4. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution.
+5. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
 
 For details regarding setup and configuration of the dev environment, see the [Developer Guide](DEVELOPER_GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -46,38 +46,42 @@ Docker images for VinylDNS live on Docker Hub at https://hub.docker.com/u/vinyld
 To start up a local instance of VinylDNS on your machine with docker:
 
 1. Ensure that you have [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/)
-1. Clone the repo: `git clone https://github.com/vinyldns/vinyldns.git`
-1. Navigate to repo: `cd vinyldns`
-1. Run `bin/docker-up-vinyldns.sh`. This will start up the api at `localhost:9000` and the portal at `localhost:9001` along with their
+2. Clone the repo: `git clone https://github.com/vinyldns/vinyldns.git`
+3. Navigate to repo: `cd vinyldns`
+4. Run `bin/docker-up-vinyldns.sh`. This will start up the api at `localhost:9000` and the portal at `localhost:9001` along with their 
 dependencies, ping the API on `http://localhost:9000/ping` and the portal on `http://localhost:9001`, and notify you if either failed to start.
-1. To stop the local setup, run `./bin/remove-vinyl-containers.sh` from the project root.
+5. To stop the local setup, run `./bin/remove-vinyl-containers.sh` from the project root.
 
 Things to try after VinylDNS is running:
 
 1. View the portal at <http://localhost:9001> in a web browser
-1. Login with the credentials ***testuser*** and ***testpassword***
-1. Navigate to the `groups` tab: <http://localhost:9001/groups>
-1. Click on the **New Group** button and create a new group
-1. Navigate to the `zones` tab: <http://localhost:9001/zones>
-1. Click on the **Connect** button to connect to zone, the `bin/docker-up-vinyldns.sh` started up a local bind9 DNS server 
+2. Login with the credentials ***testuser*** and ***testpassword***
+3. Navigate to the `groups` tab: <http://localhost:9001/groups>
+4. Click on the **New Group** button and create a new group
+5. Navigate to the `zones` tab: <http://localhost:9001/zones>
+6. Click on the **Connect** button to connect to zone, the `bin/docker-up-vinyldns.sh` started up a local bind9 DNS server 
 with a few test zones preloaded, 
 connect to `Zone Name = dummy.`, `Email = sometest@vinyldns.com`, `Admin Group = the group you just created`. The DNS
 Server and Zone Transfer Server can be left blank as the test zones use the defaults 
-1. This is async, so refresh the zones page to view the newly created zone
-1. Click the **View** button under the **Actions** column for the `dummy.` zone
-1. You will see that some records are preloaded already, this is because these records existed in the bind9 server 
+7. This is async, so refresh the zones page to view the newly created zone
+8. Click the **View** button under the **Actions** column for the `dummy.` zone
+9. You will see that some records are preloaded already, this is because these records existed in the bind9 server 
 and VinylDNS automatically syncs records with the backend DNS server upon zone connection
-1. From here, you can create DNS record sets in the **Manage Records** tab, and manage zone settings and ***ACL rules***
+10. From here, you can create DNS record sets in the **Manage Records** tab, and manage zone settings and ***ACL rules***
 in the **Manage Zone** tab
-1. To try creating a DNS record, click on the **Create Record Set** button under Records, `Record Type = A, Record Name = my-test-a,
+11. To try creating a DNS record, click on the **Create Record Set** button under Records, `Record Type = A, Record Name = my-test-a,
 TTL = 300, IP Addressess = 1.1.1.1`
-1. Click on the **Refresh** button under Records, you should see your new record created
+12. Click on the **Refresh** button under Records, you should see your new record created
 
 Things to note: 
 
 1. Upon connecting to a zone for the first time, a zone sync is ran to provide VinylDNS a copy of the records in the zone
-1. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
-1. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
+2. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
+3. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
+
+### Docker Customization
+1. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution.
+2. A similar docker/.env can be modified to change the default ports for the Portal and API.
 
 For details regarding setup and configuration of the dev environment, see the [Developer Guide](DEVELOPER_GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Things to note:
 1. Upon connecting to a zone for the first time, a zone sync is ran to provide VinylDNS a copy of the records in the zone
 2. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
 3. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
-4. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution.
+4. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution. You'll need to also modify your application.conf and uncomment the `play.filters.disabled` line. You can read more about this at https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter
 5. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
 
 For details regarding setup and configuration of the dev environment, see the [Developer Guide](DEVELOPER_GUIDE.md).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Things to note:
 1. Upon connecting to a zone for the first time, a zone sync is ran to provide VinylDNS a copy of the records in the zone
 1. Changes made via VinylDNS are made against the DNS backend, you do not need to sync the zone further to push those changes out
 1. If changes to the zone are made outside of VinylDNS, then the zone will have to be re-synced to give VinylDNS a copy of those records
-1. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution. You'll need to also modify your application.conf and uncomment the `play.filters.disabled` line. You can read more about this at https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter
+1. If you wish to modify the url used in the creation process from `http://localhost:9000`, to say `http://vinyldns.yourdomain.com:9000`, you can modify the bin/.env file before execution.
 1. A similar docker/.env can be modified to change the default ports for the Portal and API. You must also modify their config files with the new port: https://www.vinyldns.io/operator/config-portal & https://www.vinyldns.io/operator/config-api
 
 For details regarding setup and configuration of the dev environment, see the [Developer Guide](DEVELOPER_GUIDE.md).

--- a/bin/.env
+++ b/bin/.env
@@ -1,0 +1,2 @@
+VINYLDNS_API_URL="http://localhost:9000"
+VINYLDNS_PORTAL_URL="http://localhost:9001"

--- a/bin/.env
+++ b/bin/.env
@@ -1,2 +1,2 @@
-VINYLDNS_API_URL="http://localhost:9000"
-VINYLDNS_PORTAL_URL="http://localhost:9001"
+VINYLDNS_API_URL=http://localhost:9000
+VINYLDNS_PORTAL_URL=http://localhost:9001

--- a/bin/docker-up-api-server.sh
+++ b/bin/docker-up-api-server.sh
@@ -7,7 +7,14 @@
 # by default on port 9000
 ######################################################################
 
+
 DIR=$( cd $(dirname $0) ; pwd -P )
+
+set -a # Required in order to source docker/.env
+# Source customizable env files
+source .env
+source "$DIR"/../docker/.env
+
 WORK_DIR="$DIR"/../target/scala-2.12
 mkdir -p "$WORK_DIR"
 
@@ -26,13 +33,12 @@ cp -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar "$WORK_DIR"/docker/ap
 echo "Starting API server and all dependencies in the background..."
 docker-compose -f "$WORK_DIR"/docker/docker-compose-func-test.yml --project-directory "$WORK_DIR"/docker up --build -d api
 
-VINYLDNS_URL="http://localhost:9000"
-echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
+echo "Waiting for API to be ready at ${VINYLDNS_API_URL} ..."
 DATA=""
 RETRY=40
 while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
+    DATA=$(curl -I -s "${VINYLDNS_API_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
         echo "Succeeded in connecting to VinylDNS API!"

--- a/bin/docker-up-api-server.sh
+++ b/bin/docker-up-api-server.sh
@@ -12,7 +12,7 @@ DIR=$( cd $(dirname $0) ; pwd -P )
 
 set -a # Required in order to source docker/.env
 # Source customizable env files
-source .env
+source "$DIR"/.env
 source "$DIR"/../docker/.env
 
 WORK_DIR="$DIR"/../target/scala-2.12

--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -7,16 +7,20 @@
 
 DIR=$( cd $(dirname $0) ; pwd -P )
 
+set -a # Required in order to source docker/.env
+# Source customizable env files
+source .env
+source "$DIR"/../docker/.env
+
 echo "Starting portal server and all dependencies in the background..."
 docker-compose -f "$DIR"/../docker/docker-compose-build.yml up -d
 
-VINYLDNS_URL="http://localhost:9000"
-echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
+echo "Waiting for API to be ready at ${VINYLDNS_API_URL} ..."
 DATA=""
 RETRY=40
 while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
+    DATA=$(curl -I -s "${VINYLDNS_API_URL}/ping" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
         echo "Succeeded in connecting to VinylDNS API!"
@@ -35,13 +39,12 @@ do
     fi
 done
 
-VINYLDNS_URL="http://localhost:9001"
-echo "Waiting for portal to be ready at ${VINYLDNS_URL} ..."
+echo "Waiting for portal to be ready at ${VINYLDNS_PORTAL_URL} ..."
 DATA=""
 RETRY=40
 while [ "$RETRY" -gt 0 ]
 do
-    DATA=$(curl -I -s "${VINYLDNS_URL}" -o /dev/null -w "%{http_code}")
+    DATA=$(curl -I -s "${VINYLDNS_PORTAL_URL}" -o /dev/null -w "%{http_code}")
     if [ $? -eq 0 ]
     then
         echo "Succeeded in connecting to VinylDNS portal!"

--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -9,7 +9,7 @@ DIR=$( cd $(dirname $0) ; pwd -P )
 
 set -a # Required in order to source docker/.env
 # Source customizable env files
-source .env
+source "$DIR"/.env
 source "$DIR"/../docker/.env
 
 echo "Starting portal server and all dependencies in the background..."

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,7 @@
+REST_PORT=9000
+PORTAL_PORT=9001
+# Do not use quotes around the environment variables.
+MYSQL_ROOT_PASSWORD=pass
+# This is required as mysql is currently locked down to localhost
+MYSQL_ROOT_HOST=%
+

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -2,15 +2,16 @@ version: "3.0"
 services:
   mysql:
     image: "mysql:5.7"
+    env_file:
+      .env
     container_name: "vinyldns-mysql"
-    environment:
-      - MYSQL_ROOT_PASSWORD=pass # do not use quotes around the environment variables!!!
-      - MYSQL_ROOT_HOST=% # this is required as mysql is currently locked down to localhost
     ports:
       - "19002:3306"
 
   dynamodb-local:
     image: "cnadiminti/dynamodb-local:2017-02-16"
+    env_file:
+      .env
     container_name: "vinyldns-dynamodb"
     ports:
       - "19000:8000"
@@ -18,6 +19,8 @@ services:
 
   bind9:
     image: "vinyldns/bind9:0.0.1"
+    env_file:
+      .env
     container_name: "vinyldns-bind9"
     ports:
       - "19001:53/udp"
@@ -36,11 +39,11 @@ services:
 
   api:
     image: "vinyldns/api:0.8.0"
-    environment:
-      - REST_PORT=9000
+    env_file:
+      .env
     container_name: "vinyldns-api"
     ports:
-      - "9000:9000"
+      - "${REST_PORT}:${REST_PORT}"
     depends_on:
       - mysql
       - bind9
@@ -49,8 +52,10 @@ services:
 
   portal:
     image: "vinyldns/portal:0.8.0"
+    env_file:
+      .env
     ports:
-      - "9001:9001"
+      - "${PORTAL_PORT}:${PORTAL_PORT}"
     container_name: "vinyldns-portal"
     volumes:
       - ./portal/application.conf:/opt/docker/conf/application.conf

--- a/docker/docker-compose-func-test.yml
+++ b/docker/docker-compose-func-test.yml
@@ -2,21 +2,24 @@ version: "3.0"
 services:
   mysql:
     image: "mysql:5.7"
+    env_file:
+      .env
     container_name: "vinyldns-mysql"
-    environment:
-      - MYSQL_ROOT_PASSWORD=pass # do not use quotes around the environment variables!!!
-      - MYSQL_ROOT_HOST=% # this is required as mysql is currently locked down to localhost
     ports:
       - "19002:3306"
 
   dynamodb-local:
     image: "cnadiminti/dynamodb-local:2017-02-16"
+    env_file:
+      .env
     container_name: "vinyldns-dynamodb"
     ports:
       - "19000:8000"
 
   bind9:
     image: "vinyldns/bind9:0.0.1"
+    env_file:
+      .env
     container_name: "vinyldns-bind9"
     volumes:
       - ./bind9/etc:/var/cache/bind/config
@@ -27,6 +30,8 @@ services:
 
   elasticmq:
     image: s12v/elasticmq:0.13.8
+    env_file:
+      .env
     container_name: "vinyldns-elasticmq"
     ports:
       - "9324:9324"
@@ -37,8 +42,8 @@ services:
   api:
     build:
       context: api
-    environment:
-      - REST_PORT=9000
+    env_file:
+      .env
     container_name: "vinyldns-api"
     ports:
       - "9000:9000"
@@ -51,6 +56,8 @@ services:
   functest:
     build:
       context: functest
+    env_file:
+      .env
     container_name: "vinyldns-functest"
     depends_on:
       - api

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,20 +2,23 @@ version: "3.0"
 services:
   mysql:
     image: "mysql:5.7"
-    environment:
-      - MYSQL_ROOT_PASSWORD=pass # do not use quotes around the environment variables!!!
-      - MYSQL_ROOT_HOST=% # this is required as mysql is currently locked down to localhost
+    env_file:
+      .env
     ports:
       - "19002:3306"
 
   dynamodb-local:
     image: "cnadiminti/dynamodb-local:2017-02-16"
+    env_file:
+      .env
     ports:
       - "19000:8000"
     command: "--sharedDb --inMemory"
 
   bind9:
     image: "vinyldns/bind9:0.0.1"
+    env_file:
+      .env
     ports:
       - "19001:53/udp"
       - "19001:53"
@@ -25,6 +28,8 @@ services:
 
   elasticmq:
     image: s12v/elasticmq:0.13.8
+    env_file:
+      .env
     ports:
       - "9324:9324"
     volumes:

--- a/docker/portal/application.conf
+++ b/docker/portal/application.conf
@@ -81,5 +81,5 @@ links = [
   }
 ]
 
-# Uncomment if using a different hostname from localhost
-# play.filters.disabled += play.filters.hosts.AllowedHostsFilter
+# Uncomment if you want to allow more than just localhost: https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter
+play.filters.disabled += play.filters.hosts.AllowedHostsFilter

--- a/docker/portal/application.conf
+++ b/docker/portal/application.conf
@@ -80,3 +80,6 @@ links = [
     icon = "fa fa-file-text-o"
   }
 ]
+
+# Uncomment if using a different hostname from localhost
+# play.filters.disabled += play.filters.hosts.AllowedHostsFilter


### PR DESCRIPTION
Why I believe these changes are necessary: If I was someone not familiar with VinylDNS and was using the docker setup to play around, I am in a state of learning. I would want easier control over ENV values and explicit documentation. This allows me to then take the docker examples and set up my own production instance based on them without much headache and wasted time trying to infer things.

I have made multiple changes:

* Use of .env files (in docker/ and bin/), allowing customization for users.
* docker-compose files have been updated to use docker/.env values.
* Sourcing of .env in docker bash scripts.
* New example for disabling host filter in application.conf.
* README explaining it all.

I have tested all of these changes and it's working great.
