### PR TITLE
Fix portal build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,7 @@ lazy val dynamodb = (project in file("modules/dynamodb"))
   .settings(headerSettings(IntegrationTest))
   .settings(inConfig(IntegrationTest)(scalafmtConfigSettings))
   .settings(name := "dynamodb")
-  .settings(noPublishSettings)
+  .settings(corePublishSettings)
   .settings(testSettings)
   .settings(Defaults.itSettings)
   .settings(libraryDependencies ++= dynamoDBDependencies ++ commonTestDependencies.map(_ % "test, it"))
@@ -318,7 +318,7 @@ lazy val portal = (project in file("modules/portal")).enablePlugins(PlayScala, A
     // change the name of the output to portal.zip
     packageName in Universal := "portal"
   )
-  .dependsOn(core, dynamodb)
+  .dependsOn(dynamodb)
 
 lazy val docSettings = Seq(
   git.remoteRepo := "https://github.com/vinyldns/vinyldns",

--- a/build.sbt
+++ b/build.sbt
@@ -268,6 +268,7 @@ lazy val dynamodb = (project in file("modules/dynamodb"))
   .settings(libraryDependencies ++= dynamoDBDependencies ++ commonTestDependencies.map(_ % "test, it"))
   .settings(scalaStyleCompile ++ scalaStyleTest)
   .settings(
+    organization := "io.vinyldns",
     coverageMinimum := 85,
     coverageFailOnMinimum := true,
     coverageHighlighting := true


### PR DESCRIPTION
**Background**
When the portal is packaged using the universal packager, it does not automatically pull in the dependencies and transitive dependencies of the `dependsOn` submodules.  This caused the portal to not start up when we deployed to our dev environment.

**Solution**
Seemingly, adding publish settings to `dynamodb` module in the portal project forced the dependencies to be present.

You can verify by running `stage` from the `portal` project in sbt.  Look in the `target` directory for the staged files.  Go to the `lib` directory, and you will now see the dynamodb submodule, along with the core submodule and aws-sdk jars.