### PR TITLE
Kill with fire encrypt-secrets feature flag

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -131,7 +131,4 @@ vinyldns {
   }
 
   batch-change-limit = 20
-
-  # whether user secrets are expected to be encrypted or not
-  encrypt-user-secrets = true
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -51,7 +51,6 @@ object VinylDNSConfig {
   lazy val sqsConfig: Config = vinyldnsConfig.getConfig("sqs")
   lazy val cryptoConfig: Config = vinyldnsConfig.getConfig("crypto")
   lazy val system: ActorSystem = ActorSystem("VinylDNS", VinylDNSConfig.config)
-  lazy val encryptUserSecrets: Boolean = vinyldnsConfig.getBoolean("encrypt-user-secrets")
   lazy val approvedNameServers: List[Regex] =
     vinyldnsConfig.getStringList("approved-name-servers").asScala.toList.map(n => n.r)
 

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -19,8 +19,6 @@ package vinyldns.api.repository
 import cats.effect.IO
 import cats.implicits._
 import org.joda.time.DateTime
-import vinyldns.api.VinylDNSConfig
-import vinyldns.api.crypto.Crypto
 import vinyldns.core.domain.membership._
 
 // $COVERAGE-OFF$
@@ -132,11 +130,7 @@ object TestDataLoader {
   def loadTestData(repository: UserRepository): IO[List[User]] =
     (testUser :: okUser :: dummyUser :: lockedUser :: listGroupUser :: listZonesUser :: listBatchChangeSummariesUser ::
       listZeroBatchChangeSummariesUser :: zoneHistoryUser :: listOfDummyUsers).map { user =>
-      val encrypted =
-        if (VinylDNSConfig.encryptUserSecrets)
-          user.copy(secretKey = Crypto.encrypt(user.secretKey))
-        else user
-      repository.save(encrypted)
+      repository.save(user)
     }.parSequence
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
@@ -20,13 +20,12 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.server.RequestContext
 import cats.effect._
 import cats.syntax.all._
-import vinyldns.api.VinylDNSConfig
 import vinyldns.api.crypto.Crypto
 import vinyldns.api.domain.auth.{AuthPrincipalProvider, MembershipAuthPrincipalProvider}
 import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.route.Monitored
 import vinyldns.core.domain.membership.LockStatus
+import vinyldns.core.route.Monitored
 
 import scala.util.matching.Regex
 
@@ -125,11 +124,8 @@ trait VinylDNSAuthentication extends Monitored {
         content)
     } yield authPrincipal
 
-  def decryptSecret(
-      str: String,
-      encryptionEnabled: Boolean = VinylDNSConfig.encryptUserSecrets,
-      crypto: CryptoAlgebra = Crypto.instance): String =
-    if (encryptionEnabled) crypto.decrypt(str) else str
+  def decryptSecret(str: String, crypto: CryptoAlgebra = Crypto.instance): String =
+    crypto.decrypt(str)
 
   def getAuthPrincipal(accessKey: String): IO[AuthPrincipal] =
     authPrincipalProvider.getAuthPrincipal(accessKey).flatMap {

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSAuthenticatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSAuthenticatorSpec.scala
@@ -38,20 +38,14 @@ class VinylDNSAuthenticatorSpec
   private val underTest = new VinylDNSAuthenticator(mockAuthenticator, mockAuthPrincipalProvider)
 
   "VinylDNSAuthenticator" should {
-    "use Crypto if encryption is enabled" in {
+    "use Crypto" in {
       val str = "mysecret"
       val mockCrypto = mock[CryptoAlgebra]
       doReturn("decrypted!").when(mockCrypto).decrypt(str)
-      val res = underTest.decryptSecret(str, encryptionEnabled = true, crypto = mockCrypto)
+      val res = underTest.decryptSecret(str, crypto = mockCrypto)
       res shouldNot be(str)
       res shouldBe "decrypted!"
       verify(mockCrypto).decrypt(str)
-    }
-    "not use Crypto if encryption is disabled" in {
-      val str = "mysecret"
-      val mockCrypto = mock[CryptoAlgebra]
-      underTest.decryptSecret(str, encryptionEnabled = false, crypto = mockCrypto)
-      verifyZeroInteractions(mockCrypto)
     }
     "return an authPrincipal when the request is valid" in {
       val fakeHttpHeader = mock[HttpHeader]


### PR DESCRIPTION
We should always assume encrypted user secrets at this point.
The feature flag was temporary.