### PR TITLE
Increase MySQL retry count/sleep duration for API startup script

### DIFF
--- a/docker/api/run.sh
+++ b/docker/api/run.sh
@@ -23,7 +23,7 @@ export JDBC_MIGRATION_URL="jdbc:mariadb://${MYSQL_ADDRESS}:${MYSQL_PORT}/?user=$
 # wait until mysql is ready...
 echo 'Waiting for MYSQL to be ready...'
 DATA=""
-RETRY=30
+RETRY=60
 while [ $RETRY -gt 0 ]
 do
     DATA=$(nc -vzw1 vinyldns-mysql 3306)

--- a/docker/api/run.sh
+++ b/docker/api/run.sh
@@ -24,7 +24,8 @@ export JDBC_MIGRATION_URL="jdbc:mariadb://${MYSQL_ADDRESS}:${MYSQL_PORT}/?user=$
 echo 'Waiting for MYSQL to be ready...'
 DATA=""
 RETRY=60
-while [ $RETRY -gt 0 ]
+SLEEP_DURATION=1
+while [ "$RETRY" -gt 0 ]
 do
     DATA=$(nc -vzw1 vinyldns-mysql 3306)
     if [ $? -eq 0 ]
@@ -34,9 +35,9 @@ do
         echo "Retrying Again" >&2
 
         let RETRY-=1
-        sleep .5
+        sleep "$SLEEP_DURATION"
 
-        if [ $RETRY -eq 0 ]
+        if [ "$RETRY" -eq 0 ]
         then
           echo "Exceeded retries waiting for MYSQL to be ready, failing"
           return 1

--- a/docker/api/run.sh
+++ b/docker/api/run.sh
@@ -23,7 +23,7 @@ export JDBC_MIGRATION_URL="jdbc:mariadb://${MYSQL_ADDRESS}:${MYSQL_PORT}/?user=$
 # wait until mysql is ready...
 echo 'Waiting for MYSQL to be ready...'
 DATA=""
-RETRY=60
+RETRY=40
 SLEEP_DURATION=1
 while [ "$RETRY" -gt 0 ]
 do

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -4,6 +4,7 @@ VINYLDNS_URL="http://vinyldns-api:9000"
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=60
+SLEEP_DURATION=1
 while [ "$RETRY" -gt 0 ]
 do
     DATA=$(curl -I -s "${VINYLDNS_URL}/ping" -o /dev/null -w "%{http_code}")
@@ -14,7 +15,7 @@ do
         echo "Retrying Again" >&2
 
         let RETRY-=1
-        sleep 1
+        sleep "$SLEEP_DURATION"
 
         if [ "$RETRY" -eq 0 ]
         then


### PR DESCRIPTION
There are transient failures in Docker where max retries (currently set to 30) are exceeded for MySQL, and then functional tests fail. Example build: https://travis-ci.org/vinyldns/vinyldns/jobs/431178316.

- Increase retries from 30 to 40
- Increase timeout duration of API start from 0.5 seconds to 1 second (to also match func test start)