### PR TITLE
update npm bootstrap due to vulnerability 

### DIFF
--- a/modules/portal/package.json
+++ b/modules/portal/package.json
@@ -11,7 +11,7 @@
     "angular": "1.5.0",
     "angular-animate": "1.6.1",
     "angular-ui-bootstrap": "2.5.6",
-    "bootstrap": "3.3.7",
+    "bootstrap": "4.1.2",
     "font-awesome": "4.7.0",
     "gentelella": "1.4.0",
     "grunt": "^1.0.3",


### PR DESCRIPTION
github it warning us that our npm bootstrap dependency has a vulnerability. Turns out the portal renders fine without it, but our javascript unit tests fail without it. Updated it to the version recommended by Github, 4.1.2 

<img width="763" alt="screen shot 2018-09-30 at 2 26 18 pm" src="https://user-images.githubusercontent.com/9893183/46261400-0e277800-c4c1-11e8-939c-c973e8964852.png">
