### PR TITLE
allow multiple ptr records in batch change

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1851,7 +1851,7 @@ def test_ipv6_ptr_recordtype_add_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[1], input_name="fd69:27cc:fe91::abc", record_type="PTR", record_data="duplicate.record1.")
         assert_successful_change_in_error_response(response[2], input_name="fd69:27cc:fe91::abc", record_type="PTR", record_data="duplicate.record2.")
 
-    # independent validations: bad TTL, malformed host name/IP address, duplicate record
+        # independent validations: bad TTL, malformed host name/IP address, duplicate record
         assert_failed_change_in_error_response(response[3], input_name="fd69:27cc:fe91::abe", ttl=29, record_type="PTR", record_data="test.com.",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.'])
         assert_failed_change_in_error_response(response[4], input_name="fd69:27cc:fe91::bae", record_type="PTR", record_data="$malformed.hostname.",
@@ -1863,7 +1863,7 @@ def test_ipv6_ptr_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[6], input_name="fedc:ba98:7654::abc", record_type="PTR", record_data="zone.discovery.error.",
                                                error_messages=["Zone Discovery Failed: zone for \"fedc:ba98:7654::abc\" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS."])
 
-        # context validations: duplicates in batch, existing record sets pre-request
+        # context validations: existing record sets pre-request
         assert_failed_change_in_error_response(response[7], input_name="fd69:27cc:fe91::ffff", record_type="PTR", record_data="existing.ptr.",
                                                    error_messages=["Record \"fd69:27cc:fe91::ffff\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -151,7 +151,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
     // Updates require checking against other batch changes since multiple adds
     // could potentially be grouped with a single delete
     val typedValidations = change.inputChange.typ match {
-      case CNAME | PTR | TXT => recordIsUniqueInBatch(change, changeGroups)
+      case CNAME | TXT => recordIsUniqueInBatch(change, changeGroups)
       case _ => ().validNel
     }
 
@@ -182,7 +182,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
       existingRecords: ExistingRecordSets,
       auth: AuthPrincipal): SingleValidation[ChangeForValidation] = {
     val typedValidations = change.inputChange.typ match {
-      case A | AAAA | MX =>
+      case A | AAAA | MX | PTR =>
         noCnameWithRecordNameInExistingRecords(
           change.zone.id,
           change.recordName,
@@ -197,7 +197,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
           existingRecords,
           changeGroups) |+|
           cnameHasUniqueNameInBatch(change, changeGroups)
-      case PTR | TXT =>
+      case TXT =>
         noCnameWithRecordNameInExistingRecords(
           change.zone.id,
           change.recordName,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -649,7 +649,7 @@ class BatchChangeValidationsSpec
         addDuplicateCname.inputChange.typ))
   }
 
-  property("""validateChangesWithContext: both PTR records should fail
+  property("""validateChangesWithContext: both PTR records should succeed
       |if there are duplicate PTR add change inputs""".stripMargin) {
     val addA = AddChangeForValidation(
       okZone,
@@ -669,12 +669,8 @@ class BatchChangeValidationsSpec
       okAuth)
 
     result(0) shouldBe valid
-    result(1) should haveInvalid[DomainValidationError](
-      RecordNameNotUniqueInBatch(addPtr.inputChange.inputName, addPtr.inputChange.typ))
-    result(2) should haveInvalid[DomainValidationError](
-      RecordNameNotUniqueInBatch(
-        addDuplicatePtr.inputChange.inputName,
-        addDuplicatePtr.inputChange.typ))
+    result(1) shouldBe valid
+    result(2) shouldBe valid
   }
 
   property("""validateChangesWithContext: should succeed for AddChangeForValidation
@@ -1051,7 +1047,7 @@ class BatchChangeValidationsSpec
     result.map(_ shouldBe valid)
   }
 
-  property("validateChangesWithContext: should fail on PTR update including multiple adds") {
+  property("validateChangesWithContext: should succeed on PTR update including multiple adds") {
     val existingPtr = rsOk.copy(
       zoneId = validIp4ReverseZone.id,
       name = "193",
@@ -1077,10 +1073,8 @@ class BatchChangeValidationsSpec
       okAuth)
 
     result(0) shouldBe valid
-    result(1) should haveInvalid[DomainValidationError](
-      RecordNameNotUniqueInBatch("192.0.2.193", RecordType.PTR))
-    result(2) should haveInvalid[DomainValidationError](
-      RecordNameNotUniqueInBatch("192.0.2.193", RecordType.PTR))
+    result(1) shouldBe valid
+    result(2) shouldBe valid
   }
 
   property("validateAddChangeInput: should succeed for a valid TXT addChangeInput") {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -668,9 +668,7 @@ class BatchChangeValidationsSpec
       ExistingRecordSets(List()),
       okAuth)
 
-    result(0) shouldBe valid
-    result(1) shouldBe valid
-    result(2) shouldBe valid
+    result.map(_ shouldBe valid)
   }
 
   property("""validateChangesWithContext: should succeed for AddChangeForValidation
@@ -1072,9 +1070,7 @@ class BatchChangeValidationsSpec
       ExistingRecordSets(List(existingPtr)),
       okAuth)
 
-    result(0) shouldBe valid
-    result(1) shouldBe valid
-    result(2) shouldBe valid
+    result.map(_ shouldBe valid)
   }
 
   property("validateAddChangeInput: should succeed for a valid TXT addChangeInput") {


### PR DESCRIPTION
Closes #199

Changes in this pull request:
- remove recordIsUniqueInBatch validation from PTR record additions and updates in batch change. A PTR recordset can have multiple records.
- No change was actually needed in the portal since the validation happens in the API. Did verify through the portal though.

<img width="887" alt="batch change with ptr records" src="https://user-images.githubusercontent.com/4439228/46494131-15f85c80-c7e0-11e8-8821-a4b5e93178ab.png">

<img width="842" alt="zone view of the ptr recordset" src="https://user-images.githubusercontent.com/4439228/46494138-1a247a00-c7e0-11e8-9f2d-adf88d6ecd5a.png">
 
