### PR TITLE
exclude filter for local.conf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,11 @@ lazy val apiPublishSettings = Seq(
 lazy val portalPublishSettings = Seq(
   publishArtifact := false,
   publishLocal := (publishLocal in Docker).value,
-  publish := (publish in Docker).value
+  publish := (publish in Docker).value,
+  // for sbt-native-packager (docker) to exclude local.conf
+  mappings in Universal ~= (_.filterNot(_._1.name.equals("local.conf"))),
+  // for local.conf to be excluded in jars
+  mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.equals("local.conf")) }
 )
 
 lazy val pbSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -173,9 +173,13 @@ lazy val portalPublishSettings = Seq(
   publishLocal := (publishLocal in Docker).value,
   publish := (publish in Docker).value,
   // for sbt-native-packager (docker) to exclude local.conf
-  mappings in Universal ~= (_.filterNot(_._1.name.equals("local.conf"))),
+  mappings in Universal ~= ( _.filterNot {
+    case (file, _) => file.getName.equals("local.conf")
+  }),
   // for local.conf to be excluded in jars
-  mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.equals("local.conf")) }
+  mappings in (Compile, packageBin) ~= ( _.filterNot {
+    case (file, _) => file.getName.equals("local.conf")
+  })
 )
 
 lazy val pbSettings = Seq(


### PR DESCRIPTION
Fixes #209 .

Changes in this pull request:
- `modules/portal/conf/local.conf` is excluded from packaging so it doesn't show up in docker images
- `modules/portal/conf/local.conf` is excluded from `packageBin` so it doesn't show up in jars of the portal

To test: 
- have a `modules/portal/conf/local.conf` that overrides application.conf settings
- ensure that running the portal locally still has settings from local.conf
- run `sbt ";project portal;clean;docker:stage"`
- run `ls modules/portal/target/docker/stage/opt/docker/conf` and ensure `local.conf` is not there
- run `mkdir modules/portal/target/scala-2.12/test` and `cd modules/portal/target/scala-2.12/test && unzip ../portal_2.12-0.8.0-SNAPSHOT.jar && ls` and ensure `local.conf` is not in the jar
