### PR TITLE
fix typo re: SSHFP record model type attribute

### DIFF
--- a/modules/docs/src/main/tut/api/recordset-model.md
+++ b/modules/docs/src/main/tut/api/recordset-model.md
@@ -117,7 +117,7 @@ Individual SSHFP record:
     "records": [
         {
             "algorithm": 1,
-            "typ": 3,
+            "type": 3,
             "fingerprint": "560c7d19d5da9a3a5c7c19992d1fbde15d8dad31"
         }
     ],
@@ -139,17 +139,17 @@ Multiple SSHFP records:
     "records": [
         {
           "algorithm": 1,
-          "typ": 2,
+          "type": 2,
           "fingerprint": "560c7d19d5da9a3a5c7c19992d1fbde15d8dad31"
         },
         {
           "algorithm": 3,
-          "typ": 1,
+          "type": 1,
           "fingerprint": "160c7d19d5da9a3a5c7c19992d1fbde15d8dad31"
         },
         {
           "algorithm": 4,
-          "typ": 1,
+          "type": 1,
           "fingerprint": "260c7d19d5da9a3a5c7c19992d1fbde15d8dad31"
         }
     ],

--- a/modules/docs/src/main/tut/api/recordset-model.md
+++ b/modules/docs/src/main/tut/api/recordset-model.md
@@ -84,14 +84,14 @@ SOA          | minimum     | long        |
 <br>         |             |             |
 SPF          | text        | string      |
 <br>         |             |             |
-SRV          | priority    | integer     | 
+SRV          | priority    | integer     |
 SRV          | weight      | integer     |
 SRV          | port        | integer     |
 SRV          | target      | string      |
 <br>         |             |             |
-SSHFP        | algorithm   | integer     | 
-SSHFP        | typ         | integer     |
-SSHFP        | fingerprint | string      | 
+SSHFP        | algorithm   | integer     |
+SSHFP        | type        | integer     |
+SSHFP        | fingerprint | string      |
 <br>         |             |             |
 TXT          | text        | string      |
 
@@ -104,7 +104,7 @@ Use the *@* symbol to point to the zone origin
 
 **CNAME records cannot point to the zone origin, thus the RecordSet name cannot be @ nor the zone origin**
 
-Individual SSHFP record: 
+Individual SSHFP record:
 
 ```
 {
@@ -126,7 +126,7 @@ Individual SSHFP record:
 }
 ```
 
-Multiple SSHFP records: 
+Multiple SSHFP records:
 
 ```
 {


### PR DESCRIPTION
The record set model docs for SSHFP records cite a `typ` attribute. This is a typo and should be `type`.

Fixes issue #268

Changes in this pull request:
- correct SSHFP record set model documentation typo to read `type` rather than `typ`
- remove some whitespace
