### PR TITLE
Add JDK 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ sudo: false
 
 jdk:
   - oraclejdk8
+  - openjdk11
 
 services:
   - docker

--- a/modules/core/src/main/scala/vinyldns/core/queue/MessageQueueLoader.scala
+++ b/modules/core/src/main/scala/vinyldns/core/queue/MessageQueueLoader.scala
@@ -26,7 +26,12 @@ object MessageQueueLoader {
   def load(config: MessageQueueConfig): IO[MessageQueue] =
     for {
       _ <- IO(logger.error(s"Attempting to load queue ${config.className}"))
-      provider <- IO(Class.forName(config.className).newInstance.asInstanceOf[MessageQueueProvider])
+      provider <- IO(
+        Class
+          .forName(config.className)
+          .getDeclaredConstructor()
+          .newInstance()
+          .asInstanceOf[MessageQueueProvider])
       queue <- provider.load(config)
     } yield queue
 }

--- a/modules/core/src/main/scala/vinyldns/core/repository/DataStoreLoader.scala
+++ b/modules/core/src/main/scala/vinyldns/core/repository/DataStoreLoader.scala
@@ -44,7 +44,12 @@ object DataStoreLoader {
       _ <- IO(
         logger.error(
           s"Attempting to load repos ${config.repositories.keys} from ${config.className}"))
-      provider <- IO(Class.forName(config.className).newInstance.asInstanceOf[DataStoreProvider])
+      provider <- IO(
+        Class
+          .forName(config.className)
+          .getDeclaredConstructor()
+          .newInstance()
+          .asInstanceOf[DataStoreProvider])
       dataStore <- provider.load(config, crypto)
     } yield (config, dataStore)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
     "org.apache.commons"        %  "commons-text"                   % "1.4",
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
-    "javax.xml.bind"            %  "jaxb-api"                      % "2.3.1",
+    "javax.xml.bind"            %  "jaxb-api"                       % "2.3.1" % "provided",
     "com.sun.xml.bind"          %  "jaxb-impl"                      % "2.3.1"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   lazy val scalaTestV = "3.0.4"
   lazy val scodecV = "1.1.5"
   lazy val playV = "2.6.19"
-  lazy val awsV = "1.11.95"
+  lazy val awsV = "1.11.423"
 
   lazy val compileDependencies = Seq(
     "com.typesafe.akka"         %% "akka-http"                      % akkaHttpV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,9 @@ object Dependencies {
     "nl.grons"                  %% "metrics-scala"                  % metricsScalaV,
     "org.apache.commons"        %  "commons-text"                   % "1.4",
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
-    "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV
+    "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
+    "javax.xml.bind"            %  "jaxb-api"                      % "2.3.1",
+    "com.sun.xml.bind"          %  "jaxb-impl"                      % "2.3.1"
   )
 
   lazy val dynamoDBDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   lazy val scodecV = "1.1.5"
   lazy val playV = "2.6.19"
   lazy val awsV = "1.11.423"
+  lazy val jaxbV = "2.3.0"
 
   lazy val compileDependencies = Seq(
     "com.typesafe.akka"         %% "akka-http"                      % akkaHttpV,
@@ -58,8 +59,9 @@ object Dependencies {
     "org.apache.commons"        %  "commons-text"                   % "1.4",
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
-    "javax.xml.bind"            %  "jaxb-api"                       % "2.3.1" % "provided",
-    "com.sun.xml.bind"          %  "jaxb-impl"                      % "2.3.1"
+    "javax.xml.bind"            %  "jaxb-api"                       % jaxbV % "provided",
+    "com.sun.xml.bind"          %  "jaxb-core"                      % jaxbV,
+    "com.sun.xml.bind"          %  "jaxb-impl"                      % jaxbV
   )
 
   lazy val dynamoDBDependencies = Seq(

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")


### PR DESCRIPTION
Fixes #271.

Changes in this pull request:
- Adds `openjdk11` in Travis build matrix.
- Rewrites the deprecated `klass.newInstance()` with `klass.getDeclaredConstructor().newInstance()`
- Adds the `jaxb` dependencies which had been removed from JDK since JDK 9.
- Updates `aws-sdk` and `sbt-assembly` to support JDK 11.

