### PR TITLE
Nest migration url info in optional settings

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -52,8 +52,6 @@ vinyldns {
       # assumes a docker or mysql instance running locally
       name = "vinyldns"
       driver = "org.mariadb.jdbc.Driver"
-      migration-url = "jdbc:mariadb://vinyldns-mysql:3306/?user=root&password=pass"
-      migration-url = ${?JDBC_MIGRATION_URL}
       url = "jdbc:mariadb://vinyldns-mysql:3306/vinyldns?user=root&password=pass"
       url = ${?JDBC_URL}
       user = "root"
@@ -63,6 +61,10 @@ vinyldns {
       pool-max-size = 20
       connection-timeout-millis = 1000
       max-life-time = 600000
+      migration-settings {
+        migration-url = "jdbc:mariadb://vinyldns-mysql:3306/?user=root&password=pass"
+        migration-url = ${?JDBC_MIGRATION_URL}
+      }
     }
     # Repositories that use this data store are listed here
     repositories {

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -44,13 +44,15 @@ vinyldns {
       # assumes a docker or mysql instance running locally
       name = "vinyldns"
       driver = "org.mariadb.jdbc.Driver"
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
       url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
       user = "root"
       password = "pass"
       pool-max-size = 20
       connection-timeout-millis = 1000
       max-life-time = 600000
+      migration-settings {
+        migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+      }
     }
 
     repositories {

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -35,13 +35,15 @@ vinyldns {
     settings {
       name = "vinyldns"
       driver = "org.mariadb.jdbc.Driver"
-      migration-url = "jdbc:mariadb://vinyldns-mysql:3306/?user=root&password=pass"
       url = "jdbc:mariadb://vinyldns-mysql:3306/vinyldns?user=root&password=pass"
       user = "root"
       password = "pass"
       pool-max-size = 20
       connection-timeout-millis = 1000
       max-life-time = 600000
+      migration-settings {
+        migration-url = "jdbc:mariadb://vinyldns-mysql:3306/?user=root&password=pass"
+      }
     }
     repositories {
       zone {

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -205,9 +205,6 @@ vinyldns {
       # the jdbc driver, recommended to leave this as is
       driver = "org.mariadb.jdbc.Driver"
 
-      # the URL used to create the schema, typically this will be without the "database" name
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
-
       # the main connection URL
       url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
 
@@ -225,6 +222,11 @@ vinyldns {
 
       # The max lifetime of a connection in a pool.  Should be several seconds shorter than the database imposed connection time limit
       max-life-time = 600000
+      
+      migration-settings {
+        # the URL used to create the schema, typically this will be without the "database" name
+        migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+      }
     }
     
     repositories {
@@ -448,13 +450,15 @@ vinyldns {
     settings {
       name = "vinyldns"
       driver = "org.mariadb.jdbc.Driver"
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
       url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
       user = "root"
       password = "pass"
       pool-max-size = 20
       connection-timeout-millis = 1000
       max-life-time = 600000
+      migration-settings {
+        migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+      }
     }
     
     repositories {

--- a/modules/mysql/src/it/resources/application.conf
+++ b/modules/mysql/src/it/resources/application.conf
@@ -7,7 +7,6 @@ mysql {
     # assumes a docker or mysql instance running locally
     name = "vinyldns"
     driver = "org.mariadb.jdbc.Driver"
-    migration-url = "jdbc:mariadb://localhost:19004/?user=root&password=pass"
     url = "jdbc:mariadb://localhost:19004/vinyldns?user=root&password=pass"
     user = "root"
     password = "pass"
@@ -15,6 +14,9 @@ mysql {
     pool-max-size = 20
     connection-timeout-millis = 1000
     max-life-time = 600000
+    migration-settings {
+      migration-url = "jdbc:mariadb://localhost:19004/?user=root&password=pass"
+    }
   }
 
   repositories {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnectionSettings.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnectionSettings.scala
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-package vinyldns.mysql.repository
+package vinyldns.mysql
 
-case class MySqlDataStoreSettings(
+case class MySqlConnectionSettings(
     name: String,
     driver: String,
-    migrationUrl: String,
     url: String,
     user: String,
     password: String,
     poolMaxSize: Int,
     connectionTimeoutMillis: Long,
     maxLifeTime: Long,
-    migrationSchemaTable: Option[String])
+    migrationSettings: Option[MySqlMigrationSettings]
+)
+
+case class MySqlMigrationSettings(
+    migrationUrl: String,
+    migrationSchemaTable: Option[String],
+    poolMaxSize: Int = 3
+)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnector.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnector.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.mysql
+
+import cats.effect.IO
+import com.zaxxer.hikari.HikariDataSource
+import javax.sql.DataSource
+import org.flywaydb.core.Flyway
+import org.slf4j.LoggerFactory
+import scalikejdbc.{ConnectionPool, DataSourceConnectionPool}
+import scalikejdbc.config.DBs
+
+import scala.collection.JavaConverters._
+
+object MySqlConnector {
+
+  private val logger = LoggerFactory.getLogger("MySQLConnector")
+
+  def runDBMigrations(settings: MySqlConnectionSettings): IO[Unit] =
+    settings.migrationSettings match {
+      case Some(migrationSettings) =>
+        IO {
+          lazy val migrationDataSource: DataSource = {
+            val ds = new HikariDataSource()
+            ds.setDriverClassName(settings.driver)
+            ds.setJdbcUrl(migrationSettings.migrationUrl)
+            ds.setUsername(settings.user)
+            ds.setPassword(settings.password)
+            // migrations happen once on startup; without these settings the default number of connections
+            // will be created and maintained even though this datasource is no longer needed post-migration
+            ds.setMaximumPoolSize(migrationSettings.poolMaxSize)
+            ds.setMinimumIdle(0)
+            ds
+          }
+
+          logger.info("Running migrations to ready the databases")
+
+          val migration = new Flyway()
+          migration.setDataSource(migrationDataSource)
+          // flyway changed the default schema table name in v5.0.0
+          // this allows to revert to an old naming convention if needed
+          migrationSettings.migrationSchemaTable.foreach { tableName =>
+            migration.setTable(tableName)
+          }
+
+          val placeholders = Map("dbName" -> settings.name)
+          migration.setPlaceholders(placeholders.asJava)
+          migration.setSchemas(settings.name)
+
+          // Runs flyway migrations
+          migration.migrate()
+          logger.info("migrations complete")
+        }
+      case None => IO(logger.info("Migrations configured off"))
+    }
+
+  def setupDBConnection(settings: MySqlConnectionSettings): IO[Unit] = IO {
+    val dataSource: DataSource = {
+      val ds = new HikariDataSource()
+      ds.setDriverClassName(settings.driver)
+      ds.setJdbcUrl(settings.url)
+      ds.setUsername(settings.user)
+      ds.setPassword(settings.password)
+      ds.setConnectionTimeout(settings.connectionTimeoutMillis)
+      ds.setMaximumPoolSize(settings.poolMaxSize)
+      ds.setMaxLifetime(settings.maxLifeTime)
+      ds.setRegisterMbeans(true)
+      ds
+    }
+
+    logger.info("configuring connection pool")
+
+    // Configure the connection pool
+    ConnectionPool.singleton(new DataSourceConnectionPool(dataSource))
+
+    logger.info("setting up databases")
+
+    // Sets up all databases with scalikejdbc
+    DBs.setupAll()
+
+    logger.info("database init complete")
+  }
+}

--- a/modules/mysql/src/test/resources/application.conf
+++ b/modules/mysql/src/test/resources/application.conf
@@ -7,7 +7,6 @@ mysql {
     # assumes a docker or mysql instance running locally
     name = "vinyldns"
     driver = "some.test.driver"
-    migration-url = "migration-url"
     url = "url"
     user = "some-user"
     password = "some-pass"
@@ -15,6 +14,9 @@ mysql {
     pool-max-size = 20
     connection-timeout-millis = 1000
     max-life-time = 600000
+    migration-settings {
+      migration-url = "migration.url"
+    }
   }
 
   repositories {


### PR DESCRIPTION
Part of #202 

Changes in this pull request:
- Nests mysql migration config info into optional migration-settings
- If this is empty. do not run flyway migrations
- validates migration-settings is present if the MySQL database is enabled

Note: the reason for this is that this will allow us to exclude these settings (and not run flyway twice) in the case that someone is using both the mysql database and queue.
