### PR TITLE
add edit button to doc site

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -369,7 +369,8 @@ lazy val docSettings = Seq(
   micrositePushSiteWith := GitHub4s,
   micrositeGithubToken := sys.env.get("SBT_MICROSITES_PUBLISH_TOKEN"),
   ghpagesNoJekyll := false,
-  fork in tut := true
+  fork in tut := true,
+  micrositeEditButton := Some(MicrositeEditButton("Improve this page", "/edit/master/modules/docs/src/main/tut/{{ page.path }}"))
 )
 
 lazy val docs = (project in file("modules/docs"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,7 +32,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
 
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.22")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.24")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 


### PR DESCRIPTION
I added a feature to the sbt-microsites plugin that adds an edit button at the bottom of doc pages. https://github.com/47deg/sbt-microsites/pull/278. I think it will make it easier for folks to make doc contributions if they spot an issue while reading through.
 
<img width="1006" alt="edit button in doc page" src="https://user-images.githubusercontent.com/4439228/46675888-6e977300-cbad-11e8-8248-1fdbcf594063.png">


Changes in this pull request:
- Upgrade sbt-microsites plugin to 0.7.24
- enable micrositeEditButton setting:
  - Used "Improve this page" as the text
  - the link goes to the edit view of a page, for example the Portal Guide page (https://www.vinyldns.io/portal/) will link to https://github.com/VinylDNS/vinyldns/edit/master/modules/docs/src/main/tut/portal/index.md
