### PR TITLE
allow minor coverage drop

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1
+    patch:
+      default:
+        threshold: 0.1


### PR DESCRIPTION
Codecov gets angry for any small fluctuation in coverage. this should allow a very minor drop.