### PR TITLE
WIP Mysql bench

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -301,6 +301,27 @@ lazy val mysql = (project in file("modules/mysql"))
     fork in IntegrationTest := true,
   ).dependsOn(core % "compile->compile;test->test")
 
+lazy val benchmark = (project in file("modules/benchmark"))
+  .enablePlugins(DockerComposePlugin, AutomateHeaderPlugin)
+  .configs(IntegrationTest)
+  .settings(sharedSettings)
+  .settings(headerSettings(IntegrationTest))
+  .settings(inConfig(IntegrationTest)(scalafmtConfigSettings))
+  .settings(corePublishSettings)
+  .settings(testSettings)
+  .settings(Defaults.itSettings)
+  .settings(scalaStyleCompile ++ scalaStyleTest)
+  .settings(
+    name := "benchmark",
+    fork in IntegrationTest := true,
+    libraryDependencies ++= Seq(
+      "co.fs2" %% "fs2-core" % "1.0.0",
+      "org.typelevel" %% "cats-effect" % "1.0.0",
+      "org.typelevel" %% "cats-core" % "1.4.0",
+    ),
+    fork in run := true
+  ).dependsOn(core, mysql)
+
 val preparePortal = TaskKey[Unit]("preparePortal", "Runs NPM to prepare portal for start")
 val checkJsHeaders = TaskKey[Unit]("checkJsHeaders", "Runs script to check for APL 2.0 license headers")
 val createJsHeaders = TaskKey[Unit]("createJsHeaders", "Runs script to prepend APL 2.0 license headers to files")

--- a/build.sbt
+++ b/build.sbt
@@ -318,6 +318,7 @@ lazy val benchmark = (project in file("modules/benchmark"))
       "co.fs2" %% "fs2-core" % "1.0.0",
       "org.typelevel" %% "cats-effect" % "1.0.0",
       "org.typelevel" %% "cats-core" % "1.4.0",
+      "org.elasticsearch" % "metrics-elasticsearch-reporter" % "2.2.0"
     ),
     fork in run := true
   ).dependsOn(core, mysql)

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ lazy val sharedSettings = Seq(
   scalacOptions in (Compile, doc) += "-no-link-warnings",
   // Use wart remover to eliminate code badness
   wartremoverErrors ++= Seq(
-    Wart.ArrayEquals,
     Wart.EitherProjectionPartial,
     Wart.IsInstanceOf,
     Wart.JavaConversions,

--- a/build.sbt
+++ b/build.sbt
@@ -298,6 +298,7 @@ lazy val mysql = (project in file("modules/mysql"))
   .settings(scalaStyleCompile ++ scalaStyleTest)
   .settings(
     organization := "io.vinyldns",
+    fork in IntegrationTest := true,
   ).dependsOn(core % "compile->compile;test->test")
 
 val preparePortal = TaskKey[Unit]("preparePortal", "Runs NPM to prepare portal for start")

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -19,7 +19,8 @@ package vinyldns.api
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.{ActorMaterializer, Materializer}
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
+import fs2.concurrent.SignallingRef
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.dropwizard.DropwizardExports
 import io.prometheus.client.hotspot.DefaultExports
@@ -46,6 +47,7 @@ object Boot extends App {
   private implicit val system: ActorSystem = VinylDNSConfig.system
   private implicit val materializer: Materializer = ActorMaterializer()
   private implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+  private implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
   def vinyldnsBanner(): IO[String] = IO {
     val stream = getClass.getResourceAsStream("/vinyldns-ascii.txt")
@@ -68,13 +70,14 @@ object Boot extends App {
       sqsConfig <- IO(VinylDNSConfig.sqsConfig)
       sqsConnection <- IO(SqsConnection(sqsConfig))
       processingDisabled <- IO(VinylDNSConfig.vinyldnsConfig.getBoolean("processing-disabled"))
-      processingSignal <- fs2.async.signalOf[IO, Boolean](processingDisabled)
+      processingSignal <- SignallingRef[IO, Boolean](processingDisabled)
       restHost <- IO(VinylDNSConfig.restConfig.getString("host"))
       restPort <- IO(VinylDNSConfig.restConfig.getInt("port"))
       batchChangeLimit <- IO(VinylDNSConfig.vinyldnsConfig.getInt("batch-change-limit"))
       syncDelay <- IO(VinylDNSConfig.vinyldnsConfig.getInt("sync-delay"))
-      _ <- fs2.async.start(
-        ProductionZoneCommandHandler.run(sqsConnection, processingSignal, repositories, sqsConfig))
+      _ <- ProductionZoneCommandHandler
+        .run(sqsConnection, processingSignal, repositories, sqsConfig)
+        .start
     } yield {
       val zoneValidations = new ZoneValidations(syncDelay)
       val batchChangeValidations = new BatchChangeValidations(batchChangeLimit, AccessValidations)

--- a/modules/api/src/main/scala/vinyldns/api/Interfaces.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Interfaces.scala
@@ -20,10 +20,14 @@ import cats.data._
 import cats.effect._
 import cats.implicits._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object Interfaces {
+
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   /* Our standard business error type */
   type Result[A] = EitherT[IO, Throwable, A]
@@ -104,7 +108,6 @@ object Interfaces {
       case None => result[A](ifNone)
     }
   }
-
 }
 
 object Result {

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -17,7 +17,7 @@
 package vinyldns.api
 
 import akka.actor.ActorSystem
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.typesafe.config.{Config, ConfigFactory}
 import pureconfig.module.catseffect.loadConfigF
@@ -29,6 +29,9 @@ import vinyldns.core.domain.zone.ZoneConnection
 import vinyldns.core.repository.DataStoreConfig
 
 object VinylDNSConfig {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   lazy val config: Config = ConfigFactory.load()
   lazy val vinyldnsConfig: Config = config.getConfig("vinyldns")

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.engine
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.syntax.all._
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
@@ -29,6 +29,8 @@ import vinyldns.core.route.Monitored
 object ZoneSyncHandler extends DnsConversions with Monitored {
 
   private implicit val logger = LoggerFactory.getLogger("vinyldns.engine.ZoneSyncHandler")
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(
       recordSetRepository: RecordSetRepository,

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -16,13 +16,16 @@
 
 package vinyldns.api.repository
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.joda.time.DateTime
 import vinyldns.core.domain.membership._
 
 // $COVERAGE-OFF$
 object TestDataLoader {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   final val testUser = User(
     userName = "testuser",

--- a/modules/api/src/main/scala/vinyldns/api/route/StatusRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/StatusRouting.scala
@@ -20,7 +20,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives
 import akka.util.Timeout
 import cats.effect.IO
-import fs2.async.mutable.Signal
+import fs2.concurrent.SignallingRef
 import vinyldns.api.VinylDNSConfig
 
 import scala.concurrent.duration._
@@ -43,7 +43,7 @@ trait StatusRoute extends Directives {
 
   implicit val timeout = Timeout(10.seconds)
 
-  def processingDisabled: Signal[IO, Boolean]
+  def processingDisabled: SignallingRef[IO, Boolean]
 
   val statusRoute =
     (get & path("status")) {

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
@@ -19,7 +19,6 @@ package vinyldns.api.route
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.server.RequestContext
 import cats.effect._
-import cats.syntax.all._
 import vinyldns.api.crypto.Crypto
 import vinyldns.api.domain.auth.AuthPrincipalProvider
 import vinyldns.core.crypto.CryptoAlgebra

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
@@ -23,7 +23,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import akka.http.scaladsl.server.directives.LogEntry
 import cats.effect.IO
-import fs2.async.mutable.Signal
+import fs2.concurrent.SignallingRef
 import io.prometheus.client.CollectorRegistry
 import vinyldns.api.domain.auth.MembershipAuthPrincipalProvider
 import vinyldns.api.domain.batch.BatchChangeServiceAlgebra
@@ -101,7 +101,7 @@ object VinylDNSService {
 // $COVERAGE-OFF$
 class VinylDNSService(
     val membershipService: MembershipServiceAlgebra,
-    val processingDisabled: Signal[IO, Boolean],
+    val processingDisabled: SignallingRef[IO, Boolean],
     val zoneService: ZoneServiceAlgebra,
     val healthService: HealthService,
     val recordSetService: RecordSetServiceAlgebra,

--- a/modules/benchmark/src/main/resources/application.conf
+++ b/modules/benchmark/src/main/resources/application.conf
@@ -1,0 +1,67 @@
+mysql {
+  class-name = "vinyldns.mysql.repository.MySqlDataStoreProvider"
+
+  settings {
+    # JDBC Settings, these are all values in scalikejdbc-config, not our own
+    # these must be overridden to use MYSQL for production use
+    # assumes a docker or mysql instance running locally
+    name = "vinyldns"
+    driver = "org.mariadb.jdbc.Driver"
+
+    # LOCAL DOCKER
+    migration-url = "jdbc:mariadb://localhost:19004/?user=root&password=pass"
+    url = "jdbc:mariadb://localhost:19004/vinyldns?user=root&password=pass"
+    user = "root"
+    password = "pass"
+
+    # TODO: Research optimal values for settings
+    pool-max-size = 20
+    connection-timeout-millis = 5000
+    max-life-time = 600000
+  }
+
+  repositories {
+    batch-change {}
+    zone {}
+    record-set {}
+    record-change {}
+  }
+}
+
+benchmark {
+  // benchmar config designed to insert 240 MM records across ~2 million zones
+  // number of zones that have 10 records
+  //xs = 1000000 // 1 million = 10 million records
+
+  // number of zones that have 100 records
+  //s = 1000000 // 1 million = 100 million records
+
+  // number of zones that have 1000 records
+  //m = 100000 // 100,000 = 100 million records
+
+  // number of zones that have 10,000 records
+  //l = 1000 // 1000 = 10 million records
+
+  // number of zones that have 100,000 records
+  //xl = 100 // 100 = 10 million records
+
+  // number of zones that have 1,000,000 records
+  //xxl = 10 // 10 = 10 million records
+
+  // TEST RUN
+  xs = 1
+  s = 1
+  m = 1
+  l = 1
+  xl = 1
+  xxl = 0
+}
+
+//scalikejdbc.global.loggingSQLAndTime.enabled=true
+//scalikejdbc.global.loggingSQLAndTime.logLevel=error
+//scalikejdbc.global.loggingSQLAndTime.warningEnabled=true
+//scalikejdbc.global.loggingSQLAndTime.warningThresholdMillis=1000
+//scalikejdbc.global.loggingSQLAndTime.warningLogLevel=warn
+//scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
+//scalikejdbc.global.loggingSQLAndTime.printUnprocessedStackTrace=false
+//scalikejdbc.global.loggingSQLAndTime.stackTraceDepth=10

--- a/modules/benchmark/src/main/resources/application.conf
+++ b/modules/benchmark/src/main/resources/application.conf
@@ -28,6 +28,9 @@ mysql {
   }
 }
 
+// host:port of where to repot elastic search data to
+elasic-search-host = "1.2.3.4:9200"
+
 benchmark {
   // benchmar config designed to insert 240 MM records across ~2 million zones
   // number of zones that have 10 records

--- a/modules/benchmark/src/main/resources/application.conf
+++ b/modules/benchmark/src/main/resources/application.conf
@@ -53,7 +53,7 @@ benchmark {
   s = 1
   m = 1
   l = 1
-  xl = 1
+  xl = 0
   xxl = 0
 }
 

--- a/modules/benchmark/src/main/resources/logback.xml
+++ b/modules/benchmark/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <!-- Test configuration, log to console so we can get the docker logs -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d [test] %-5p | \(%logger{4}:%line\) | %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.flywaydb" level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/BenchmarkConfig.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/BenchmarkConfig.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+import cats.effect.IO
+import com.typesafe.config.ConfigFactory
+import pureconfig.module.catseffect._
+
+/**
+  * Benchmark configuration
+  * @param xs - number of xs zones, each contains 10 records
+  * @param s - number of s zones, each contains 100 records
+  * @param m - number of m zones, each contains 1000 records
+  * @param l - number of large zones, each contains 10,000 records
+  * @param xl - number of xl zones, each contains 100,000 records
+  * @param xxl - number of xxl zones, each contains 1MM records
+  */
+final case class BenchmarkConfig(xs: Int, s: Int, m: Int, l: Int, xl: Int, xxl: Int)
+object BenchmarkConfig {
+  def apply(): IO[BenchmarkConfig] =
+    loadConfigF[IO, BenchmarkConfig](ConfigFactory.load(), "benchmark")
+}

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/BulkLoader.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/BulkLoader.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+
+import java.util.concurrent.atomic.AtomicLong
+
+import cats.effect._
+import cats.implicits._
+import fs2.{Chunk, Sink, Stream}
+import org.slf4j.LoggerFactory
+import vinyldns.core.domain.record.{
+  ChangeSet,
+  RecordChangeRepository,
+  RecordSetChange,
+  RecordSetRepository
+}
+import vinyldns.core.domain.zone.ZoneRepository
+import vinyldns.core.route.Monitor
+
+object BulkLoader {
+  import ZoneGeneration._
+  implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+  private val logger = LoggerFactory.getLogger("BENCHMARK")
+
+  def saveChunkOfChanges(
+      recordRepo: RecordSetRepository,
+      changeRepo: RecordChangeRepository): Sink[IO, Chunk[RecordSetChange]] =
+    _.evalMap { changes =>
+      if (changes.isEmpty) IO.unit
+      else {
+        for {
+          cs <- IO(ChangeSet(changes.toList))
+          _ <- recordRepo.apply(cs)
+          _ <- changeRepo.save(cs)
+        } yield ()
+      }
+    }
+
+  def saveZone(zoneRepository: ZoneRepository): Sink[IO, ZoneGenerator] = _.evalMap { zg =>
+    zoneRepository.save(zg.zone).as(())
+  }
+
+  def benchmarkFlow(
+      config: BenchmarkConfig,
+      zoneRepo: ZoneRepository,
+      recordRepo: RecordSetRepository,
+      changeRepo: RecordChangeRepository): Stream[IO, Unit] = {
+    val recordSink = saveChunkOfChanges(recordRepo, changeRepo)
+    val saveThatZone = saveZone(zoneRepo)
+
+    // Zone streams is a stream of zone generators, each one having 10 - 1MM records
+    zoneStreams(config)
+      .observe(saveThatZone)
+      .map { zg =>
+        val startTime = new AtomicLong()
+        Stream
+          .eval(IO { startTime.set(System.currentTimeMillis) })
+          .flatMap { _ =>
+            zg.records.chunkN(10000).map(Stream.emit(_).covary[IO].to(recordSink)).parJoinUnbounded
+          }
+          .evalMap { _ =>
+            IO {
+              val runTime = System.currentTimeMillis - startTime.get
+              // add the latency to zone duration for this size
+              Monitor(s"bulkLoad.zone").latency += runTime
+              Monitor(s"bulkLoad.zone.${zg.size.value}").latency += runTime
+            }
+          }
+      }
+      .parJoinUnbounded
+  }
+
+  def run(
+      config: BenchmarkConfig,
+      zoneRepo: ZoneRepository,
+      recordRepo: RecordSetRepository,
+      changeRepo: RecordChangeRepository): Unit = {
+    val program = benchmarkFlow(config, zoneRepo, recordRepo, changeRepo).compile.drain
+
+    // run our program
+    logger.info("STARTING LOAD!!!")
+    val startTime = System.currentTimeMillis()
+    program.unsafeRunSync()
+    val duration = System.currentTimeMillis() - startTime
+    logger.info(s"FINISHED LOADING, took ${duration.toDouble / 1000.0} SECONDS!!!")
+  }
+}

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/MySql.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/MySql.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+import com.typesafe.config.{Config, ConfigFactory}
+import vinyldns.core.crypto.NoOpCrypto
+import vinyldns.core.domain.batch.BatchChangeRepository
+import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetRepository}
+import vinyldns.core.domain.zone.{ZoneChangeRepository, ZoneRepository}
+import vinyldns.core.repository.{DataStore, DataStoreConfig, RepositoryName}
+import vinyldns.mysql.repository.MySqlDataStoreProvider
+
+trait MySqlIntegrationSpec {
+  def mysqlConfig: Config
+
+  lazy val dataStoreConfig: DataStoreConfig =
+    pureconfig.loadConfigOrThrow[DataStoreConfig](mysqlConfig)
+
+  lazy val instance: DataStore =
+    new MySqlDataStoreProvider().load(dataStoreConfig, new NoOpCrypto()).unsafeRunSync()
+
+  lazy val batchChangeRepository: BatchChangeRepository =
+    instance.get[BatchChangeRepository](RepositoryName.batchChange).get
+  lazy val zoneRepository: ZoneRepository =
+    instance.get[ZoneRepository](RepositoryName.zone).get
+  lazy val zoneChangeRepository: ZoneChangeRepository =
+    instance.get[ZoneChangeRepository](RepositoryName.zoneChange).get
+  lazy val recordSetRepository: RecordSetRepository =
+    instance.get[RecordSetRepository](RepositoryName.recordSet).get
+  lazy val recordChangeRepository: RecordChangeRepository =
+    instance.get[RecordChangeRepository](RepositoryName.recordChange).get
+}
+
+object TestMySqlInstance extends MySqlIntegrationSpec {
+  def mysqlConfig: Config = ConfigFactory.load().getConfig("mysql")
+}

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/NameGenerators.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/NameGenerators.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+import scala.util.Random
+
+object NameGenerators {
+
+  // Random words that we will use for record names
+  val rList1 =
+    Seq("fresh", "wrong", "nippy", "dusty", "loose", "gabby", "picky", "flaky", "weary", "curly")
+  val rList2 = Seq("sofa", "boat", "baby", "skin", "bell", "army", "drug", "fish", "duck", "food")
+
+  // Random words that we will use for zone names
+  val zoneName = Seq(
+    "floaty",
+    "mythos",
+    "uproot",
+    "alcade",
+    "octroi",
+    "hosier",
+    "pixies",
+    "helice",
+    "stager",
+    "logier")
+  val zoneTLD = Seq("net", "com", "foo", "bar", "pop", "mom", "you", "can", "dan", "she")
+
+  def generateRecordName(idx: Int): String = {
+    val nameIdx = idx % 10
+    "r" + idx + "-" + rList1(nameIdx) + "-" + rList2(nameIdx)
+  }
+
+  def recordNamePermutations: Seq[String] =
+    for {
+      r1 <- rList1
+      r2 <- rList2
+    } yield r1 + "-" + r2
+
+  val zoneRnd = new Random
+  def generateZoneName(zoneSize: ZoneSize, idx: Int): String = {
+    val r1 = zoneRnd.nextInt(10)
+    val r2 = zoneRnd.nextInt(10)
+    val sb = new StringBuilder
+
+    // Important, zone name follows z.xl.100.floaty.net., as subsequent processing depends on this zone name
+    sb.append("z.")
+      .append(zoneSize.value)
+      .append(".")
+      .append(idx)
+      .append(".")
+      .append(zoneName(r1))
+      .append(".")
+      .append(zoneTLD(r2))
+      .append(".")
+    sb.toString
+  }
+
+}

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/RecordSetQueryTester.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/RecordSetQueryTester.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+
+import cats.data.{NonEmptyList, OptionT}
+import cats.effect._
+import cats.implicits._
+import fs2._
+import vinyldns.core.domain.record.RecordType.RecordType
+import vinyldns.core.domain.record.{FQDN, RecordSet, RecordSetRepository, RecordType}
+import vinyldns.core.domain.zone.{Zone, ZoneRepository}
+import vinyldns.core.route.{Monitor, Monitored}
+
+/* Let's run different queries across each zone size */
+object RecordSetQueryTester extends Monitored {
+  final case class KnownRecord(name: String, typ: RecordType)
+  final case class TestZone(size: ZoneSize, zone: Zone, rs: RecordSet)
+  final case class TestZones(
+      xs: Option[TestZone],
+      s: Option[TestZone],
+      m: Option[TestZone],
+      l: Option[TestZone],
+      xl: Option[TestZone],
+      xxl: Option[TestZone]) {
+    def toList: List[TestZone] = (xs ++ s ++ m ++ l ++ xl ++ xxl).toList
+  }
+
+  // we know the records because the generation is deterministic
+  val knownRecords: NonEmptyList[KnownRecord] = NonEmptyList.of(
+    KnownRecord(NameGenerators.generateRecordName(1), RecordType.AAAA),
+    KnownRecord(NameGenerators.generateRecordName(2), RecordType.CNAME),
+    KnownRecord(NameGenerators.generateRecordName(3), RecordType.A)
+  )
+
+  def loadTestZone(
+      zoneRepo: ZoneRepository,
+      recordRepo: RecordSetRepository,
+      size: ZoneSize): IO[Option[TestZone]] = {
+    for {
+      zone <- OptionT(zoneRepo.getZonesByFilters(Set(s"z.${size.value}.1.")).map(_.headOption)) // ONLY 1 ZONE!!!
+      kr <- OptionT.liftF(IO.pure(knownRecords.head))
+      rs <- OptionT(recordRepo.getRecordSets(zone.id, kr.name, kr.typ).map(_.headOption))
+    } yield TestZone(size, zone, rs)
+  }.value
+
+  /* Load one zone of each size, there maybe none of a certain size keep that in mind */
+  def loadTestZones(zoneRepo: ZoneRepository, recordRepo: RecordSetRepository): IO[TestZones] =
+    for {
+      xs <- loadTestZone(zoneRepo, recordRepo, ZoneSize.XS)
+      s <- loadTestZone(zoneRepo, recordRepo, ZoneSize.S)
+      m <- loadTestZone(zoneRepo, recordRepo, ZoneSize.M)
+      l <- loadTestZone(zoneRepo, recordRepo, ZoneSize.L)
+      xl <- loadTestZone(zoneRepo, recordRepo, ZoneSize.XL)
+      xxl <- loadTestZone(zoneRepo, recordRepo, ZoneSize.XXL)
+    } yield TestZones(xs, s, m, l, xl, xxl)
+
+  def measure[A](name: String, size: ZoneSize)(f: => IO[A]): IO[Unit] =
+    for {
+      startTime <- IO(System.currentTimeMillis)
+      _ <- f
+      latency <- IO(System.currentTimeMillis - startTime)
+    } yield {
+      Monitor(s"query.$name.${size.value}").latency += latency
+      Monitor(s"query.$name").latency += latency
+    }
+
+  def measure[A](name: String, testZones: TestZones)(f: TestZone => IO[A]): IO[Unit] =
+    testZones.toList
+      .map(z => measure(name, z.size)(f(z)))
+      .sequence
+      .as(())
+
+  def getRecordSetsByNameAndType(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    measure("getRecordSetsByNameAndType", testZones) { z =>
+      recordRepo.getRecordSets(z.zone.id, z.rs.name, z.rs.typ)
+    }
+
+  def getRecordSetById(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    measure("getRecordSetById", testZones) { z =>
+      recordRepo.getRecordSet(z.zone.id, z.rs.id)
+    }
+
+  def listRecordSets(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    measure("listRecordSets", testZones) { z =>
+      recordRepo.listRecordSets(z.zone.id, None, Some(100), None)
+    }
+
+  def getRecordSetsByName(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    measure("getRecordSetsByName", testZones) { z =>
+      recordRepo.getRecordSetsByName(z.zone.id, z.rs.name)
+    }
+
+  def getRecordSetCount(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    measure("getRecordSetCount", testZones) { z =>
+      recordRepo.getRecordSetCount(z.zone.id)
+    }
+
+  def getRecordSetByFQDN(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    measure("getRecordSetByFQDN", testZones) { z =>
+      recordRepo.getRecordSetsByFQDN(List(FQDN(z.rs.name, z.zone.name)))
+    }
+
+  // These following functions break the pattern for this special test...
+  def getFQDNs(recordRepo: RecordSetRepository, testZone: TestZone): List[FQDN] = {
+    // first load 500 records from the repo
+    val records = recordRepo.listRecordSets(testZone.zone.id, None, Some(500), None).unsafeRunSync()
+
+    // generate the list of FQDNs
+    records.recordSets.map(r => FQDN(r.name, testZone.zone.name))
+  }
+
+  def getRecordSetsByFQDN500(recordRepo: RecordSetRepository, fqdns: List[FQDN]): IO[Unit] =
+    recordRepo.getRecordSetsByFQDN(fqdns).as(())
+
+  def getRecordSetByFQDN500(recordRepo: RecordSetRepository, testZones: TestZones): IO[Unit] =
+    testZones.toList
+      .map { z =>
+        val fqdns = getFQDNs(recordRepo, z) // done first so we do not time it!! Important!!
+        measure("getRecordSetsByFQDN500", z.size)(getRecordSetsByFQDN500(recordRepo, fqdns))
+      }
+      .sequence
+      .as(())
+
+  def runSingle(testZones: TestZones, recordRepo: RecordSetRepository): IO[Unit] =
+    for {
+      _ <- getRecordSetsByNameAndType(recordRepo, testZones)
+      _ <- getRecordSetById(recordRepo, testZones)
+      _ <- listRecordSets(recordRepo, testZones)
+      _ <- getRecordSetsByName(recordRepo, testZones)
+      _ <- getRecordSetCount(recordRepo, testZones)
+      _ <- getRecordSetByFQDN(recordRepo, testZones)
+      _ <- getRecordSetByFQDN500(recordRepo, testZones)
+    } yield ()
+
+  // Runs the test count number of times
+  def iterations(count: Int)(singleTest: IO[Unit]): IO[Unit] =
+    Stream.repeatEval(singleTest).take(count).compile.drain
+
+  def run(zoneRepo: ZoneRepository, recordRepo: RecordSetRepository): Unit = {
+    // NOTE!  Assumes the BulkLoader has been run!!
+    val program = for {
+      _ <- IO(println("STARTING QUERY TESTS!!!"))
+      testZones <- loadTestZones(zoneRepo, recordRepo)
+      _ <- IO(println(s"WE HAVE ${testZones.toList.size} TEST ZONES!!!"))
+      _ <- iterations(100)(runSingle(testZones, recordRepo))
+      _ <- IO(println("FINISHED QUERY TESTS!!!"))
+    } yield ()
+    program.unsafeRunSync()
+  }
+}

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/Runner.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/Runner.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+import cats.effect.IO
+import com.codahale.metrics.CsvReporter
+import vinyldns.core.VinylDNSMetrics
+import vinyldns.mysql.repository.{
+  MySqlRecordChangeRepository,
+  MySqlRecordSetRepository,
+  MySqlZoneRepository
+}
+
+object Runner {
+
+  def main(args: Array[String]): Unit = {
+    // kick off our CSV recording
+    val reporter = CsvReporter
+      .forRegistry(VinylDNSMetrics.metricsRegistry)
+      .formatFor(Locale.US)
+      .convertRatesTo(TimeUnit.SECONDS)
+      .convertDurationsTo(TimeUnit.MILLISECONDS)
+      .build(new File(("target/")))
+
+    reporter.start(1, TimeUnit.SECONDS)
+
+    val config = BenchmarkConfig().unsafeRunSync()
+    val recordRepo = IO(TestMySqlInstance.recordSetRepository)
+      .unsafeRunSync()
+      .asInstanceOf[MySqlRecordSetRepository]
+    val zoneRepo = IO(TestMySqlInstance.zoneRepository)
+      .unsafeRunSync()
+      .asInstanceOf[MySqlZoneRepository]
+    val changeRepo = IO(TestMySqlInstance.recordChangeRepository)
+      .unsafeRunSync()
+      .asInstanceOf[MySqlRecordChangeRepository]
+    BulkLoader.run(config, zoneRepo, recordRepo, changeRepo)
+    RecordSetQueryTester.run(zoneRepo, recordRepo)
+
+    // sleep a little to allow the reporter to output some things
+    println("FINISHED BENCHMARK!")
+    Thread.sleep(5000)
+  }
+}

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/Runner.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/Runner.scala
@@ -15,12 +15,10 @@
  */
 
 package vinyldns.benchmark
-import java.io.File
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
-import com.codahale.metrics.CsvReporter
+import org.elasticsearch.metrics.ElasticsearchReporter
 import vinyldns.core.VinylDNSMetrics
 import vinyldns.mysql.repository.{
   MySqlRecordChangeRepository,
@@ -32,15 +30,11 @@ object Runner {
 
   def main(args: Array[String]): Unit = {
     // kick off our CSV recording
-    val reporter = CsvReporter
+    val reporter = ElasticsearchReporter
       .forRegistry(VinylDNSMetrics.metricsRegistry)
-      .formatFor(Locale.US)
-      .convertRatesTo(TimeUnit.SECONDS)
-      .convertDurationsTo(TimeUnit.MILLISECONDS)
-      .build(new File(("target/")))
-
+      .hosts("96.118.208.210:9200")
+      .build()
     reporter.start(1, TimeUnit.SECONDS)
-
     val config = BenchmarkConfig().unsafeRunSync()
     val recordRepo = IO(TestMySqlInstance.recordSetRepository)
       .unsafeRunSync()

--- a/modules/benchmark/src/main/scala/vinyldns/benchmark/ZoneGeneration.scala
+++ b/modules/benchmark/src/main/scala/vinyldns/benchmark/ZoneGeneration.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.benchmark
+import java.util.UUID
+
+import cats.effect.IO
+import fs2.Stream
+import org.joda.time.DateTime
+import vinyldns.core.domain.record._
+import vinyldns.core.domain.zone.Zone
+
+final case class ZoneGenerator(zone: Zone, size: ZoneSize, records: fs2.Stream[IO, RecordSetChange])
+
+sealed abstract class ZoneSize(val value: String, val recordCount: Int)
+object ZoneSize {
+  case object XS extends ZoneSize("xs", 10)
+  case object S extends ZoneSize("s", 100)
+  case object M extends ZoneSize("m", 1000)
+  case object L extends ZoneSize("l", 10000)
+  case object XL extends ZoneSize("xl", 100000)
+  case object XXL extends ZoneSize("xxl", 1000000)
+}
+
+object ZoneGeneration {
+  // a zone generator has a zone, but also an FS2 stream of records that you can pull from lazily
+  // to manage memory
+  val ZoneEmail = "test@test.com"
+  val BenchMarkGroupId = "benchmark-00000000000000000000000000"
+
+  val aTemplate: RecordSet = RecordSet(
+    "change-me",
+    "ok",
+    RecordType.A,
+    200,
+    RecordSetStatus.Active,
+    DateTime.now,
+    None,
+    List(AData("10.1.1.1")))
+
+  val aaaaTemplate: RecordSet = RecordSet(
+    "change-me",
+    "aaaa",
+    RecordType.AAAA,
+    200,
+    RecordSetStatus.Pending,
+    DateTime.now,
+    None,
+    List(AAAAData("1:2:3:4:5:6:7:8")))
+
+  val cnameTemplate: RecordSet = RecordSet(
+    "change-me",
+    "cname",
+    RecordType.CNAME,
+    200,
+    RecordSetStatus.Pending,
+    DateTime.now,
+    None,
+    List(CNAMEData("cname")))
+
+  val userId = "some-user"
+
+  def generateRecordSet(zoneId: String, idx: Int): RecordSet = {
+    // most records are going to be A, AAAA, CNAME with a single RData, pick from the 3
+    val rs = idx % 3 match {
+      case 0 => aTemplate
+      case 1 => aaaaTemplate
+      case 2 => cnameTemplate
+    }
+    rs.copy(
+      zoneId = zoneId,
+      name = NameGenerators.generateRecordName(idx),
+      id = UUID.randomUUID().toString)
+  }
+
+  def generateZone(zoneSize: ZoneSize, idx: Int): Zone =
+    Zone(
+      NameGenerators.generateZoneName(zoneSize, idx),
+      ZoneEmail,
+      adminGroupId = BenchMarkGroupId
+    )
+
+  /**
+    * Continues to pull new records lazily until we have released the `count` number of record changes
+    */
+  def recordSetStream(zone: Zone, recordCount: Int): Stream[IO, RecordSetChange] =
+    Stream
+      .unfold(1) {
+        // if we have hit our record count, by the laws of unfold return a none
+        case exhausted if exhausted > recordCount => None
+        case offset =>
+          // we have not reached our record count, generate another my good man
+          val record =
+            RecordSetChange(
+              zone,
+              generateRecordSet(zone.id, offset),
+              userId,
+              RecordSetChangeType.Create,
+              RecordSetChangeStatus.Applied
+            )
+          Some((record, offset + 1))
+      }
+      .covary[IO]
+
+  /**
+    * Lazily creates zone generators for zones of a given record size.  Follows pattern of recordSetStream
+    */
+  def zoneStream(zoneSize: ZoneSize, zoneCount: Int): Stream[IO, ZoneGenerator] =
+    Stream
+      .unfold(1) {
+        case exhausted if exhausted > zoneCount => None
+        case offset =>
+          val z = generateZone(zoneSize, offset)
+          val generator = ZoneGenerator(z, zoneSize, recordSetStream(z, zoneSize.recordCount))
+          Some(generator, offset + 1) // be sure to advance
+      }
+
+  /**
+    * We will create a stream for each zone size (s, m, l, xl, xxl)
+    * So this is essentially a stream of streams.  We will concurrent join them through
+    * to the database
+    */
+  def zoneStreams(config: BenchmarkConfig): Stream[IO, ZoneGenerator] =
+    zoneStream(ZoneSize.XS, config.xs) ++
+      zoneStream(ZoneSize.S, config.s) ++
+      zoneStream(ZoneSize.M, config.m) ++
+      zoneStream(ZoneSize.L, config.l) ++
+      zoneStream(ZoneSize.XL, config.xl) ++
+      zoneStream(ZoneSize.XXL, config.xxl)
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/FQDN.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/FQDN.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain.record
+
+final case class FQDN private (value: String) extends AnyVal
+object FQDN {
+  // zoneName cannot be apex!
+  def apply(recordName: String, zoneName: String): FQDN = {
+    val rn = if (recordName.endsWith(".")) recordName else recordName + "."
+    val zn = if (zoneName.endsWith(".")) zoneName else zoneName + "."
+    new FQDN(rn + zn)
+  }
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -18,11 +18,14 @@ package vinyldns.core.domain.record
 
 import cats.effect._
 import vinyldns.core.domain.record.RecordType.RecordType
+import vinyldns.core.domain.zone.Zone
 import vinyldns.core.repository.Repository
 
 trait RecordSetRepository extends Repository {
 
   def apply(changeSet: ChangeSet): IO[ChangeSet]
+
+  def insert(zone: Zone, recordSets: List[RecordSet]): IO[Unit]
 
   def listRecordSets(
       zoneId: String,
@@ -37,4 +40,6 @@ trait RecordSetRepository extends Repository {
   def getRecordSetCount(zoneId: String): IO[Int]
 
   def getRecordSetsByName(zoneId: String, name: String): IO[List[RecordSet]]
+
+  def getRecordSetsByFQDN(fqdns: List[FQDN]): IO[List[RecordSet]]
 }

--- a/modules/core/src/main/scala/vinyldns/core/repository/DataStoreLoader.scala
+++ b/modules/core/src/main/scala/vinyldns/core/repository/DataStoreLoader.scala
@@ -17,7 +17,7 @@
 package vinyldns.core.repository
 
 import cats.data._
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import vinyldns.core.crypto.CryptoAlgebra
 import org.slf4j.LoggerFactory
@@ -28,6 +28,7 @@ import scala.reflect.ClassTag
 object DataStoreLoader {
 
   private val logger = LoggerFactory.getLogger("DataStoreLoader")
+  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def loadAll[A <: DataAccessor](
       configs: List[DataStoreConfig],

--- a/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
+++ b/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
@@ -66,7 +66,7 @@ trait Monitored {
   */
 object Monitor {
 
-  lazy val monitors: mutable.Map[String, Monitor] = concurrent.TrieMap.empty
+  lazy val monitors: mutable.Map[String, Monitor] = scala.collection.concurrent.TrieMap.empty
 
   def apply(name: String): Monitor = monitors.getOrElseUpdate(name, new Monitor(name))
 

--- a/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
+++ b/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
@@ -94,13 +94,13 @@ class Monitor(val name: String) extends Instrumented {
   def duration(startTimeInMillis: Long): Long = System.currentTimeMillis() - startTimeInMillis
 
   def capture(duration: Long, success: Boolean): Unit = {
-    logger.info(Monitor.logEntry(name, duration, success))
+    logger.debug(Monitor.logEntry(name, duration, success))
     latency += duration
     if (!success) errors.mark()
   }
 
   def fail(duration: Long): Unit = {
-    logger.info(Monitor.logEntry(name, duration, success = false))
+    logger.debug(Monitor.logEntry(name, duration, success = false))
     latency += duration
     errors.mark()
   }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProvider.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProvider.scala
@@ -17,7 +17,7 @@
 package vinyldns.dynamodb.repository
 
 import cats.implicits._
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import org.slf4j.LoggerFactory
 import vinyldns.core.repository._
 import pureconfig.module.catseffect.loadConfigF
@@ -33,6 +33,8 @@ class DynamoDBDataStoreProvider extends DataStoreProvider {
   private val logger = LoggerFactory.getLogger("DynamoDBDataStoreProvider")
   private val implementedRepositories =
     Set(user, group, membership, groupChange, recordSet, recordChange, zoneChange, userChange)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def load(config: DataStoreConfig, crypto: CryptoAlgebra): IO[DataStore] =
     for {

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBHelper.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBHelper.scala
@@ -28,7 +28,7 @@ import org.slf4j.Logger
 import vinyldns.core.VinylDNSMetrics
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuration = 1.millis)
@@ -48,6 +48,7 @@ class DynamoDBHelper(dynamoDB: AmazonDynamoDBClient, log: Logger) {
 
   private[repository] val retryCount: Int = 10
   private val retryBackoff: FiniteDuration = 1.millis
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   private[repository] val provisionedThroughputMeter =
     VinylDNSMetrics.metricsRegistry.meter("dynamo.provisionedThroughput")

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -24,7 +24,8 @@ import com.amazonaws.services.dynamodbv2.model._
 import org.slf4j.{Logger, LoggerFactory}
 import vinyldns.core.domain.DomainHelpers.omitTrailingDot
 import vinyldns.core.domain.record.RecordType.RecordType
-import vinyldns.core.domain.record.{ChangeSet, ListRecordSetResults, RecordSet, RecordSetRepository}
+import vinyldns.core.domain.record._
+import vinyldns.core.domain.zone.Zone
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
 
@@ -123,6 +124,24 @@ class DynamoDBRecordSetRepository private[repository] (
       // Assuming we succeeded, then return the change set with a status of applied
       result.map(_ => changeSet)
     }
+
+  def insert(zone: Zone, recordSets: List[RecordSet]): IO[Unit] = {
+    monitor("repo.RecordSet.insert") {
+      val writeItems = recordSets.map(toWriteRequest)
+      val batchWrites = writeItems
+        .grouped(25)
+        .map(group => dynamoDBHelper.toBatchWriteItemRequest(group, recordSetTableName))
+
+      // Fold left will attempt each batch sequentially, and fail fast on error
+      val result = batchWrites.foldLeft(IO.pure(List.empty[BatchWriteItemResult])) {
+        case (acc, req) =>
+          acc.flatMap { lst =>
+            dynamoDBHelper.batchWriteItem(recordSetTableName, req).map(result => result :: lst)
+          }
+      }
+      result.as(())
+    }
+  }
 
   def putRecordSet(recordSet: RecordSet): IO[RecordSet] = { //TODO remove me
     val item = toItem(recordSet)
@@ -234,4 +253,9 @@ class DynamoDBRecordSetRepository private[repository] (
 
       responseFuture.map(resp => resp.asInstanceOf[QueryResponseCount].count)
     }
+
+  // NOT SUPPORTED!
+  def getRecordSetsByFQDN(fqdns: List[FQDN]): IO[List[RecordSet]] = IO {
+    Nil
+  }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -48,6 +48,8 @@ object DynamoDBUserRepository {
   private[repository] val USER_NAME_INDEX_NAME = "username_index"
   private[repository] val ACCESS_KEY_INDEX_NAME = "access_key_index"
   private val log: Logger = LoggerFactory.getLogger(classOf[DynamoDBUserRepository])
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(
       config: DynamoDBRepositorySettings,

--- a/modules/mysql/docker/conf/config-file.cnf
+++ b/modules/mysql/docker/conf/config-file.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+# Turn this on to record queries
+general_log = 1

--- a/modules/mysql/docker/docker-compose.yml
+++ b/modules/mysql/docker/docker-compose.yml
@@ -7,3 +7,5 @@ services:
     - MYSQL_ROOT_HOST=% # this is required as mysql is currently locked down to localhost
     ports:
     - "19004:3306"
+    volumes:
+    - ./conf:/etc/mysql/conf.d

--- a/modules/mysql/src/it/resources/application.conf
+++ b/modules/mysql/src/it/resources/application.conf
@@ -7,8 +7,8 @@ mysql {
     # assumes a docker or mysql instance running locally
     name = "vinyldns"
     driver = "org.mariadb.jdbc.Driver"
-    migration-url = "jdbc:mariadb://localhost:19004/?user=root&password=pass"
-    url = "jdbc:mariadb://localhost:19004/vinyldns?user=root&password=pass"
+    migration-url = "jdbc:mariadb://localhost:19004/?user=root&password=pass&rewriteBatchedStatements=true"
+    url = "jdbc:mariadb://localhost:19004/vinyldns?user=root&password=pass&rewriteBatchedStatements=true"
     user = "root"
     password = "pass"
     # TODO: Research optimal values for settings
@@ -20,5 +20,15 @@ mysql {
   repositories {
     batch-change {}
     zone {}
+    record-set {}
   }
 }
+
+scalikejdbc.global.loggingSQLAndTime.enabled=true
+scalikejdbc.global.loggingSQLAndTime.logLevel=error
+scalikejdbc.global.loggingSQLAndTime.warningEnabled=true
+scalikejdbc.global.loggingSQLAndTime.warningThresholdMillis=1000
+scalikejdbc.global.loggingSQLAndTime.warningLogLevel=warn
+scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
+scalikejdbc.global.loggingSQLAndTime.printUnprocessedStackTrace=false
+scalikejdbc.global.loggingSQLAndTime.stackTraceDepth=10

--- a/modules/mysql/src/it/resources/logback.xml
+++ b/modules/mysql/src/it/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <!-- Test configuration, log to console so we can get the docker logs -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d [test] %-5p | \(%logger{4}:%line\) | %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.flywaydb" level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlIntegrationSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.zone.{ZoneChangeRepository, ZoneRepository}
 import vinyldns.core.crypto.NoOpCrypto
-import vinyldns.core.domain.record.RecordSetRepository
+import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetRepository}
 import vinyldns.core.repository.{DataStore, DataStoreConfig, RepositoryName}
 
 trait MySqlIntegrationSpec {
@@ -39,6 +39,8 @@ trait MySqlIntegrationSpec {
     instance.get[ZoneChangeRepository](RepositoryName.zoneChange).get
   lazy val recordSetRepository: RecordSetRepository =
     instance.get[RecordSetRepository](RepositoryName.recordSet).get
+  lazy val recordChangeRepository: RecordChangeRepository =
+    instance.get[RecordChangeRepository](RepositoryName.recordChange).get
 }
 
 object TestMySqlInstance extends MySqlIntegrationSpec {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlIntegrationSpec.scala
@@ -20,6 +20,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.zone.{ZoneChangeRepository, ZoneRepository}
 import vinyldns.core.crypto.NoOpCrypto
+import vinyldns.core.domain.record.RecordSetRepository
 import vinyldns.core.repository.{DataStore, DataStoreConfig, RepositoryName}
 
 trait MySqlIntegrationSpec {
@@ -36,6 +37,8 @@ trait MySqlIntegrationSpec {
     instance.get[ZoneRepository](RepositoryName.zone).get
   lazy val zoneChangeRepository: ZoneChangeRepository =
     instance.get[ZoneChangeRepository](RepositoryName.zoneChange).get
+  lazy val recordSetRepository: RecordSetRepository =
+    instance.get[RecordSetRepository](RepositoryName.recordSet).get
 }
 
 object TestMySqlInstance extends MySqlIntegrationSpec {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import cats.scalatest.EitherMatchers
 import org.scalatest._
 import scalikejdbc.DB
-import vinyldns.core.domain.record.{ChangeSet, FQDN, RecordSetChange}
+import vinyldns.core.domain.record.{ChangeSet, RecordSetChange}
 import vinyldns.core.domain.zone.Zone
 
 class MySqlRecordSetRepositoryIntegrationSpec
@@ -77,14 +77,14 @@ class MySqlRecordSetRepositoryIntegrationSpec
       repo.apply(bigPendingChangeSet).attempt.unsafeRunSync() shouldBe right
     }
     "work for multiple inserts" in {
-      val pendingChanges = generateInserts(okZone, 1000)
+      val pendingChanges = generateInserts(okZone, 20)
 
       val bigPendingChangeSet = ChangeSet(pendingChanges)
       repo.apply(bigPendingChangeSet).unsafeRunSync()
 
       // let's make sure we have all 1000 records
       val recordCount = repo.getRecordSetCount(okZone.id).unsafeRunSync()
-      recordCount shouldBe 1000
+      recordCount shouldBe 20
     }
     "works for deletes, updates, and inserts" in {
       // create some record sets to be updated

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package vinyldns.mysql.repository
 import java.util.UUID
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -1,0 +1,101 @@
+package vinyldns.mysql.repository
+import java.util.UUID
+
+import cats.scalatest.EitherMatchers
+import org.scalatest._
+import scalikejdbc.DB
+import vinyldns.core.domain.record.{ChangeSet, RecordSetChange}
+import vinyldns.core.domain.zone.Zone
+
+class MySqlRecordSetRepositoryIntegrationSpec
+  extends WordSpec
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with Matchers
+    with Inspectors
+    with OptionValues with EitherMatchers {
+
+  import vinyldns.core.TestRecordSetData._
+  import vinyldns.core.TestZoneData._
+  private var repo: MySqlRecordSetRepository = _
+
+  override protected def beforeAll(): Unit =
+    repo = TestMySqlInstance.recordSetRepository.asInstanceOf[MySqlRecordSetRepository]
+
+  override protected def beforeEach(): Unit =
+    DB.localTx { s =>
+      s.executeUpdate("DELETE FROM recordset")
+    }
+
+  def generateInserts(zone: Zone, count: Int): List[RecordSetChange] = {
+    val newRecordSets =
+      for {
+        i <- 1 to count
+      } yield
+        aaaa.copy(
+          zoneId = zone.id,
+          name = s"$i-apply-test",
+          id = UUID.randomUUID().toString)
+
+    newRecordSets.map(makeTestAddChange(_, zone)).toList
+  }
+
+  def insert(zone: Zone, count: Int): List[RecordSetChange] = {
+    val pendingChanges = generateInserts(zone, count)
+    val bigPendingChangeSet = ChangeSet(pendingChanges)
+    repo.apply(bigPendingChangeSet).unsafeRunSync()
+    pendingChanges
+  }
+
+  "inserting record sets" should {
+    "be idempotent for inserts" in {
+      val pendingChanges = generateInserts(okZone, 1000)
+      val bigPendingChangeSet = ChangeSet(pendingChanges)
+      repo.apply(bigPendingChangeSet).unsafeRunSync()
+      repo.apply(bigPendingChangeSet).attempt.unsafeRunSync() shouldBe right
+    }
+    "work for multiple inserts" in {
+      val pendingChanges = generateInserts(okZone, 1000)
+
+      val bigPendingChangeSet = ChangeSet(pendingChanges)
+      repo.apply(bigPendingChangeSet).unsafeRunSync()
+
+      // let's make sure we have all 1000 records
+      val recordCount = repo.getRecordSetCount(okZone.id).unsafeRunSync()
+      recordCount shouldBe 1000
+    }
+    "works for deletes, updates, and inserts" in {
+      // create some record sets to be updated
+      val existing = insert(okZone, 10).map(_.recordSet)
+
+      // update a few, delete a few
+      val deletes = existing.take(2).map(makeTestDeleteChange(_, okZone))
+
+      // updates we will just add the letter u to
+      val updates = existing.slice(3, 5).map { rs =>
+        val update = rs.copy(name = "u" + rs.name)
+        makeTestUpdateChange(rs, update, okZone)
+      }
+
+      // insert a few more
+      val inserts = generateInserts(okZone, 2)
+
+      // exercise the entire change set
+      val cs = ChangeSet(deletes ++ updates ++ inserts)
+      repo.apply(cs).unsafeRunSync()
+
+      // make sure the deletes are gone
+      repo.getRecordSet(okZone.id, deletes(0).recordSet.id).unsafeRunSync() shouldBe None
+      repo.getRecordSet(okZone.id, deletes(1).recordSet.id).unsafeRunSync() shouldBe None
+
+      // make sure the updates are updated
+      repo.getRecordSet(okZone.id, updates(0).recordSet.id).unsafeRunSync().map(_.name) shouldBe Some(updates(0).recordSet.name)
+      repo.getRecordSet(okZone.id, updates(1).recordSet.id).unsafeRunSync().map(_.name) shouldBe Some(updates(1).recordSet.name)
+
+      // make sure the new ones are there
+      repo.getRecordSet(okZone.id, inserts(0).recordSet.id).unsafeRunSync().map(_.name) shouldBe Some(inserts(0).recordSet.name)
+      repo.getRecordSet(okZone.id, inserts(1).recordSet.id).unsafeRunSync().map(_.name) shouldBe Some(inserts(1).recordSet.name)
+    }
+  }
+
+}

--- a/modules/mysql/src/main/resources/db/migration/V3.2__RecordSet.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.2__RecordSet.sql
@@ -6,8 +6,10 @@ CREATE TABLE recordset (
   id CHAR(36) NOT NULL,
   zone_id CHAR(36) NOT NULL,
   name VARCHAR(256) NOT NULL,
+  fqdn VARCHAR(256) NOT NULL,
   type TINYINT NOT NULL,
   data BLOB NOT NULL,
   PRIMARY KEY (id),
-  INDEX zone_id_name_index (zone_id, name, type)
+  INDEX zone_id_name_index (zone_id, name, type),
+  INDEX fqdn_index (fqdn, type)
 );

--- a/modules/mysql/src/main/resources/db/migration/V3.2__RecordSet.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.2__RecordSet.sql
@@ -1,0 +1,13 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+CREATE TABLE recordset (
+  id CHAR(36) NOT NULL,
+  zone_id CHAR(36) NOT NULL,
+  name VARCHAR(256) NOT NULL,
+  type TINYINT NOT NULL,
+  data BLOB NOT NULL,
+  PRIMARY KEY (id),
+  INDEX zone_id_name_index (zone_id, name, type)
+);

--- a/modules/mysql/src/main/resources/db/migration/V3.3__RecordChange.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.3__RecordChange.sql
@@ -1,0 +1,14 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+CREATE TABLE record_change (
+  id CHAR(36) NOT NULL,
+  zone_id CHAR(36) NOT NULL,
+  created BIGINT(13) NOT NULL,
+  type TINYINT NOT NULL,
+  data BLOB NOT NULL,
+  PRIMARY KEY (id),
+  INDEX zone_id_index (zone_id),
+  INDEX created_index (created)
+);

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -117,6 +117,17 @@ class MySqlDataStoreProvider extends DataStoreProvider {
       ds.setMaximumPoolSize(settings.poolMaxSize)
       ds.setMaxLifetime(settings.maxLifeTime)
       ds.setRegisterMbeans(true)
+
+      // rewriteBatchedStatements is critical to bulk inserts
+      // the others come recommended by HikariCP
+      ds.addDataSourceProperty("rewriteBatchedStatements", true)
+      ds.addDataSourceProperty("cachePrepStmts", true)
+      ds.addDataSourceProperty("useServerPrepStmts", true)
+      ds.addDataSourceProperty("useLocalSessionState", true)
+      ds.addDataSourceProperty("cacheResultSetMetadata", true)
+      ds.addDataSourceProperty("cacheServerConfiguration", true)
+      ds.addDataSourceProperty("prepStmtCacheSize", 250)
+      ds.addDataSourceProperty("prepStmtCacheSqlLimit", 4096)
       ds
     }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -37,7 +37,9 @@ class MySqlDataStoreProvider extends DataStoreProvider {
       RepositoryName.zone,
       RepositoryName.batchChange,
       RepositoryName.zoneChange,
-      RepositoryName.recordSet)
+      RepositoryName.recordSet,
+      RepositoryName.recordChange
+    )
 
   def load(config: DataStoreConfig, cryptoAlgebra: CryptoAlgebra): IO[DataStore] =
     for {
@@ -64,11 +66,13 @@ class MySqlDataStoreProvider extends DataStoreProvider {
     val batchChanges = Some(new MySqlBatchChangeRepository())
     val zoneChanges = Some(new MySqlZoneChangeRepository())
     val recordSets = Some(new MySqlRecordSetRepository())
+    val recordChanges = Some(new MySqlRecordChangeRepository())
     DataStore(
       zoneRepository = zones,
       batchChangeRepository = batchChanges,
       zoneChangeRepository = zoneChanges,
-      recordSetRepository = recordSets
+      recordSetRepository = recordSets,
+      recordChangeRepository = recordChanges
     )
   }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -33,7 +33,11 @@ class MySqlDataStoreProvider extends DataStoreProvider {
 
   private val logger = LoggerFactory.getLogger("MySqlDataStoreProvider")
   private val implementedRepositories =
-    Set(RepositoryName.zone, RepositoryName.batchChange, RepositoryName.zoneChange)
+    Set(
+      RepositoryName.zone,
+      RepositoryName.batchChange,
+      RepositoryName.zoneChange,
+      RepositoryName.recordSet)
 
   def load(config: DataStoreConfig, cryptoAlgebra: CryptoAlgebra): IO[DataStore] =
     for {
@@ -59,10 +63,13 @@ class MySqlDataStoreProvider extends DataStoreProvider {
     val zones = Some(new MySqlZoneRepository())
     val batchChanges = Some(new MySqlBatchChangeRepository())
     val zoneChanges = Some(new MySqlZoneChangeRepository())
+    val recordSets = Some(new MySqlRecordSetRepository())
     DataStore(
       zoneRepository = zones,
       batchChangeRepository = batchChanges,
-      zoneChangeRepository = zoneChanges)
+      zoneChangeRepository = zoneChanges,
+      recordSetRepository = recordSets
+    )
   }
 
   def runDBMigrations(settings: MySqlDataStoreSettings): IO[Unit] = IO {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -65,7 +65,7 @@ class MySqlDataStoreProvider extends DataStoreProvider {
     val zones = Some(new MySqlZoneRepository())
     val batchChanges = Some(new MySqlBatchChangeRepository())
     val zoneChanges = Some(new MySqlZoneChangeRepository())
-    val recordSets = Some(new MySqlRecordSetRepository())
+    val recordSets = Some(new MySqlRecordSetRepository(500))
     val recordChanges = Some(new MySqlRecordChangeRepository())
     DataStore(
       zoneRepository = zones,
@@ -135,7 +135,7 @@ class MySqlDataStoreProvider extends DataStoreProvider {
       ds
     }
 
-    logger.info("configuring connection pool")
+    logger.info("configuring connection pool for url " + settings.url)
 
     // Configure the connection pool
     ConnectionPool.singleton(new DataSourceConnectionPool(dataSource))

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
@@ -1,0 +1,124 @@
+package vinyldns.mysql.repository
+
+import java.sql.Connection
+
+import cats.effect._
+import cats.implicits._
+import org.mariadb.jdbc.MariaDbBlob
+import scalikejdbc._
+import vinyldns.core.domain.record.RecordSetChangeType.RecordSetChangeType
+import vinyldns.core.domain.record._
+import vinyldns.core.protobuf.ProtobufConversions
+import vinyldns.core.route.Monitored
+import vinyldns.proto.VinylDNSProto
+
+class MySqlRecordChangeRepository extends RecordChangeRepository with Monitored with ProtobufConversions {
+  import MySqlRecordChangeRepository._
+
+  // Important!  MySQL 5.6 does not have sorted indexes, so this maybe slow
+  private val LIST_CHANGES_WITH_START =
+    sql"""
+      |SELECT data
+      |  FROM record_change
+      | WHERE zone_id = ?
+      |   AND created < ?
+      |  ORDER BY created DESC
+      |  LIMIT ?
+    """.stripMargin
+
+  private val LIST_CHANGES_NO_START =
+    sql"""
+         |SELECT data
+         |  FROM record_change
+         | WHERE zone_id = ?
+         |  ORDER BY created DESC
+         |  LIMIT ?
+    """.stripMargin
+
+  private val GET_CHANGE =
+    sql"""
+      |SELECT data
+      |  FROM record_change
+      | WHERE id = ?
+    """.stripMargin
+
+  private def insert(records: Seq[RecordSetChange], conn: Connection): Seq[Int] = {
+    // Important!  We must do INSERT IGNORE here as we cannot do ON DUPLICATE KEY UPDATE
+    // with this mysql bulk insert.  To maintain idempotency, we must handle the possibility
+    // of the same insert happening multiple times.  IGNORE will ignore all errors unfortunately,
+    // but I fear we have no choice in the matter
+    val ps = conn.prepareStatement(
+      "INSERT IGNORE INTO record_change (id, zone_id, created, type, data) VALUES (?, ?, ?, ?, ?)")
+    records.foreach { r =>
+      ps.setString(1, r.id)
+      ps.setString(2, r.zoneId)
+      ps.setTimestamp(3, new java.sql.Timestamp(r.created.getMillis))
+      ps.setInt(4, fromChangeType(r.changeType))
+      ps.setBlob(6, new MariaDbBlob(toPB(r).toByteArray))
+      ps.addBatch()
+    }
+    ps.executeBatch().toSeq
+  }
+  /**
+  * We have the same issue with changes as record sets, namely we may have to save millions of them
+    *
+    * We do not need to distinguish between create, update, delete so this is simpler
+    */
+  def save(changeSet: ChangeSet): IO[ChangeSet] =
+    monitor("repo.RecordChange.save") {
+      IO {
+        DB.localTx { implicit s =>
+          changeSet.changes.grouped(1000).foreach { group =>
+            insert(group, s.connection)
+          }
+        }
+      }.as(changeSet)
+    }
+
+  def listRecordSetChanges(zoneId: String, startFrom: Option[String], maxItems: Int):
+    IO[ListRecordSetChangesResults] =
+      monitor("repo.RecordChange.listRecordSetChanges") {
+        IO {
+          DB.readOnly { implicit s =>
+            val changes = startFrom match {
+              case Some(start) =>
+                LIST_CHANGES_WITH_START.bind(zoneId, start, maxItems).map(toRecordSetChange).list().apply()
+              case None =>
+                LIST_CHANGES_NO_START.bind(zoneId, maxItems).map(toRecordSetChange).list().apply()
+            }
+
+            val nextId = if (changes.size < maxItems) None else changes.lastOption.map(_.created.getMillis.toString)
+
+            ListRecordSetChangesResults(
+              changes,
+              nextId,
+              startFrom,
+              maxItems
+            )
+          }
+        }
+      }
+
+  def getRecordSetChange(zoneId: String, changeId: String): IO[Option[RecordSetChange]] =
+    monitor("repo.RecordChange.listRecordSetChanges") {
+      IO {
+        DB.readOnly { implicit s =>
+          GET_CHANGE.bind(changeId).map(toRecordSetChange).single().apply()
+        }
+      }
+    }
+}
+
+object MySqlRecordChangeRepository extends ProtobufConversions {
+  val changeTypeLookup: Map[RecordSetChangeType, Int] = Map(
+    RecordSetChangeType.Create -> 1,
+    RecordSetChangeType.Delete -> 2,
+    RecordSetChangeType.Update -> 3
+  )
+
+  // This can throw an exception if the change type is not in the lookup map
+  def fromChangeType(ct: RecordSetChangeType): Int = changeTypeLookup(ct)
+
+  def toRecordSetChange(ws: WrappedResultSet): RecordSetChange =
+    fromPB(VinylDNSProto.RecordSetChange.parseFrom(ws.bytes(1)))
+}

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
@@ -135,6 +135,13 @@ class MySqlRecordChangeRepository
         }
       }
     }
+
+  def getTotalRecordChangeCount(): IO[Int] =
+    IO {
+      DB.readOnly { implicit s =>
+        sql"SELECT COUNT(*) FROM record_change".map(_.int(1)).single().apply().getOrElse(-1)
+      }
+    }
 }
 
 object MySqlRecordChangeRepository extends ProtobufConversions {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.mysql.repository
+
+import java.sql.Connection
+
+import cats.effect._
+import cats.implicits._
+import org.mariadb.jdbc.MariaDbBlob
+import scalikejdbc._
+import vinyldns.core.domain.record.RecordType.RecordType
+import vinyldns.core.domain.record._
+import vinyldns.core.protobuf.ProtobufConversions
+import vinyldns.core.route.Monitored
+import vinyldns.proto.VinylDNSProto
+
+class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
+  import MySqlRecordSetRepository._
+
+  private val FIND_BY_ZONEID_NAME_TYPE =
+    sql"""
+      |SELECT data
+      |  FROM recordset
+      | WHERE zone_id = {zoneId}, name = {name}, type = {type}
+    """.stripMargin
+
+  private val FIND_BY_ZONEID_NAME =
+    sql"""
+         |SELECT data
+         |  FROM recordset
+         | WHERE zone_id = {zoneId}, name = {name}
+    """.stripMargin
+
+  private val FIND_BY_ID =
+    sql"""
+         |SELECT data
+         |  FROM recordset
+         | WHERE id = {id}
+    """.stripMargin
+
+  private val COUNT_RECORDSETS_IN_ZONE =
+    sql"""
+         |SELECT count(*)
+         |  FROM recordset
+         | WHERE zone_id = {zoneId}
+    """.stripMargin
+
+  //private val INSERT_RECORDSET =
+  //  sql"INSERT INTO recordset (id, zone_id, name, type, data) VALUES (?, ?, ?, ?, ?)"
+
+  private val UPDATE_RECORDSET =
+    sql"UPDATE recordset SET zone_id = ?, name = ?, type = ?, data = ? WHERE id = ?"
+
+  private val DELETE_RECORDSET =
+    sql"DELETE FROM recordset WHERE id = ?"
+
+  /**
+    * Unsure if scalikejdbc is doing the correct thing by bulk insert in MySQL.
+    *
+    * This method takes a sequence of records, and appropriately builds the batch prepared statement
+    * using underlying JDBC things
+    */
+  private def insert(records: Seq[InsertRecord], conn: Connection): Seq[Int] = {
+    val ps = conn.prepareStatement(
+      "INSERT IGNORE INTO recordset (id, zone_id, name, type, data) VALUES (?, ?, ?, ?, ?)")
+    records.foreach { r =>
+      ps.setString(1, r.id)
+      ps.setString(2, r.zoneId)
+      ps.setString(3, r.recordName)
+      ps.setInt(4, r.recordType)
+      ps.setBlob(5, new MariaDbBlob(r.data))
+      ps.addBatch()
+    }
+    ps.executeBatch().toSeq
+  }
+
+  /**
+    * This is going to be tricky.  We need to generate INSERT INTO IGNORE VALUES
+    * using bulk insert syntax.  We have to group these into batches of some arbitrary size
+    * and loop through until we are done.
+    *
+    * This is going to be especially painful for large zones (millions of records)
+    *
+    * The size of each group needs to be profiled.  Articles point to being able to do bulk
+    * insert of 200,000 rows per second (for small rows of 26 bytes).  Our rows will be considerably
+    * larger than that (maybe 500 bytes).  Attempting to do batches of 1000 and seeing where
+    * we can go from there
+    */
+  def apply(changeSet: ChangeSet): IO[ChangeSet] =
+    monitor("repo.MySql.apply") {
+      val byChangeType = changeSet.changes.groupBy(_.changeType)
+      val inserts: Seq[InsertRecord] = byChangeType.getOrElse(RecordSetChangeType.Create, Nil).map {
+        i =>
+          // to avoid overhead, we are just returning Seq[Any]
+          // id, zone_id, name, type, data
+          InsertRecord(
+            i.recordSet.id,
+            i.zoneId,
+            i.recordSet.name,
+            fromRecordType(i.recordSet.typ),
+            toPB(i.recordSet).toByteArray
+          )
+      }
+
+      val updates: Seq[Seq[Any]] = byChangeType.getOrElse(RecordSetChangeType.Update, Nil).map {
+        u =>
+          // zone_id, name, type, data, id
+          Seq[Any](
+            u.zoneId,
+            u.recordSet.name,
+            fromRecordType(u.recordSet.typ),
+            toPB(u.recordSet).toByteArray,
+            u.recordSet.id)
+      }
+
+      // deletes are just the record set id
+      val deletes: Seq[Seq[Any]] =
+        byChangeType.getOrElse(RecordSetChangeType.Delete, Nil).map(d => Seq[Any](d.recordSet.id))
+
+      // Totally don't know if this is right or not, are effectively doing the entire operation in a single transaction
+      // and from what I have read that is the correct way to do it
+      // Most zones won't have many changes on a sync once the zone is in vinyldns
+      // However, for initially loading a zone, we could have millions of inserts.  Need to fine tune
+      // both the INSERT SQL as well as how we are using scalikejdbc
+      IO {
+        DB.localTx { implicit s =>
+          inserts.grouped(1000).foreach { group =>
+            val r = insert(group, s.connection)
+            println(r)
+          }
+          updates.grouped(1000).foreach { group =>
+            UPDATE_RECORDSET.batch(group: _*).apply()
+          }
+          deletes.grouped(1000).foreach { group =>
+            DELETE_RECORDSET.batch(group: _*).apply()
+          }
+        }
+      }.as(changeSet)
+    }
+
+  /**
+    *   maxItems is an option here because we use this to load all record sets in a zone, which could be very large
+    * (millions of records).  This could cause memory issues for the application.
+    *
+    * For DynamoDB, we can only get 100 at a time.  We will attempt to get 1000 at a time and
+    * tune from there
+    */
+  def listRecordSets(
+      zoneId: String,
+      startFrom: Option[String],
+      maxItems: Option[Int],
+      recordNameFilter: Option[String]): IO[ListRecordSetResults] =
+    monitor("repo.MySql.listRecordSets") {
+      IO {
+        DB.readOnly { implicit s =>
+          // make sure we sort ascending, so we can do the correct comparison later
+          val opts = (startFrom.as("AND name > {name}") ++
+            recordNameFilter.as("AND name LIKE '%{filter}'") ++
+            Some(" ORDER BY name ASC ") ++
+            maxItems.as("LIMIT {maxItems}")).toList.mkString(" ")
+
+          val params = (Some('zoneId -> zoneId) ++
+            startFrom.map(n => 'name -> n) ++
+            recordNameFilter.map(f => 'filter -> f) ++
+            maxItems.map(m => 'maxItems -> m)).toSeq
+
+          val query = "SELECT data FROM recordset WHERE zone_id = {zoneId} " + opts
+
+          val results = SQL(query)
+            .bindByName(params: _*)
+            .map(toRecordSet)
+            .list()
+            .apply()
+
+          ListRecordSetResults(
+            recordSets = results,
+            nextId = results.lastOption.map(_.name),
+            startFrom = startFrom,
+            maxItems = maxItems,
+            recordNameFilter = recordNameFilter
+          )
+        }
+      }
+    }
+
+  def getRecordSets(zoneId: String, name: String, typ: RecordType): IO[List[RecordSet]] =
+    monitor("repo.MySql.getRecordSets") {
+      IO {
+        DB.readOnly { implicit s =>
+          FIND_BY_ZONEID_NAME_TYPE
+            .bindByName('zoneId -> zoneId, 'name -> name, 'type -> typ)
+            .map(toRecordSet)
+            .list()
+            .apply()
+        }
+      }
+    }
+
+  // Note: In MySql we do not need the zone id, we can hit the key directly
+  def getRecordSet(zoneId: String, recordSetId: String): IO[Option[RecordSet]] =
+    monitor("repo.MySql.getRecordSet") {
+      IO {
+        DB.readOnly { implicit s =>
+          FIND_BY_ID.bindByName('id -> recordSetId).map(toRecordSet).single().apply()
+        }
+      }
+    }
+
+  def getRecordSetCount(zoneId: String): IO[Int] =
+    monitor("repo.MySql.getRecordSetCount") {
+      IO {
+        DB.readOnly { implicit s =>
+          // this is a count query, so should always return a value.  However, scalikejdbc doesn't have this,
+          // so we have to default to 0.  it is literally impossible to not return a value
+          COUNT_RECORDSETS_IN_ZONE
+            .bindByName('zoneId -> zoneId)
+            .map(_.int(1))
+            .single
+            .apply()
+            .getOrElse(0)
+        }
+      }
+    }
+
+  def getRecordSetsByName(zoneId: String, name: String): IO[List[RecordSet]] =
+    monitor("repo.MySql.getRecordSetsByName") {
+      IO {
+        DB.readOnly { implicit s =>
+          // this is a count query, so should always return a value.  However, scalikejdbc doesn't have this,
+          // so we have to default to 0.  it is literally impossible to not return a value
+          FIND_BY_ZONEID_NAME
+            .bindByName('zoneId -> zoneId, 'name -> name)
+            .map(toRecordSet)
+            .list()
+            .apply()
+        }
+      }
+    }
+}
+
+object MySqlRecordSetRepository extends ProtobufConversions {
+  final case class InvalidRecordType(value: Int)
+      extends Throwable(s"Invalid record type value $value")
+
+  final case class InsertRecord(
+      id: String,
+      zoneId: String,
+      recordName: String,
+      recordType: Int,
+      data: Array[Byte])
+
+  val unknownRecordType: Int = 100
+  val recordTypeLookup: Map[Int, RecordType] = Map(
+    1 -> RecordType.A,
+    2 -> RecordType.AAAA,
+    3 -> RecordType.CNAME,
+    4 -> RecordType.MX,
+    5 -> RecordType.NS,
+    6 -> RecordType.PTR,
+    7 -> RecordType.SPF,
+    8 -> RecordType.SRV,
+    9 -> RecordType.SSHFP,
+    10 -> RecordType.TXT,
+    unknownRecordType -> RecordType.UNKNOWN
+  )
+  val inverseRecordTypeLookup: Map[RecordType, Int] = recordTypeLookup.map { case (i, t) => t -> i }
+
+  def toRecordSet(rs: WrappedResultSet): RecordSet =
+    fromPB(VinylDNSProto.RecordSet.parseFrom(rs.bytes(1)))
+  def toRecordType(i: Int): Either[InvalidRecordType, RecordType] =
+    recordTypeLookup.get(i).map(t => Right(t)).getOrElse(Left(InvalidRecordType(i)))
+
+  def fromRecordType(typ: RecordType): Int =
+    inverseRecordTypeLookup.getOrElse(typ, unknownRecordType)
+}

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -86,7 +86,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     * a configuration setting
     */
   def apply(changeSet: ChangeSet): IO[ChangeSet] =
-    monitor("repo.MySql.apply") {
+    monitor("repo.RecordSet.apply") {
       val byChangeType = changeSet.changes.groupBy(_.changeType)
       val inserts: Seq[Seq[Any]] = byChangeType.getOrElse(RecordSetChangeType.Create, Nil).map {
         i =>
@@ -147,7 +147,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       startFrom: Option[String],
       maxItems: Option[Int],
       recordNameFilter: Option[String]): IO[ListRecordSetResults] =
-    monitor("repo.MySql.listRecordSets") {
+    monitor("repo.RecordSet.listRecordSets") {
       IO {
         DB.readOnly { implicit s =>
           // make sure we sort ascending, so we can do the correct comparison later
@@ -187,7 +187,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
 
   // TODO: Refactor this, need "getRecordSetsByNameAndType"
   def getRecordSets(zoneId: String, name: String, typ: RecordType): IO[List[RecordSet]] =
-    monitor("repo.MySql.getRecordSets") {
+    monitor("repo.RecordSet.getRecordSets") {
       IO {
         DB.readOnly { implicit s =>
           FIND_BY_ZONEID_NAME_TYPE
@@ -201,7 +201,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
 
   // Note: In MySql we do not need the zone id, we can hit the key directly
   def getRecordSet(zoneId: String, recordSetId: String): IO[Option[RecordSet]] =
-    monitor("repo.MySql.getRecordSet") {
+    monitor("repo.RecordSet.getRecordSet") {
       IO {
         DB.readOnly { implicit s =>
           FIND_BY_ID.bindByName('id -> recordSetId).map(toRecordSet).single().apply()
@@ -210,7 +210,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     }
 
   def getRecordSetCount(zoneId: String): IO[Int] =
-    monitor("repo.MySql.getRecordSetCount") {
+    monitor("repo.RecordSet.getRecordSetCount") {
       IO {
         DB.readOnly { implicit s =>
           // this is a count query, so should always return a value.  However, scalikejdbc doesn't have this,
@@ -226,7 +226,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     }
 
   def getRecordSetsByName(zoneId: String, name: String): IO[List[RecordSet]] =
-    monitor("repo.MySql.getRecordSetsByName") {
+    monitor("repo.RecordSet.getRecordSetsByName") {
       IO {
         DB.readOnly { implicit s =>
           // this is a count query, so should always return a value.  However, scalikejdbc doesn't have this,
@@ -241,7 +241,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     }
 
   def getRecordSetsByFQDN(fqdns: List[FQDN]): IO[List[RecordSet]] =
-    monitor("repo.MySql.getRecordSetByFQDN") {
+    monitor("repo.RecordSet.getRecordSetsByFQDN") {
       IO {
         DB.readOnly { implicit s =>
           val inClause = " IN (" + fqdns.as("?").mkString(",") + ")"

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -376,4 +376,11 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
       else
         IO.raiseError(error)
     }
+
+  def getZoneCount(): IO[Int] =
+    IO {
+      DB.readOnly { implicit s =>
+        sql"SELECT COUNT(*) FROM zone".map(_.int(1)).single().apply().getOrElse(-1)
+      }
+    }
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -37,6 +37,8 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
   private final val INITIAL_RETRY_DELAY = 1.millis
   final val MAX_RETRIES = 10
   private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   /**
     * use INSERT INTO ON DUPLICATE KEY UPDATE for the zone, which will update the values if the zone already exists

--- a/modules/mysql/src/test/resources/application.conf
+++ b/modules/mysql/src/test/resources/application.conf
@@ -13,8 +13,8 @@ mysql {
     password = "some-pass"
     # TODO: Research optimal values for settings
     pool-max-size = 20
-    connection-timeout-millis = 1000
-    max-life-time = 600000
+    connection-timeout-millis = 40000
+    max-life-time = 40000
   }
 
   repositories {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val pureConfigV = "0.9.2"
   lazy val metricsScalaV = "3.5.9"
   lazy val prometheusV = "0.4.0"
-  lazy val catsEffectV = "0.10.1"
+  lazy val catsEffectV = "1.0.0"
   lazy val configV = "1.3.2"
   lazy val scalikejdbcV = "3.3.1"
   lazy val scalaTestV = "3.0.4"
@@ -39,7 +39,7 @@ object Dependencies {
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "org.scodec"                %% "scodec-bits"                    % scodecV,
     "org.slf4j"                 %  "slf4j-api"                      % "1.7.7",
-    "co.fs2"                    %% "fs2-core"                       % "0.10.5",
+    "co.fs2"                    %% "fs2-core"                       % "1.0.0",
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
     "io.prometheus"             % "simpleclient_hotspot"            % prometheusV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
 
   lazy val mysqlDependencies = Seq(
     "org.flywaydb"              %  "flyway-core"                    % "5.1.4",
-    "org.mariadb.jdbc"          %  "mariadb-java-client"            % "2.2.6",
+    "org.mariadb.jdbc"          %  "mariadb-java-client"            % "2.3.0",
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "com.zaxxer"                %  "HikariCP"                       % "3.2.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,8 @@ object Dependencies {
     "org.mariadb.jdbc"          %  "mariadb-java-client"            % "2.2.6",
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
-    "com.zaxxer"                %  "HikariCP"                       % "3.2.0"
+    "com.zaxxer"                %  "HikariCP"                       % "3.2.0",
+    "ch.qos.logback"            %  "logback-classic"                % "1.0.7"
   )
 
   lazy val commonTestDependencies = Seq(


### PR DESCRIPTION
Create Benchmark

Only need to look at the last commit.

**Benchmark Config**
Allows you to configure how many zones of each size to create as part of the benchmark.  For example `xs = 5` will create 5 "extra small zones", each zone having 10 records.

* `xs` - 10 records
* `s` - 100 records
* `m` - 1000 records
* `l` - 10,000 records
* `xl` - 100,000 records
* `xxl` - 1,000,000 records

**Bulk Loading**
Bulk loading is done lazily, as we aim to create some 2MM zones, 250MM record sets, and 250MM record set changes.  Generating all of those up front would blow the heap.

Further, "guessing" at the correct size could be similarly disastrous.  Creating more than the backend can handle will blow the heap.  Creating too little, and we are underutilizing the database.

The perfect solution here is to use FS2.  FS2 will only generate zones and records as the bulk loading process has capacity.  This limits memory while maximizing the capacity of our database.

The process of bulk loading follows:

1. Create a `Stream[ZoneGenerator]`, this will create new `ZoneGenerators` on demand. 
1. Each `ZoneGenerator` gets a `Zone`, as well as its _own_ `Stream[RecordSetChange]`.
1. Each `Stream[RecordSetChange]` will generate new record sets and record set changes _on demand_ for that zone until it exhausts the record count for that `ZoneSize` (xs, s, m, l, etc.)

Once we have our "Stream of Streams", we can then process them.  When reviewing the `benchmarkFlow`, think of it as though 1 `ZoneGenerator` is processed at a time, follow top down...

1. Save the zone to the `ZoneRepository`
1. Take the `recordStream` from the `ZoneGenerator`, and generate a "Stream of Streams".  Each Stream containing exactly 10,000 record set changes (Note: this number is arbitrary, we want it to be low enough so we do not blow the heap, but large enough to maximize our backend.  Brute force testing showed this to have good performance)
1. Take each substream of 10,000 and save the record set and record set changes to their repositories
1. We run the "Stream of Streams" in parallel using `parJoinUnbounded`.  For large zones of 1MM records, we want to run those sub-streams as fast as possible.
1. At the end of the stream, we do a _second_ `parJoinUnbounded`, why?  Because we want to run multiple _zones_ in parallel as well.  If we are loading 1MM xs smalls, we cannot have those go sequentially.

**Naming**
We have a `NameGenerator` that _predictably_ names all record sets.  This is **critical** to how the query tests work.  Those tests expect certain record names to be present in each zone.  For example, we guarantee that there will be a record set named `r1-fresh-sofa` with type `AAAA` in every zone.  Without this, our record set query tests will not run.

**Query Benchmarking**
We are only testing RecordSet queries right now.  More can easily be added later for other repositories.

We start the testing by loading one `TestZone` for each `ZoneSize` (xs, s, m, l, etc.) . For each `TestZone`, we execute each query from the `RecordSetRepository`.  Along the way, we record the latency for each query/zone size combination.

To ensure we have enough samples, we run the entire suite of tests 100 times before finishing.

**Output**
All latency is captured in dropwizard metrics.  Output goes to elastic search, so we can query, stats, and graph each run.