### PR TITLE
Update to latest cats and fs2

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -19,7 +19,8 @@ package vinyldns.api
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.{ActorMaterializer, Materializer}
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
+import fs2.concurrent.SignallingRef
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.dropwizard.DropwizardExports
 import io.prometheus.client.hotspot.DefaultExports
@@ -46,6 +47,7 @@ object Boot extends App {
   private implicit val system: ActorSystem = VinylDNSConfig.system
   private implicit val materializer: Materializer = ActorMaterializer()
   private implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+  private implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
   def vinyldnsBanner(): IO[String] = IO {
     val stream = getClass.getResourceAsStream("/vinyldns-ascii.txt")
@@ -69,13 +71,14 @@ object Boot extends App {
       sqsConfig <- IO(VinylDNSConfig.sqsConfig)
       sqsConnection <- IO(SqsConnection(sqsConfig))
       processingDisabled <- IO(VinylDNSConfig.vinyldnsConfig.getBoolean("processing-disabled"))
-      processingSignal <- fs2.async.signalOf[IO, Boolean](processingDisabled)
+      processingSignal <- SignallingRef[IO, Boolean](processingDisabled)
       restHost <- IO(VinylDNSConfig.restConfig.getString("host"))
       restPort <- IO(VinylDNSConfig.restConfig.getInt("port"))
       batchChangeLimit <- IO(VinylDNSConfig.vinyldnsConfig.getInt("batch-change-limit"))
       syncDelay <- IO(VinylDNSConfig.vinyldnsConfig.getInt("sync-delay"))
-      _ <- fs2.async.start(
-        ProductionZoneCommandHandler.run(sqsConnection, processingSignal, repositories, sqsConfig))
+      _ <- ProductionZoneCommandHandler
+        .run(sqsConnection, processingSignal, repositories, sqsConfig)
+        .start
     } yield {
       val zoneValidations = new ZoneValidations(syncDelay)
       val batchChangeValidations = new BatchChangeValidations(batchChangeLimit, AccessValidations)

--- a/modules/api/src/main/scala/vinyldns/api/Interfaces.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Interfaces.scala
@@ -20,10 +20,14 @@ import cats.data._
 import cats.effect._
 import cats.implicits._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object Interfaces {
+
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   /* Our standard business error type */
   type Result[A] = EitherT[IO, Throwable, A]
@@ -104,7 +108,6 @@ object Interfaces {
       case None => result[A](ifNone)
     }
   }
-
 }
 
 object Result {

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -17,7 +17,7 @@
 package vinyldns.api
 
 import akka.actor.ActorSystem
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.typesafe.config.{Config, ConfigFactory}
 import pureconfig.module.catseffect.loadConfigF
@@ -29,6 +29,9 @@ import vinyldns.core.domain.zone.ZoneConnection
 import vinyldns.core.repository.DataStoreConfig
 
 object VinylDNSConfig {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   lazy val config: Config = ConfigFactory.load()
   lazy val vinyldnsConfig: Config = config.getConfig("vinyldns")

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.engine
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.syntax.all._
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
@@ -29,6 +29,8 @@ import vinyldns.core.route.Monitored
 object ZoneSyncHandler extends DnsConversions with Monitored {
 
   private implicit val logger = LoggerFactory.getLogger("vinyldns.engine.ZoneSyncHandler")
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(
       recordSetRepository: RecordSetRepository,

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -16,13 +16,16 @@
 
 package vinyldns.api.repository
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.joda.time.DateTime
 import vinyldns.core.domain.membership._
 
 // $COVERAGE-OFF$
 object TestDataLoader {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   final val testUser = User(
     userName = "testuser",

--- a/modules/api/src/main/scala/vinyldns/api/route/StatusRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/StatusRouting.scala
@@ -20,7 +20,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives
 import akka.util.Timeout
 import cats.effect.IO
-import fs2.async.mutable.Signal
+import fs2.concurrent.SignallingRef
 import vinyldns.api.VinylDNSConfig
 
 import scala.concurrent.duration._
@@ -43,7 +43,7 @@ trait StatusRoute extends Directives {
 
   implicit val timeout = Timeout(10.seconds)
 
-  def processingDisabled: Signal[IO, Boolean]
+  def processingDisabled: SignallingRef[IO, Boolean]
 
   val statusRoute =
     (get & path("status")) {

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
@@ -19,7 +19,6 @@ package vinyldns.api.route
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.server.RequestContext
 import cats.effect._
-import cats.syntax.all._
 import vinyldns.api.crypto.Crypto
 import vinyldns.api.domain.auth.AuthPrincipalProvider
 import vinyldns.core.crypto.CryptoAlgebra

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
@@ -23,7 +23,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import akka.http.scaladsl.server.directives.LogEntry
 import cats.effect.IO
-import fs2.async.mutable.Signal
+import fs2.concurrent.SignallingRef
 import io.prometheus.client.CollectorRegistry
 import vinyldns.api.domain.auth.MembershipAuthPrincipalProvider
 import vinyldns.api.domain.batch.BatchChangeServiceAlgebra
@@ -101,7 +101,7 @@ object VinylDNSService {
 // $COVERAGE-OFF$
 class VinylDNSService(
     val membershipService: MembershipServiceAlgebra,
-    val processingDisabled: Signal[IO, Boolean],
+    val processingDisabled: SignallingRef[IO, Boolean],
     val zoneService: ZoneServiceAlgebra,
     val healthService: HealthService,
     val recordSetService: RecordSetServiceAlgebra,

--- a/modules/api/src/test/scala/vinyldns/api/CatsHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/CatsHelpers.scala
@@ -25,9 +25,12 @@ import scala.concurrent.duration._
 import org.scalatest.Assertions._
 import org.scalatest.matchers.{MatchResult, Matcher}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 trait CatsHelpers {
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def await[E, T](f: => IO[T], duration: FiniteDuration = 1.second): T = {
     val i: IO[Either[E, T]] = f.attempt.map {

--- a/modules/api/src/test/scala/vinyldns/api/ResultHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/ResultHelpers.scala
@@ -23,13 +23,16 @@ import cats.implicits._
 import cats.scalatest.ValidatedMatchers
 import org.scalatest.{Matchers, PropSpec}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect.ClassTag
 
 final case class TimeoutException(message: String) extends Throwable(message)
 
 trait ResultHelpers {
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def await[T](f: => IO[_], duration: FiniteDuration = 1.second): T =
     awaitResultOf[T](f.map(_.asInstanceOf[T]).attempt, duration).toOption.get

--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -15,28 +15,25 @@
  */
 
 package vinyldns.api.backend
-import java.util.concurrent.Executors
-
-import cats.effect.IO
+import cats.effect.{ContextShift, IO, Timer}
 import cats.scalatest.EitherMatchers
 import fs2._
 import org.mockito
 import org.mockito.Matchers._
-import org.mockito.{ArgumentCaptor, Mockito}
 import org.mockito.Mockito._
+import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, EitherValues, Matchers, WordSpec}
 import vinyldns.api.VinylDNSTestData
 import vinyldns.api.backend.CommandHandler.{DeleteMessage, RetryMessage}
 import vinyldns.api.domain.dns.DnsConnection
-import vinyldns.core.domain.zone.{ZoneChange, ZoneChangeType, ZoneCommand}
 import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetChange, RecordSetRepository}
-import vinyldns.core.domain.zone._
+import vinyldns.core.domain.zone.{ZoneChange, ZoneChangeType, ZoneCommand, _}
 import vinyldns.core.queue.{CommandMessage, MessageCount, MessageId, MessageQueue}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class CommandHandlerSpec
     extends WordSpec
@@ -53,8 +50,9 @@ class CommandHandlerSpec
   }
 
   private val mq = mock[MessageQueue]
-  implicit val sched: Scheduler =
-    Scheduler.fromScheduledExecutorService(Executors.newScheduledThreadPool(2))
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   private val messages = for { i <- 0 to 10 } yield
     TestCommandMessage(pendingCreateAAAA, i.toString)
   private val count = MessageCount(10).right.value
@@ -250,7 +248,7 @@ class CommandHandlerSpec
 
   "main flow" should {
     "process successfully" in {
-      val stop = fs2.async.signalOf[IO, Boolean](false).unsafeRunSync()
+      val stop = fs2.concurrent.SignallingRef[IO, Boolean](false).unsafeRunSync()
       val cmd = TestCommandMessage(pendingCreateAAAA, "foo")
 
       // stage pulling from the message queue
@@ -288,18 +286,17 @@ class CommandHandlerSpec
       verify(mq).remove(cmd)
     }
     "continue processing on unexpected failure" in {
-      val stop = fs2.async.signalOf[IO, Boolean](false).unsafeRunSync()
+      val stop = fs2.concurrent.SignallingRef[IO, Boolean](false).unsafeRunSync()
       val cmd = TestCommandMessage(pendingCreateAAAA, "foo")
 
-      // stage pulling from the message queue, make sure we always return our command
-      doReturn(IO.pure(List(cmd)))
+      // stage pulling from the message queue, return an error then our command
+      doReturn(IO.raiseError(new RuntimeException("fail")))
         .doReturn(IO.pure(List(cmd)))
         .when(mq)
         .receive(count)
 
-      // stage our record change processing failure, and then a success
-      doReturn(IO.raiseError(new RuntimeException("fail")))
-        .doReturn(IO.pure(cmd.command))
+      // stage our record change processing our command
+      doReturn(IO.pure(cmd.command))
         .when(mockRecordChangeProcessor)
         .apply(any[DnsConnection], any[RecordSetChange])
 
@@ -326,9 +323,9 @@ class CommandHandlerSpec
       // verify our interactions
       verify(mq, atLeastOnce()).receive(count)
 
-      // verify that our record was attempted two times
-      verify(mockRecordChangeProcessor, times(2))
-        .apply(any[DnsConnection], mockito.Matchers.eq(pendingCreateAAAA))
+      // verify that our message queue was polled twice
+      verify(mq, times(2))
+        .receive(count)
       verify(mq).remove(cmd)
     }
   }
@@ -336,7 +333,7 @@ class CommandHandlerSpec
   "run" should {
     "process a zone update change through the flow" in {
       // testing the run method, which does nothing more than simplify construction of the main flow
-      val stop = fs2.async.signalOf[IO, Boolean](false).unsafeRunSync()
+      val stop = fs2.concurrent.SignallingRef[IO, Boolean](false).unsafeRunSync()
       val cmd = TestCommandMessage(zoneUpdate, "foo")
 
       val zoneRepo = mock[ZoneRepository]

--- a/modules/api/src/test/scala/vinyldns/api/route/StatusRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/StatusRoutingSpec.scala
@@ -20,8 +20,8 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.IO
-import fs2.async.mutable.Signal
+import cats.effect.{ContextShift, IO}
+import fs2.concurrent.SignallingRef
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 
@@ -38,8 +38,11 @@ class StatusRoutingSpec
 
   def actorRefFactory: ActorSystem = system
 
-  val processingDisabled: Signal[IO, Boolean] =
-    fs2.async.signalOf[IO, Boolean](false).unsafeRunSync()
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  val processingDisabled: SignallingRef[IO, Boolean] =
+    fs2.concurrent.SignallingRef[IO, Boolean](false).unsafeRunSync()
 
   "GET /status" should {
     "return the current status of true" in {

--- a/modules/core/src/main/scala/vinyldns/core/repository/DataStoreLoader.scala
+++ b/modules/core/src/main/scala/vinyldns/core/repository/DataStoreLoader.scala
@@ -17,7 +17,7 @@
 package vinyldns.core.repository
 
 import cats.data._
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import vinyldns.core.crypto.CryptoAlgebra
 import org.slf4j.LoggerFactory
@@ -39,6 +39,7 @@ object DataStoreLoader {
   }
 
   private val logger = LoggerFactory.getLogger("DataStoreLoader")
+  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def loadAll[A <: DataAccessor](
       configs: List[DataStoreConfig],

--- a/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
+++ b/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
@@ -66,7 +66,7 @@ trait Monitored {
   */
 object Monitor {
 
-  lazy val monitors: mutable.Map[String, Monitor] = concurrent.TrieMap.empty
+  lazy val monitors: mutable.Map[String, Monitor] = scala.collection.concurrent.TrieMap.empty
 
   def apply(name: String): Monitor = monitors.getOrElseUpdate(name, new Monitor(name))
 

--- a/modules/core/src/test/scala/vinyldns/core/repository/DataStoreLoaderSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/repository/DataStoreLoaderSpec.scala
@@ -17,7 +17,7 @@
 package vinyldns.core.repository
 
 import cats.data._
-import cats.implicits._
+import cats.syntax.validated._
 import cats.scalatest.{EitherMatchers, EitherValues, ValidatedMatchers}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.mockito.MockitoSugar

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProviderIntegrationSpec.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.dynamodb.repository
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
 import com.typesafe.config.{Config, ConfigFactory}
@@ -31,6 +31,8 @@ import vinyldns.core.repository.RepositoryName._
 
 class DynamoDBDataStoreProviderIntegrationSpec extends DynamoDBIntegrationSpec {
 
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   val config: Config = ConfigFactory.load()
   val dynamoDBConfig: DataStoreConfig =
     pureconfig.loadConfigOrThrow[DataStoreConfig](config, "dynamodb")

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBGroupChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBGroupChangeRepositoryIntegrationSpec.scala
@@ -16,6 +16,7 @@
 
 package vinyldns.dynamodb.repository
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model._
 import org.joda.time.DateTime
@@ -26,6 +27,9 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 class DynamoDBGroupChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   private implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_.isAfter(_))
 
   private val GROUP_CHANGES_TABLE = "group-changes-live"

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBGroupRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBGroupRepositoryIntegrationSpec.scala
@@ -16,6 +16,7 @@
 
 package vinyldns.dynamodb.repository
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model._
 import vinyldns.core.domain.membership.{Group, GroupStatus}
@@ -24,6 +25,10 @@ import vinyldns.core.TestMembershipData._
 import scala.concurrent.duration._
 
 class DynamoDBGroupRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+
   private val GROUP_TABLE = "groups-live"
 
   private val tableConfig = DynamoDBRepositorySettings(s"$GROUP_TABLE", 30, 30)

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBMembershipRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBMembershipRepositoryIntegrationSpec.scala
@@ -16,11 +16,15 @@
 
 package vinyldns.dynamodb.repository
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 
 import scala.concurrent.duration._
 
 class DynamoDBMembershipRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   private val membershipTable = "membership-live"
 
   private val tableConfig = DynamoDBRepositorySettings(s"$membershipTable", 30, 30)

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositoryIntegrationSpec.scala
@@ -18,6 +18,7 @@ package vinyldns.dynamodb.repository
 
 import java.util.UUID
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model._
 import org.joda.time.DateTime
@@ -33,6 +34,8 @@ class DynamoDBRecordSetRepositoryIntegrationSpec
     extends DynamoDBIntegrationSpec
     with DynamoDBRecordSetConversions {
 
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   private val recordSetTable = "record-sets-live"
   private[repository] val recordSetTableName: String = recordSetTable
 

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -16,15 +16,19 @@
 
 package vinyldns.dynamodb.repository
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
 import com.typesafe.config.ConfigFactory
 import vinyldns.core.crypto.NoOpCrypto
-import vinyldns.core.domain.membership.{User, LockStatus}
+import vinyldns.core.domain.membership.{LockStatus, User}
+
 import scala.concurrent.duration._
 
 class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
 
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   private val userTable = "users-live"
 
   private val tableConfig = DynamoDBRepositorySettings(s"$userTable", 30, 30)

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBZoneChangeRepositoryIntegrationSpec.scala
@@ -16,6 +16,7 @@
 
 package vinyldns.dynamodb.repository
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model._
 import org.joda.time.DateTime
@@ -29,6 +30,9 @@ import scala.util.Random
 
 class DynamoDBZoneChangeRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
 
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+  
   private val zoneChangeTable = "zone-changes-live"
 
   private val tableConfig = DynamoDBRepositorySettings(s"$zoneChangeTable", 30, 30)

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProvider.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProvider.scala
@@ -17,7 +17,7 @@
 package vinyldns.dynamodb.repository
 
 import cats.implicits._
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import org.slf4j.LoggerFactory
 import vinyldns.core.repository._
 import pureconfig.module.catseffect.loadConfigF
@@ -33,6 +33,8 @@ class DynamoDBDataStoreProvider extends DataStoreProvider {
   private val logger = LoggerFactory.getLogger("DynamoDBDataStoreProvider")
   private val implementedRepositories =
     Set(user, group, membership, groupChange, recordSet, recordChange, zoneChange, userChange)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def load(config: DataStoreConfig, crypto: CryptoAlgebra): IO[DataStore] =
     for {

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBHelper.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBHelper.scala
@@ -28,7 +28,7 @@ import org.slf4j.Logger
 import vinyldns.core.VinylDNSMetrics
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuration = 1.millis)
@@ -48,6 +48,7 @@ class DynamoDBHelper(dynamoDB: AmazonDynamoDBClient, log: Logger) {
 
   private[repository] val retryCount: Int = 10
   private val retryBackoff: FiniteDuration = 1.millis
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   private[repository] val provisionedThroughputMeter =
     VinylDNSMetrics.metricsRegistry.meter("dynamo.provisionedThroughput")

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -48,6 +48,8 @@ object DynamoDBUserRepository {
   private[repository] val USER_NAME_INDEX_NAME = "username_index"
   private[repository] val ACCESS_KEY_INDEX_NAME = "access_key_index"
   private val log: Logger = LoggerFactory.getLogger(classOf[DynamoDBUserRepository])
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def apply(
       config: DynamoDBRepositorySettings,

--- a/modules/mysql/src/it/scala/vinyldns/mysql/queue/MySqlMessageQueueIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/queue/MySqlMessageQueueIntegrationSpec.scala
@@ -51,6 +51,9 @@ class MySqlMessageQueueIntegrationSpec extends WordSpec with Matchers
   import vinyldns.core.TestRecordSetData._
   import vinyldns.core.TestZoneData._
 
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+
   private val underTest = new MySqlMessageQueue()
 
   private val rsChange: RecordSetChange = pendingCreateAAAA

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -18,6 +18,7 @@ package vinyldns.mysql.repository
 
 import java.util.UUID
 
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.joda.time.DateTime
 import org.scalatest._
@@ -40,6 +41,8 @@ class MySqlZoneChangeRepositoryIntegrationSpec
     with Inspectors
     with OptionValues {
 
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
   private var repo: ZoneChangeRepository = _
 
   object TestData {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -37,6 +37,8 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
   private final val INITIAL_RETRY_DELAY = 1.millis
   final val MAX_RETRIES = 10
   private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   /**
     * use INSERT INTO ON DUPLICATE KEY UPDATE for the zone, which will update the values if the zone already exists

--- a/modules/portal/app/controllers/Settings.scala
+++ b/modules/portal/app/controllers/Settings.scala
@@ -18,7 +18,7 @@ package controllers
 
 import java.net.URI
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.typesafe.config.{Config, ConfigFactory}
 import play.api.{ConfigLoader, Configuration}
@@ -27,7 +27,11 @@ import vinyldns.core.repository.DataStoreConfig
 
 import scala.collection.JavaConverters._
 
+// $COVERAGE-OFF$
 class Settings(private val config: Configuration) {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   val ldapUser: String = config.get[String]("LDAP.user")
   val ldapPwd: String = config.get[String]("LDAP.password")
@@ -59,5 +63,5 @@ class Settings(private val config: Configuration) {
       }
     }
 }
-
+// $COVERAGE-ON$
 object Settings extends Settings(Configuration(ConfigFactory.load()))

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -20,7 +20,7 @@ import java.util.Base64
 import java.util.concurrent.TimeUnit.SECONDS
 
 import cats.data._
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
@@ -47,6 +47,8 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
     with Monitored {
 
   import SqsMessageQueue._
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   // Helper for handling SQS requests and responses
   def sqsAsync[A <: AmazonWebServiceRequest, B <: AmazonWebServiceResult[_]](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val pureConfigV = "0.9.2"
   lazy val metricsScalaV = "3.5.9"
   lazy val prometheusV = "0.4.0"
-  lazy val catsEffectV = "0.10.1"
+  lazy val catsEffectV = "1.0.0"
   lazy val configV = "1.3.2"
   lazy val scalikejdbcV = "3.3.1"
   lazy val scalaTestV = "3.0.4"
@@ -37,7 +37,7 @@ object Dependencies {
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "org.scodec"                %% "scodec-bits"                    % scodecV,
     "org.slf4j"                 %  "slf4j-api"                      % "1.7.7",
-    "co.fs2"                    %% "fs2-core"                       % "0.10.5",
+    "co.fs2"                    %% "fs2-core"                       % "1.0.0",
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
     "io.prometheus"             % "simpleclient_hotspot"            % prometheusV,


### PR DESCRIPTION
**Motivation**
We are on an old version of both cats, cats-effect, and fs2.  The primary issue is that `parSequence` and other parallel commands don't actually run in parallel.

**Changes**
Running in parallel now requires in some instances a `Timer` to be available in implicit scope, and others `ContextShift`.

Added the necessary implicits.
