### PR TITLE
remove config defaults

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -66,6 +66,7 @@ vinyldns {
       max-lifetime = 600000
       maximum-pool-size = 20
       minimum-idle = 20
+      register-mbeans = true
     }
     # Repositories that use this data store are listed here
     repositories {

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -19,12 +19,23 @@ vinyldns {
     }
   }
 
-  mysql.repositories {
-    zone {
-      # no additional settings for now
-    },
-    batch-change {
-      # no additional settings for now
+  mysql {
+    settings {
+      # see https://github.com/brettwooldridge/HikariCP
+      connection-timeout-millis = 1000
+      idle-timeout = 10000
+      max-lifetime = 600000
+      maximum-pool-size = 5
+      minimum-idle = 1
+    }
+
+    repositories {
+      zone {
+        # no additional settings for now
+      },
+      batch-change {
+        # no additional settings for now
+      }
     }
   }
 

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -37,12 +37,24 @@ vinyldns {
     queue-url = "http://localhost:9324/queue/vinyldns-zones" // this is in the docker/elasticmq/custom.conf file
   }
 
-  mysql.repositories {
-    zone {
-      # no additional settings for now
-    },
-    batch-change {
-      # no additional settings for now
+  mysql {
+    settings {
+      # see https://github.com/brettwooldridge/HikariCP
+      connection-timeout-millis = 1000
+      idle-timeout = 10000
+      max-lifetime = 600000
+      maximum-pool-size = 5
+      minimum-idle = 1
+      register-mbeans = true
+    }
+
+    repositories {
+      zone {
+        # no additional settings for now
+      },
+      batch-change {
+        # no additional settings for now
+      }
     }
   }
 
@@ -94,4 +106,5 @@ vinyldns {
     type = "vinyldns.core.crypto.JavaCrypto"
     secret = "8B06A7F3BC8A2497736F1916A123AA40E88217BE9264D8872597EF7A6E5DCE61"
   }
+
 }

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -48,14 +48,6 @@ vinyldns {
       url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
       user = "root"
       password = "pass"
-
-      # see https://github.com/brettwooldridge/HikariCP
-      connection-timeout-millis = 1000
-      idle-timeout = 10000
-      max-lifetime = 600000
-      maximum-pool-size = 5
-      minimum-idle = 5
-      register-mbeans = true
     }
 
     repositories {

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -42,9 +42,9 @@ vinyldns {
 
       # see https://github.com/brettwooldridge/HikariCP
       connection-timeout-millis = 1000
-      idle-timeout = 600000
       max-lifetime = 600000
       maximum-pool-size = 20
+      register-mbeans = true
     }
     repositories {
       zone {

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -217,14 +217,34 @@ vinyldns {
       # the password to connect to MySQL
       password = "pass"
 
+      ## see https://github.com/brettwooldridge/HikariCP for more detail on the following fields
       # the maximum number of connections to scale the connection pool to
       maximum-pool-size = 20
 
-      # the maximum number of seconds to wait for a connection from the connection pool
+      # the maximum number of milliseconds to wait for a connection from the connection pool
       connection-timeout-millis = 1000
+      
+      # the minimum number of idle connections that HikariCP tries to maintain in the pool
+      minimum-idle = 10
+            
+      # the maximum number of milliseconds that a connection is can sit idle in the pool
+      idle-timeout = 10000
 
       # The max lifetime of a connection in a pool.  Should be several seconds shorter than the database imposed connection time limit
-      max-life-time = 600000
+      max-lifetime = 600000
+      
+      # controls whether JMX MBeans are registered
+      register-mbeans = true
+      
+      # my-sql-properties allows you to include any additional mysql performance settings you want.
+      # Note that the properties within my-sql-properties must be camel case!
+      # see https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration for guidance
+      my-sql-properties {
+        prepStmtCacheSize = 300
+        prepStmtCacheSqlLimit = 2048
+        cachePrepStmts = true
+        useServerPrepStmts = true
+      }
     }
     
     repositories {
@@ -452,9 +472,18 @@ vinyldns {
       url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
       user = "root"
       password = "pass"
-      pool-max-size = 20
+      maximum-pool-size = 20
+      minimum-idle = 10
       connection-timeout-millis = 1000
-      max-life-time = 600000
+      idle-timeout = 10000
+      max-lifetime = 600000
+      register-mbeans = true
+      my-sql-properties {
+        prepStmtCacheSize = 300
+        prepStmtCacheSqlLimit = 2048
+        cachePrepStmts = true
+        useServerPrepStmts = true
+      }
     }
     
     repositories {


### PR DESCRIPTION
related to https://github.com/vinyldns/vinyldns/pull/283

one of the mysql fields (connection-timeout-millis, idle-timeout, etc) was excluded from our deploy application.conf, but still being applied because in reference.conf.

took it out, should fall back to hikari defaults, not what we set


also updated docs