### PR TITLE
create a simple way to start Dockerized API

### DIFF
--- a/bin/docker-up-api-server-local.sh
+++ b/bin/docker-up-api-server-local.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+######################################################################
+# Copies the contents of `docker` into target/scala-2.12
+# to start up dependent services via docker compose.  Once
+# dependent services are started up, the fat jar built by sbt assembly
+# is loaded into a docker container.  The api will be available
+# by default on port 9000
+######################################################################
+
+
+DIR=$( cd $(dirname $0) ; pwd -P )
+
+set -a # Required in order to source docker/.env
+# Source customizable env files
+source "$DIR"/.env
+source "$DIR"/../docker/.env
+
+WORK_DIR="$DIR"/../target/scala-2.12
+mkdir -p "$WORK_DIR"
+
+echo "Copy all Docker to the target directory so we can start up properly and the Docker context is small..."
+cp -af "$DIR"/../docker "$WORK_DIR"/
+
+echo "Copy the vinyldns.jar to the API Docker folder so it is in context..."
+if [[ ! -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
+    echo "vinyldns.jar not found, building..."
+    cd "$DIR"/../
+    sbt api/clean api/assembly
+    cd "$DIR"
+fi
+cp -f "$DIR"/../modules/api/target/scala-2.12/vinyldns.jar "$WORK_DIR"/docker/api
+
+echo "Starting API server and all dependencies in the background..."
+docker-compose -f "$WORK_DIR"/docker/docker-compose-func-test.yml --project-directory "$WORK_DIR"/docker up --build -d api
+
+echo "Waiting for API to be ready at ${VINYLDNS_API_URL} ..."
+DATA=""
+RETRY=40
+while [ "$RETRY" -gt 0 ]
+do
+    DATA=$(curl -I -s "${VINYLDNS_API_URL}/ping" -o /dev/null -w "%{http_code}")
+    if [ $? -eq 0 ]
+    then
+        echo "Succeeded in connecting to VinylDNS API!"
+        break
+    else
+        echo "Retrying Again" >&2
+
+        let RETRY-=1
+        sleep 1
+
+        if [ "$RETRY" -eq 0 ]
+        then
+          echo "Exceeded retries waiting for VinylDNS API to be ready, failing"
+          exit 1
+        fi
+    fi
+done

--- a/docker/docker-compose-api.yml
+++ b/docker/docker-compose-api.yml
@@ -1,0 +1,51 @@
+version: "3.0"
+services:
+  mysql:
+    image: "mysql:5.7"
+    env_file:
+      .env
+    container_name: "vinyldns-mysql"
+    ports:
+      - "19002:3306"
+
+  dynamodb-local:
+    image: "cnadiminti/dynamodb-local:2017-02-16"
+    env_file:
+      .env
+    container_name: "vinyldns-dynamodb"
+    ports:
+      - "19000:8000"
+    command: "--sharedDb --inMemory"
+
+  bind9:
+    image: "vinyldns/bind9:0.0.1"
+    env_file:
+      .env
+    container_name: "vinyldns-bind9"
+    ports:
+      - "19001:53/udp"
+      - "19001:53"
+    volumes:
+      - ./bind9/etc:/var/cache/bind/config
+      - ./bind9/zones:/var/cache/bind/zones
+
+  elasticmq:
+    image: s12v/elasticmq:0.13.8
+    container_name: "vinyldns-elasticmq"
+    ports:
+      - "9324:9324"
+    volumes:
+      - ./elasticmq/custom.conf:/etc/elasticmq/elasticmq.conf
+
+  api:
+    image: "vinyldns/api:0.8.0"
+    env_file:
+      .env
+    container_name: "vinyldns-api"
+    ports:
+      - "${REST_PORT}:${REST_PORT}"
+    depends_on:
+      - mysql
+      - bind9
+      - elasticmq
+      - dynamodb-local


### PR DESCRIPTION
This seeks to fix issue #270 and, specifically, address these comments:
https://github.com/vinyldns/vinyldns/issues/270#issuecomment-434758538

While it's not a particularly DRY solution, it seeks to provide users
a simple way to start a Dockerized VinylDNS API _without_ the need to either...

* start the VinylDNS portal as well
* build a VinylDNS jar file

There is likely room to refactor and simplify the `bin/*.sh` files.

Fixes #.

Changes in this pull request:
-
-
