### PR TITLE
prevent duplicate zone creation

### DIFF
--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -471,3 +471,66 @@ def test_user_cannot_create_zone_with_failed_validations(shared_zone_test_contex
     assert_that(result['errors'], contains_inanyorder(
         contains_string("not-approved.thing.com. is not an approved name server")
     ))
+
+@pytest.mark.skip_production
+def test_create_zone_same_name_fails_during_processing(shared_zone_test_context):
+    """
+    Test create a zone errors if the name is found during processing
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    result_zone = None
+    duplicate_result_zone = None
+    try:
+        zone_name = 'one-time'
+
+        zone = {
+            'name': zone_name,
+            'email': 'test@test.com',
+            'adminGroupId': shared_zone_test_context.ok_group['id'],
+            'connection': {
+                'name': 'vinyldns.',
+                'keyName': VinylDNSTestContext.dns_key_name,
+                'key': VinylDNSTestContext.dns_key,
+                'primaryServer': VinylDNSTestContext.dns_ip
+            },
+            'transferConnection': {
+                'name': 'vinyldns.',
+                'keyName': VinylDNSTestContext.dns_key_name,
+                'key': VinylDNSTestContext.dns_key,
+                'primaryServer': VinylDNSTestContext.dns_ip
+            }
+        }
+        result = client.create_zone(zone, status=202)
+        duplicate_result = client.create_zone(zone, status=202)
+        result_zone = result['zone']
+
+        client.wait_until_zone_change_status(result, 'Synced')
+        client.wait_until_zone_change_status(duplicate_result, 'Failed')
+
+        get_result = client.get_zone(result_zone['id'])
+
+        get_zone = get_result['zone']
+
+        assert_that(get_zone['name'], is_(zone['name']+'.'))
+        assert_that(get_zone['email'], is_(zone['email']))
+        assert_that(get_zone['adminGroupId'], is_(zone['adminGroupId']))
+        assert_that(get_zone['latestSync'], is_not(none()))
+        assert_that(get_zone['status'], is_('Active'))
+
+        # confirm that the recordsets in DNS have been saved in vinyldns
+        recordsets = client.list_recordsets(result_zone['id'])['recordSets']
+
+        assert_that(len(recordsets), is_(7))
+        for rs in recordsets:
+            small_rs = dict((k, rs[k]) for k in ['name', 'type', 'records'])
+            small_rs['records'] = sorted(small_rs['records'])
+            assert_that(records_in_dns, has_item(small_rs))
+
+        duplicate_result_zone = duplicate_result['zone']
+        get_duplicate_result = client.get_zone(duplicate_result_zone['id'])
+
+        assert_that(get_duplicate_result, contains_string("does not exists"))
+
+    finally:
+        if result_zone:
+            client.abandon_zones([result_zone['id']], status=202)


### PR DESCRIPTION
Fixes #310.

Changes in this pull request:
- Add a check to see if a zone exists during the ZoneChange processing
- If a zone exists, change the ZoneChangeStatus to Failed and raise a ZoneAlreadyExistsError
- The error is swallowed as message flow continues, but no duplicate zone is created.

Expect the tests to fail at the moment, need to test this at the point two zone requests are on the message queue, under the assumption they passed the validations in the ZoneService. I did create one test that conditionally passes right now in the func tests. "test_create_zone_same_name_fails_during_processing" should pass if you comment out `_ <- zoneDoesNotExist(zone)` in the ZoneService.

To kind of test in the portal:
- Comment out `_ <- zoneDoesNotExist(zone)` in the ZoneService
- Create a zone in the portal and click the refresh button. You should see the new zone.
- Create a zone with the same name and click the refresh button. You should still only see one zone.