### PR TITLE
Allow skipping of production tags from tests

### DIFF
--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -15,6 +15,13 @@ else
   TEST_PATTERN="-k ${TEST_PATTERN}"
 fi
 
+# If we are to skip tests not suitable for prod environments, set to true or omit
+if [ -z "${FOR_PROD}" ]; then
+  SKIP_TAGS=
+else
+  SKIP_TAGS="-m \"not skip_production\""
+fi
+
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=60
@@ -42,4 +49,4 @@ done
 echo "Running live tests against ${VINYLDNS_URL} and DNS server ${DNS_IP}"
 
 cd /app
-./run-tests.py live_tests -v ${TEST_PATTERN} --url=${VINYLDNS_URL} --dns-ip=${DNS_IP}
+./run-tests.py live_tests -v ${TEST_PATTERN} ${SKIP_TAGS} --url=${VINYLDNS_URL} --dns-ip=${DNS_IP}

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -44,11 +44,11 @@ echo "Running live tests against ${VINYLDNS_URL} and DNS server ${DNS_IP}"
 cd /app
 
 # If PROD_ENV is not true, we are in a local docker environment so do not skip anything
-if [ "${PROD_ENV}" != "true"]; then
-    echo "./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}"
-    ./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}
-else
+if [ "${PROD_ENV}" = "true"]; then
     # -m plays havoc with -k, using variables is a headache, so doing this by hand
     echo "./run-tests.py live_tests -m \"not skip_production\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}"
     ./run-tests.py live_tests -v -m "not skip_production" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}
+else
+    echo "./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}"
+    ./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}
 fi

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -44,7 +44,7 @@ echo "Running live tests against ${VINYLDNS_URL} and DNS server ${DNS_IP}"
 cd /app
 
 # If PROD_ENV is unset, we are in a local docker environment so do not skip anything
-if [ -z "${PROD_ENV}" ]; then
+if [ "${PROD_ENV}" != "true"]; then
     echo "./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}"
     ./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}
 else

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -43,7 +43,7 @@ echo "Running live tests against ${VINYLDNS_URL} and DNS server ${DNS_IP}"
 
 cd /app
 
-# If PROD_ENV is unset, we are in a local docker environment so do not skip anything
+# If PROD_ENV is not true, we are in a local docker environment so do not skip anything
 if [ "${PROD_ENV}" != "true"]; then
     echo "./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}"
     ./run-tests.py live_tests -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN}


### PR DESCRIPTION
Some of our func tests are not meant to be run against "real" environments.  Since we now run the functest container against non docker environments, we have to skip these tests.

