### PR TITLE
Account for maximum batch entries in SQS SendMessageBatchRequest

### DIFF
--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -173,8 +173,12 @@ object SqsMessageQueue extends ProtobufConversions {
   // $COVERAGE-OFF$
   final val MINIMUM_VISIBILITY_TIMEOUT = 0
   final val MAXIMUM_VISIBILITY_TIMEOUT = 43200
+
+  // AWS SQS limits specified at:
+  // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/
+  // sqs-client-side-buffering-request-batching.html#configuring-buffered-async-client
   final val MAXIMUM_BATCH_SIZE = 262144
-  final val MAXIMUM_BATCH_ENTRY_COUNT = 10 // Hard limit on the max entries per message batch
+  final val MAXIMUM_BATCH_ENTRY_COUNT = 10
   // $COVERAGE-ON$
 
   def validateMessageTimeout(

--- a/modules/sqs/src/test/scala/vinyldns/sqs/queue/SqsMessageQueueSpec.scala
+++ b/modules/sqs/src/test/scala/vinyldns/sqs/queue/SqsMessageQueueSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
+import vinyldns.core.domain.record.RecordSetChange
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.proto.VinylDNSProto
 import vinyldns.sqs.queue.SqsMessageType._
@@ -43,6 +44,9 @@ class SqsMessageQueueSpec
 
   import SqsMessageQueue._
 
+  implicit val largeRsChange: RecordSetChange =
+    makeTestAddChange(rsOk, okZone).copy(singleBatchChangeIds = List("a" * 20000))
+
   "parseMessageType" should {
     "return the appropriate message type" in {
       fromString("SqsRecordSetChangeMessage") shouldBe Right(SqsRecordSetChangeMessage)
@@ -52,22 +56,42 @@ class SqsMessageQueueSpec
 
   "toSendMessageBatchRequest" should {
     "create a single batch request if total message payload is under 256KB" in {
-      val messageSize = messageData(makeTestAddChange(rsOk, okZone)).getBytes().length
+      val messageSize = messageData(largeRsChange).getBytes().length
       val requestMaxChanges = MAXIMUM_BATCH_SIZE / messageSize
       val recordSetChanges = for (_ <- 1 until requestMaxChanges)
-        yield makeTestAddChange(rsOk, okZone)
+        yield
+          makeTestAddChange(rsOk, okZone).copy(
+            singleBatchChangeIds = largeRsChange.singleBatchChangeIds)
       val commands = NonEmptyList.fromListUnsafe(recordSetChanges.toList)
+
       toSendMessageBatchRequest(commands).length shouldBe 1
     }
 
     "create multiple batch requests if total message payload is over 256KB" in {
-      val messageSize = messageData(makeTestAddChange(rsOk, okZone)).getBytes().length
+      val messageSize = messageData(largeRsChange).getBytes().length
       val requestMaxChanges = MAXIMUM_BATCH_SIZE / messageSize
       val requestTotalChanges = requestMaxChanges * 4 // Create four batches
       val recordSetChanges = for (_ <- 1 until requestTotalChanges)
-        yield makeTestAddChange(rsOk, okZone)
+        yield
+          makeTestAddChange(rsOk, okZone).copy(
+            singleBatchChangeIds = largeRsChange.singleBatchChangeIds)
       val commands = NonEmptyList.fromListUnsafe(recordSetChanges.toList)
       toSendMessageBatchRequest(commands).length shouldBe 4
+    }
+
+    "allow at most MAXIMUM_BATCH_ENTRY_COUNT items in a batch" in {
+      val rsChange = makeTestAddChange(rsOk, okZone).copy(singleBatchChangeIds = List("a" * 1800))
+      val messageSize = messageData(rsChange).getBytes().length
+
+      val requestMaxChanges = MAXIMUM_BATCH_SIZE / messageSize
+      val requestTotalChanges = requestMaxChanges * 2
+      val recordSetChanges = for (_ <- 1 until requestTotalChanges)
+        yield
+          makeTestAddChange(rsOk, okZone).copy(singleBatchChangeIds = rsChange.singleBatchChangeIds)
+      val commands = NonEmptyList.fromListUnsafe(recordSetChanges.toList)
+
+      val result = toSendMessageBatchRequest(commands)
+      result.foreach(_.getEntries.size() should be <= SqsMessageQueue.MAXIMUM_BATCH_ENTRY_COUNT)
     }
   }
 


### PR DESCRIPTION
Fixes #347.

Changes in this pull request:
- Add `MAXIMUM_BATCH_ENTRY_COUNT`
- Take lower of `MAXIMUM_BATCH_ENTRY_COUNT` and `maxMessageGroupCount` when partitioning batch change request into `SendMessageBatchRequest`
