### PR TITLE
Wait for zone and record set promises in portal before displaying record sets

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -150,16 +150,16 @@
                                             {{batchError}}
                                         </p>
                                     </td>
-                                    <td><button class="btn btn-danger batch-change-delete" ng-click="deleteSingleChange($index)">Delete</button></td>
+                                    <td><button type="button" class="btn btn-danger batch-change-delete" ng-click="deleteSingleChange($index)">Delete</button></td>
                                 </tr>
                                 </tbody>
                             </table>
-                            <button id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length == batchChangeLimit"><span class="fa fa-plus"></span> Add a Change</button>
+                            <button type="button" id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length == batchChangeLimit"><span class="fa fa-plus"></span> Add a Change</button>
                             <span ng-if="newBatch.changes.length == batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</span>
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">
-                                <button id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange()">Submit</button>
+                                <button type="button" id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange()">Submit</button>
                             </div>
                             <div ng-if="formStatus=='pendingConfirm'" class="pull-right">
                                 <span>Are you sure you want to submit this batch change request?</span>

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -28,7 +28,6 @@
             $scope.formStatus = "pendingSubmit";
 
             $scope.addSingleChange = function() {
-                event.preventDefault();
                 $scope.newBatch.changes.push({changeType: "Add", type: "A", ttl: 200});
                 var changesLength =$scope.newBatch.changes.length;
                 $timeout(function() {document.getElementsByClassName("changeType")[changesLength - 1].focus()});
@@ -75,13 +74,11 @@
             };
 
             $scope.deleteSingleChange = function(changeNumber) {
-                event.preventDefault();
                 $('.batch-change-delete').blur();
                 $scope.newBatch.changes.splice(changeNumber, 1);
             };
 
             $scope.submitChange = function() {
-                event.preventDefault();
                 $scope.formStatus = "pendingConfirm";
             }
 

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -126,17 +126,14 @@ angular.module('controller.records', [])
     };
 
     $scope.viewRecordInfo = function(record) {
-        $q.all([loadZonesPromise, loadRecordsPromise])
-            .then(function(){
-                $scope.currentRecord = recordsService.toDisplayRecord(record);
-                $scope.recordModal = {
-                    action: $scope.recordModalState.VIEW_DETAILS,
-                    title: "Record Info",
-                    basics: $scope.recordModalParams.readOnly,
-                    details: $scope.recordModalParams.readOnly
-                };
-                $("#record_modal").modal("show");
-            });
+        $scope.currentRecord = recordsService.toDisplayRecord(record);
+        $scope.recordModal = {
+            action: $scope.recordModalState.VIEW_DETAILS,
+            title: "Record Info",
+            basics: $scope.recordModalParams.readOnly,
+            details: $scope.recordModalParams.readOnly
+        };
+        $("#record_modal").modal("show");
     };
 
     /**


### PR DESCRIPTION
Need to wait for promises from multiple asynchronous calls to return before displaying records so that dotted host warning message does not erroneously appear.

Fixes #141.

Changes in this pull request:
- Update `controller.records.js` so that calls to `toDisplayRecord` wait for resolved zone and records promises.
- Update `batch-change-new-controller.js` and batch change view to remove unnecessary `event.preventDefault()` calls.

----
Note to reviewers: 
- Tested this by increasing the timeout of `loadZonesPromise = $timeout($scope.refreshZone, 0);` from `0` to `2000`.
- Information about the `$q` service/promise construction ca be found at: https://docs.angularjs.org/api/ng/service/$q
