### PR TITLE
Postman Fix, add content-length support

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
@@ -136,6 +136,7 @@ class Aws4Authenticator {
       signedHeaderNames: Set[String]): TreeMap[String, Seq[String]] = {
     def getHeaderValue(name: String): Option[String] = name match {
       case "content-type" => Some(req.entity.contentType.value)
+      case "content-length" => req.entity.contentLengthOption.map(_.toString)
       case _ => req.headers.find(_.name.toLowerCase == name).map(_.value)
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/Aws4AuthenticatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/Aws4AuthenticatorSpec.scala
@@ -32,5 +32,15 @@ class Aws4AuthenticatorSpec extends WordSpec with Matchers {
       canonicalHeaders.keys should contain("content-type")
       canonicalHeaders("content-type") should contain("application/json")
     }
+    "pull the content-length" in {
+      val entity = HttpEntity(ContentTypes.`application/json`, "")
+      val req = HttpRequest(
+        entity = entity
+      )
+
+      val canonicalHeaders = new Aws4Authenticator().canonicalHeaders(req, Set("content-length"))
+      canonicalHeaders.keys should contain("content-length")
+      canonicalHeaders("content-length") should contain("0")
+    }
   }
 }


### PR DESCRIPTION
**Background**
In PostMan, we cannot send POST/PUT requests.  We see an error "Unable to validate signature".  The reason is because PostMan includes `Content-Length` header in the list of headers it uses to calculate the AWS Signature.  Unfortunately, we do not properly pull this header out when we do authentication, so the resulting signature VinylDNS calculates does not match what was sent by PostMan

**Steps to Replicate**
You can replicate against any real environment, but the easiest to debug is to spin up a local vinyldns api instance.

1. `sbt` from project folder
1. once sbt starts up, run `root/killDocker` just to make sure there are no stale containers
1. `project api` to switch to the api project
1. `dockerComposeUp` to start up our docker containers
1. `reStart` to start up the api

Next, open up PostMan.  We can test this by attempting to create a group.

1. Create a new Request
1. Change the action (request type) to `Post`
1. Change the URL to `http://localhost:9000/groups`
1. In the `Authorization` change the **Type** to `AWS Signature`
1. In `Authorization` set the **Access Key** to `testUserAccessKey`
1. In `Authorization` set the **Secret Key** to `testUserSecretKey`
1. In `Authorization` `Advanced`, set the **AWS Region** to `us-east-1`
1. In `Authorization` `Advanced`, set the **Service Name** to `VinylDNS`
1. In `Headers` add `Content-Type` and set to `application/json`
1. In `Headers` add `X-Amz-Target` and set to `VinylDNS`
1. In `Body` set the option to `raw`
1. Set the content to the json below

```json
{
	"name": "postman-create",
	"email": "test@test.com",
	"description": "testing postman",
	"members": [ { "id": "testuser" }],
	"admins": [ { "id": "testuser" } ]
}
```

1. Click the `Send` button

**Actual Result**
A message returned _Authentication Failed: Request signature could not be validated_

**Expected Result**
The group was created (200 response code)

**Notes**
You _must_ set the `Content-Type` header, or else the request will fail.  You do not strictly have to set the `X-Amz-Target` header.


