### PR TITLE
Remove zone history check

### DIFF
--- a/modules/api/functional_test/live_tests/internal/status_test.py
+++ b/modules/api/functional_test/live_tests/internal/status_test.py
@@ -64,7 +64,7 @@ def test_toggle_processing(shared_zone_test_context):
     assert_that(record_change['status'], is_('Pending'))
 
     # Make sure that the changes are processed
-    client.wait_until_zone_change_status(zone_change_result, 'Synced')
+    client.wait_until_zone_change_status_synced(zone_change_result)
     client.wait_until_recordset_change_status(record_change, 'Complete')
 
     recordset_length = len(client.list_recordsets(ok_zone['id'])['recordSets'])

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -63,7 +63,7 @@ def test_create_zone_success(shared_zone_test_context):
         }
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
-        client.wait_until_zone_change_status(result, 'Synced')
+        client.wait_until_zone_change_status_synced(result)
 
         get_result = client.get_zone(result_zone['id'])
 

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -63,8 +63,7 @@ def test_create_zone_success(shared_zone_test_context):
         }
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
-        client.wait_until_zone_change_status_synced(result)
-        client.wait_until_zone_synced(result)
+        client.wait_until_zone_active(result)
 
         get_result = client.get_zone(result_zone['id'])
 

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -65,6 +65,8 @@ def test_create_zone_success(shared_zone_test_context):
         result_zone = result['zone']
         client.wait_until_zone_change_status_synced(result)
 
+        time.sleep(1)
+
         get_result = client.get_zone(result_zone['id'])
 
         get_zone = get_result['zone']

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -35,57 +35,57 @@ records_in_dns = [
      'type': u'A',
      'records': [{u'address': u'6.6.6.6'}]}]
 
-# def test_create_zone_success(shared_zone_test_context):
-#     """
-#     Test successfully creating a zone
-#     """
-#     client = shared_zone_test_context.ok_vinyldns_client
-#     result_zone = None
-#     try:
-#         zone_name = 'one-time'
-#
-#         zone = {
-#             'name': zone_name,
-#             'email': 'test@test.com',
-#             'adminGroupId': shared_zone_test_context.ok_group['id'],
-#             'connection': {
-#                 'name': 'vinyldns.',
-#                 'keyName': VinylDNSTestContext.dns_key_name,
-#                 'key': VinylDNSTestContext.dns_key,
-#                 'primaryServer': VinylDNSTestContext.dns_ip
-#             },
-#             'transferConnection': {
-#                 'name': 'vinyldns.',
-#                 'keyName': VinylDNSTestContext.dns_key_name,
-#                 'key': VinylDNSTestContext.dns_key,
-#                 'primaryServer': VinylDNSTestContext.dns_ip
-#             }
-#         }
-#         result = client.create_zone(zone, status=202)
-#         result_zone = result['zone']
-#         client.wait_until_zone_change_status_synced(result)
-#
-#         get_result = client.get_zone(result_zone['id'])
-#
-#         get_zone = get_result['zone']
-#         assert_that(get_zone['name'], is_(zone['name']+'.'))
-#         assert_that(get_zone['email'], is_(zone['email']))
-#         assert_that(get_zone['adminGroupId'], is_(zone['adminGroupId']))
-#         assert_that(get_zone['latestSync'], is_not(none()))
-#         assert_that(get_zone['status'], is_('Active'))
-#
-#         # confirm that the recordsets in DNS have been saved in vinyldns
-#         recordsets = client.list_recordsets(result_zone['id'])['recordSets']
-#
-#         assert_that(len(recordsets), is_(7))
-#         for rs in recordsets:
-#             small_rs = dict((k, rs[k]) for k in ['name', 'type', 'records'])
-#             small_rs['records'] = sorted(small_rs['records'])
-#             assert_that(records_in_dns, has_item(small_rs))
-#
-#     finally:
-#         if result_zone:
-#             client.abandon_zones([result_zone['id']], status=202)
+def test_create_zone_success(shared_zone_test_context):
+    """
+    Test successfully creating a zone
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    result_zone = None
+    try:
+        zone_name = 'one-time'
+
+        zone = {
+            'name': zone_name,
+            'email': 'test@test.com',
+            'adminGroupId': shared_zone_test_context.ok_group['id'],
+            'connection': {
+                'name': 'vinyldns.',
+                'keyName': VinylDNSTestContext.dns_key_name,
+                'key': VinylDNSTestContext.dns_key,
+                'primaryServer': VinylDNSTestContext.dns_ip
+            },
+            'transferConnection': {
+                'name': 'vinyldns.',
+                'keyName': VinylDNSTestContext.dns_key_name,
+                'key': VinylDNSTestContext.dns_key,
+                'primaryServer': VinylDNSTestContext.dns_ip
+            }
+        }
+        result = client.create_zone(zone, status=202)
+        result_zone = result['zone']
+        client.wait_until_zone_change_status_synced(result)
+
+        get_result = client.get_zone(result_zone['id'])
+
+        get_zone = get_result['zone']
+        assert_that(get_zone['name'], is_(zone['name']+'.'))
+        assert_that(get_zone['email'], is_(zone['email']))
+        assert_that(get_zone['adminGroupId'], is_(zone['adminGroupId']))
+        assert_that(get_zone['latestSync'], is_not(none()))
+        assert_that(get_zone['status'], is_('Active'))
+
+        # confirm that the recordsets in DNS have been saved in vinyldns
+        recordsets = client.list_recordsets(result_zone['id'])['recordSets']
+
+        assert_that(len(recordsets), is_(7))
+        for rs in recordsets:
+            small_rs = dict((k, rs[k]) for k in ['name', 'type', 'records'])
+            small_rs['records'] = sorted(small_rs['records'])
+            assert_that(records_in_dns, has_item(small_rs))
+
+    finally:
+        if result_zone:
+            client.abandon_zones([result_zone['id']], status=202)
 
 
 @pytest.mark.skip_production

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -65,8 +65,6 @@ def test_create_zone_success(shared_zone_test_context):
         result_zone = result['zone']
         client.wait_until_zone_change_status_synced(result)
 
-        time.sleep(1)
-
         get_result = client.get_zone(result_zone['id'])
 
         get_zone = get_result['zone']

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -35,57 +35,57 @@ records_in_dns = [
      'type': u'A',
      'records': [{u'address': u'6.6.6.6'}]}]
 
-def test_create_zone_success(shared_zone_test_context):
-    """
-    Test successfully creating a zone
-    """
-    client = shared_zone_test_context.ok_vinyldns_client
-    result_zone = None
-    try:
-        zone_name = 'one-time'
-
-        zone = {
-            'name': zone_name,
-            'email': 'test@test.com',
-            'adminGroupId': shared_zone_test_context.ok_group['id'],
-            'connection': {
-                'name': 'vinyldns.',
-                'keyName': VinylDNSTestContext.dns_key_name,
-                'key': VinylDNSTestContext.dns_key,
-                'primaryServer': VinylDNSTestContext.dns_ip
-            },
-            'transferConnection': {
-                'name': 'vinyldns.',
-                'keyName': VinylDNSTestContext.dns_key_name,
-                'key': VinylDNSTestContext.dns_key,
-                'primaryServer': VinylDNSTestContext.dns_ip
-            }
-        }
-        result = client.create_zone(zone, status=202)
-        result_zone = result['zone']
-        client.wait_until_zone_change_status_synced(result)
-
-        get_result = client.get_zone(result_zone['id'])
-
-        get_zone = get_result['zone']
-        assert_that(get_zone['name'], is_(zone['name']+'.'))
-        assert_that(get_zone['email'], is_(zone['email']))
-        assert_that(get_zone['adminGroupId'], is_(zone['adminGroupId']))
-        assert_that(get_zone['latestSync'], is_not(none()))
-        assert_that(get_zone['status'], is_('Active'))
-
-        # confirm that the recordsets in DNS have been saved in vinyldns
-        recordsets = client.list_recordsets(result_zone['id'])['recordSets']
-
-        assert_that(len(recordsets), is_(7))
-        for rs in recordsets:
-            small_rs = dict((k, rs[k]) for k in ['name', 'type', 'records'])
-            small_rs['records'] = sorted(small_rs['records'])
-            assert_that(records_in_dns, has_item(small_rs))
-
-    finally:
-        if result_zone:
-            client.abandon_zones([result_zone['id']], status=202)
+# def test_create_zone_success(shared_zone_test_context):
+#     """
+#     Test successfully creating a zone
+#     """
+#     client = shared_zone_test_context.ok_vinyldns_client
+#     result_zone = None
+#     try:
+#         zone_name = 'one-time'
+#
+#         zone = {
+#             'name': zone_name,
+#             'email': 'test@test.com',
+#             'adminGroupId': shared_zone_test_context.ok_group['id'],
+#             'connection': {
+#                 'name': 'vinyldns.',
+#                 'keyName': VinylDNSTestContext.dns_key_name,
+#                 'key': VinylDNSTestContext.dns_key,
+#                 'primaryServer': VinylDNSTestContext.dns_ip
+#             },
+#             'transferConnection': {
+#                 'name': 'vinyldns.',
+#                 'keyName': VinylDNSTestContext.dns_key_name,
+#                 'key': VinylDNSTestContext.dns_key,
+#                 'primaryServer': VinylDNSTestContext.dns_ip
+#             }
+#         }
+#         result = client.create_zone(zone, status=202)
+#         result_zone = result['zone']
+#         client.wait_until_zone_change_status_synced(result)
+#
+#         get_result = client.get_zone(result_zone['id'])
+#
+#         get_zone = get_result['zone']
+#         assert_that(get_zone['name'], is_(zone['name']+'.'))
+#         assert_that(get_zone['email'], is_(zone['email']))
+#         assert_that(get_zone['adminGroupId'], is_(zone['adminGroupId']))
+#         assert_that(get_zone['latestSync'], is_not(none()))
+#         assert_that(get_zone['status'], is_('Active'))
+#
+#         # confirm that the recordsets in DNS have been saved in vinyldns
+#         recordsets = client.list_recordsets(result_zone['id'])['recordSets']
+#
+#         assert_that(len(recordsets), is_(7))
+#         for rs in recordsets:
+#             small_rs = dict((k, rs[k]) for k in ['name', 'type', 'records'])
+#             small_rs['records'] = sorted(small_rs['records'])
+#             assert_that(records_in_dns, has_item(small_rs))
+#
+#     finally:
+#         if result_zone:
+#             client.abandon_zones([result_zone['id']], status=202)
 
 
 @pytest.mark.skip_production

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -64,6 +64,7 @@ def test_create_zone_success(shared_zone_test_context):
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
         client.wait_until_zone_change_status_synced(result)
+        client.wait_until_zone_synced(result)
 
         get_result = client.get_zone(result_zone['id'])
 

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -63,7 +63,7 @@ def test_create_zone_success(shared_zone_test_context):
         }
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
-        client.wait_until_zone_active(result)
+        client.wait_until_zone_active(result_zone['id'])
 
         get_result = client.get_zone(result_zone['id'])
 

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -113,7 +113,7 @@ def test_sync_zone_success(shared_zone_test_context):
         zone_change = client.create_zone(zone, status=202)
         zone = zone_change['zone']
         client.wait_until_zone_exists(zone_change)
-        client.wait_until_zone_change_status(zone_change, 'Synced')
+        client.wait_until_zone_change_status_synced(zone_change)
 
         time.sleep(.5)
 
@@ -151,7 +151,7 @@ def test_sync_zone_success(shared_zone_test_context):
 
         # sync again
         change = client.sync_zone(zone['id'], status=202)
-        client.wait_until_zone_change_status(change, 'Synced')
+        client.wait_until_zone_change_status_synced(change)
 
         # confirm cannot again sync without waiting
         client.sync_zone(zone['id'], status=403)

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -163,9 +163,7 @@ def test_sync_zone_success(shared_zone_test_context):
         time.sleep(10)
 
         # sync again
-        change = client.sync_zone(zone['id'], status=202)
-        client.wait_until_zone_change_status_synced(change)
-
+        client.sync_zone(zone['id'], status=202)
         wait_for_zone_sync_to_complete(client, zone['id'], latest_sync)
 
         # confirm cannot again sync without waiting

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -112,7 +112,7 @@ def test_sync_zone_success(shared_zone_test_context):
     try:
         zone_change = client.create_zone(zone, status=202)
         zone = zone_change['zone']
-        client.wait_until_zone_active(zone_change)
+        client.wait_until_zone_active(zone['id'])
 
         time.sleep(.5)
 

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -150,7 +150,8 @@ def test_sync_zone_success(shared_zone_test_context):
         time.sleep(10)
 
         # sync again
-        client.sync_zone(zone['id'], status=202)
+        change = client.sync_zone(zone['id'], status=202)
+        client.wait_until_zone_change_status_synced(change)
 
         # confirm cannot again sync without waiting
         client.sync_zone(zone['id'], status=403)

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -112,8 +112,7 @@ def test_sync_zone_success(shared_zone_test_context):
     try:
         zone_change = client.create_zone(zone, status=202)
         zone = zone_change['zone']
-        client.wait_until_zone_exists(zone_change)
-        client.wait_until_zone_change_status_synced(zone_change)
+        client.wait_until_zone_active(zone_change)
 
         time.sleep(.5)
 
@@ -152,9 +151,6 @@ def test_sync_zone_success(shared_zone_test_context):
         # sync again
         change = client.sync_zone(zone['id'], status=202)
         client.wait_until_zone_change_status_synced(change)
-
-        # confirm cannot again sync without waiting
-        client.sync_zone(zone['id'], status=403)
 
         # validate zone
         get_result = client.get_zone(zone['id'])

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -151,10 +151,11 @@ def test_sync_zone_success(shared_zone_test_context):
 
         # sync again
         change = client.sync_zone(zone['id'], status=202)
-        client.wait_until_zone_change_status_synced(change)
 
         # confirm cannot again sync without waiting
         client.sync_zone(zone['id'], status=403)
+
+        client.wait_until_zone_change_status_synced(change)
 
         # validate zone
         get_result = client.get_zone(zone['id'])

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -150,12 +150,10 @@ def test_sync_zone_success(shared_zone_test_context):
         time.sleep(10)
 
         # sync again
-        change = client.sync_zone(zone['id'], status=202)
+        client.sync_zone(zone['id'], status=202)
 
         # confirm cannot again sync without waiting
         client.sync_zone(zone['id'], status=403)
-
-        client.wait_until_zone_change_status_synced(change)
 
         # validate zone
         get_result = client.get_zone(zone['id'])

--- a/modules/api/functional_test/live_tests/zones/update_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/update_zone_test.py
@@ -48,7 +48,7 @@ def test_update_zone_success(shared_zone_test_context):
         result_zone['email'] = 'foo@bar.com'
         result_zone['acl']['rules'] = [acl_rule]
         update_result = client.update_zone(result_zone, status=202)
-        client.wait_until_zone_change_status(update_result, 'Synced')
+        client.wait_until_zone_change_status_synced(update_result)
 
         assert_that(update_result['changeType'], is_('Update'))
         assert_that(update_result['userId'], is_('ok'))
@@ -617,7 +617,7 @@ def test_update_reverse_v4_zone(shared_zone_test_context):
     import json
     print json.dumps(zone, indent=4)
     update_result = client.update_zone(zone, status=202)
-    client.wait_until_zone_change_status(update_result, 'Synced')
+    client.wait_until_zone_change_status_synced(update_result)
 
     assert_that(update_result['changeType'], is_('Update'))
     assert_that(update_result['userId'], is_('ok'))
@@ -641,7 +641,7 @@ def test_update_reverse_v6_zone(shared_zone_test_context):
     zone['email'] = 'update-test@bar.com'
 
     update_result = client.update_zone(zone, status=202)
-    client.wait_until_zone_change_status(update_result, 'Synced')
+    client.wait_until_zone_change_status_synced(update_result)
 
     assert_that(update_result['changeType'], is_('Update'))
     assert_that(update_result['userId'], is_('ok'))
@@ -738,7 +738,7 @@ def test_user_can_update_zone_to_another_admin_group(shared_zone_test_context):
         zone_update['adminGroupId'] = group['id']
 
         result = client.update_zone(zone_update, status=202)
-        client.wait_until_zone_change_status(result, 'Synced')
+        client.wait_until_zone_change_status_synced(result)
     finally:
         if zone:
             client.delete_zone(zone['id'], status=202)

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -262,70 +262,70 @@ def remove_rules_from_zone(zone, deleted_rules):
 def add_ok_acl_rules(test_context, rules):
     updated_zone = add_rules_to_zone(test_context.ok_zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def add_ip4_acl_rules(test_context, rules):
     updated_zone = add_rules_to_zone(test_context.ip4_reverse_zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def add_ip6_acl_rules(test_context, rules):
     updated_zone = add_rules_to_zone(test_context.ip6_reverse_zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def add_classless_acl_rules(test_context, rules):
     updated_zone = add_rules_to_zone(test_context.classless_zone_delegation_zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def remove_ok_acl_rules(test_context, rules):
     zone = test_context.ok_vinyldns_client.get_zone(test_context.ok_zone['id'])['zone']
     updated_zone = remove_rules_from_zone(zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def remove_ip4_acl_rules(test_context, rules):
     zone = test_context.ok_vinyldns_client.get_zone(test_context.ip4_reverse_zone['id'])['zone']
     updated_zone = remove_rules_from_zone(zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def remove_ip6_acl_rules(test_context, rules):
     zone = test_context.ok_vinyldns_client.get_zone(test_context.ip6_reverse_zone['id'])['zone']
     updated_zone = remove_rules_from_zone(zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def remove_classless_acl_rules(test_context, rules):
     zone = test_context.ok_vinyldns_client.get_zone(test_context.classless_zone_delegation_zone['id'])['zone']
     updated_zone = remove_rules_from_zone(zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def clear_ok_acl_rules(test_context):
     zone = test_context.ok_zone
     zone['acl']['rules'] = []
     update_change = test_context.ok_vinyldns_client.update_zone(zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def clear_ip4_acl_rules(test_context):
     zone = test_context.ip4_reverse_zone
     zone['acl']['rules'] = []
     update_change = test_context.ok_vinyldns_client.update_zone(zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def clear_ip6_acl_rules(test_context):
     zone = test_context.ip6_reverse_zone
     zone['acl']['rules'] = []
     update_change = test_context.ok_vinyldns_client.update_zone(zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def clear_classless_acl_rules(test_context):
     zone = test_context.classless_zone_delegation_zone
     zone['acl']['rules'] = []
     update_change = test_context.ok_vinyldns_client.update_zone(zone, status=202)
-    test_context.ok_vinyldns_client.wait_until_zone_change_status(update_change, 'Synced')
+    test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def seed_text_recordset(client, record_name, zone, records=[{'text':'someText'}]):
     new_rs = {

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -696,7 +696,9 @@ class VinylDNSClient(object):
         retries = MAX_RETRIES
         url = urljoin(self.index_url, u'/zones/{0}'.format(zone_id))
         response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, status=(200, 404), **kwargs)
+        print("RESPONSE: " + str(response))
         while response != 404 and retries > 0:
+            print("RESPONSE: " + str(response))
             url = urljoin(self.index_url, u'/zones/{0}'.format(zone_id))
             response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, status=(200, 404), **kwargs)
             retries -= 1

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -679,7 +679,7 @@ class VinylDNSClient(object):
 
         while change[u'status'] != expected_status and retries > 0:
             latest_changes = self.list_zone_changes(change['zone']['id'])
-            if latest_changes[u'zoneChanges']:
+            if type(latest_changes).__name__  == 'dict' and latest_changes[u'zoneChanges']:
                 matching_changes = filter(change_id_match, latest_changes[u'zoneChanges'])
                 if len(matching_changes) > 0:
                     change = matching_changes[0]

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -732,14 +732,14 @@ class VinylDNSClient(object):
         """
         zone_id = zone_change[u'zone'][u'id']
         retries = MAX_RETRIES
-        something = self.get_zone(zone_id)
+        zone = self.get_zone(zone_id)
 
-        while u'latestSync' not in something and retries > 0:
-            something = self.get_zone(zone_id)
+        while u'latestSync' not in zone and retries > 0:
+            zone = self.get_zone(zone_id)
             time.sleep(RETRY_WAIT)
             retries -= 1
 
-        assert_that(something[u'zone']['latestSync'], is_not(none()))
+        assert_that(zone[u'zone']['latestSync'], is_not(none()))
 
     def wait_until_recordset_exists(self, zone_id, record_set_id, **kwargs):
         """

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -736,7 +736,6 @@ class VinylDNSClient(object):
 
         while u'latestSync' not in something and retries > 0:
             something = self.get_zone(zone_id)
-            print(something)
             time.sleep(RETRY_WAIT)
             retries -= 1
 

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -2,7 +2,6 @@ import json
 import time
 import logging
 import collections
-import datetime
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -674,7 +673,7 @@ class VinylDNSClient(object):
         latest_change = zone_change
         retries = MAX_RETRIES
 
-        while (latest_change[u'status'] != 'Synced' and retries > 0) and latest_change[u'status'] != 'Failed':
+        while latest_change[u'status'] != 'Synced' and latest_change[u'status'] != 'Failed' and retries > 0:
             changes = self.list_zone_changes(zone_change['zone']['id'])
             if u'zoneChanges' in changes:
                 matching_changes = filter(lambda change: change[u'id'] == zone_change[u'id'], changes[u'zoneChanges'])
@@ -696,9 +695,7 @@ class VinylDNSClient(object):
         retries = MAX_RETRIES
         url = urljoin(self.index_url, u'/zones/{0}'.format(zone_id))
         response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, status=(200, 404), **kwargs)
-        print("RESPONSE: " + str(response))
         while response != 404 and retries > 0:
-            print("RESPONSE: " + str(response))
             url = urljoin(self.index_url, u'/zones/{0}'.format(zone_id))
             response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, status=(200, 404), **kwargs)
             retries -= 1
@@ -735,7 +732,7 @@ class VinylDNSClient(object):
         retries = MAX_RETRIES
         zone_request = self.get_zone(zone_id)
 
-        while ('status' not in zone_request or zone_request[u'zone'][u'status'] != 'Active') and retries > 0:
+        while (u'zone' not in zone_request or zone_request[u'zone'][u'status'] != 'Active') and retries > 0:
             zone_request = self.get_zone(zone_id)
             time.sleep(RETRY_WAIT)
             retries -= 1

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -384,39 +384,6 @@ class VinylDNSClient(object):
 
         return data
 
-    def get_zone_history(self, zone_id, **kwargs):
-        """
-        Gets the zone history for the given zone id
-        :param zone_id: the id of the zone to retrieve
-        :return: the zone, or will 404 if not found
-        """
-        url = urljoin(self.index_url, u'/zones/{0}/history'.format(zone_id))
-
-        response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, **kwargs)
-        return data
-
-    def get_zone_change(self, zone_change, **kwargs):
-        """
-        Gets a zone change with the provided id
-
-        Unfortunately, there is no endpoint, so we have to get all zone history and parse
-        """
-        zone_change_id = zone_change[u'id']
-        change = None
-
-        def change_id_match(possible_match):
-            return possible_match[u'id'] == zone_change_id
-
-        history = self.get_zone_history(zone_change[u'zone'][u'id'])
-        if u'zoneChanges' in history:
-            zone_changes = history[u'zoneChanges']
-            matching_changes = filter(change_id_match, zone_changes)
-
-            if len(matching_changes) > 0:
-                change = matching_changes[0]
-
-        return change
-
     def list_zone_changes(self, zone_id, start_from=None, max_items=None, **kwargs):
         """
         Gets the zone changes for the given zone id
@@ -704,22 +671,9 @@ class VinylDNSClient(object):
         """
         Waits until the zone change status matches the expected status
         """
-        zone_change_id = zone_change[u'id']
-
-        def change_id_match(change):
-            return change[u'id'] == zone_change_id
-
         change = zone_change
         retries = MAX_RETRIES
         while change[u'status'] != expected_status and retries > 0:
-            history = self.get_zone_history(zone_change[u'zone'][u'id'])
-
-            if u'zoneChanges' in history:
-                zone_changes = history[u'zoneChanges']
-                matching_changes = filter(change_id_match, zone_changes)
-
-                if len(matching_changes) > 0:
-                    change = matching_changes[0]
             time.sleep(RETRY_WAIT)
             retries -= 1
 

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -724,6 +724,24 @@ class VinylDNSClient(object):
 
         return response == 200
 
+    def wait_until_zone_synced(self, zone_change):
+        """
+        Waits a period of time for the zone sync to complete.
+
+        :param zone_change: the create zone change for the zone that has been created.
+        """
+        zone_id = zone_change[u'zone'][u'id']
+        retries = MAX_RETRIES
+        something = self.get_zone(zone_id)
+
+        while u'latestSync' not in something and retries > 0:
+            something = self.get_zone(zone_id)
+            print(something)
+            time.sleep(RETRY_WAIT)
+            retries -= 1
+
+        assert_that(something[u'zone']['latestSync'], is_not(none()))
+
     def wait_until_recordset_exists(self, zone_id, record_set_id, **kwargs):
         """
         Waits a period of time for the record set creation to complete.

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -673,10 +673,16 @@ class VinylDNSClient(object):
         """
         change = zone_change
         retries = MAX_RETRIES
+
+        def change_id_match(change):
+            return change[u'id'] == zone_change[u'id']
+
         while change[u'status'] != expected_status and retries > 0:
             latest_changes = self.list_zone_changes(change['zone']['id'])
             if latest_changes[u'zoneChanges']:
-                change = latest_changes[u'zoneChanges'][0]
+                matching_changes = filter(change_id_match, latest_changes[u'zoneChanges'])
+                if len(matching_changes) > 0:
+                    change = matching_changes[0]
             else:
                 change = change
             time.sleep(RETRY_WAIT)

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -674,7 +674,7 @@ class VinylDNSClient(object):
         latest_change = zone_change
         retries = MAX_RETRIES
 
-        while latest_change[u'status'] != 'Synced' and retries > 0:
+        while (latest_change[u'status'] != 'Synced' and retries > 0) and latest_change[u'status'] != 'Failed':
             changes = self.list_zone_changes(zone_change['zone']['id'])
             if u'zoneChanges' in changes:
                 matching_changes = filter(lambda change: change[u'id'] == zone_change[u'id'], changes[u'zoneChanges'])

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -360,8 +360,6 @@ class VinylDNSClient(object):
         """
         url = urljoin(self.index_url, u'/zones/{0}/sync'.format(zone_id))
         response, data = self.make_request(url, u'POST', self.headers, not_found_ok=True, **kwargs)
-        print("SYNC RESPONSE: " + str(response))
-        print("TIME NOW: ") + str(datetime.datetime.now())
         return data
 
     def delete_zone(self, zone_id, **kwargs):

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -674,6 +674,11 @@ class VinylDNSClient(object):
         change = zone_change
         retries = MAX_RETRIES
         while change[u'status'] != expected_status and retries > 0:
+            latest_changes = self.list_zone_changes(change['zone']['id'])
+            if latest_changes[u'zoneChanges']:
+                change = latest_changes[u'zoneChanges'][0]
+            else:
+                change = change
             time.sleep(RETRY_WAIT)
             retries -= 1
 

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -724,7 +724,7 @@ class VinylDNSClient(object):
 
         return response == 200
 
-    def wait_until_zone_synced(self, zone_change):
+    def wait_until_zone_active(self, zone_change):
         """
         Waits a period of time for the zone sync to complete.
 

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -683,7 +683,7 @@ class VinylDNSClient(object):
             time.sleep(RETRY_WAIT)
             retries -= 1
 
-        return latest_change[u'status'] == 'Synced'
+        assert_that(latest_change[u'status'], is_('Synced'))
 
     def wait_until_zone_deleted(self, zone_id, **kwargs):
         """

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -2,6 +2,7 @@ import json
 import time
 import logging
 import collections
+import datetime
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -359,7 +360,8 @@ class VinylDNSClient(object):
         """
         url = urljoin(self.index_url, u'/zones/{0}/sync'.format(zone_id))
         response, data = self.make_request(url, u'POST', self.headers, not_found_ok=True, **kwargs)
-
+        print("SYNC RESPONSE: " + str(response))
+        print("TIME NOW: ") + str(datetime.datetime.now())
         return data
 
     def delete_zone(self, zone_id, **kwargs):

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -683,7 +683,7 @@ class VinylDNSClient(object):
             time.sleep(RETRY_WAIT)
             retries -= 1
 
-        assert_that(latest_change[u'status'], is_('Synced'))
+        return latest_change[u'status'] == 'Synced'
 
     def wait_until_zone_deleted(self, zone_id, **kwargs):
         """

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -726,22 +726,21 @@ class VinylDNSClient(object):
 
         return response == 200
 
-    def wait_until_zone_active(self, zone_change):
+    def wait_until_zone_active(self, zone_id):
         """
         Waits a period of time for the zone sync to complete.
 
-        :param zone_change: the create zone change for the zone that has been created.
+        :param zone_id: the ID for the zone.
         """
-        zone_id = zone_change[u'zone'][u'id']
         retries = MAX_RETRIES
-        zone = self.get_zone(zone_id)
+        zone_request = self.get_zone(zone_id)
 
-        while u'latestSync' not in zone and retries > 0:
-            zone = self.get_zone(zone_id)
+        while ('status' not in zone_request or zone_request[u'zone'][u'status'] != 'Active') and retries > 0:
+            zone_request = self.get_zone(zone_id)
             time.sleep(RETRY_WAIT)
             retries -= 1
 
-        assert_that(zone[u'zone']['status'], is_('Active'))
+        assert_that(zone_request[u'zone'][u'status'], is_('Active'))
 
     def wait_until_recordset_exists(self, zone_id, record_set_id, **kwargs):
         """

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -741,7 +741,7 @@ class VinylDNSClient(object):
             time.sleep(RETRY_WAIT)
             retries -= 1
 
-        assert_that(zone[u'zone']['latestSync'], is_not(none()))
+        assert_that(zone[u'zone']['status'], is_('Active'))
 
     def wait_until_recordset_exists(self, zone_id, record_set_id, **kwargs):
         """


### PR DESCRIPTION
Fixes #362

Changes in this pull request:
- removed `get_zone_history method` and `get_zone_change` methods
- update `wait_until_zone_change_status` method to check the status of the most recent zone change