### PR TITLE
Support admin

### DIFF
--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -440,7 +440,7 @@ def test_user_cannot_create_zone_with_nonmember_admin_group(shared_zone_test_con
         }
     }
 
-    shared_zone_test_context.ok_vinyldns_client.create_zone(zone, status=400)
+    shared_zone_test_context.ok_vinyldns_client.create_zone(zone, status=403)
 
 
 def test_user_cannot_create_zone_with_failed_validations(shared_zone_test_context):

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -102,11 +102,12 @@ object AccessValidations extends AccessValidationAlgebra {
       }
 
       recordSets.map { rs =>
+        val aclAccessLevel = getAccessFromUserAcls(rs.name, rs.typ)
         val accessLevel = {
-          if ((getAccessFromUserAcls(rs.name, rs.typ) == AccessLevel.NoAccess) && auth.signedInUser.isSupport)
+          if ((aclAccessLevel == AccessLevel.NoAccess) && auth.canReadAll)
             AccessLevel.Read
           else
-            getAccessFromUserAcls(rs.name, rs.typ)
+            aclAccessLevel
         }
         RecordSetInfo(rs, accessLevel)
       }

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -173,8 +173,7 @@ object AccessValidations extends AccessValidationAlgebra {
       recordName: String,
       recordType: RecordType,
       zone: Zone): AccessLevel = auth match {
-    case superUser if superUser.canEditAll => AccessLevel.Delete
-    case groupMember if groupMember.isGroupMember(zone.adminGroupId) => AccessLevel.Delete
+    case admin if admin.canEditAll || admin.isGroupMember(zone.adminGroupId) => AccessLevel.Delete
     case supportUser if supportUser.canReadAll => {
       val aclAccess = getAccessFromAcl(auth, recordName, recordType, zone)
       if (aclAccess == AccessLevel.NoAccess) AccessLevel.Read else aclAccess

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -103,7 +103,7 @@ object AccessValidations extends AccessValidationAlgebra {
 
       recordSets.map { rs =>
         val accessLevel = {
-          if ((getAccessFromUserAcls(rs.name, rs.typ) == AccessLevel.NoAccess) && auth.signedInUser.isSupport.get)
+          if ((getAccessFromUserAcls(rs.name, rs.typ) == AccessLevel.NoAccess) && auth.signedInUser.isSupport)
             AccessLevel.Read
           else
             getAccessFromUserAcls(rs.name, rs.typ)

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -103,7 +103,7 @@ object AccessValidations extends AccessValidationAlgebra {
 
       recordSets.map { rs =>
         val accessLevel = {
-          if ((getAccessFromUserAcls(rs.name, rs.typ) == AccessLevel.NoAccess) && auth.signedInUser.isSupport)
+          if ((getAccessFromUserAcls(rs.name, rs.typ) == AccessLevel.NoAccess) && auth.signedInUser.isSupport.get)
             AccessLevel.Read
           else
             getAccessFromUserAcls(rs.name, rs.typ)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -325,7 +325,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
   def canGetBatchChange(
       batchChange: BatchChange,
       auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId || auth.signedInUser.isSupport) {
+    if (auth.canReadAll || auth.userId == batchChange.userId) {
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -325,7 +325,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
   def canGetBatchChange(
       batchChange: BatchChange,
       auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId) {
+    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId || auth.signedInUser.isSupport) {
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -325,7 +325,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
   def canGetBatchChange(
       batchChange: BatchChange,
       auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId || auth.signedInUser.isSupport.get) {
+    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId || auth.signedInUser.isSupport) {
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -325,7 +325,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
   def canGetBatchChange(
       batchChange: BatchChange,
       auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId || auth.signedInUser.isSupport) {
+    if (auth.signedInUser.isSuper || auth.userId == batchChange.userId || auth.signedInUser.isSupport.get) {
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -132,7 +132,7 @@ class MembershipService(
       maxItems: Int,
       authPrincipal: AuthPrincipal): Result[ListMyGroupsResponse] = {
     val groupsCall =
-      if (authPrincipal.signedInUser.isSuper || authPrincipal.signedInUser.isSupport.get) {
+      if (authPrincipal.signedInUser.isSuper || authPrincipal.signedInUser.isSupport) {
         groupRepo.getAllGroups()
       } else {
         groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -132,7 +132,7 @@ class MembershipService(
       maxItems: Int,
       authPrincipal: AuthPrincipal): Result[ListMyGroupsResponse] = {
     val groupsCall =
-      if (authPrincipal.signedInUser.isSuper || authPrincipal.signedInUser.isSupport) {
+      if (authPrincipal.canReadAll) {
         groupRepo.getAllGroups()
       } else {
         groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -132,7 +132,7 @@ class MembershipService(
       maxItems: Int,
       authPrincipal: AuthPrincipal): Result[ListMyGroupsResponse] = {
     val groupsCall =
-      if (authPrincipal.signedInUser.isSuper || authPrincipal.signedInUser.isSupport) {
+      if (authPrincipal.signedInUser.isSuper || authPrincipal.signedInUser.isSupport.get) {
         groupRepo.getAllGroups()
       } else {
         groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -131,11 +131,12 @@ class MembershipService(
       startFrom: Option[String],
       maxItems: Int,
       authPrincipal: AuthPrincipal): Result[ListMyGroupsResponse] = {
-    val groupsCall = if (authPrincipal.signedInUser.isSuper) {
-      groupRepo.getAllGroups()
-    } else {
-      groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)
-    }
+    val groupsCall =
+      if (authPrincipal.signedInUser.isSuper || authPrincipal.signedInUser.isSupport) {
+        groupRepo.getAllGroups()
+      } else {
+        groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)
+      }
 
     groupsCall.map { grp =>
       pageListGroupsResponse(grp.toList, groupNameFilter, startFrom, maxItems)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -68,7 +68,7 @@ class MembershipService(
     for {
       existingGroup <- getExistingGroup(groupId)
       newGroup = existingGroup.withUpdates(name, email, description, memberIds, adminUserIds)
-      _ <- isGroupAdmin(existingGroup, authPrincipal).toResult
+      _ <- canEditGroup(existingGroup, authPrincipal).toResult
       addedMembers = newGroup.memberIds.diff(existingGroup.memberIds)
       removedMembers = existingGroup.memberIds.diff(newGroup.memberIds)
       _ <- hasMembersAndAdmins(newGroup).toResult
@@ -85,7 +85,7 @@ class MembershipService(
   def deleteGroup(groupId: String, authPrincipal: AuthPrincipal): Result[Group] =
     for {
       existingGroup <- getExistingGroup(groupId)
-      _ <- isGroupAdmin(existingGroup, authPrincipal).toResult
+      _ <- canEditGroup(existingGroup, authPrincipal).toResult
       _ <- groupCanBeDeleted(existingGroup)
       _ <- groupChangeRepo
         .save(GroupChange.forDelete(existingGroup, authPrincipal))

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -38,8 +38,13 @@ object MembershipValidations {
       authPrincipal.signedInUser.isSuper
     }
 
+  def isSupportAdmin(authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
+    ensuring(NotAuthorizedError("Not authorized")) {
+      authPrincipal.signedInUser.isSupport
+    }
+
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.isAuthorized(groupId)
+      authPrincipal.isAuthorized(groupId) || authPrincipal.signedInUser.isSupport
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -30,16 +30,16 @@ object MembershipValidations {
 
   def isGroupAdmin(group: Group, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      group.adminUserIds.contains(authPrincipal.userId) || authPrincipal.signedInUser.isSuper
+      authPrincipal.isGroupAdmin(group) || authPrincipal.canEditAll
     }
 
   def isSuperAdmin(authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.signedInUser.isSuper
+      authPrincipal.canEditAll
     }
 
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.canReadAll(groupId)
+      authPrincipal.isGroupMember(groupId) || authPrincipal.canReadAll
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -45,6 +45,6 @@ object MembershipValidations {
 
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.isAuthorized(groupId) || authPrincipal.signedInUser.isSupport
+      authPrincipal.canReadAll(groupId)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -28,7 +28,7 @@ object MembershipValidations {
       group.memberIds.nonEmpty && group.adminUserIds.nonEmpty
     }
 
-  def isGroupAdmin(group: Group, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
+  def canEditGroup(group: Group, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
       authPrincipal.isGroupAdmin(group) || authPrincipal.canEditAll
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -38,11 +38,6 @@ object MembershipValidations {
       authPrincipal.signedInUser.isSuper
     }
 
-  def isSupportAdmin(authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.signedInUser.isSupport
-    }
-
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
       authPrincipal.canReadAll(groupId)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -77,7 +77,7 @@ class ZoneService(
       _ <- validateZoneConnectionIfChanged(newZone, existingZone)
       _ <- canChangeZone(auth, existingZone).toResult
       _ <- adminGroupExists(newZone.adminGroupId)
-      _ <- canChangeZone(auth, newZone).toResult
+      _ <- canChangeZone(auth, newZone).toResult //if admin group changes this confirms user has access to new group
       updateZoneChange <- ZoneChangeGenerator.forUpdate(newZone, existingZone, auth).toResult
       _ <- messageQueue.send(updateZoneChange).toResult[Unit]
     } yield updateZoneChange

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -65,7 +65,7 @@ class ZoneService(
       _ <- connectionValidator.validateZoneConnections(zone)
       _ <- zoneDoesNotExist(zone)
       _ <- adminGroupExists(zone.adminGroupId)
-      _ <- userIsMemberOfGroup(zone.adminGroupId, auth).toResult
+      _ <- canChangeZone(auth, zone).toResult
       createZoneChange <- ZoneChangeGenerator.forAdd(zone, auth).toResult
       _ <- messageQueue.send(createZoneChange).toResult[Unit]
     } yield createZoneChange
@@ -77,7 +77,7 @@ class ZoneService(
       _ <- validateZoneConnectionIfChanged(newZone, existingZone)
       _ <- canChangeZone(auth, existingZone).toResult
       _ <- adminGroupExists(newZone.adminGroupId)
-      _ <- userIsMemberOfGroup(newZone.adminGroupId, auth).toResult
+      _ <- canChangeZone(auth, newZone).toResult
       updateZoneChange <- ZoneChangeGenerator.forUpdate(newZone, existingZone, auth).toResult
       _ <- messageQueue.send(updateZoneChange).toResult[Unit]
     } yield updateZoneChange

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -30,7 +30,7 @@ class ZoneValidations(syncDelayMillis: Int) {
 
   def userIsMemberOfGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(InvalidZoneAdminError(s"User is not a member of $groupId."))(
-      authPrincipal.isAuthorized(groupId))
+      authPrincipal.canEditAll(groupId))
 
   def outsideSyncDelay(zone: Zone): Either[Throwable, Unit] =
     zone.latestSync match {

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -20,17 +20,12 @@ import cats.syntax.either._
 import com.aaronbedra.orchard.CIDR
 import org.joda.time.DateTime
 import vinyldns.api.Interfaces.ensuring
-import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone.{ACLRule, Zone, ZoneACL}
 
 import scala.util.{Failure, Success, Try}
 
 class ZoneValidations(syncDelayMillis: Int) {
-
-  def userIsMemberOfGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    ensuring(InvalidZoneAdminError(s"User is not a member of $groupId."))(
-      authPrincipal.canEditAll(groupId))
 
   def outsideSyncDelay(zone: Zone): Either[Throwable, Unit] =
     zone.latestSync match {

--- a/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
@@ -300,10 +300,10 @@ class AccessValidationsSpec
     }
   }
 
-  "getFullAccessLevel" should {
+  "getAccessLevel" should {
     "return AccessLevel.Delete if the user is admin/super" in {
       val mockRecordSet = mock[RecordSet]
-      val result = accessValidationTest.getFullAccessLevel(
+      val result = accessValidationTest.getAccessLevel(
         okUserAuth,
         mockRecordSet.name,
         mockRecordSet.typ,
@@ -311,24 +311,24 @@ class AccessValidationsSpec
       result shouldBe AccessLevel.Delete
     }
 
-    "return AccessLevel.NoAccess if the user is support only" in {
+    "return AccessLevel.Read if the user is support only" in {
       val mockRecordSet = mock[RecordSet]
       val supportAuth = okGroupAuth.copy(
         signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq.empty)
-      val result = accessValidationTest.getFullAccessLevel(
+      val result = accessValidationTest.getAccessLevel(
         supportAuth,
         mockRecordSet.name,
         mockRecordSet.typ,
         memberOkZoneAuthorized)
-      result shouldBe AccessLevel.NoAccess
+      result shouldBe AccessLevel.Read
     }
 
     "return the result of getAccessLevel if the user is support but also an admin" in {
       val mockRecordSet = mock[RecordSet]
       val supportAuth =
         okGroupAuth.copy(signedInUser = okGroupAuth.signedInUser.copy(isSupport = true))
-      val result = accessValidationTest.getFullAccessLevel(
+      val result = accessValidationTest.getAccessLevel(
         supportAuth,
         mockRecordSet.name,
         mockRecordSet.typ,
@@ -344,11 +344,7 @@ class AccessValidationsSpec
       val zoneIn = memberZoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
 
       val result =
-        accessValidationTest.getFullAccessLevel(
-          userAuth,
-          mockRecordSet.name,
-          mockRecordSet.typ,
-          zoneIn)
+        accessValidationTest.getAccessLevel(userAuth, mockRecordSet.name, mockRecordSet.typ, zoneIn)
       result shouldBe AccessLevel.Write
     }
 
@@ -360,40 +356,8 @@ class AccessValidationsSpec
       val zoneIn = memberZoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
 
       val result =
-        accessValidationTest.getFullAccessLevel(
-          userAuth,
-          mockRecordSet.name,
-          mockRecordSet.typ,
-          zoneIn)
+        accessValidationTest.getAccessLevel(userAuth, mockRecordSet.name, mockRecordSet.typ, zoneIn)
       result shouldBe AccessLevel.Read
-    }
-  }
-
-  "getReadAccessLevel" should {
-    "return AccessLevel.Delete if the user is admin/super/support" in {
-      val mockRecordSet = mock[RecordSet]
-      val result = accessValidationTest.getReadAccessLevel(
-        okUserAuth,
-        mockRecordSet.name,
-        mockRecordSet.typ,
-        memberOkZoneAuthorized)
-      result shouldBe AccessLevel.Read
-    }
-
-    "return the result of getAccessLevel if user is not admin/super" in {
-      val mockRecordSet = mock[RecordSet]
-      val userAccess = okUser.copy(id = "Read")
-      val userAuth = AuthPrincipal(userAccess, groupIds)
-      val userAcl = ACLRule(AccessLevel.Write, userId = Some(userAuth.userId), groupId = None)
-      val zoneIn = memberZoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
-
-      val result =
-        accessValidationTest.getReadAccessLevel(
-          userAuth,
-          mockRecordSet.name,
-          mockRecordSet.typ,
-          zoneIn)
-      result shouldBe AccessLevel.Write
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
@@ -113,7 +113,14 @@ class AccessValidationsSpec
       accessValidationTest.canChangeZone(okUserAuth, memberOkZoneAuthorized) should be(right)
     }
 
-    "return a NotAuthorizedError if the user is a support user" in {
+    "return true if the user is an admin and a support user" in {
+      val auth = okAuth.copy(
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+        memberGroupIds = Seq(okGroup.id))
+      accessValidationTest.canChangeZone(auth, memberOkZoneAuthorized) should be(right)
+    }
+
+    "return a NotAuthorizedError if the user is a support user only" in {
       val auth = okAuth.copy(
         signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq.empty)

--- a/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
@@ -97,7 +97,7 @@ class AccessValidationsSpec
 
     "return true if the user is a support admin" in {
       val supportAuth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq.empty)
       accessValidationTest.canSeeZone(supportAuth, memberOkZoneAuthorized) should be(right)
     }
@@ -115,14 +115,14 @@ class AccessValidationsSpec
 
     "return true if the user is an admin and a support user" in {
       val auth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq(okGroup.id))
       accessValidationTest.canChangeZone(auth, memberOkZoneAuthorized) should be(right)
     }
 
     "return a NotAuthorizedError if the user is a support user only" in {
       val auth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq.empty)
       val error = leftValue(accessValidationTest.canChangeZone(auth, memberOkZoneAuthorized))
       error shouldBe a[NotAuthorizedError]
@@ -321,7 +321,7 @@ class AccessValidationsSpec
     "return AccessLevel.Read if the user is support only" in {
       val mockRecordSet = mock[RecordSet]
       val supportAuth = okGroupAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq.empty)
       val result = accessValidationTest.getAccessLevel(
         supportAuth,
@@ -334,7 +334,7 @@ class AccessValidationsSpec
     "return the result of getAccessLevel if the user is support but also an admin" in {
       val mockRecordSet = mock[RecordSet]
       val supportAuth =
-        okGroupAuth.copy(signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)))
+        okGroupAuth.copy(signedInUser = okGroupAuth.signedInUser.copy(isSupport = true))
       val result = accessValidationTest.getAccessLevel(
         supportAuth,
         mockRecordSet.name,
@@ -345,7 +345,7 @@ class AccessValidationsSpec
 
     "return the result of getAccessLevel if the user is support but also has ACL rule access" in {
       val mockRecordSet = mock[RecordSet]
-      val userAccess = okUser.copy(id = "Write", isSupport = Some(true))
+      val userAccess = okUser.copy(id = "Write", isSupport = true)
       val userAuth = AuthPrincipal(userAccess, groupIds)
       val userAcl = ACLRule(AccessLevel.Write, userId = Some(userAuth.userId), groupId = None)
       val zoneIn = memberZoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
@@ -789,7 +789,7 @@ class AccessValidationsSpec
 
     "return access level Read if there is no ACL rule for the user and user is a support admin" in {
       val supportAuth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
         memberGroupIds = Seq.empty)
 
       val recordList = List("rs1", "rs2", "rs3").map {

--- a/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
@@ -97,7 +97,7 @@ class AccessValidationsSpec
 
     "return true if the user is a support admin" in {
       val supportAuth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
         memberGroupIds = Seq.empty)
       accessValidationTest.canSeeZone(supportAuth, memberOkZoneAuthorized) should be(right)
     }
@@ -115,14 +115,14 @@ class AccessValidationsSpec
 
     "return true if the user is an admin and a support user" in {
       val auth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
         memberGroupIds = Seq(okGroup.id))
       accessValidationTest.canChangeZone(auth, memberOkZoneAuthorized) should be(right)
     }
 
     "return a NotAuthorizedError if the user is a support user only" in {
       val auth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
         memberGroupIds = Seq.empty)
       val error = leftValue(accessValidationTest.canChangeZone(auth, memberOkZoneAuthorized))
       error shouldBe a[NotAuthorizedError]
@@ -321,7 +321,7 @@ class AccessValidationsSpec
     "return AccessLevel.Read if the user is support only" in {
       val mockRecordSet = mock[RecordSet]
       val supportAuth = okGroupAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
         memberGroupIds = Seq.empty)
       val result = accessValidationTest.getAccessLevel(
         supportAuth,
@@ -334,7 +334,7 @@ class AccessValidationsSpec
     "return the result of getAccessLevel if the user is support but also an admin" in {
       val mockRecordSet = mock[RecordSet]
       val supportAuth =
-        okGroupAuth.copy(signedInUser = okGroupAuth.signedInUser.copy(isSupport = true))
+        okGroupAuth.copy(signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)))
       val result = accessValidationTest.getAccessLevel(
         supportAuth,
         mockRecordSet.name,
@@ -345,7 +345,7 @@ class AccessValidationsSpec
 
     "return the result of getAccessLevel if the user is support but also has ACL rule access" in {
       val mockRecordSet = mock[RecordSet]
-      val userAccess = okUser.copy(id = "Write", isSupport = true)
+      val userAccess = okUser.copy(id = "Write", isSupport = Some(true))
       val userAuth = AuthPrincipal(userAccess, groupIds)
       val userAcl = ACLRule(AccessLevel.Write, userId = Some(userAuth.userId), groupId = None)
       val zoneIn = memberZoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
@@ -789,7 +789,7 @@ class AccessValidationsSpec
 
     "return access level Read if there is no ACL rule for the user and user is a support admin" in {
       val supportAuth = okAuth.copy(
-        signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+        signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
         memberGroupIds = Seq.empty)
 
       val recordList = List("rs1", "rs2", "rs3").map {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -216,6 +216,17 @@ class BatchChangeServiceSpec
 
       result shouldBe batchChange
     }
+
+    "Succeed if user is a support user" in {
+      val batchChange = BatchChange("badID", "badUN", None, DateTime.now, List())
+      batchChangeRepo.save(batchChange)
+
+      val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSupport = true))
+
+      val result = rightResultOf(underTest.getBatchChange(batchChange.id, authSuper).value)
+
+      result shouldBe batchChange
+    }
   }
 
   "getExistingRecordSets" should {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -221,7 +221,7 @@ class BatchChangeServiceSpec
       val batchChange = BatchChange("badID", "badUN", None, DateTime.now, List())
       batchChangeRepo.save(batchChange)
 
-      val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSupport = true))
+      val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSupport = Some(true)))
 
       val result = rightResultOf(underTest.getBatchChange(batchChange.id, authSuper).value)
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -221,7 +221,7 @@ class BatchChangeServiceSpec
       val batchChange = BatchChange("badID", "badUN", None, DateTime.now, List())
       batchChangeRepo.save(batchChange)
 
-      val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSupport = Some(true)))
+      val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSupport = true))
 
       val result = rightResultOf(underTest.getBatchChange(batchChange.id, authSuper).value)
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -571,7 +571,7 @@ class MembershipServiceSpec
           GroupInfo(okGroup))
       }
       "return groups from the database for support users" in {
-        val supportAuth = AuthPrincipal(okUser.copy(isSupport = Some(true)), Seq())
+        val supportAuth = AuthPrincipal(okUser.copy(isSupport = true), Seq())
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
           rightResultOf(underTest.listMyGroups(None, None, 100, supportAuth).value)
@@ -646,7 +646,7 @@ class MembershipServiceSpec
         val testListUsersResult = ListUsersResults(testUsers, Some("1"))
         val expectedMembers = List(MemberInfo(okUser, okGroup), MemberInfo(dummyUser, dummyGroup))
         val supportAuth = okAuth.copy(
-          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = Some(true)),
+          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = true),
           memberGroupIds = Seq.empty)
 
         doReturn(IO.pure(Some(testGroup))).when(mockGroupRepo).getGroup(testGroup.id)
@@ -841,7 +841,7 @@ class MembershipServiceSpec
 
       "return an error if the signed in user is only a support admin" in {
         val supportAuth = okAuth.copy(
-          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = Some(true)),
+          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = true),
           memberGroupIds = Seq.empty)
         val error = leftResultOf(
           underTest

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -571,7 +571,7 @@ class MembershipServiceSpec
           GroupInfo(okGroup))
       }
       "return groups from the database for support users" in {
-        val supportAuth = AuthPrincipal(okUser.copy(isSupport = true), Seq())
+        val supportAuth = AuthPrincipal(okUser.copy(isSupport = Some(true)), Seq())
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
           rightResultOf(underTest.listMyGroups(None, None, 100, supportAuth).value)
@@ -646,7 +646,7 @@ class MembershipServiceSpec
         val testListUsersResult = ListUsersResults(testUsers, Some("1"))
         val expectedMembers = List(MemberInfo(okUser, okGroup), MemberInfo(dummyUser, dummyGroup))
         val supportAuth = okAuth.copy(
-          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = true),
+          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = Some(true)),
           memberGroupIds = Seq.empty)
 
         doReturn(IO.pure(Some(testGroup))).when(mockGroupRepo).getGroup(testGroup.id)
@@ -841,7 +841,7 @@ class MembershipServiceSpec
 
       "return an error if the signed in user is only a support admin" in {
         val supportAuth = okAuth.copy(
-          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = true),
+          signedInUser = dummyUserAuth.signedInUser.copy(isSupport = Some(true)),
           memberGroupIds = Seq.empty)
         val error = leftResultOf(
           underTest

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -570,6 +570,16 @@ class MembershipServiceSpec
           GroupInfo(dummyGroup),
           GroupInfo(okGroup))
       }
+      "return groups from the database for support users" in {
+        val supportAuth = AuthPrincipal(okUser.copy(isSupport = true), Seq())
+        doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
+        val result: ListMyGroupsResponse =
+          rightResultOf(underTest.listMyGroups(None, None, 100, supportAuth).value)
+        verify(mockGroupRepo).getAllGroups()
+        result.groups should contain theSameElementsAs Seq(
+          GroupInfo(dummyGroup),
+          GroupInfo(okGroup))
+      }
       "do not return deleted groups" in {
         doReturn(IO.pure(Set(deletedGroup)))
           .when(mockGroupRepo)

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -80,6 +80,11 @@ class MembershipValidationsSpec
         val superAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, superAuth) should be(right)
       }
+      "return true when the user is a support admin" in {
+        val user = User("some", "new", "user", isSupport = true)
+        val supportAuth = AuthPrincipal(user, Seq())
+        canSeeGroup(okGroup.id, supportAuth) should be(right)
+      }
       "return an error when the user has no access and is not super" in {
         val user = User("some", "new", "user")
         val nonSuperAuth = AuthPrincipal(user, Seq())

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -64,7 +64,7 @@ class MembershipValidationsSpec
         isGroupAdmin(okGroup, superAuth) should be(right)
       }
       "return an error when the user is a support admin only" in {
-        val user = User("some", "new", "user", isSupport = Some(true))
+        val user = User("some", "new", "user", isSupport = true)
         val supportAuth = AuthPrincipal(user, Seq())
         val error = leftValue(isGroupAdmin(okGroup, supportAuth))
         error shouldBe an[NotAuthorizedError]
@@ -87,7 +87,7 @@ class MembershipValidationsSpec
         canSeeGroup(okGroup.id, superAuth) should be(right)
       }
       "return true when the user is a support admin" in {
-        val user = User("some", "new", "user", isSupport = Some(true))
+        val user = User("some", "new", "user", isSupport = true)
         val supportAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, supportAuth) should be(right)
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -56,23 +56,23 @@ class MembershipValidationsSpec
 
     "isAdmin" should {
       "return true when the user is in admin group" in {
-        isGroupAdmin(okGroup, okUserAuth) should be(right)
+        canEditGroup(okGroup, okUserAuth) should be(right)
       }
       "return true when the user is a super user" in {
         val user = User("some", "new", "user", isSuper = true)
         val superAuth = AuthPrincipal(user, Seq())
-        isGroupAdmin(okGroup, superAuth) should be(right)
+        canEditGroup(okGroup, superAuth) should be(right)
       }
       "return an error when the user is a support admin only" in {
         val user = User("some", "new", "user", isSupport = true)
         val supportAuth = AuthPrincipal(user, Seq())
-        val error = leftValue(isGroupAdmin(okGroup, supportAuth))
+        val error = leftValue(canEditGroup(okGroup, supportAuth))
         error shouldBe an[NotAuthorizedError]
       }
       "return an error when the user has no access and is not super" in {
         val user = User("some", "new", "user")
         val nonSuperAuth = AuthPrincipal(user, Seq())
-        val error = leftValue(isGroupAdmin(okGroup, nonSuperAuth))
+        val error = leftValue(canEditGroup(okGroup, nonSuperAuth))
         error shouldBe an[NotAuthorizedError]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -63,6 +63,12 @@ class MembershipValidationsSpec
         val superAuth = AuthPrincipal(user, Seq())
         isGroupAdmin(okGroup, superAuth) should be(right)
       }
+      "return an error when the user is a support admin only" in {
+        val user = User("some", "new", "user", isSupport = true)
+        val supportAuth = AuthPrincipal(user, Seq())
+        val error = leftValue(isGroupAdmin(okGroup, supportAuth))
+        error shouldBe an[NotAuthorizedError]
+      }
       "return an error when the user has no access and is not super" in {
         val user = User("some", "new", "user")
         val nonSuperAuth = AuthPrincipal(user, Seq())

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -64,7 +64,7 @@ class MembershipValidationsSpec
         isGroupAdmin(okGroup, superAuth) should be(right)
       }
       "return an error when the user is a support admin only" in {
-        val user = User("some", "new", "user", isSupport = true)
+        val user = User("some", "new", "user", isSupport = Some(true))
         val supportAuth = AuthPrincipal(user, Seq())
         val error = leftValue(isGroupAdmin(okGroup, supportAuth))
         error shouldBe an[NotAuthorizedError]
@@ -87,7 +87,7 @@ class MembershipValidationsSpec
         canSeeGroup(okGroup.id, superAuth) should be(right)
       }
       "return true when the user is a support admin" in {
-        val user = User("some", "new", "user", isSupport = true)
+        val user = User("some", "new", "user", isSupport = Some(true))
         val supportAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, supportAuth) should be(right)
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -360,7 +360,7 @@ class RecordSetServiceSpec
             maxItems = None,
             recordNameFilter = None,
             authPrincipal = okAuth.copy(
-              signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+              signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
               memberGroupIds = Seq.empty)
           )
           .value)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -343,6 +343,29 @@ class RecordSetServiceSpec
           .value)
       result.recordSets shouldBe List(RecordSetInfo(aaaa, AccessLevel.Delete))
     }
+    "return the recordSet for support admin" in {
+      doReturn(IO.pure(ListRecordSetResults(List(aaaa))))
+        .when(mockRecordRepo)
+        .listRecordSets(
+          zoneId = zoneAuthorized.id,
+          startFrom = None,
+          maxItems = None,
+          recordNameFilter = None)
+
+      val result: ListRecordSetsResponse = rightResultOf(
+        underTest
+          .listRecordSets(
+            zoneAuthorized.id,
+            startFrom = None,
+            maxItems = None,
+            recordNameFilter = None,
+            authPrincipal = okAuth.copy(
+              signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
+              memberGroupIds = Seq.empty)
+          )
+          .value)
+      result.recordSets shouldBe List(RecordSetInfo(aaaa, AccessLevel.Read))
+    }
     "fails when the account is not authorized" in {
       val result = leftResultOf(
         underTest

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -360,7 +360,7 @@ class RecordSetServiceSpec
             maxItems = None,
             recordNameFilter = None,
             authPrincipal = okAuth.copy(
-              signedInUser = okGroupAuth.signedInUser.copy(isSupport = Some(true)),
+              signedInUser = okGroupAuth.signedInUser.copy(isSupport = true),
               memberGroupIds = Seq.empty)
           )
           .value)

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneValidationsSpec.scala
@@ -37,17 +37,6 @@ class ZoneValidationsSpec
 
   import testing._
 
-  "userIsMemberOfGroup" should {
-    "return true when authorized" in {
-      userIsMemberOfGroup(okUserAuth.memberGroupIds.head, okUserAuth) should be(right)
-    }
-
-    "return a InvalidZoneAdminError when not authorized" in {
-      val outcome = leftValue(userIsMemberOfGroup("badId", okUserAuth))
-      outcome shouldBe a[InvalidZoneAdminError]
-    }
-  }
-
   "outsideSyncDelay" should {
     "return ok when the zone has not been synced" in {
       val zone = memberOkZoneAuthorized.copy(latestSync = None)

--- a/modules/api/src/test/scala/vinyldns/api/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/protobuf/ProtobufConversionsSpec.scala
@@ -769,19 +769,20 @@ class ProtobufConversionsSpec
       pb.getId shouldBe user.id
       pb.getIsSuper shouldBe user.isSuper
       pb.getLockStatus shouldBe "Unlocked"
-      pb.getIsSupport shouldBe user.isSupport
+      pb.getIsSupport shouldBe false
 
       fromPB(pb) shouldBe user
     }
 
-    "convert to/from protobuf with firstname, lastname, and email" in {
+    "convert to/from protobuf with firstname, lastname, email, and isSupport" in {
       val user = User(
         "testName",
         "testAccess",
         "testSecret",
         firstName = Some("testFirstName"),
         lastName = Some("testLastName"),
-        email = Some("testEmail")
+        email = Some("testEmail"),
+        isSupport = Some(true)
       )
       val pb = toPB(user)
 
@@ -795,7 +796,7 @@ class ProtobufConversionsSpec
       pb.getId shouldBe user.id
       pb.getIsSuper shouldBe user.isSuper
       pb.getLockStatus shouldBe "Unlocked"
-      pb.getIsSupport shouldBe user.isSupport
+      pb.getIsSupport shouldBe true
 
       fromPB(pb) shouldBe user
     }
@@ -837,7 +838,7 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf with supportAdmin true" in {
-      val user = User("testName", "testAccess", "testSecret", isSupport = true)
+      val user = User("testName", "testAccess", "testSecret", isSupport = Some(true))
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName

--- a/modules/api/src/test/scala/vinyldns/api/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/protobuf/ProtobufConversionsSpec.scala
@@ -782,7 +782,7 @@ class ProtobufConversionsSpec
         firstName = Some("testFirstName"),
         lastName = Some("testLastName"),
         email = Some("testEmail"),
-        isSupport = Some(true)
+        isSupport = true
       )
       val pb = toPB(user)
 
@@ -838,7 +838,7 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf with supportAdmin true" in {
-      val user = User("testName", "testAccess", "testSecret", isSupport = Some(true))
+      val user = User("testName", "testAccess", "testSecret", isSupport = true)
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName

--- a/modules/api/src/test/scala/vinyldns/api/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/protobuf/ProtobufConversionsSpec.scala
@@ -769,6 +769,7 @@ class ProtobufConversionsSpec
       pb.getId shouldBe user.id
       pb.getIsSuper shouldBe user.isSuper
       pb.getLockStatus shouldBe "Unlocked"
+      pb.getIsSupport shouldBe user.isSupport
 
       fromPB(pb) shouldBe user
     }
@@ -794,6 +795,7 @@ class ProtobufConversionsSpec
       pb.getId shouldBe user.id
       pb.getIsSuper shouldBe user.isSuper
       pb.getLockStatus shouldBe "Unlocked"
+      pb.getIsSupport shouldBe user.isSupport
 
       fromPB(pb) shouldBe user
     }
@@ -830,6 +832,25 @@ class ProtobufConversionsSpec
       pb.getId shouldBe user.id
       pb.getIsSuper shouldBe user.isSuper
       pb.getLockStatus shouldBe "Locked"
+
+      fromPB(pb) shouldBe user
+    }
+
+    "convert to/from protobuf with supportAdmin true" in {
+      val user = User("testName", "testAccess", "testSecret", isSupport = true)
+      val pb = toPB(user)
+
+      pb.getUserName shouldBe user.userName
+      pb.getAccessKey shouldBe user.accessKey
+      pb.getSecretKey shouldBe user.secretKey
+      pb.hasFirstName shouldBe false
+      pb.hasLastName shouldBe false
+      pb.hasEmail shouldBe false
+      pb.getCreated shouldBe user.created.getMillis
+      pb.getId shouldBe user.id
+      pb.getIsSuper shouldBe user.isSuper
+      pb.getLockStatus shouldBe "Unlocked"
+      pb.getIsSupport shouldBe true
 
       fromPB(pb) shouldBe user
     }

--- a/modules/core/src/main/protobuf/VinylDNSProto.proto
+++ b/modules/core/src/main/protobuf/VinylDNSProto.proto
@@ -192,7 +192,7 @@ message User {
   optional string firstName = 8;
   optional string lastName = 9;
   optional string email = 10;
-  required bool isSupport = 11;
+  optional bool isSupport = 11 [default = false];
 }
 
 message UserChange {

--- a/modules/core/src/main/protobuf/VinylDNSProto.proto
+++ b/modules/core/src/main/protobuf/VinylDNSProto.proto
@@ -192,6 +192,7 @@ message User {
   optional string firstName = 8;
   optional string lastName = 9;
   optional string email = 10;
+  required bool isSupport = 11;
 }
 
 message UserChange {

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -24,7 +24,7 @@ case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
     signedInUser.isSuper
 
   def canReadAll: Boolean =
-    signedInUser.isSuper || signedInUser.isSupport
+    signedInUser.isSuper || signedInUser.isSupport.get
 
   def isGroupAdmin(group: Group): Boolean =
     group.adminUserIds.contains(signedInUser.id)

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -17,13 +17,20 @@
 package vinyldns.core.domain.auth
 
 import vinyldns.core.domain.membership.User
+import vinyldns.core.domain.membership.Group
 
 case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
-  def canEditAll(adminGroupId: String): Boolean =
-    signedInUser.isSuper || memberGroupIds.contains(adminGroupId)
+  def canEditAll: Boolean =
+    signedInUser.isSuper
 
-  def canReadAll(adminGroupId: String): Boolean =
-    canEditAll(adminGroupId: String) || signedInUser.isSupport
+  def canReadAll: Boolean =
+    signedInUser.isSuper || signedInUser.isSupport
+
+  def isGroupAdmin(group: Group): Boolean =
+    group.adminUserIds.contains(signedInUser.id)
+
+  def isGroupMember(groupId: String): Boolean =
+    memberGroupIds.contains(groupId)
 
   val secretKey: String = signedInUser.secretKey
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -24,7 +24,7 @@ case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
     signedInUser.isSuper
 
   def canReadAll: Boolean =
-    signedInUser.isSuper || signedInUser.isSupport.get
+    signedInUser.isSuper || signedInUser.isSupport
 
   def isGroupAdmin(group: Group): Boolean =
     group.adminUserIds.contains(signedInUser.id)

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -23,6 +23,9 @@ case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
   def isAuthorized(adminGroupId: String): Boolean =
     signedInUser.isSuper || memberGroupIds.contains(adminGroupId)
 
+  def readOnlyAuthorization(adminGroupId: String): Boolean =
+    signedInUser.isSuper || signedInUser.isSupport || memberGroupIds.contains(adminGroupId)
+
   val secretKey: String = signedInUser.secretKey
 
   val userId: String = signedInUser.id

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -19,12 +19,11 @@ package vinyldns.core.domain.auth
 import vinyldns.core.domain.membership.User
 
 case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
-
-  def isAuthorized(adminGroupId: String): Boolean =
+  def canEditAll(adminGroupId: String): Boolean =
     signedInUser.isSuper || memberGroupIds.contains(adminGroupId)
 
-  def readOnlyAuthorization(adminGroupId: String): Boolean =
-    signedInUser.isSuper || signedInUser.isSupport || memberGroupIds.contains(adminGroupId)
+  def canReadAll(adminGroupId: String): Boolean =
+    canEditAll(adminGroupId: String) || signedInUser.isSupport
 
   val secretKey: String = signedInUser.secretKey
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -39,7 +39,7 @@ final case class User(
     id: String = UUID.randomUUID().toString,
     isSuper: Boolean = false,
     lockStatus: LockStatus = LockStatus.Unlocked,
-    isSupport: Boolean = false
+    isSupport: Option[Boolean] = Some(false)
 ) {
 
   def updateUserLockStatus(lockStatus: LockStatus): User =

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -39,7 +39,7 @@ final case class User(
     id: String = UUID.randomUUID().toString,
     isSuper: Boolean = false,
     lockStatus: LockStatus = LockStatus.Unlocked,
-    isSupport: Option[Boolean] = Some(false)
+    isSupport: Boolean = false
 ) {
 
   def updateUserLockStatus(lockStatus: LockStatus): User =

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -38,7 +38,8 @@ final case class User(
     created: DateTime = DateTime.now,
     id: String = UUID.randomUUID().toString,
     isSuper: Boolean = false,
-    lockStatus: LockStatus = LockStatus.Unlocked
+    lockStatus: LockStatus = LockStatus.Unlocked,
+    isSupport: Boolean = false
 ) {
 
   def updateUserLockStatus(lockStatus: LockStatus): User =

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -351,7 +351,7 @@ trait ProtobufConversions {
       data.getId,
       data.getIsSuper,
       LockStatus.withName(data.getLockStatus),
-      if (data.hasIsSupport) Some(data.getIsSupport) else Some(false)
+      data.getIsSupport
     )
 
   def toPB(user: User): VinylDNSProto.User = {
@@ -364,11 +364,11 @@ trait ProtobufConversions {
       .setId(user.id)
       .setIsSuper(user.isSuper)
       .setLockStatus(user.lockStatus.toString)
+      .setIsSupport(user.isSupport)
 
     user.firstName.foreach(fn => builder.setFirstName(fn))
     user.lastName.foreach(ln => builder.setLastName(ln))
     user.email.foreach(e => builder.setEmail(e))
-    user.isSupport.foreach(sa => builder.setIsSupport(sa))
 
     builder.build()
   }

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -350,7 +350,8 @@ trait ProtobufConversions {
       new DateTime(data.getCreated),
       data.getId,
       data.getIsSuper,
-      LockStatus.withName(data.getLockStatus)
+      LockStatus.withName(data.getLockStatus),
+      data.getIsSupport,
     )
 
   def toPB(user: User): VinylDNSProto.User = {
@@ -363,6 +364,7 @@ trait ProtobufConversions {
       .setId(user.id)
       .setIsSuper(user.isSuper)
       .setLockStatus(user.lockStatus.toString)
+      .setIsSupport(user.isSupport)
 
     user.firstName.foreach(fn => builder.setFirstName(fn))
     user.lastName.foreach(ln => builder.setLastName(ln))

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -351,7 +351,7 @@ trait ProtobufConversions {
       data.getId,
       data.getIsSuper,
       LockStatus.withName(data.getLockStatus),
-      data.getIsSupport
+      if (data.hasIsSupport) Some(data.getIsSupport) else Some(false)
     )
 
   def toPB(user: User): VinylDNSProto.User = {
@@ -364,11 +364,11 @@ trait ProtobufConversions {
       .setId(user.id)
       .setIsSuper(user.isSuper)
       .setLockStatus(user.lockStatus.toString)
-      .setIsSupport(user.isSupport)
 
     user.firstName.foreach(fn => builder.setFirstName(fn))
     user.lastName.foreach(ln => builder.setLastName(ln))
     user.email.foreach(e => builder.setEmail(e))
+    user.isSupport.foreach(sa => builder.setIsSupport(sa))
 
     builder.build()
   }

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -351,7 +351,7 @@ trait ProtobufConversions {
       data.getId,
       data.getIsSuper,
       LockStatus.withName(data.getLockStatus),
-      data.getIsSupport,
+      data.getIsSupport
     )
 
   def toPB(user: User): VinylDNSProto.User = {

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -157,5 +157,24 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
       f shouldBe Some(users.head)
       f.get.lockStatus shouldBe LockStatus.Unlocked
     }
+    "returns the support flag when true" in {
+      val testUser = User(
+        userName = "testSuper",
+        accessKey = "testSuper",
+        secretKey = "testUser",
+        isSupport = Some(true))
+
+      val saved = repo.save(testUser).unsafeRunSync()
+      val result = repo.getUser(saved.id).unsafeRunSync()
+
+      result shouldBe Some(testUser)
+      result.get.isSupport shouldBe Some(true)
+    }
+    "returns the support flag when false" in {
+      val f = repo.getUserByAccessKey(users.head.accessKey).unsafeRunSync()
+
+      f shouldBe Some(users.head)
+      f.get.isSupport shouldBe Some(false)
+    }
   }
 }

--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBUserRepositoryIntegrationSpec.scala
@@ -162,19 +162,19 @@ class DynamoDBUserRepositoryIntegrationSpec extends DynamoDBIntegrationSpec {
         userName = "testSuper",
         accessKey = "testSuper",
         secretKey = "testUser",
-        isSupport = Some(true))
+        isSupport = true)
 
       val saved = repo.save(testUser).unsafeRunSync()
       val result = repo.getUser(saved.id).unsafeRunSync()
 
       result shouldBe Some(testUser)
-      result.get.isSupport shouldBe Some(true)
+      result.get.isSupport shouldBe true
     }
     "returns the support flag when false" in {
       val f = repo.getUserByAccessKey(users.head.accessKey).unsafeRunSync()
 
       f shouldBe Some(users.head)
-      f.get.isSupport shouldBe Some(false)
+      f.get.isSupport shouldBe false
     }
   }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -45,6 +45,7 @@ object DynamoDBUserRepository {
   private[repository] val SECRET_KEY = "secretkey"
   private[repository] val IS_SUPER = "super"
   private[repository] val LOCK_STATUS = "lockstatus"
+  private[repository] val IS_SUPPORT = "support"
   private[repository] val USER_NAME_INDEX_NAME = "username_index"
   private[repository] val ACCESS_KEY_INDEX_NAME = "access_key_index"
   private val log: Logger = LoggerFactory.getLogger(classOf[DynamoDBUserRepository])
@@ -104,6 +105,7 @@ object DynamoDBUserRepository {
     item.put(SECRET_KEY, new AttributeValue(crypto.encrypt(user.secretKey)))
     item.put(IS_SUPER, new AttributeValue().withBOOL(user.isSuper))
     item.put(LOCK_STATUS, new AttributeValue(user.lockStatus.toString))
+    item.put(IS_SUPPORT, new AttributeValue().withBOOL(user.isSupport))
 
     val firstName =
       user.firstName.map(new AttributeValue(_)).getOrElse(new AttributeValue().withNULL(true))
@@ -134,7 +136,8 @@ object DynamoDBUserRepository {
       isSuper = if (item.get(IS_SUPER) == null) false else item.get(IS_SUPER).getBOOL,
       lockStatus =
         if (item.get(LOCK_STATUS) == null) LockStatus.Unlocked
-        else userStatus(item.get(LOCK_STATUS).getS)
+        else userStatus(item.get(LOCK_STATUS).getS),
+      isSupport = if (item.get(IS_SUPPORT) == null) false else item.get(IS_SUPPORT).getBOOL
     )
   }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -105,7 +105,7 @@ object DynamoDBUserRepository {
     item.put(SECRET_KEY, new AttributeValue(crypto.encrypt(user.secretKey)))
     item.put(IS_SUPER, new AttributeValue().withBOOL(user.isSuper))
     item.put(LOCK_STATUS, new AttributeValue(user.lockStatus.toString))
-    item.put(IS_SUPPORT, new AttributeValue().withBOOL(user.isSupport.get))
+    item.put(IS_SUPPORT, new AttributeValue().withBOOL(user.isSupport))
 
     val firstName =
       user.firstName.map(new AttributeValue(_)).getOrElse(new AttributeValue().withNULL(true))
@@ -137,7 +137,7 @@ object DynamoDBUserRepository {
       lockStatus =
         if (item.get(LOCK_STATUS) == null) LockStatus.Unlocked
         else userStatus(item.get(LOCK_STATUS).getS),
-      isSupport = Option(item.get(IS_SUPPORT)).flatMap(s => Option(s.getBOOL))
+      isSupport = if (item.get(IS_SUPPORT) == null) false else item.get(IS_SUPPORT).getBOOL
     )
   }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBUserRepository.scala
@@ -105,7 +105,7 @@ object DynamoDBUserRepository {
     item.put(SECRET_KEY, new AttributeValue(crypto.encrypt(user.secretKey)))
     item.put(IS_SUPER, new AttributeValue().withBOOL(user.isSuper))
     item.put(LOCK_STATUS, new AttributeValue(user.lockStatus.toString))
-    item.put(IS_SUPPORT, new AttributeValue().withBOOL(user.isSupport))
+    item.put(IS_SUPPORT, new AttributeValue().withBOOL(user.isSupport.get))
 
     val firstName =
       user.firstName.map(new AttributeValue(_)).getOrElse(new AttributeValue().withNULL(true))
@@ -137,7 +137,7 @@ object DynamoDBUserRepository {
       lockStatus =
         if (item.get(LOCK_STATUS) == null) LockStatus.Unlocked
         else userStatus(item.get(LOCK_STATUS).getS),
-      isSupport = if (item.get(IS_SUPPORT) == null) false else item.get(IS_SUPPORT).getBOOL
+      isSupport = Option(item.get(IS_SUPPORT)).flatMap(s => Option(s.getBOOL))
     )
   }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserRepositoryIntegrationSpec.scala
@@ -93,11 +93,11 @@ class MySqlUserRepositoryIntegrationSpec
     }
 
     "save support user with support status" in {
-      val supportUser = User("lockedName", "lockedAccess", "lockedSecret", isSupport = Some(true))
+      val supportUser = User("lockedName", "lockedAccess", "lockedSecret", isSupport = true)
       repo.save(supportUser).unsafeRunSync() shouldBe supportUser
       val result = repo.getUser(supportUser.id).unsafeRunSync()
       result shouldBe Some(supportUser)
-      result.get.isSupport shouldBe Some(true)
+      result.get.isSupport shouldBe true
     }
 
     "save non-support user with non-support status" in {
@@ -105,7 +105,7 @@ class MySqlUserRepositoryIntegrationSpec
       repo.save(nonSupportdUser).unsafeRunSync() shouldBe nonSupportdUser
       val result = repo.getUser(nonSupportdUser.id).unsafeRunSync()
       result shouldBe Some(nonSupportdUser)
-      result.get.isSupport shouldBe Some(false)
+      result.get.isSupport shouldBe false
     }
   }
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserRepositoryIntegrationSpec.scala
@@ -91,6 +91,22 @@ class MySqlUserRepositoryIntegrationSpec
       result shouldBe Some(unlockedUser)
       result.get.lockStatus shouldBe LockStatus.Unlocked
     }
+
+    "save support user with support status" in {
+      val supportUser = User("lockedName", "lockedAccess", "lockedSecret", isSupport = Some(true))
+      repo.save(supportUser).unsafeRunSync() shouldBe supportUser
+      val result = repo.getUser(supportUser.id).unsafeRunSync()
+      result shouldBe Some(supportUser)
+      result.get.isSupport shouldBe Some(true)
+    }
+
+    "save non-support user with non-support status" in {
+      val nonSupportdUser = User("unlockedName", "unlockedAccess", "unlockedSecret")
+      repo.save(nonSupportdUser).unsafeRunSync() shouldBe nonSupportdUser
+      val result = repo.getUser(nonSupportdUser.id).unsafeRunSync()
+      result shouldBe Some(nonSupportdUser)
+      result.get.isSupport shouldBe Some(false)
+    }
   }
 
   "MySqlUserRepository.getUser" should {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -253,10 +253,11 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
 
   private def withAccessors(user: User, groupIds: Seq[String]): (String, Seq[Any]) =
     // Super users do not need to join across to check zone access as they have access to all of the zones
-    if (user.isSuper) {
+    if (user.isSuper || user.isSupport) {
       (BASE_ZONE_SEARCH_SQL, Seq.empty)
     } else {
-      // User is not super, let's join across to the zone access table so we return only zones a user has access to
+      // User is not super or support,
+      // let's join across to the zone access table so we return only zones a user has access to
       val accessors = buildZoneSearchAccessorList(user, groupIds)
       val questionMarks = List.fill(accessors.size)("?").mkString(",")
       val withAccessorCheck = BASE_ZONE_SEARCH_SQL +


### PR DESCRIPTION
Fixes #368.

Changes in this pull request:
- add isSupport attribute to Users. Boolean like isSuper.
- Group services are set up a bit differently than Zones and records. For groups add the support check to view a group and also to list_my_groups so it returns all groups, like the behavior of a super user.
- For Zones and Records added support user to `canSeeZones`. Also added support user in `getPrioritizedAccessLevel` so their existing access rules will apply first but if they have no access rules then they'd get read access.
