### PR TITLE
Remove SQS access and secret key from logging

### DIFF
--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueueProvider.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueueProvider.scala
@@ -56,7 +56,10 @@ class SqsMessageQueueProvider extends MessageQueueProvider {
 
   def setupClient(sqsMessageQueueSettings: SqsMessageQueueSettings): IO[AmazonSQSAsync] =
     IO {
-      logger.error(s"Setting up queue client SqsMessageQueueSettings: $sqsMessageQueueSettings")
+      logger.error(s"Setting up queue client with settings: " +
+        s"service endpoint: ${sqsMessageQueueSettings.serviceEndpoint}; " +
+        s"signing region: ${sqsMessageQueueSettings.serviceEndpoint}; " +
+        s"queue name: ${sqsMessageQueueSettings.queueName}")
       AmazonSQSAsyncClientBuilder
         .standard()
         .withEndpointConfiguration(


### PR DESCRIPTION
Break out SQS settings logging so access and secret key aren't printed.

Fixes #381.

Changes in this pull request:
- Update logging message in `SqsMessageQueueProvider.scala`.
