### PR TITLE
maven-cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ services:
 cache:
   pip: true
   bundler: true
+  npm: true
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
-    - node_modules
+    - $HOME/.m2
   timeout: 900
 
 before_install:


### PR DESCRIPTION
Noticed we're not caching maven dependencies, also, according to https://docs.travis-ci.com/user/caching/, npm should be cached this way instead of `node_modules` 
