### PR TITLE
Add health check for DNS backend

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.domain.zone
+import cats.scalatest.EitherMatchers
+import org.scalatest.{Matchers, WordSpec}
+import vinyldns.api.VinylDNSConfig
+
+class ZoneConnectionValidatorIntegrationSpec extends WordSpec with Matchers with EitherMatchers {
+  "ZoneConnectionValidatorIntegrationSpec" should {
+    "have a valid health check if we can connect to DNS backend" in {
+      val check = new ZoneConnectionValidator(VinylDNSConfig.defaultZoneConnection)
+        .healthCheck()
+        .unsafeRunSync()
+      check should beRight(())
+    }
+  }
+}

--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
@@ -18,6 +18,7 @@ package vinyldns.api.domain.zone
 import cats.scalatest.EitherMatchers
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.api.VinylDNSConfig
+import vinyldns.core.health.HealthCheck.HealthCheckError
 
 class ZoneConnectionValidatorIntegrationSpec extends WordSpec with Matchers with EitherMatchers {
   "ZoneConnectionValidatorIntegrationSpec" should {
@@ -26,6 +27,15 @@ class ZoneConnectionValidatorIntegrationSpec extends WordSpec with Matchers with
         .healthCheck()
         .unsafeRunSync()
       check should beRight(())
+    }
+
+    "respond with a failure if health check fails" in {
+      val result =
+        new ZoneConnectionValidator(
+          VinylDNSConfig.defaultZoneConnection.copy(primaryServer = "localhost:1234"))
+          .healthCheck()
+          .unsafeRunSync()
+      result should beLeft(HealthCheckError("Connection refused (Connection refused)"))
     }
   }
 }

--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
@@ -24,7 +24,7 @@ class ZoneConnectionValidatorIntegrationSpec extends WordSpec with Matchers with
   "ZoneConnectionValidatorIntegrationSpec" should {
     "have a valid health check if we can connect to DNS backend" in {
       val check = new ZoneConnectionValidator(VinylDNSConfig.defaultZoneConnection)
-        .healthCheck()
+        .healthCheck(10000)
         .unsafeRunSync()
       check should beRight(())
     }
@@ -33,7 +33,7 @@ class ZoneConnectionValidatorIntegrationSpec extends WordSpec with Matchers with
       val result =
         new ZoneConnectionValidator(
           VinylDNSConfig.defaultZoneConnection.copy(primaryServer = "localhost:1234"))
-          .healthCheck()
+          .healthCheck(10000)
           .unsafeRunSync()
       result should beLeft(HealthCheckError("Connection refused (Connection refused)"))
     }

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -8,6 +8,17 @@ vinyldns {
   # if we should start up polling for change requests, set this to false for the inactive cluster
   processing-disabled = false
 
+  health-check {
+    dns-backend {
+      # connection information for DNS backend
+      address = "localhost"
+      port = 19001
+
+      # timeout in millis to test connection
+      timeout = 20000
+    }
+  }
+
   queue {
     class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
 

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -8,16 +8,7 @@ vinyldns {
   # if we should start up polling for change requests, set this to false for the inactive cluster
   processing-disabled = false
 
-  health-check {
-    dns-backend {
-      # connection information for DNS backend
-      address = "localhost"
-      port = 19001
-
-      # timeout in millis to test connection
-      timeout = 20000
-    }
-  }
+  health-check.dns-backend.timeout = 10000
 
   queue {
     class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -8,8 +8,6 @@ vinyldns {
   # if we should start up polling for change requests, set this to false for the inactive cluster
   processing-disabled = false
 
-  health-check.dns-backend.timeout = 10000
-
   queue {
     class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
 

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -20,7 +20,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.{ActorMaterializer, Materializer}
 import cats.effect.{ContextShift, IO, Timer}
-import pureconfig.module.catseffect.loadConfigF
 import fs2.concurrent.SignallingRef
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.dropwizard.DropwizardExports
@@ -80,9 +79,7 @@ object Boot extends App {
       batchChangeLimit <- IO(VinylDNSConfig.vinyldnsConfig.getInt("batch-change-limit"))
       syncDelay <- IO(VinylDNSConfig.vinyldnsConfig.getInt("sync-delay"))
       msgsPerPoll <- IO.fromEither(MessageCount(queueConfig.messagesPerPoll))
-      healthCheckTimeout <- loadConfigF[IO, Option[Int]](
-        VinylDNSConfig.vinyldnsConfig,
-        "health-check-timeout")
+      healthCheckTimeout <- VinylDNSConfig.healthCheckTimeout
       _ <- CommandHandler
         .run(
           messageQueue,
@@ -111,8 +108,7 @@ object Boot extends App {
         zoneValidations,
         AccessValidations)
       val healthService = new HealthService(
-        messageQueue.healthCheck :: connectionValidator.healthCheck(
-          healthCheckTimeout.getOrElse(10000)) ::
+        messageQueue.healthCheck :: connectionValidator.healthCheck(healthCheckTimeout) ::
           loaderResponse.healthChecks)
       val batchChangeConverter =
         new BatchChangeConverter(repositories.batchChangeRepository, messageQueue)

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -106,7 +106,9 @@ object Boot extends App {
         messageQueue,
         zoneValidations,
         AccessValidations)
-      val healthService = new HealthService(messageQueue.healthCheck :: loaderResponse.healthChecks)
+      val healthService = new HealthService(
+        messageQueue.healthCheck :: connectionValidator.healthCheck ::
+          loaderResponse.healthChecks)
       val batchChangeConverter =
         new BatchChangeConverter(repositories.batchChangeRepository, messageQueue)
       val batchChangeService =

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -73,7 +73,4 @@ object VinylDNSConfig {
     val primaryServer = connectionConfig.getString("primaryServer")
     ZoneConnection(name, keyName, key, primaryServer).encrypted(Crypto.instance)
   }
-
-  lazy val dnsBackendHealthCheckConfig: Config =
-    vinyldnsConfig.getConfig("health-check.dns-backend")
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -73,4 +73,8 @@ object VinylDNSConfig {
     val primaryServer = connectionConfig.getString("primaryServer")
     ZoneConnection(name, keyName, key, primaryServer).encrypted(Crypto.instance)
   }
+
+  lazy val healthCheckTimeout: IO[Int] =
+    loadConfigF[IO, Option[Int]](vinyldnsConfig, "health-check-timeout").map(_.getOrElse(10000))
+
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -73,4 +73,7 @@ object VinylDNSConfig {
     val primaryServer = connectionConfig.getString("primaryServer")
     ZoneConnection(name, keyName, key, primaryServer).encrypted(Crypto.instance)
   }
+
+  lazy val dnsBackendHealthCheckConfig: Config =
+    vinyldnsConfig.getConfig("health-check.dns-backend")
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConnection.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConnection.scala
@@ -97,12 +97,7 @@ class DnsConnection(val resolver: DNS.SimpleResolver) extends DnsConversions {
   }
 
   def resolve(name: String, zoneName: String, typ: RecordType): Result[List[RecordSet]] =
-    IO {
-      for {
-        query <- toQuery(name, zoneName, typ)
-        records <- runQuery(query)
-      } yield records
-    }.toResult
+    queryDnsBackend(name, zoneName, typ).toResult
 
   private[dns] def toQuery(
       name: String,
@@ -194,6 +189,17 @@ class DnsConnection(val resolver: DNS.SimpleResolver) extends DnsConversions {
       case DNS.Lookup.SUCCESSFUL => Right(toFlattenedRecordSets(answers, query.zoneName))
     }
   }
+
+  private[domain] def queryDnsBackend(
+      name: String,
+      zoneName: String,
+      typ: RecordType): IO[Either[Throwable, List[RecordSet]]] =
+    IO {
+      for {
+        query <- toQuery(name, zoneName, typ)
+        records <- runQuery(query)
+      } yield records
+    }
 }
 
 object DnsConnection {

--- a/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConnection.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConnection.scala
@@ -16,20 +16,15 @@
 
 package vinyldns.api.domain.dns
 
-import java.net.InetSocketAddress
-
 import cats.effect._
 import cats.syntax.all._
 import org.slf4j.{Logger, LoggerFactory}
 import org.xbill.DNS
 import vinyldns.api.Interfaces.{result, _}
-import vinyldns.api.VinylDNSConfig
 import vinyldns.api.crypto.Crypto
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.{RecordSet, RecordSetChange, RecordSetChangeType}
 import vinyldns.core.domain.zone.{Zone, ZoneConnection}
-
-import scala.util.Try
 
 object DnsProtocol {
 
@@ -108,21 +103,6 @@ class DnsConnection(val resolver: DNS.SimpleResolver) extends DnsConversions {
         records <- runQuery(query)
       } yield records
     }.toResult
-
-  def healthCheck(): Try[Unit] = {
-    val socket = new java.net.Socket()
-    val address = VinylDNSConfig.dnsBackendHealthCheckConfig.getString("address")
-    val port = VinylDNSConfig.dnsBackendHealthCheckConfig.getInt("port")
-    val socketTimeout = VinylDNSConfig.dnsBackendHealthCheckConfig.getInt("timeout")
-
-    val result = for {
-      socketConnectionAttempt <- Try(
-        socket.connect(new InetSocketAddress(address, port), socketTimeout))
-    } yield socketConnectionAttempt
-    socket.close()
-
-    result
-  }
 
   private[dns] def toQuery(
       name: String,
@@ -231,7 +211,7 @@ object DnsConnection {
     resolver
   }
 
-  private def parseHostAndPort(primaryServer: String): (String, Int) = {
+  def parseHostAndPort(primaryServer: String): (String, Int) = {
     val parts = primaryServer.trim().split(':')
     if (parts.length < 2)
       (primaryServer, 53)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -23,6 +23,7 @@ import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.dns.DnsConnection
 import vinyldns.core.domain.record.{RecordSet, RecordType}
 import vinyldns.core.domain.zone.{Zone, ZoneConnection}
+import vinyldns.core.health.HealthCheck._
 
 import scala.concurrent.duration._
 
@@ -34,6 +35,7 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
     extends ZoneConnectionValidatorAlgebra {
 
   import ZoneRecordValidations._
+  import ZoneConnectionValidator._
 
   val opTimeout: FiniteDuration = 6.seconds
 
@@ -85,5 +87,14 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
     }
   }
 
+  def healthCheck(): HealthCheck =
+    dnsConnection(defaultConnection)
+      .queryDnsBackend(healthCheckRecordName, defaultConnection.name, RecordType.A)
+      .asHealthCheck
+
   private[domain] def dnsConnection(conn: ZoneConnection): DnsConnection = DnsConnection(conn)
+}
+
+object ZoneConnectionValidator {
+  private[zone] val healthCheckRecordName = "maybe-exists"
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -42,7 +42,6 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
 
   val (healthCheckAddress, healthCheckPort) =
     DnsConnection.parseHostAndPort(defaultConnection.primaryServer)
-  val healthCheckSocketTimeout: Int = VinylDNSConfig.dnsBackendHealthCheckConfig.getInt("timeout")
 
   def loadDns(zone: Zone): IO[ZoneView] = DnsZoneViewLoader(zone).load()
 
@@ -92,15 +91,11 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
     }
   }
 
-  def healthCheck(): HealthCheck =
+  def healthCheck(timeout: Int): HealthCheck =
     Resource
       .fromAutoCloseable(IO(new Socket()))
-      .use(
-        socket =>
-          IO(
-            socket.connect(
-              new InetSocketAddress(healthCheckAddress, healthCheckPort),
-              healthCheckSocketTimeout)))
+      .use(socket =>
+        IO(socket.connect(new InetSocketAddress(healthCheckAddress, healthCheckPort), timeout)))
       .attempt
       .asHealthCheck
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -87,10 +87,11 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
   }
 
   def healthCheck(): HealthCheck =
-    dnsConnection(defaultConnection)
-      .resolve("maybe-exists-record", "vinyldns.", RecordType.A)
-      .value
-      .asHealthCheck
+    IO {
+      dnsConnection(defaultConnection)
+        .healthCheck()
+        .toEither
+    }.asHealthCheck
 
   private[domain] def dnsConnection(conn: ZoneConnection): DnsConnection = DnsConnection(conn)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -35,7 +35,6 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
     extends ZoneConnectionValidatorAlgebra {
 
   import ZoneRecordValidations._
-  import ZoneConnectionValidator._
 
   val opTimeout: FiniteDuration = 6.seconds
 
@@ -89,12 +88,9 @@ class ZoneConnectionValidator(defaultConnection: ZoneConnection)
 
   def healthCheck(): HealthCheck =
     dnsConnection(defaultConnection)
-      .queryDnsBackend(healthCheckRecordName, defaultConnection.name, RecordType.A)
+      .resolve("maybe-exists-record", "vinyldns.", RecordType.A)
+      .value
       .asHealthCheck
 
   private[domain] def dnsConnection(conn: ZoneConnection): DnsConnection = DnsConnection(conn)
-}
-
-object ZoneConnectionValidator {
-  private[zone] val healthCheckRecordName = "maybe-exists"
 }

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -342,8 +342,16 @@ VinylDNS has **2** connections for each zone:
 VinylDNS supports the ability to provide _default_ connections, so keys do not need to be generated for _every_ zone.  This assumes a
 "default" DNS backend.
 
+VinylDNS also ties in testing network connectivity to the default zone connection's primary server into its API health checks. A value
+for the health check connection timeout in milliseconds can be specified using `health-check-timeout`; a default value of 10000 will
+be used if not provided.
+
 ```yaml
 vinyldns {
+
+    # timeout for DNS backend connectivity health check
+    health-check-timeout = 5000
+
   # the DDNS connection information for the default dns backend
   defaultZoneConnection {
     # this is not really used, but must be set, usually set to the keyName itself, or a descriptive name if you are interested


### PR DESCRIPTION
Add health check for DNS backend and tie into `Boot`.

Fixes #357.

Changes in this pull request:
- Split off IO component of `resolve` into `queryDnsBackend` (to avoid converting `IO` → `Result` → `IO` → `HealthCheck`)
- Create health check on `ZoneConnectionValidator` to test using the default zone connection info