### PR TITLE
remove existing shared zone logic

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -34,7 +34,7 @@ object AccessValidations extends AccessValidationAlgebra {
   def canSeeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =
     ensuring(
       NotAuthorizedError(s"User ${auth.signedInUser.userName} cannot access zone '${zone.name}'"))(
-      (hasZoneAdminAccess(auth, zone) || zone.shared) || userHasAclRules(auth, zone))
+      hasZoneAdminAccess(auth, zone) || userHasAclRules(auth, zone))
 
   def canChangeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =
     ensuring(


### PR DESCRIPTION
Fixes #390

Changes in this pull request:
- removed `zone.shared` from `def canSeeZone` in AccessValidations.scala

Looked like that was the only place it existed and wasn't included in tests
