### PR TITLE
correct zoneChange status in ZoneChangeHandler

### DIFF
--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -87,17 +87,6 @@ records_post_update = [
      'records': [{u'address': u'6.7.8.9'}]}]
 
 
-def wait_for_zone_sync_to_complete(client, zone_id, latest_sync):
-    retries = MAX_RETRIES
-    zone_request = client.get_zone(zone_id)
-
-    while zone_request[u'zone'][u'latestSync'] == latest_sync and retries > 0:
-        zone_request = client.get_zone(zone_id)
-        time.sleep(RETRY_WAIT)
-        retries -= 1
-
-    assert_that(zone_request[u'zone'][u'latestSync'], is_not(latest_sync))
-
 @pytest.mark.skip_production
 def test_sync_zone_success(shared_zone_test_context):
     """
@@ -163,8 +152,8 @@ def test_sync_zone_success(shared_zone_test_context):
         time.sleep(10)
 
         # sync again
-        client.sync_zone(zone['id'], status=202)
-        wait_for_zone_sync_to_complete(client, zone['id'], latest_sync)
+        change = client.sync_zone(zone['id'], status=202)
+        client.wait_until_zone_change_status_synced(change)
 
         # confirm cannot again sync without waiting
         client.sync_zone(zone['id'], status=403)

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneChangeHandler.scala
@@ -17,12 +17,7 @@
 package vinyldns.api.engine
 
 import cats.effect.IO
-import vinyldns.core.domain.zone.{
-  ZoneChange,
-  ZoneChangeRepository,
-  ZoneChangeStatus,
-  ZoneRepository
-}
+import vinyldns.core.domain.zone._
 
 object ZoneChangeHandler {
   def apply(
@@ -36,6 +31,10 @@ object ZoneChangeHandler {
               status = ZoneChangeStatus.Failed,
               systemMessage = Some(duplicateZoneError.message))
           )
+        case Right(_)
+            if zoneChange.zone.status == ZoneStatus.Syncing &&
+              (zoneChange.changeType == ZoneChangeType.Sync || zoneChange.changeType == ZoneChangeType.Create) =>
+          zoneChangeRepository.save(zoneChange)
         case Right(_) =>
           zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
     }


### PR DESCRIPTION
Fixes #391.

If a zoneChange is of type Sync or Create we shouldn't change the status to Synced until after the zone syncs.

Changes in this pull request:
-  check the zoneChange status and the zone status, if the zoneChange type is Sync or Create and the zone status is Syncing we won't change the zoneChange status to Synced.
