### PR TITLE
Allow super users to create shared zones

### DIFF
--- a/modules/api/functional_test/live_tests/shared_zone_test_context.py
+++ b/modules/api/functional_test/live_tests/shared_zone_test_context.py
@@ -87,7 +87,7 @@ class SharedZoneTestContext(object):
                 {
                     'name': '1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.',
                     'email': 'test@test.com',
-                    'shared': True,
+                    'shared': False,
                     'adminGroupId': self.ok_group['id'],
                     'connection': {
                         'name': 'ip6.',
@@ -109,7 +109,7 @@ class SharedZoneTestContext(object):
                 {
                     'name': '30.172.in-addr.arpa.',
                     'email': 'test@test.com',
-                    'shared': True,
+                    'shared': False,
                     'adminGroupId': self.ok_group['id'],
                     'connection': {
                         'name': 'ip4.',
@@ -175,7 +175,7 @@ class SharedZoneTestContext(object):
                 {
                     'name': 'system-test.',
                     'email': 'test@test.com',
-                    'shared': True,
+                    'shared': False,
                     'adminGroupId': self.ok_group['id'],
                     'connection': {
                         'name': 'system-test.',

--- a/modules/api/functional_test/live_tests/zone_history_context.py
+++ b/modules/api/functional_test/live_tests/zone_history_context.py
@@ -36,7 +36,7 @@ class ZoneHistoryContext(object):
             {
                 'name': 'system-test-history.',
                 'email': 'i.changed.this.1.times@history-test.com',
-                'shared': True,
+                'shared': False,
                 'adminGroupId': self.group['id'],
                 'connection': {
                     'name': 'vinyldns.',

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -165,11 +165,11 @@ def test_create_invalid_zone_data(shared_zone_test_context):
     zone = {
         'name': zone_name,
         'email': 'test@test.com',
-        'status': 'invalid_status'
+        'shared': 'invalid_value'
     }
 
     errors = client.create_zone(zone, status=400)['errors']
-    assert_that(errors, contains_inanyorder('Invalid ZoneStatus'))
+    assert_that(errors, contains_inanyorder('Do not know how to convert JString(invalid_value) into boolean'))
 
 
 def test_create_zone_with_connection_failure(shared_zone_test_context):

--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 import uuid
 
@@ -151,7 +152,7 @@ def test_create_missing_zone_data(shared_zone_test_context):
     }
 
     errors = client.create_zone(zone, status=400)['errors']
-    assert_that(errors, contains_inanyorder('Missing Zone.name', 'Missing Zone.email'))
+    assert_that(errors, contains_inanyorder('Missing Zone.name', 'Missing Zone.email', 'Missing Zone.adminGroupId'))
 
 
 def test_create_invalid_zone_data(shared_zone_test_context):
@@ -165,7 +166,8 @@ def test_create_invalid_zone_data(shared_zone_test_context):
     zone = {
         'name': zone_name,
         'email': 'test@test.com',
-        'shared': 'invalid_value'
+        'shared': 'invalid_value',
+        'adminGroupId': 'admin-group-id'
     }
 
     errors = client.create_zone(zone, status=400)['errors']
@@ -471,3 +473,12 @@ def test_user_cannot_create_zone_with_failed_validations(shared_zone_test_contex
     assert_that(result['errors'], contains_inanyorder(
         contains_string("not-approved.thing.com. is not an approved name server")
     ))
+
+def test_normal_user_cannot_create_shared_zone(shared_zone_test_context):
+    """
+    Test that a normal user cannot create a shared zone
+    """
+    super_zone = copy.deepcopy(shared_zone_test_context.ok_zone)
+    super_zone['shared'] = True
+
+    shared_zone_test_context.ok_vinyldns_client.create_zone(super_zone, status=403)

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -17,7 +17,12 @@
 package vinyldns.api.domain
 
 import vinyldns.api.Interfaces.ensuring
-import vinyldns.api.domain.zone.{ACLRuleOrdering, NotAuthorizedError, PTRACLRuleOrdering, RecordSetInfo}
+import vinyldns.api.domain.zone.{
+  ACLRuleOrdering,
+  NotAuthorizedError,
+  PTRACLRuleOrdering,
+  RecordSetInfo
+}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.{RecordSet, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -200,3 +200,5 @@ case class ConnectionFailed(zone: Zone, message: String) extends Throwable(messa
 
 case class ZoneValidationFailed(zone: Zone, errors: List[String], message: String)
     extends Throwable(message)
+
+case class UnauthorizedSharedZoneAction(msg: String) extends Throwable(msg)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -200,5 +200,3 @@ case class ConnectionFailed(zone: Zone, message: String) extends Throwable(messa
 
 case class ZoneValidationFailed(zone: Zone, errors: List[String], message: String)
     extends Throwable(message)
-
-case class UnauthorizedSharedZoneAction(msg: String) extends Throwable(msg)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -66,6 +66,7 @@ class ZoneService(
       _ <- zoneDoesNotExist(zone)
       _ <- adminGroupExists(zone.adminGroupId)
       _ <- canChangeZone(auth, zone).toResult
+      _ <- checkSharedZone(zone, auth.signedInUser).toResult
       createZoneChange <- ZoneChangeGenerator.forAdd(zone, auth).toResult
       _ <- messageQueue.send(createZoneChange).toResult[Unit]
     } yield createZoneChange

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -62,11 +62,11 @@ class ZoneService(
   def connectToZone(zone: Zone, auth: AuthPrincipal): Result[ZoneCommandResult] =
     for {
       _ <- isValidZoneAcl(zone.acl).toResult
+      _ <- validateSharedZoneAuthorized(zone, auth.signedInUser).toResult
       _ <- connectionValidator.validateZoneConnections(zone)
       _ <- zoneDoesNotExist(zone)
       _ <- adminGroupExists(zone.adminGroupId)
       _ <- canChangeZone(auth, zone).toResult
-      _ <- checkSharedZone(zone, auth.signedInUser).toResult
       createZoneChange <- ZoneChangeGenerator.forAdd(zone, auth).toResult
       _ <- messageQueue.send(createZoneChange).toResult[Unit]
     } yield createZoneChange

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -73,6 +73,6 @@ class ZoneValidations(syncDelayMillis: Int) {
 
   // Validates that the zone is either not shared or shared and the user is a super user
   def validateSharedZoneAuthorized(zone: Zone, user: User): Either[Throwable, Unit] =
-    ensuring(UnauthorizedSharedZoneAction("Only super users are allowed to create shared zones."))(
+    ensuring(NotAuthorizedError("Not authorized to create shared zones."))(
       !zone.shared || user.isSuper)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -20,6 +20,7 @@ import cats.syntax.either._
 import com.aaronbedra.orchard.CIDR
 import org.joda.time.DateTime
 import vinyldns.api.Interfaces.ensuring
+import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone.{ACLRule, Zone, ZoneACL}
 
@@ -69,4 +70,8 @@ class ZoneValidations(syncDelayMillis: Int) {
         }
       case None => ().asRight
     }
+
+  def checkSharedZone(zone: Zone, user: User): Either[Throwable, Unit] =
+    ensuring(UnauthorizedSharedZoneAction("Only super users are allowed to create shared zones."))(
+      !zone.shared || user.isSuper)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -71,7 +71,8 @@ class ZoneValidations(syncDelayMillis: Int) {
       case None => ().asRight
     }
 
-  def checkSharedZone(zone: Zone, user: User): Either[Throwable, Unit] =
+  // Validates that the zone is either not shared or shared and the user is a super user
+  def validateSharedZoneAuthorized(zone: Zone, user: User): Either[Throwable, Unit] =
     ensuring(UnauthorizedSharedZoneAction("Only super users are allowed to create shared zones."))(
       !zone.shared || user.isSuper)
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -32,6 +32,7 @@ trait DnsJsonProtocol extends JsonValidation {
   import vinyldns.core.domain.record.RecordType._
 
   val dnsSerializers = Seq(
+    ZoneCreateInputSerializer,
     ZoneSerializer,
     ZoneConnectionSerializer,
     RecordSetSerializer,
@@ -86,6 +87,21 @@ trait DnsJsonProtocol extends JsonValidation {
         (js \ "id").default[String](UUID.randomUUID.toString),
         (js \ "singleBatchChangeIds").default[List[String]](List())
       ).mapN(RecordSetChange.apply)
+  }
+
+  case object ZoneCreateInputSerializer extends ValidationSerializer[CreateZoneInput] {
+    override def fromJson(js: JValue): ValidatedNel[String, CreateZoneInput] =
+      (
+        (js \ "name")
+          .required[String]("Missing Zone.name")
+          .map(name => if (name.endsWith(".")) name else s"$name."),
+        (js \ "email").required[String]("Missing Zone.email"),
+        (js \ "connection").optional[ZoneConnection],
+        (js \ "transferConnection").optional[ZoneConnection],
+        (js \ "shared").optional[Boolean],
+        (js \ "acl").default[ZoneACL](ZoneACL()),
+        (js \ "adminGroupId").default[String]("system")
+      ).mapN(CreateZoneInput.apply)
   }
 
   case object ZoneSerializer extends ValidationSerializer[Zone] {

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -32,7 +32,7 @@ trait DnsJsonProtocol extends JsonValidation {
   import vinyldns.core.domain.record.RecordType._
 
   val dnsSerializers = Seq(
-    ZoneCreateInputSerializer,
+    CreateZoneInputSerializer,
     ZoneSerializer,
     ZoneConnectionSerializer,
     RecordSetSerializer,
@@ -89,7 +89,7 @@ trait DnsJsonProtocol extends JsonValidation {
       ).mapN(RecordSetChange.apply)
   }
 
-  case object ZoneCreateInputSerializer extends ValidationSerializer[CreateZoneInput] {
+  case object CreateZoneInputSerializer extends ValidationSerializer[CreateZoneInput] {
     override def fromJson(js: JValue): ValidatedNel[String, CreateZoneInput] =
       (
         (js \ "name")

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -98,9 +98,9 @@ trait DnsJsonProtocol extends JsonValidation {
         (js \ "email").required[String]("Missing Zone.email"),
         (js \ "connection").optional[ZoneConnection],
         (js \ "transferConnection").optional[ZoneConnection],
-        (js \ "shared").optional[Boolean],
+        (js \ "shared").default[Boolean](false),
         (js \ "acl").default[ZoneACL](ZoneACL()),
-        (js \ "adminGroupId").default[String]("system")
+        (js \ "adminGroupId").required[String]("Missing Zone.adminGroupId")
       ).mapN(CreateZoneInput.apply)
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -155,7 +155,6 @@ trait ZoneRoute extends Directives {
       case Left(RecentSyncError(msg)) => complete(StatusCodes.Forbidden, msg)
       case Left(ZoneInactiveError(msg)) => complete(StatusCodes.BadRequest, msg)
       case Left(InvalidRequest(msg)) => complete(StatusCodes.BadRequest, msg)
-      case Left(UnauthorizedSharedZoneAction(msg)) => complete(StatusCodes.Forbidden, msg)
       case Left(e) => failWith(e)
     }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -776,7 +776,7 @@ class MembershipServiceSpec
         result should be(right)
       }
 
-      "return a InvalidGroupRequestError when a group for deletion is admin of a zone" in {
+      "return an InvalidGroupRequestError when a group for deletion is admin of a zone" in {
         doReturn(IO.pure(List(mock[Zone])))
           .when(mockZoneRepo)
           .getZonesByAdminGroupId(okGroup.id)

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -106,7 +106,7 @@ class ZoneServiceSpec
       error shouldBe a[ZoneAlreadyExistsError]
     }
 
-    "return a InvalidZoneAdminError error if the zone admin group does not exist" in {
+    "return an InvalidZoneAdminError error if the zone admin group does not exist" in {
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
       doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(anyString)
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -147,12 +147,12 @@ class ZoneServiceSpec
       resultZone.shared shouldBe true
     }
 
-    "return an UnauthorizedSharedZoneAction error if zone is shared and user is not a super user" in {
+    "return a NotAuthorizedError if zone is shared and user is not a super user" in {
       val newZone = zoneAuthorized.copy(shared = true)
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
 
       val error = leftResultOf(underTest.connectToZone(newZone, okAuth).value)
-      error shouldBe an[UnauthorizedSharedZoneAction]
+      error shouldBe a[NotAuthorizedError]
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -139,7 +139,7 @@ class ZoneServiceSpec
       val resultZone = rightResultOf(
         underTest.connectToZone(newZone, superAuth).map(_.asInstanceOf[ZoneChange]).value).zone
 
-      Option(resultZone.id) shouldBe defined
+      Option(resultZone.id) should not be None
       resultZone.email shouldBe zoneAuthorized.email
       resultZone.name shouldBe zoneAuthorized.name
       resultZone.status shouldBe ZoneStatus.Syncing

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -95,9 +95,10 @@ class ZoneServiceSpec
       resultZone.name shouldBe zoneAuthorized.name
       resultZone.status shouldBe ZoneStatus.Syncing
       resultZone.connection shouldBe zoneAuthorized.connection
+      resultZone.shared shouldBe false
     }
 
-    "returns a ZoneAlreadyExists error if the zone exists" in {
+    "return a ZoneAlreadyExists error if the zone exists" in {
       doReturn(IO.pure(Some(zoneAuthorized))).when(mockZoneRepo).getZoneByName(anyString)
 
       val error = leftResultOf(underTest.connectToZone(zoneAuthorized, okAuth).value)
@@ -105,13 +106,13 @@ class ZoneServiceSpec
       error shouldBe a[ZoneAlreadyExistsError]
     }
 
-    "returns a InvalidZoneAdminError error if the zone admin group does not exist" in {
+    "return a InvalidZoneAdminError error if the zone admin group does not exist" in {
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
       doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(anyString)
 
       val error = leftResultOf(underTest.connectToZone(zoneAuthorized, okAuth).value)
 
-      error shouldBe a[InvalidZoneAdminError]
+      error shouldBe an[InvalidZoneAdminError]
     }
 
     "allow the zone to be created if it exists and the zone is deleted" in {
@@ -127,7 +128,31 @@ class ZoneServiceSpec
       val newZone = zoneAuthorized.copy(acl = ZoneACL(Set(badAcl)))
 
       val error = leftResultOf(underTest.connectToZone(newZone, okAuth).value)
-      error shouldBe a[InvalidRequest]
+      error shouldBe an[InvalidRequest]
+    }
+
+    "succeed if zone is shared and user is a super user" in {
+      val newZone = zoneAuthorized.copy(shared = true)
+      val superAuth = okAuth.copy(signedInUser = okUser.copy(isSuper = true))
+      doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
+
+      val resultZone = rightResultOf(
+        underTest.connectToZone(newZone, superAuth).map(_.asInstanceOf[ZoneChange]).value).zone
+
+      Option(resultZone.id) shouldBe defined
+      resultZone.email shouldBe zoneAuthorized.email
+      resultZone.name shouldBe zoneAuthorized.name
+      resultZone.status shouldBe ZoneStatus.Syncing
+      resultZone.connection shouldBe zoneAuthorized.connection
+      resultZone.shared shouldBe true
+    }
+
+    "return an UnauthorizedSharedZoneAction error if zone is shared and user is not a super user" in {
+      val newZone = zoneAuthorized.copy(shared = true)
+      doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
+
+      val error = leftResultOf(underTest.connectToZone(newZone, okAuth).value)
+      error shouldBe an[UnauthorizedSharedZoneAction]
     }
   }
 
@@ -186,7 +211,7 @@ class ZoneServiceSpec
       val newZone = zoneAuthorized.copy(acl = ZoneACL(Set(badAcl)))
 
       val error = leftResultOf(underTest.updateZone(newZone, okAuth).value)
-      error shouldBe a[InvalidRequest]
+      error shouldBe an[InvalidRequest]
     }
   }
 
@@ -504,7 +529,7 @@ class ZoneServiceSpec
       val error =
         leftResultOf(
           underTest.addACLRule(zoneAuthorized.id, invalidRegexMaskRuleInfo, okAuth).value)
-      error shouldBe a[InvalidRequest]
+      error shouldBe an[InvalidRequest]
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -22,70 +22,130 @@ import org.json4s._
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.api.VinylDNSTestData
 import vinyldns.core.domain.record._
-import vinyldns.core.domain.zone.{Zone, ZoneConnection}
+import vinyldns.core.domain.zone.{CreateZoneInput, Zone, ZoneConnection}
 
 class VinylDNSJsonProtocolSpec
     extends WordSpec
     with Matchers
     with VinylDNSJsonProtocol
     with VinylDNSTestData {
+
+  private val completeCreateZoneInput = CreateZoneInput(
+    "testZone.",
+    "test@test.com",
+    connection = Some(
+      ZoneConnection(
+        "primaryConnection",
+        "primaryConnectionKeyName",
+        "primaryConnectionKey",
+        "10.1.1.1")),
+    transferConnection = Some(
+      ZoneConnection(
+        "transferConnection",
+        "transferConnectionKeyName",
+        "transferConnectionKey",
+        "10.1.1.2")),
+    adminGroupId = "admin-group-id"
+  )
+
+  private val completeZone = Zone(completeCreateZoneInput)
+
+  private val primaryConnection: JValue =
+    ("name" -> "primaryConnection") ~~
+      ("keyName" -> "primaryConnectionKeyName") ~~
+      ("key" -> "primaryConnectionKey") ~~
+      ("primaryServer" -> "10.1.1.1")
+
+  private val transferConnection: JValue =
+    ("name" -> "transferConnection") ~~
+      ("keyName" -> "transferConnectionKeyName") ~~
+      ("key" -> "transferConnectionKey") ~~
+      ("primaryServer" -> "10.1.1.2")
+
   "ZoneSerializer" should {
     "parse a zone with no connections" in {
       val zone: JValue =
         ("name" -> "testZone.") ~~
-          ("email" -> "test@test.com")
+          ("email" -> "test@test.com") ~~
+          ("adminGroupId" -> "admin-group-id")
 
-      val expected = Zone("testZone.", "test@test.com")
+      val expected = completeZone.copy(connection = None, transferConnection = None)
       val actual = zone.extract[Zone]
       anonymize(actual) shouldBe anonymize(expected)
     }
     "parse a zone with a connection and no transferConnection" in {
-      val connection: JValue =
-        ("name" -> "connection") ~~
-          ("keyName" -> "keyName") ~~
-          ("key" -> "key") ~~
-          ("primaryServer" -> "10.1.1.1")
-
       val zone: JValue =
         ("name" -> "testZone.") ~~
           ("email" -> "test@test.com") ~~
-          ("connection" -> connection)
+          ("connection" -> primaryConnection) ~~
+          ("adminGroupId" -> "admin-group-id")
 
-      val expected = Zone(
-        "testZone.",
-        "test@test.com",
-        connection = Some(ZoneConnection("connection", "keyName", "key", "10.1.1.1")),
-        transferConnection = None)
+      val expected = completeZone.copy(transferConnection = None)
       val actual = zone.extract[Zone]
       anonymize(actual) shouldBe anonymize(expected)
     }
     "parse a zone with a transferConnection" in {
-      val connection: JValue =
-        ("name" -> "connection1") ~~
-          ("keyName" -> "keyName1") ~~
-          ("key" -> "key1") ~~
-          ("primaryServer" -> "10.1.1.1")
-
-      val transferConnection: JValue =
-        ("name" -> "connection2") ~~
-          ("keyName" -> "keyName2") ~~
-          ("key" -> "key2") ~~
-          ("primaryServer" -> "10.1.1.2")
-
       val zone: JValue =
         ("name" -> "testZone.") ~~
           ("email" -> "test@test.com") ~~
-          ("connection" -> connection) ~~
-          ("transferConnection" -> transferConnection)
+          ("connection" -> primaryConnection) ~~
+          ("transferConnection" -> transferConnection) ~~
+          ("adminGroupId" -> "admin-group-id")
 
-      val expected = Zone(
-        "testZone.",
-        "test@test.com",
-        connection = Some(ZoneConnection("connection1", "keyName1", "key1", "10.1.1.1")),
-        transferConnection = Some(ZoneConnection("connection2", "keyName2", "key2", "10.1.1.2"))
-      )
       val actual = zone.extract[Zone]
-      anonymize(actual) shouldBe anonymize(expected)
+      anonymize(actual) shouldBe anonymize(completeZone)
+    }
+  }
+
+  "CreateZoneInputSerializer" should {
+    "parse a create zone input with no connections" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("email" -> "test@test.com") ~~
+          ("adminGroupId" -> "admin-group-id")
+
+      val expected = completeCreateZoneInput.copy(connection = None, transferConnection = None)
+      val actual = createZoneInput.extract[CreateZoneInput]
+      actual shouldBe expected
+    }
+
+    "parse a create zone input with a connection and no transfer connection" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("email" -> "test@test.com") ~~
+          ("connection" -> primaryConnection) ~~
+          ("adminGroupId" -> "admin-group-id")
+
+      val expected = completeCreateZoneInput.copy(transferConnection = None)
+      val actual = createZoneInput.extract[CreateZoneInput]
+      actual shouldBe expected
+    }
+
+    "parse a create zone input with a transfer connection" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("email" -> "test@test.com") ~~
+          ("connection" -> primaryConnection) ~~
+          ("transferConnection" -> transferConnection) ~~
+          ("adminGroupId" -> "admin-group-id")
+
+      val actual = createZoneInput.extract[CreateZoneInput]
+      actual shouldBe completeCreateZoneInput
+    }
+
+    "parse a shared create zone input" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("email" -> "test@test.com") ~~
+          ("connection" -> primaryConnection) ~~
+          ("transferConnection" -> transferConnection) ~~
+          ("shared" -> true) ~~
+          ("adminGroupId" -> "admin-group-id")
+
+      val expected = completeCreateZoneInput.copy(shared = Some(true))
+      val actual = createZoneInput.extract[CreateZoneInput]
+      actual shouldBe expected
+      actual.shared shouldBe Some(true)
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -142,10 +142,10 @@ class VinylDNSJsonProtocolSpec
           ("shared" -> true) ~~
           ("adminGroupId" -> "admin-group-id")
 
-      val expected = completeCreateZoneInput.copy(shared = Some(true))
+      val expected = completeCreateZoneInput.copy(shared = true)
       val actual = createZoneInput.extract[CreateZoneInput]
       actual shouldBe expected
-      actual.shared shouldBe Some(true)
+      actual.shared shouldBe true
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -147,6 +147,39 @@ class VinylDNSJsonProtocolSpec
       actual shouldBe expected
       actual.shared shouldBe true
     }
+
+    "throw an error if zone name is missing" in {
+      val createZoneInput: JValue =
+        ("email" -> "test@test.com") ~~
+          ("adminGroupId" -> "admin-group-id")
+
+      assertThrows[MappingException](createZoneInput.extract[CreateZoneInput])
+    }
+
+    "throw an error if zone email is missing" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("adminGroupId" -> "admin-group-id")
+
+      assertThrows[MappingException](createZoneInput.extract[CreateZoneInput])
+    }
+
+    "throw an error if adminGroupId is missing" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("email" -> "test@test.com")
+
+      assertThrows[MappingException](createZoneInput.extract[CreateZoneInput])
+    }
+
+    "throw an error if there is a type mismatch during deserialization" in {
+      val createZoneInput: JValue =
+        ("name" -> "testZone.") ~~
+          ("email" -> "test@test.com") ~~
+          ("adminGroupId" -> true)
+
+      assertThrows[MappingException](createZoneInput.extract[CreateZoneInput])
+    }
   }
 
   "RecordSetSerializer" should {

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -139,7 +139,7 @@ class ZoneRoutingSpec
         case zoneValidationFailed.email =>
           Left(ZoneValidationFailed(zone, List("fail"), "failure message"))
         case nonSuperUserSharedZone.email =>
-          Left(UnauthorizedSharedZoneAction("unauth"))
+          Left(NotAuthorizedError("unauth"))
       }
       outcome.map(c => c.asInstanceOf[ZoneCommandResult]).toResult
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -44,10 +44,10 @@ class ZoneRoutingSpec
     with GroupTestData {
 
   private val okAuth = okGroupAuth
-  private val alreadyExists = Zone("already.exists.", "test@test.com")
-  private val notFound = Zone("not.found.", "test@test.com")
-  private val notAuthorized = Zone("not.authorized.", "test@test.com")
-  private val badAdminId = Zone("bad.admin.", "test@test.com")
+  private val alreadyExists = Zone("already.exists.", "already-exists@test.com")
+  private val notFound = Zone("not.found.", "not-found@test.com")
+  private val notAuthorized = Zone("not.authorized.", "not-authorized@test.com")
+  private val badAdminId = Zone("bad.admin.", "bad-admin@test.com")
 
   private val userAclRule = ACLRule(
     AccessLevel.Read,
@@ -72,41 +72,42 @@ class ZoneRoutingSpec
     Set(RecordType.A, RecordType.AAAA, RecordType.CNAME))
   private val zoneAcl = ZoneACL(Set(userAclRule, groupAclRule))
 
-  private val ok = Zone("ok.", "test@test.com", shared = true, acl = zoneAcl, adminGroupId = "test")
+  private val ok = Zone("ok.", "ok@test.com", acl = zoneAcl, adminGroupId = "test")
   private val aclAsInfo = ZoneACLInfo(zoneAcl.rules.map(ACLRuleInfo(_, Some("name"))))
   private val okAsZoneInfo = ZoneInfo(ok, aclAsInfo, okGroup.name)
-  private val badRegex = Zone("ok.", "test@test.com", shared = true, adminGroupId = "test")
-  private val trailingDot = Zone("trailing.dot", "test@test.com")
+  private val badRegex = Zone("ok.", "bad-regex@test.com", adminGroupId = "test")
+  private val trailingDot = Zone("trailing.dot", "trailing-dot@test.com")
   private val connectionOk = Zone(
     "connection.ok.",
-    "test@test.com",
+    "connection-ok@test.com",
     connection = Some(ZoneConnection("connection.ok", "keyName", "key", "10.1.1.1")),
     transferConnection = Some(ZoneConnection("connection.ok", "keyName", "key", "10.1.1.1"))
   )
   private val connectionFailed = Zone(
     "connection.fail",
-    "test@test.com",
+    "connection-failed@test.com",
     connection = Some(ZoneConnection("connection.fail", "keyName", "key", "10.1.1.1")))
   private val zoneValidationFailed = Zone(
     "validation.fail",
-    "test@test.com",
+    "zone-validation-failed@test.com",
     connection = Some(ZoneConnection("validation.fail", "keyName", "key", "10.1.1.1")))
-  private val zone1 = Zone("zone1.", "test@test.com", ZoneStatus.Active)
+  private val zone1 = Zone("zone1.", "zone1@test.com", ZoneStatus.Active)
   private val zoneSummaryInfo1 = ZoneSummaryInfo(zone1, okGroup.name)
-  private val zone2 = Zone("zone2.", "test@test.com", ZoneStatus.Active)
+  private val zone2 = Zone("zone2.", "zone2@test.com", ZoneStatus.Active)
   private val zoneSummaryInfo2 = ZoneSummaryInfo(zone2, okGroup.name)
-  private val zone3 = Zone("zone3.", "test@test.com", ZoneStatus.Active)
+  private val zone3 = Zone("zone3.", "zone3@test.com", ZoneStatus.Active)
   private val zoneSummaryInfo3 = ZoneSummaryInfo(zone3, okGroup.name)
-  private val zone4 = Zone("zone4.", "test@test.com", ZoneStatus.Active)
-  private val zone5 = Zone("zone5.", "test@test.com", ZoneStatus.Active)
-  private val error = Zone("error.", "test@test.com")
+  private val zone4 = Zone("zone4.", "zone4@test.com", ZoneStatus.Active)
+  private val zone5 = Zone("zone5.", "zone5@test.com", ZoneStatus.Active)
+  private val error = Zone("error.", "error@test.com")
 
   private val missingFields: JValue =
     ("invalidField" -> "randomValue") ~~
       ("connection" -> ("k" -> "value"))
-  private val invalidZone: JValue =
-    ("name" -> "invalidZone.") ~~
-      ("email" -> "test@test.com") ~~
+
+  private val zoneWithInvalidStatus: JValue =
+    ("name" -> "invalidZoneStatus.") ~~
+      ("email" -> "invalid-zone-status@test.com") ~~
       ("status" -> "invalidStatus")
 
   private val zoneCreate = ZoneChange(ok, "ok", ZoneChangeType.Create, ZoneChangeStatus.Complete)
@@ -120,19 +121,19 @@ class ZoneRoutingSpec
 
   object TestZoneService extends ZoneServiceAlgebra {
     def connectToZone(zone: Zone, auth: AuthPrincipal): Result[ZoneCommandResult] = {
-      val outcome = zone.id match {
-        case alreadyExists.id => Left(ZoneAlreadyExistsError(s"$zone"))
-        case notFound.id => Left(ZoneNotFoundError(s"$zone"))
-        case notAuthorized.id => Left(NotAuthorizedError(s"$zone"))
-        case badAdminId.id => Left(InvalidZoneAdminError(s"$zone"))
-        case ok.id | connectionOk.id | trailingDot.id =>
+      val outcome = zone.email match {
+        case alreadyExists.email => Left(ZoneAlreadyExistsError(s"$zone"))
+        case notFound.email => Left(ZoneNotFoundError(s"$zone"))
+        case notAuthorized.email => Left(NotAuthorizedError(s"$zone"))
+        case badAdminId.email => Left(InvalidZoneAdminError(s"$zone"))
+        case ok.email | connectionOk.email | trailingDot.email | "invalid-zone-status@test.com" =>
           Right(
             zoneCreate.copy(
               status = ZoneChangeStatus.Complete,
               zone = zone.copy(status = ZoneStatus.Active)))
-        case error.id => Left(new RuntimeException("fail"))
-        case connectionFailed.id => Left(ConnectionFailed(zone, "fail"))
-        case zoneValidationFailed.id =>
+        case error.email => Left(new RuntimeException("fail"))
+        case connectionFailed.email => Left(ConnectionFailed(zone, "fail"))
+        case zoneValidationFailed.email =>
           Left(ZoneValidationFailed(zone, List("fail"), "failure message"))
       }
       outcome.map(c => c.asInstanceOf[ZoneCommandResult]).toResult
@@ -682,13 +683,9 @@ class ZoneRoutingSpec
       }
     }
 
-    "report invalid enum" in {
-      post(invalidZone) ~> Route.seal(zoneRoute(okAuth)) ~> check {
-        status shouldBe BadRequest
-        val result = responseAs[JValue]
-        val errs = (result \ "errors").extractOpt[List[String]]
-        errs should not be None
-        errs.get shouldBe List("Invalid ZoneStatus")
+    "ignore fields not defined in CreateZoneInput" in {
+      post(zoneWithInvalidStatus) ~> Route.seal(zoneRoute(okAuth)) ~> check {
+        status shouldBe Accepted
       }
     }
   }
@@ -952,8 +949,9 @@ class ZoneRoutingSpec
     }
 
     "report invalid enum" in {
-      Put(s"/zones/${ok.id}").withEntity(
-        HttpEntity(ContentTypes.`application/json`, compact(render(invalidZone)))) ~> Route
+      Put(s"/zones/${ok.id}").withEntity(HttpEntity(
+        ContentTypes.`application/json`,
+        compact(render(zoneWithInvalidStatus)))) ~> Route
         .seal(zoneRoute(okAuth)) ~> check {
         status shouldBe BadRequest
         val result = responseAs[JValue]

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -110,7 +110,8 @@ class ZoneRoutingSpec
   private val zoneWithInvalidStatus: JValue =
     ("name" -> "invalidZoneStatus.") ~~
       ("email" -> "invalid-zone-status@test.com") ~~
-      ("status" -> "invalidStatus")
+      ("status" -> "invalidStatus") ~~
+      ("adminGroupId" -> "admin-group-id")
 
   private val zoneCreate = ZoneChange(ok, "ok", ZoneChangeType.Create, ZoneChangeStatus.Complete)
   private val zoneUpdate = ZoneChange(ok, "ok", ZoneChangeType.Update, ZoneChangeStatus.Complete)
@@ -688,7 +689,8 @@ class ZoneRoutingSpec
           "Missing ZoneConnection.name",
           "Missing ZoneConnection.keyName",
           "Missing ZoneConnection.key",
-          "Missing ZoneConnection.primaryServer"
+          "Missing ZoneConnection.primaryServer",
+          "Missing Zone.adminGroupId"
         )
       }
     }

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
@@ -78,7 +78,7 @@ object Zone {
       email,
       connection = connection,
       transferConnection = transferConnection,
-      shared = shared.getOrElse(false),
+      shared = shared,
       acl = acl,
       adminGroupId = adminGroupId)
   }
@@ -89,7 +89,7 @@ case class CreateZoneInput(
     email: String,
     connection: Option[ZoneConnection] = None,
     transferConnection: Option[ZoneConnection] = None,
-    shared: Option[Boolean] = None,
+    shared: Boolean = false,
     acl: ZoneACL = ZoneACL(),
     adminGroupId: String)
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
@@ -69,6 +69,30 @@ case class Zone(
   }
 }
 
+object Zone {
+  def apply(createZoneInput: CreateZoneInput): Zone = {
+    import createZoneInput._
+
+    Zone(
+      name,
+      email,
+      connection = connection,
+      transferConnection = transferConnection,
+      shared = shared.getOrElse(false),
+      acl = acl,
+      adminGroupId = adminGroupId)
+  }
+}
+
+case class CreateZoneInput(
+    name: String,
+    email: String,
+    connection: Option[ZoneConnection] = None,
+    transferConnection: Option[ZoneConnection] = None,
+    shared: Option[Boolean] = None,
+    acl: ZoneACL = ZoneACL(),
+    adminGroupId: String)
+
 case class ZoneACL(rules: Set[ACLRule] = Set.empty) {
 
   def addRule(newRule: ACLRule): ZoneACL = copy(rules = rules + newRule)


### PR DESCRIPTION
Allow super users to create shared zones.
Fixes #345.

Changes in this pull request:
- Add `CreateZoneInput` class to restrict what is parsed into a zone creation request. Implement corresponding serializer and tie-in into routing.
- Add zone validation to check whether zone is shared, and if so, whether user is a super user.
- Updated existing create zone tests. Added new tests for shared flag.
