### PR TITLE
move zone change processing into zone sync handler

### DIFF
--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -87,17 +87,6 @@ records_post_update = [
      'records': [{u'address': u'6.7.8.9'}]}]
 
 
-def wait_for_zone_sync_to_complete(client, zone_id, latest_sync):
-    retries = MAX_RETRIES
-    zone_request = client.get_zone(zone_id)
-
-    while zone_request[u'zone'][u'latestSync'] == latest_sync and retries > 0:
-        zone_request = client.get_zone(zone_id)
-        time.sleep(RETRY_WAIT)
-        retries -= 1
-
-    assert_that(zone_request[u'zone'][u'latestSync'], is_not(latest_sync))
-
 @pytest.mark.skip_production
 def test_sync_zone_success(shared_zone_test_context):
     """
@@ -163,8 +152,8 @@ def test_sync_zone_success(shared_zone_test_context):
         time.sleep(10)
 
         # sync again
-        client.sync_zone(zone['id'], status=202)
-        wait_for_zone_sync_to_complete(client, zone['id'], latest_sync)
+        change = client.sync_zone(zone['id'], status=202)
+        client.wait_until_zone_change_status_synced(change)
 
         # confirm cannot again sync without waiting
         client.sync_zone(zone['id'], status=403)

--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -134,14 +134,7 @@ object CommandHandler {
       message.command match {
         case sync: ZoneChange
             if sync.changeType == ZoneChangeType.Sync || sync.changeType == ZoneChangeType.Create =>
-          val doSync =
-            for {
-              _ <- zoneChangeProcessor(sync) // make sure zone is updated to a syncing status
-              syncChange <- zoneSyncProcessor(sync)
-              _ <- zoneChangeProcessor(syncChange) // update zone to Active
-            } yield syncChange
-
-          outcomeOf(message)(doSync)
+          outcomeOf(message)(zoneSyncProcessor(sync))
 
         case zoneChange: ZoneChange =>
           outcomeOf(message)(zoneChangeProcessor(zoneChange))
@@ -196,7 +189,7 @@ object CommandHandler {
     val recordChangeHandler =
       RecordSetChangeHandler(recordSetRepo, recordChangeRepo, batchChangeRepo)
     val zoneSyncHandler =
-      ZoneSyncHandler(recordSetRepo, recordChangeRepo)
+      ZoneSyncHandler(recordSetRepo, recordChangeRepo, zoneChangeRepo, zoneRepo)
 
     CommandHandler
       .mainFlow(

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -69,8 +69,6 @@ object ZoneSyncHandler extends DnsConversions with Monitored {
             status = ZoneChangeStatus.Failed,
             systemMessage = Some(duplicateZoneError.message))
         )
-      case Right(_) if zoneChange.zone.status == ZoneStatus.Active =>
-        zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
       case Right(_) =>
         zoneChangeRepository.save(zoneChange)
     }
@@ -131,7 +129,8 @@ object ZoneSyncHandler extends DnsConversions with Monitored {
               _ <- saveRecordSets
             } yield
               zoneChange.copy(
-                zone.copy(status = ZoneStatus.Active, latestSync = Some(DateTime.now)))
+                zone.copy(status = ZoneStatus.Active, latestSync = Some(DateTime.now)),
+                status = ZoneChangeStatus.Synced)
           }
         }
       }

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -48,14 +48,16 @@ object ZoneSyncHandler extends DnsConversions with Monitored {
         VinylDNSZoneViewLoader.apply): ZoneChange => IO[ZoneChange] =
     zoneChange =>
       for {
-        _ <- saveZoneAndChange(zoneRepository, zoneChangeRepository, zoneChange) // zone status: Syncing
+        _ <- saveZoneAndChange(zoneRepository, zoneChangeRepository, zoneChange) // initial save to store zone status
+        // as Syncing
         syncChange <- runSync(
           recordSetRepository,
           recordChangeRepository,
           zoneChange,
           dnsLoader,
           vinyldnsLoader)
-        _ <- saveZoneAndChange(zoneRepository, zoneChangeRepository, syncChange) // zone status: Active
+        _ <- saveZoneAndChange(zoneRepository, zoneChangeRepository, syncChange) // final save to store zone status
+        // as Active
       } yield syncChange
 
   def saveZoneAndChange(

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -23,8 +23,14 @@ import org.slf4j.LoggerFactory
 import vinyldns.api.domain.dns.DnsConversions
 import vinyldns.api.domain.zone.{DnsZoneViewLoader, VinylDNSZoneViewLoader}
 import vinyldns.core.domain.record._
-import vinyldns.core.domain.zone.{Zone, ZoneChange, ZoneChangeStatus, ZoneStatus}
+import vinyldns.core.domain.zone.{Zone, ZoneStatus}
 import vinyldns.core.route.Monitored
+import vinyldns.core.domain.zone.{
+  ZoneChange,
+  ZoneChangeRepository,
+  ZoneChangeStatus,
+  ZoneRepository
+}
 
 object ZoneSyncHandler extends DnsConversions with Monitored {
 
@@ -35,71 +41,108 @@ object ZoneSyncHandler extends DnsConversions with Monitored {
   def apply(
       recordSetRepository: RecordSetRepository,
       recordChangeRepository: RecordChangeRepository,
+      zoneChangeRepository: ZoneChangeRepository,
+      zoneRepository: ZoneRepository,
       dnsLoader: Zone => DnsZoneViewLoader = DnsZoneViewLoader.apply,
       vinyldnsLoader: (Zone, RecordSetRepository) => VinylDNSZoneViewLoader =
         VinylDNSZoneViewLoader.apply): ZoneChange => IO[ZoneChange] =
     zoneChange =>
-      monitor("zone.sync") {
-        time(s"zone.sync(${zoneChange.zoneId})") {
-          val zone = zoneChange.zone
+      for {
+        _ <- saveZoneAndChange(zoneRepository, zoneChangeRepository, zoneChange) // zone status: Syncing
+        syncChange <- runSync(
+          recordSetRepository,
+          recordChangeRepository,
+          zoneChange,
+          dnsLoader,
+          vinyldnsLoader)
+        _ <- saveZoneAndChange(zoneRepository, zoneChangeRepository, syncChange) // zone status: Active
+      } yield syncChange
 
-          val dnsView = time(s"zone.sync.loadDnsView(${zoneChange.id})")(dnsLoader(zone).load())
-          val vinyldnsView = time(s"zone.sync.loadVinylDNSView(${zoneChange.id})")(
-            vinyldnsLoader(zone, recordSetRepository).load())
-          val recordSetChanges = (dnsView, vinyldnsView).parTupled.map {
-            case (dnsZoneView, vinylDnsZoneView) => vinylDnsZoneView.diff(dnsZoneView)
+  def saveZoneAndChange(
+      zoneRepository: ZoneRepository,
+      zoneChangeRepository: ZoneChangeRepository,
+      zoneChange: ZoneChange): IO[ZoneChange] =
+    zoneRepository.save(zoneChange.zone).flatMap {
+      case Left(duplicateZoneError) =>
+        zoneChangeRepository.save(
+          zoneChange.copy(
+            status = ZoneChangeStatus.Failed,
+            systemMessage = Some(duplicateZoneError.message))
+        )
+      case Right(_) if zoneChange.zone.status == ZoneStatus.Active =>
+        zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
+      case Right(_) =>
+        zoneChangeRepository.save(zoneChange)
+    }
+
+  def runSync(
+      recordSetRepository: RecordSetRepository,
+      recordChangeRepository: RecordChangeRepository,
+      zoneChange: ZoneChange,
+      dnsLoader: Zone => DnsZoneViewLoader = DnsZoneViewLoader.apply,
+      vinyldnsLoader: (Zone, RecordSetRepository) => VinylDNSZoneViewLoader =
+        VinylDNSZoneViewLoader.apply): IO[ZoneChange] =
+    monitor("zone.sync") {
+      time(s"zone.sync(${zoneChange.zoneId})") {
+        val zone = zoneChange.zone
+
+        val dnsView = time(s"zone.sync.loadDnsView(${zoneChange.id})")(dnsLoader(zone).load())
+        val vinyldnsView = time(s"zone.sync.loadVinylDNSView(${zoneChange.id})")(
+          vinyldnsLoader(zone, recordSetRepository).load())
+        val recordSetChanges = (dnsView, vinyldnsView).parTupled.map {
+          case (dnsZoneView, vinylDnsZoneView) => vinylDnsZoneView.diff(dnsZoneView)
+        }
+
+        recordSetChanges.flatMap { allChanges =>
+          val changesWithUserIds = allChanges.map(_.withUserId(zoneChange.userId))
+          // not accepting unknown record types or dotted hosts
+          val (changes, dropped) = changesWithUserIds.partition { rs =>
+            rs.recordSet.typ != RecordType.UNKNOWN
           }
 
-          recordSetChanges.flatMap { allChanges =>
-            val changesWithUserIds = allChanges.map(_.withUserId(zoneChange.userId))
-            // not accepting unknown record types or dotted hosts
-            val (changes, dropped) = changesWithUserIds.partition { rs =>
-              rs.recordSet.typ != RecordType.UNKNOWN
-            }
+          if (dropped.nonEmpty) {
+            val droppedInfo = dropped
+              .map(chg => chg.recordSet.name + " " + chg.recordSet.typ)
+              .mkString(", ")
+            logger.warn(
+              s"Zone sync for change $zoneChange dropped ${dropped.size} recordsets: $droppedInfo")
+          }
 
-            if (dropped.nonEmpty) {
-              val droppedInfo = dropped
-                .map(chg => chg.recordSet.name + " " + chg.recordSet.typ)
-                .mkString(", ")
-              logger.warn(
-                s"Zone sync for change $zoneChange dropped ${dropped.size} recordsets: $droppedInfo")
-            }
+          if (changes.isEmpty) {
+            logger.info(s"Zone sync for change $zoneChange had no records to sync")
+            IO.pure(
+              zoneChange.copy(
+                zone.copy(status = ZoneStatus.Active, latestSync = Some(DateTime.now))))
+          } else {
+            logger.info(
+              s"Zone sync for change $zoneChange found ${changes.size} changes to be saved")
+            val changeSet = ChangeSet(changes).copy(status = ChangeSetStatus.Applied)
 
-            if (changes.isEmpty) {
-              logger.info(s"Zone sync for change $zoneChange had no records to sync")
-              IO.pure(
-                zoneChange.copy(
-                  zone.copy(status = ZoneStatus.Active, latestSync = Some(DateTime.now))))
-            } else {
-              logger.info(
-                s"Zone sync for change $zoneChange found ${changes.size} changes to be saved")
-              val changeSet = ChangeSet(changes).copy(status = ChangeSetStatus.Applied)
+            // we want to make sure we write to both the change repo and record set repo
+            // at the same time as this can take a while
+            val saveRecordChanges = time(s"zone.sync.saveChanges(${zoneChange.zoneId})")(
+              recordChangeRepository.save(changeSet))
+            val saveRecordSets = time(s"zone.sync.saveRecordSets(${zoneChange.zoneId})")(
+              recordSetRepository.apply(changeSet))
 
-              // we want to make sure we write to both the change repo and record set repo
-              // at the same time as this can take a while
-              val saveRecordChanges = time(s"zone.sync.saveChanges(${zoneChange.zoneId})")(
-                recordChangeRepository.save(changeSet))
-              val saveRecordSets = time(s"zone.sync.saveRecordSets(${zoneChange.zoneId})")(
-                recordSetRepository.apply(changeSet))
-
-              // join together the results of saving both the record changes as well as the record sets
-              for {
-                _ <- saveRecordChanges
-                _ <- saveRecordSets
-              } yield
-                zoneChange.copy(
-                  zone.copy(status = ZoneStatus.Active, latestSync = Some(DateTime.now)))
-            }
+            // join together the results of saving both the record changes as well as the record sets
+            for {
+              _ <- saveRecordChanges
+              _ <- saveRecordSets
+            } yield
+              zoneChange.copy(
+                zone.copy(status = ZoneStatus.Active, latestSync = Some(DateTime.now)))
           }
         }
-      }.attempt
-        .map {
-          case Left(e: Throwable) =>
-            logger.error(s"Encountered error syncing zone ${zoneChange.zone.name}", e)
-            // We want to just move back to an active status, do not update latest sync
-            zoneChange.copy(
-              zone = zoneChange.zone.copy(status = ZoneStatus.Active),
-              status = ZoneChangeStatus.Failed)
-          case Right(ok) => ok
+      }
+    }.attempt
+      .map {
+        case Left(e: Throwable) =>
+          logger.error(s"Encountered error syncing zone ${zoneChange.zone.name}", e)
+          // We want to just move back to an active status, do not update latest sync
+          zoneChange.copy(
+            zone = zoneChange.zone.copy(status = ZoneStatus.Active),
+            status = ZoneChangeStatus.Failed)
+        case Right(ok) => ok
       }
 }

--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -221,7 +221,6 @@ class CommandHandlerSpec
         .apply(zoneCreate)
       doReturn(IO.pure(zoneCreate)).when(mockZoneSyncProcessor).apply(zoneCreate)
       Stream.emit(change).covary[IO].through(processor).compile.drain.unsafeRunSync()
-      verify(mockZoneChangeProcessor, times(2)).apply(zoneCreate)
       verify(mockZoneSyncProcessor).apply(zoneCreate)
       verifyZeroInteractions(mockRecordChangeProcessor)
     }
@@ -231,7 +230,6 @@ class CommandHandlerSpec
       doReturn(IO.pure(sync)).doReturn(IO.pure(change)).when(mockZoneChangeProcessor).apply(sync)
       doReturn(IO.pure(sync)).when(mockZoneSyncProcessor).apply(sync)
       Stream.emit(change).covary[IO].through(processor).compile.drain.unsafeRunSync()
-      verify(mockZoneChangeProcessor, times(2)).apply(sync)
       verify(mockZoneSyncProcessor).apply(sync)
       verifyZeroInteractions(mockRecordChangeProcessor)
     }

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -246,8 +246,7 @@ class ZoneSyncHandlerSpec
     "save zone and zoneChange with given statuses" in {
       doReturn(IO.pure(Right(testZoneChange))).when(zoneRepo).save(testZoneChange.zone)
 
-      val saver = ZoneSyncHandler.saveZoneAndChange(zoneRepo, zoneChangeRepo, testZoneChange)
-      saver.unsafeRunSync()
+      ZoneSyncHandler.saveZoneAndChange(zoneRepo, zoneChangeRepo, testZoneChange).unsafeRunSync()
 
       val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
       verify(zoneChangeRepo).save(changeCaptor.capture())
@@ -262,8 +261,7 @@ class ZoneSyncHandlerSpec
     "handle duplicateZoneError" in {
       doReturn(IO.pure(Left(DuplicateZoneError("error")))).when(zoneRepo).save(testZoneChange.zone)
 
-      val saver = ZoneSyncHandler.saveZoneAndChange(zoneRepo, zoneChangeRepo, testZoneChange)
-      saver.unsafeRunSync()
+      ZoneSyncHandler.saveZoneAndChange(zoneRepo, zoneChangeRepo, testZoneChange).unsafeRunSync()
 
       val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
       verify(zoneChangeRepo).save(changeCaptor.capture())

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -283,15 +283,14 @@ class ZoneSyncHandlerSpec
       val dnsLoader = mock[Zone => DnsZoneViewLoader]
       doReturn(mockDNSLoader).when(dnsLoader).apply(any[Zone])
 
-      val syncer =
-        ZoneSyncHandler.runSync(
+      ZoneSyncHandler
+        .runSync(
           recordSetRepo,
           recordChangeRepo,
           testZoneChange,
           dnsLoader,
           (_, _) => mockVinylDNSLoader)
-
-      syncer.unsafeRunSync()
+        .unsafeRunSync()
 
       verify(dnsLoader).apply(captor.capture())
       val req = captor.getValue
@@ -300,15 +299,14 @@ class ZoneSyncHandlerSpec
     }
 
     "load the dns zone from DNSZoneViewLoader" in {
-      val syncer =
-        ZoneSyncHandler.runSync(
+      ZoneSyncHandler
+        .runSync(
           recordSetRepo,
           recordChangeRepo,
           testZoneChange,
           _ => mockDNSLoader,
           (_, _) => mockVinylDNSLoader)
-
-      syncer.unsafeRunSync()
+        .unsafeRunSync()
 
       verify(mockDNSLoader, times(1)).load
     }
@@ -320,14 +318,14 @@ class ZoneSyncHandlerSpec
       val vinyldnsLoader = mock[(Zone, RecordSetRepository) => VinylDNSZoneViewLoader]
       doReturn(mockVinylDNSLoader).when(vinyldnsLoader).apply(any[Zone], any[RecordSetRepository])
 
-      val syncer =
-        ZoneSyncHandler.runSync(
+      ZoneSyncHandler
+        .runSync(
           recordSetRepo,
           recordChangeRepo,
           testZoneChange,
           _ => mockDNSLoader,
           vinyldnsLoader)
-      syncer.unsafeRunSync()
+        .unsafeRunSync()
 
       verify(vinyldnsLoader).apply(zoneCaptor.capture(), repoCaptor.capture())
       val req = zoneCaptor.getValue
@@ -421,13 +419,14 @@ class ZoneSyncHandlerSpec
 
       val zoneChange = ZoneChange(testReverseZone, testReverseZone.account, ZoneChangeType.Sync)
 
-      val syncer = ZoneSyncHandler.runSync(
-        recordSetRepo,
-        recordChangeRepo,
-        zoneChange,
-        _ => mockDNSLoader,
-        (_, _) => mockVinylDNSLoader)
-      syncer.unsafeRunSync()
+      ZoneSyncHandler
+        .runSync(
+          recordSetRepo,
+          recordChangeRepo,
+          zoneChange,
+          _ => mockDNSLoader,
+          (_, _) => mockVinylDNSLoader)
+        .unsafeRunSync()
 
       captor.getValue.changes should contain theSameElementsAs expectedChanges
     }


### PR DESCRIPTION
Fixes #391.

Changes in this pull request:
- move the zone change handling for zone creates and syncs into the ZoneSyncHandler
