### PR TITLE
Ns record docs

### DIFF
--- a/modules/docs/src/main/tut/api/recordset-model.md
+++ b/modules/docs/src/main/tut/api/recordset-model.md
@@ -57,8 +57,8 @@ account       | string      | **DEPRECATED** The account that created the Record
 Current supported record types are: A, AAAA, CNAME, PTR, MX, NS, SOA, SRV, TXT, SSHFP, and SPF.
 Each individual record encodes its data in a record data object, in which each record type has different required attributes
 <br><br>
-**SOA records and NS origin records (record with the same name as the zone) are currently read-only and cannot be created, updated or deleted.
-Non-origin NS records can be created, updated or deleted for approved name servers only.**
+SOA records and NS origin records (record with the same name as the zone) are currently read-only and cannot be created, updated or deleted.
+Non-origin NS records can be created or updated for [approved name servers](../operator/config-api#additional-configuration-settings) only. Any non-origin NS record can be deleted.
 
 record type  | attribute   | type        |
 ------------ | :---------- | :---------- |

--- a/modules/docs/src/main/tut/api/recordset-model.md
+++ b/modules/docs/src/main/tut/api/recordset-model.md
@@ -57,7 +57,8 @@ account       | string      | **DEPRECATED** The account that created the Record
 Current supported record types are: A, AAAA, CNAME, PTR, MX, NS, SOA, SRV, TXT, SSHFP, and SPF.
 Each individual record encodes its data in a record data object, in which each record type has different required attributes
 <br><br>
-**NS and SOA records are currently read-only and cannot be created, updated or deleted**
+**SOA records and NS origin records (record with the same name as the zone) are currently read-only and cannot be created, updated or deleted.
+Non-origin NS records can be created, updated or deleted for approved name servers only.**
 
 record type  | attribute   | type        |
 ------------ | :---------- | :---------- |


### PR DESCRIPTION
Fixes #377.

Changes in this pull request:
- Note that non-origin NS records can be created and deleted for approved name servers only. Link to information in the docs about approved name servers.
- Any non-origin NS record can be deleted.
- SOA and origin NS records are still read only.
