### PR TITLE
ownergroup id logic for create and update recordset endpoints

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1769,6 +1769,7 @@ def test_create_with_owner_group_in_private_zone_by_admin_passes(shared_zone_tes
         record_json['ownerGroupId'] = group['id']
         create_response = client.create_recordset(record_json, status=202)
         create_rs = client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
+        assert_that(create_rs['ownerGroupId'], is_(group['id']))
 
     finally:
         if create_rs:
@@ -1791,6 +1792,7 @@ def test_create_with_owner_group_in_shared_zone_by_admin_passes(shared_zone_test
         record_json['ownerGroupId'] = group['id']
         create_response = client.create_recordset(record_json, status=202)
         create_rs = client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
+        assert_that(create_rs['ownerGroupId'], is_(group['id']))
 
     finally:
         if create_rs:
@@ -1816,6 +1818,7 @@ def test_create_with_owner_group_in_private_zone_by_acl_passes(shared_zone_test_
         record_json['ownerGroupId'] = group['id']
         create_response = client.create_recordset(record_json, status=202)
         create_rs = client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
+        assert_that(create_rs['ownerGroupId'], is_(group['id']))
 
     finally:
         clear_ok_acl_rules(shared_zone_test_context)
@@ -1842,6 +1845,7 @@ def test_create_with_owner_group_in_shared_zone_by_acl_passes(shared_zone_test_c
         record_json['ownerGroupId'] = group['id']
         create_response = client.create_recordset(record_json, status=202)
         create_rs = client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
+        assert_that(create_rs['ownerGroupId'], is_(group['id']))
 
     finally:
         clear_shared_zone_acl_rules(shared_zone_test_context)

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1850,7 +1850,7 @@ def test_create_with_owner_group_in_shared_zone_by_acl_passes(shared_zone_test_c
             shared_zone_test_context.shared_zone_vinyldns_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
-def test_create_in_shared_zone_by_non_unassociated_user_fails(shared_zone_test_context):
+def test_create_in_shared_zone_by_unassociated_user_fails(shared_zone_test_context):
     """
     Test that creating a record in a shared zone by a user with no write permissions fails
     """
@@ -1875,7 +1875,8 @@ def test_create_with_not_found_owner_group_fails(shared_zone_test_context):
 
     record_json = get_recordset_json(zone, 'test_shared_bad_owner', 'A', [{'address': '1.1.1.1'}])
     record_json['ownerGroupId'] = 'no-existo'
-    client.create_recordset(record_json, status=422)
+    error = client.create_recordset(record_json, status=422)
+    assert_that(error, is_('Record owner group with id "no-existo" not found'))
 
 
 def test_create_with_owner_group_when_not_member_fails(shared_zone_test_context):
@@ -1890,4 +1891,4 @@ def test_create_with_owner_group_when_not_member_fails(shared_zone_test_context)
     record_json = get_recordset_json(zone, 'test_shared_not_group_member', 'A', [{'address': '1.1.1.1'}])
     record_json['ownerGroupId'] = group['id']
     error = client.create_recordset(record_json, status=422)
-    assert_that(error, is_('User not in record owner group ' + group['id']))
+    assert_that(error, is_('User not in record owner group with id "' + group['id'] + '"'))

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -2030,7 +2030,7 @@ def test_update_from_user_in_record_owner_group_passes_for_shared_zone(shared_zo
     shared_record_group = shared_zone_test_context.shared_record_group
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     zone = shared_zone_test_context.shared_zone
-    create_rs = None
+    update_rs = None
 
     try:
         record_json = get_recordset_json(zone, 'test_shared_success', 'A', [{'address': '1.1.1.1'}])
@@ -2040,11 +2040,12 @@ def test_update_from_user_in_record_owner_group_passes_for_shared_zone(shared_zo
 
         update = create_rs
         update['ttl'] = update['ttl'] + 100
-        ok_client.update_recordset(update, status=202)
+        update_response = ok_client.update_recordset(update, status=202)
+        update_rs = shared_client.wait_until_recordset_change_status(update_response, 'Complete')['recordSet']
 
     finally:
-        if create_rs:
-            delete_result = shared_client.delete_recordset(zone['id'], create_rs['id'], status=202)
+        if update_rs:
+            delete_result = shared_client.delete_recordset(zone['id'], update_rs['id'], status=202)
             shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
@@ -2057,21 +2058,22 @@ def test_update_to_no_group_owner_passes(shared_zone_test_context):
     shared_record_group = shared_zone_test_context.shared_record_group
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     zone = shared_zone_test_context.shared_zone
-    create_rs = None
+    update_rs = None
 
     try:
-        record_json = get_recordset_json(zone, 'test_shared_success', 'A', [{'address': '1.1.1.1'}])
+        record_json = get_recordset_json(zone, 'test_shared_success_no_owner', 'A', [{'address': '1.1.1.1'}])
         record_json['ownerGroupId'] = shared_record_group['id']
         create_response = shared_client.create_recordset(record_json, status=202)
         create_rs = shared_client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
 
         update = create_rs
         update['ownerGroupId'] = None
-        ok_client.update_recordset(update, status=202)
+        update_response = ok_client.update_recordset(update, status=202)
+        update_rs = shared_client.wait_until_recordset_change_status(update_response, 'Complete')['recordSet']
 
     finally:
-        if create_rs:
-            delete_result = shared_client.delete_recordset(zone['id'], create_rs['id'], status=202)
+        if update_rs:
+            delete_result = shared_client.delete_recordset(zone['id'], update_rs['id'], status=202)
             shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
@@ -2087,7 +2089,7 @@ def test_update_to_invalid_record_owner_group_fails(shared_zone_test_context):
     create_rs = None
 
     try:
-        record_json = get_recordset_json(zone, 'test_shared_success', 'A', [{'address': '1.1.1.1'}])
+        record_json = get_recordset_json(zone, 'test_shared_fail_no_owner', 'A', [{'address': '1.1.1.1'}])
         record_json['ownerGroupId'] = shared_record_group['id']
         create_response = shared_client.create_recordset(record_json, status=202)
         create_rs = shared_client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -264,6 +264,11 @@ def add_ok_acl_rules(test_context, rules):
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
     test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
+def add_shared_zone_acl_rules(test_context, rules):
+    updated_zone = add_rules_to_zone(test_context.shared_zone, rules)
+    update_change = test_context.shared_zone_vinyldns_client.update_zone(updated_zone, status=202)
+    test_context.shared_zone_vinyldns_client.wait_until_zone_change_status_synced(update_change)
+
 def add_ip4_acl_rules(test_context, rules):
     updated_zone = add_rules_to_zone(test_context.ip4_reverse_zone, rules)
     update_change = test_context.ok_vinyldns_client.update_zone(updated_zone, status=202)
@@ -308,6 +313,12 @@ def clear_ok_acl_rules(test_context):
     zone['acl']['rules'] = []
     update_change = test_context.ok_vinyldns_client.update_zone(zone, status=202)
     test_context.ok_vinyldns_client.wait_until_zone_change_status_synced(update_change)
+
+def clear_shared_zone_acl_rules(test_context):
+    zone = test_context.shared_zone
+    zone['acl']['rules'] = []
+    update_change = test_context.shared_zone_vinyldns_client.update_zone(zone, status=202)
+    test_context.shared_zone_vinyldns_client.wait_until_zone_change_status_synced(update_change)
 
 def clear_ip4_acl_rules(test_context):
     zone = test_context.ip4_reverse_zone

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -435,7 +435,7 @@ class RecordSetServiceIntegrationSpec
       }
     }
 
-    "fail if user is in owner group but zone is not shared" in {
+    "fail updating if user is in owner group but zone is not shared" in {
       val result = testRecordSetService
         .updateRecordSet(testOwnerGroupRecordInNormalZone, auth2)
         .value
@@ -444,7 +444,7 @@ class RecordSetServiceIntegrationSpec
       leftValue(result) shouldBe a[NotAuthorizedError]
     }
 
-    "fail if owner group does not exist" in {
+    "fail updating if owner group does not exist" in {
       val newRecord = sharedTestRecord.copy(ownerGroupId = Some("no-existo"))
 
       val result = testRecordSetService
@@ -455,7 +455,7 @@ class RecordSetServiceIntegrationSpec
       leftValue(result) shouldBe a[InvalidGroupError]
     }
 
-    "fail if user is not in new owner group" in {
+    "fail updating if user is not in new owner group" in {
       val newRecord = sharedTestRecord.copy(ownerGroupId = Some(group.id))
 
       val result = testRecordSetService
@@ -466,7 +466,7 @@ class RecordSetServiceIntegrationSpec
       leftValue(result) shouldBe a[InvalidRequest]
     }
 
-    "succeed if user is in owner group and zone is shared" in {
+    "update successfully if user is in owner group and zone is shared" in {
       val newRecord = sharedTestRecord.copy(ttl = sharedTestRecord.ttl + 100)
       val result = testRecordSetService
         .updateRecordSet(newRecord, auth2)
@@ -478,7 +478,7 @@ class RecordSetServiceIntegrationSpec
         sharedTestRecord.ownerGroupId
     }
 
-    "succeed if user is changing owner group to None" in {
+    "update successfully if user is changing owner group to None" in {
       val newRecord = sharedTestRecord.copy(ownerGroupId = None)
       val result = testRecordSetService
         .updateRecordSet(newRecord, auth2)
@@ -488,7 +488,7 @@ class RecordSetServiceIntegrationSpec
       rightValue(result).asInstanceOf[RecordSetChange].recordSet.ownerGroupId shouldBe None
     }
 
-    "succeed if user is changing owner group to another group they are a part of" in {
+    "update successfully if user is changing owner group to another group they are a part of" in {
       val newRecord = sharedTestRecord.copy(ownerGroupId = Some(group2.id))
       val result = testRecordSetService
         .updateRecordSet(newRecord, auth2)

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 import vinyldns.api._
 import vinyldns.api.domain.{AccessValidations, HighValueDomainError}
-import vinyldns.api.domain.zone.{InvalidRequest, RecordSetAlreadyExists, RecordSetInfo}
+import vinyldns.api.domain.zone._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData.testConnection
@@ -61,10 +61,11 @@ class RecordSetServiceIntegrationSpec
   private val user = User("live-test-user", "key", "secret")
   private val user2 = User("shared-record-test-user", "key-shared", "secret-shared")
   private val group = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id))
+  private val group2 = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id, user2.id))
   private val sharedGroup =
-    Group(s"test-shared-group", "test@test.com", adminUserIds = Set(user2.id))
-  private val auth = AuthPrincipal(user, Seq(group.id))
-  private val auth2 = AuthPrincipal(user2, Seq(sharedGroup.id))
+    Group(s"test-shared-group", "test@test.com", adminUserIds = Set(user.id, user2.id))
+  private val auth = AuthPrincipal(user, Seq(group.id, sharedGroup.id))
+  private val auth2 = AuthPrincipal(user2, Seq(sharedGroup.id, group2.id))
 
   private val zone = Zone(
     s"live-zone-test.",
@@ -184,7 +185,7 @@ class RecordSetServiceIntegrationSpec
 
   private val sharedTestRecordBadOwnerGroup = RecordSet(
     sharedZone.id,
-    "shared-record",
+    "shared-record-bad-owner-group",
     A,
     200,
     RecordSetStatus.Active,
@@ -194,12 +195,24 @@ class RecordSetServiceIntegrationSpec
     ownerGroupId = Some("non-existent")
   )
 
+  private val testOwnerGroupRecordInNormalZone = RecordSet(
+    zone.id,
+    "user-in-owner-group-but-zone-not-shared",
+    A,
+    38400,
+    RecordSetStatus.Active,
+    DateTime.now,
+    None,
+    List(AData("10.1.1.1")),
+    ownerGroupId = Some(sharedGroup.id)
+  )
+
   def setup(): Unit = {
     recordSetRepo =
       DynamoDBRecordSetRepository(recordSetStoreConfig, dynamoIntegrationConfig).unsafeRunSync()
     zoneRepo = zoneRepository
     groupRepo = groupRepository
-    List(group, sharedGroup).map(g => waitForSuccess(groupRepo.save(g)))
+    List(group, group2, sharedGroup).map(g => waitForSuccess(groupRepo.save(g)))
     List(zone, zoneTestNameConflicts, zoneTestAddRecords, sharedZone).map(z =>
       waitForSuccess(zoneRepo.save(z)))
 
@@ -214,7 +227,8 @@ class RecordSetServiceIntegrationSpec
       subTestRecordNameConflict,
       highValueDomainRecord,
       sharedTestRecord,
-      sharedTestRecordBadOwnerGroup
+      sharedTestRecordBadOwnerGroup,
+      testOwnerGroupRecordInNormalZone
     )
     records.map(record => waitForSuccess(recordSetRepo.putRecordSet(record)))
 
@@ -408,7 +422,7 @@ class RecordSetServiceIntegrationSpec
       }
     }
 
-    "get a shared record when ownerGroup can't be found" in {
+    "get a shared record when owner group can't be found" in {
       val result =
         testRecordSetService
           .getRecordSet(sharedTestRecordBadOwnerGroup.id, sharedTestRecord.zoneId, auth)
@@ -416,9 +430,73 @@ class RecordSetServiceIntegrationSpec
           .unsafeToFuture()
           .mapTo[Either[Throwable, RecordSetInfo]]
       whenReady(result, timeout) { out =>
-        rightValue(out).name shouldBe "shared-record"
+        rightValue(out).name shouldBe "shared-record-bad-owner-group"
         rightValue(out).ownerGroupName shouldBe None
       }
+    }
+
+    "fail if user is in owner group but zone is not shared" in {
+      val result = testRecordSetService
+        .updateRecordSet(testOwnerGroupRecordInNormalZone, auth2)
+        .value
+        .unsafeRunSync()
+
+      leftValue(result) shouldBe a[NotAuthorizedError]
+    }
+
+    "fail if owner group does not exist" in {
+      val newRecord = sharedTestRecord.copy(ownerGroupId = Some("no-existo"))
+
+      val result = testRecordSetService
+        .updateRecordSet(newRecord, auth2)
+        .value
+        .unsafeRunSync()
+
+      leftValue(result) shouldBe a[InvalidGroupError]
+    }
+
+    "fail if user is not in new owner group" in {
+      val newRecord = sharedTestRecord.copy(ownerGroupId = Some(group.id))
+
+      val result = testRecordSetService
+        .updateRecordSet(newRecord, auth2)
+        .value
+        .unsafeRunSync()
+
+      leftValue(result) shouldBe a[InvalidRequest]
+    }
+
+    "succeed if user is in owner group and zone is shared" in {
+      val newRecord = sharedTestRecord.copy(ttl = sharedTestRecord.ttl + 100)
+      val result = testRecordSetService
+        .updateRecordSet(newRecord, auth2)
+        .value
+        .unsafeRunSync()
+
+      rightValue(result).asInstanceOf[RecordSetChange].recordSet.ttl shouldBe newRecord.ttl
+      rightValue(result).asInstanceOf[RecordSetChange].recordSet.ownerGroupId shouldBe
+        sharedTestRecord.ownerGroupId
+    }
+
+    "succeed if user is changing owner group to None" in {
+      val newRecord = sharedTestRecord.copy(ownerGroupId = None)
+      val result = testRecordSetService
+        .updateRecordSet(newRecord, auth2)
+        .value
+        .unsafeRunSync()
+
+      rightValue(result).asInstanceOf[RecordSetChange].recordSet.ownerGroupId shouldBe None
+    }
+
+    "succeed if user is changing owner group to another group they are a part of" in {
+      val newRecord = sharedTestRecord.copy(ownerGroupId = Some(group2.id))
+      val result = testRecordSetService
+        .updateRecordSet(newRecord, auth2)
+        .value
+        .unsafeRunSync()
+
+      rightValue(result).asInstanceOf[RecordSetChange].recordSet.ownerGroupId shouldBe
+        Some(group2.id)
     }
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -60,8 +60,9 @@ object AccessValidations extends AccessValidationAlgebra {
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit] = {
-    val accessLevel = getAccessLevel(auth, recordName, recordType, zone)
+      zone: Zone,
+      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] = {
+    val accessLevel = getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId)
     ensuring(
       NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to update " +
         s"$recordName.${zone.name}"))(

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
@@ -41,7 +41,8 @@ trait AccessValidationAlgebra {
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit]
+      zone: Zone,
+      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
 
   def canDeleteRecordSet(
       auth: AuthPrincipal,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -211,12 +211,15 @@ object RecordSetValidations {
   }
 
   def canUseOwnerGroup(
+      ownerGroupId: Option[String],
       group: Option[Group],
       authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    group match {
-      case Some(g) if authPrincipal.signedInUser.isSuper || authPrincipal.isGroupMember(g.id) =>
-        ().asRight
-      case None => ().asRight
-      case Some(g) => InvalidRequest(s"User not in record owner group ${g.id}").asLeft
+    (ownerGroupId, group) match {
+      case (None, _) => ().asRight
+      case (Some(groupId), None) =>
+        InvalidGroupError(s"""Record owner group with id "$groupId" not found""").asLeft
+      case (Some(groupId), Some(_)) =>
+        if (authPrincipal.canEditAll || authPrincipal.isGroupMember(groupId)) ().asRight
+        else InvalidRequest(s"""User not in record owner group with id "$groupId"""").asLeft
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -25,6 +25,7 @@ import vinyldns.core.domain.DomainHelpers.omitTrailingDot
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.api.domain.zone._
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.Group
 import vinyldns.core.domain.record.{RecordSet, RecordType}
 import vinyldns.core.domain.zone.Zone
 
@@ -210,12 +211,12 @@ object RecordSetValidations {
   }
 
   def canUseOwnerGroup(
-      groupId: Option[String],
+      group: Option[Group],
       authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    groupId match {
-      case Some(id) if authPrincipal.signedInUser.isSuper || authPrincipal.isGroupMember(id) =>
+    group match {
+      case Some(g) if authPrincipal.signedInUser.isSuper || authPrincipal.isGroupMember(g.id) =>
         ().asRight
       case None => ().asRight
-      case _ => InvalidRequest(s"User not in record owner group $groupId").asLeft
+      case Some(g) => InvalidRequest(s"User not in record owner group ${g.id}").asLeft
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -223,7 +223,7 @@ case class NotAuthorizedError(msg: String) extends Throwable(msg)
 
 case class ZoneUnavailableError(msg: String) extends Throwable(msg)
 
-case class InvalidZoneAdminError(msg: String) extends Throwable(msg)
+case class InvalidGroupError(msg: String) extends Throwable(msg)
 
 case class InvalidSyncStateError(msg: String) extends Throwable(msg)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -215,7 +215,7 @@ class ZoneService(
       .getGroup(groupId)
       .map {
         case Some(_) => ().asRight
-        case None => InvalidZoneAdminError(s"Admin group with ID $groupId does not exist").asLeft
+        case None => InvalidGroupError(s"Admin group with ID $groupId does not exist").asLeft
       }
       .toResult
 

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -158,6 +158,7 @@ trait RecordSetRoute extends Directives {
       case Left(InvalidRequest(msg)) => complete(StatusCodes.UnprocessableEntity, msg)
       case Left(PendingUpdateError(msg)) => complete(StatusCodes.Conflict, msg)
       case Left(RecordSetChangeNotFoundError(msg)) => complete(StatusCodes.NotFound, msg)
+      case Left(InvalidGroupError(msg)) => complete(StatusCodes.UnprocessableEntity, msg)
       case Left(e) => failWith(e)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -154,7 +154,7 @@ trait ZoneRoute extends Directives {
       case Left(ZoneValidationFailed(zone, errors, _)) =>
         complete(StatusCodes.BadRequest, ZoneRejected(zone, errors))
       case Left(NotAuthorizedError(msg)) => complete(StatusCodes.Forbidden, msg)
-      case Left(InvalidZoneAdminError(msg)) => complete(StatusCodes.BadRequest, msg)
+      case Left(InvalidGroupError(msg)) => complete(StatusCodes.BadRequest, msg)
       case Left(ZoneNotFoundError(msg)) => complete(StatusCodes.NotFound, msg)
       case Left(ZoneUnavailableError(msg)) => complete(StatusCodes.Conflict, msg)
       case Left(InvalidSyncStateError(msg)) => complete(StatusCodes.BadRequest, msg)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -331,5 +331,41 @@ class RecordSetValidationsSpec
         isNotHighValueDomain(recordAAAA, zoneAAAA) should be(right)
       }
     }
+
+    "canUseOwnerGroup" should {
+      "fail if user is not in owner group" in {
+        val auth = okAuth.copy(memberGroupIds = Seq("foo"))
+        val ownerGroupId = Some("bar")
+
+        leftValue(canUseOwnerGroup(ownerGroupId, auth)) shouldBe a[InvalidRequest]
+      }
+      "pass if user is not in owner group but super" in {
+        val auth = okAuth.copy(
+          memberGroupIds = Seq("foo"),
+          signedInUser = okAuth.signedInUser.copy(isSuper = true))
+        val ownerGroupId = Some("bar")
+
+        canUseOwnerGroup(ownerGroupId, auth) should be(right)
+      }
+      "pass if user is in owner group and super" in {
+        val auth = okAuth.copy(
+          memberGroupIds = Seq("foo"),
+          signedInUser = okAuth.signedInUser.copy(isSuper = true))
+        val ownerGroupId = Some("foo")
+
+        canUseOwnerGroup(ownerGroupId, auth) should be(right)
+      }
+      "pass if user is in owner group and not super" in {
+        val auth = okAuth.copy(memberGroupIds = Seq("foo"))
+        val ownerGroupId = Some("foo")
+
+        canUseOwnerGroup(ownerGroupId, auth) should be(right)
+      }
+      "pass if owner group is None" in {
+        val ownerGroupId = None
+
+        canUseOwnerGroup(ownerGroupId, okAuth) should be(right)
+      }
+    }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -25,6 +25,8 @@ import vinyldns.api.domain.zone.{InvalidRequest, PendingUpdateError, RecordSetAl
 import vinyldns.api.ResultHelpers
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
+import vinyldns.core.TestMembershipData._
+import vinyldns.core.domain.membership.Group
 import vinyldns.core.domain.record._
 
 class RecordSetValidationsSpec
@@ -335,36 +337,34 @@ class RecordSetValidationsSpec
     "canUseOwnerGroup" should {
       "fail if user is not in owner group" in {
         val auth = okAuth.copy(memberGroupIds = Seq("foo"))
-        val ownerGroupId = Some("bar")
+        val ownerGroup = Group(id = "bar", name = "test", email = "test@test.com")
 
-        leftValue(canUseOwnerGroup(ownerGroupId, auth)) shouldBe a[InvalidRequest]
+        leftValue(canUseOwnerGroup(Some(ownerGroup), auth)) shouldBe a[InvalidRequest]
       }
       "pass if user is not in owner group but super" in {
         val auth = okAuth.copy(
           memberGroupIds = Seq("foo"),
           signedInUser = okAuth.signedInUser.copy(isSuper = true))
-        val ownerGroupId = Some("bar")
+        val ownerGroup = Group(id = "bar", name = "test", email = "test@test.com")
 
-        canUseOwnerGroup(ownerGroupId, auth) should be(right)
+        canUseOwnerGroup(Some(ownerGroup), auth) should be(right)
       }
       "pass if user is in owner group and super" in {
         val auth = okAuth.copy(
           memberGroupIds = Seq("foo"),
           signedInUser = okAuth.signedInUser.copy(isSuper = true))
-        val ownerGroupId = Some("foo")
+        val ownerGroup = Group(id = "foo", name = "test", email = "test@test.com")
 
-        canUseOwnerGroup(ownerGroupId, auth) should be(right)
+        canUseOwnerGroup(Some(ownerGroup), auth) should be(right)
       }
       "pass if user is in owner group and not super" in {
         val auth = okAuth.copy(memberGroupIds = Seq("foo"))
-        val ownerGroupId = Some("foo")
+        val ownerGroup = Group(id = "foo", name = "test", email = "test@test.com")
 
-        canUseOwnerGroup(ownerGroupId, auth) should be(right)
+        canUseOwnerGroup(Some(ownerGroup), auth) should be(right)
       }
       "pass if owner group is None" in {
-        val ownerGroupId = None
-
-        canUseOwnerGroup(ownerGroupId, okAuth) should be(right)
+        canUseOwnerGroup(None, okAuth) should be(right)
       }
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -125,7 +125,7 @@ class ZoneServiceSpec
 
       val error = leftResultOf(underTest.connectToZone(createZoneAuthorized, okAuth).value)
 
-      error shouldBe an[InvalidZoneAdminError]
+      error shouldBe an[InvalidGroupError]
     }
 
     "allow the zone to be created if it exists and the zone is deleted" in {

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -129,7 +129,7 @@ class ZoneRoutingSpec
         case alreadyExists.email => Left(ZoneAlreadyExistsError(s"$createZoneInput"))
         case notFound.email => Left(ZoneNotFoundError(s"$createZoneInput"))
         case notAuthorized.email => Left(NotAuthorizedError(s"$createZoneInput"))
-        case badAdminId.email => Left(InvalidZoneAdminError(s"$createZoneInput"))
+        case badAdminId.email => Left(InvalidGroupError(s"$createZoneInput"))
         case ok.email | connectionOk.email | trailingDot.email | "invalid-zone-status@test.com" =>
           Right(
             zoneCreate.copy(
@@ -152,7 +152,7 @@ class ZoneRoutingSpec
         case alreadyExists.email => Left(ZoneAlreadyExistsError(s"$updateZoneInput"))
         case notFound.email => Left(ZoneNotFoundError(s"$updateZoneInput"))
         case notAuthorized.email => Left(NotAuthorizedError(s"$updateZoneInput"))
-        case badAdminId.email => Left(InvalidZoneAdminError(s"$updateZoneInput"))
+        case badAdminId.email => Left(InvalidGroupError(s"$updateZoneInput"))
         case ok.email | connectionOk.email =>
           Right(
             zoneUpdate.copy(


### PR DESCRIPTION
Fixes #354.

Changes in this pull request:
- being in the ownerGroup only allows updates in a shared zone
- those with normal write, update, privileges can alter owner group id freely
- for non super users, the owner group must exist and the user must be in it
