### PR TITLE
Add owner group ID to batch change (without context validations)

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2528,6 +2528,7 @@ def test_create_batch_change_for_shared_zone_updates_recordset_owner_group_id_su
         completed_batch = shared_client.wait_until_batch_change_completed(result)
         to_delete = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
 
+        assert_that(result['ownerGroupId'], is_('shared-zone-group'))
         assert_change_success_response_values(result['changes'], zone=shared_zone, index=0, record_name="no-owner-group-id",
                                               input_name="no-owner-group-id.shared.", record_data="4.3.2.1")
         assert_change_success_response_values(result['changes'], zone=shared_zone, index=1, record_name="update",
@@ -2573,4 +2574,4 @@ def test_create_batch_change_for_shared_zone_with_unauthorized_owner_group_id_fa
     }
 
     errors = shared_client.create_batch_change(batch_change_input, status=403)
-    assert_that(errors, is_('User "sharedZoneUser" is not a member of group "' + ok_group['id'] + '". Owner group ID is only required for record set changes in shared zones.'))
+    assert_that(errors, is_('User "sharedZoneUser" must be a member of group ' + ok_group['id'] + ' to apply this group to batch changes'))

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2545,7 +2545,7 @@ def test_create_batch_change_for_shared_zone_updates_recordset_owner_group_id_su
 
 def test_create_batch_change_for_shared_zone_with_invalid_owner_group_id_fails(shared_zone_test_context):
     """
-    Test successfully creating a batch change with owner group ID saves value for records in shared zone
+    Test creating a batch change with invalid owner group ID fails
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
 
@@ -2561,7 +2561,7 @@ def test_create_batch_change_for_shared_zone_with_invalid_owner_group_id_fails(s
 
 def test_create_batch_change_for_shared_zone_with_unauthorized_owner_group_id_fails(shared_zone_test_context):
     """
-    Test successfully creating a batch change with owner group ID saves value for records in shared zone
+    Test creating a batch change with unauthorized owner group ID fails
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     ok_group = shared_zone_test_context.ok_group

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -570,8 +570,8 @@ def test_empty_batch_fails(shared_zone_test_context):
         "changes": []
     }
 
-    error = shared_zone_test_context.ok_vinyldns_client.create_batch_change(batch_change_input, status=422)
-    assert_that(error, is_("Batch change contained no changes. Batch change must have at least one change, up to a maximum of 20 changes."))
+    errors = shared_zone_test_context.ok_vinyldns_client.create_batch_change(batch_change_input, status=400)['errors']
+    assert_that(errors, contains("Batch change contained no changes. Batch change must have at least one change, up to a maximum of 20 changes."))
 
 
 def test_create_batch_exceeding_change_limit_fails(shared_zone_test_context):
@@ -585,9 +585,8 @@ def test_create_batch_exceeding_change_limit_fails(shared_zone_test_context):
     for x in range(100):
         batch_change_input['changes'].append(get_change_A_AAAA_json("ok.", address=("1.2.3." + str(x))))
 
-    errors = client.create_batch_change(batch_change_input, status=413)
-
-    assert_that(errors, is_("Cannot request more than 20 changes in a single batch change request"))
+    errors = client.create_batch_change(batch_change_input, status=400)['errors']
+    assert_that(errors, contains("Cannot request more than 20 changes in a single batch change request"))
 
 
 def test_create_batch_change_without_changes_fails(shared_zone_test_context):
@@ -2582,8 +2581,8 @@ def test_create_batch_change_for_shared_zone_with_invalid_owner_group_id_fails(s
         "ownerGroupId": "non-existent-owner-group-id"
     }
 
-    errors = shared_client.create_batch_change(batch_change_input, status=400)
-    assert_that(errors, is_('Group with ID "non-existent-owner-group-id" was not found'))
+    errors = shared_client.create_batch_change(batch_change_input, status=400)['errors']
+    assert_that(errors, contains('Group with ID "non-existent-owner-group-id" was not found'))
 
 def test_create_batch_change_for_shared_zone_with_unauthorized_owner_group_id_fails(shared_zone_test_context):
     """
@@ -2599,5 +2598,5 @@ def test_create_batch_change_for_shared_zone_with_unauthorized_owner_group_id_fa
         "ownerGroupId": ok_group['id']
     }
 
-    errors = shared_client.create_batch_change(batch_change_input, status=403)
-    assert_that(errors, is_('User "sharedZoneUser" must be a member of group "' + ok_group['id'] + '" to apply this group to batch changes.'))
+    errors = shared_client.create_batch_change(batch_change_input, status=400)['errors']
+    assert_that(errors, contains('User "sharedZoneUser" must be a member of group "' + ok_group['id'] + '" to apply this group to batch changes.'))

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2502,7 +2502,7 @@ def test_create_batch_change_does_not_save_owner_group_id_for_non_shared_zone(sh
 def test_create_batch_change_for_shared_zone_owner_group_applied_logic(shared_zone_test_context):
     """
     Test successfully creating a batch change with owner group ID in shared zone succeeds and sets owner group ID
-    on creates and updates (if existing value does not exist)
+    on creates and only updates without a pre-existing owner group ID
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     shared_zone = shared_zone_test_context.shared_zone

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2574,4 +2574,4 @@ def test_create_batch_change_for_shared_zone_with_unauthorized_owner_group_id_fa
     }
 
     errors = shared_client.create_batch_change(batch_change_input, status=403)
-    assert_that(errors, is_('User "sharedZoneUser" must be a member of group ' + ok_group['id'] + ' to apply this group to batch changes'))
+    assert_that(errors, is_('User "sharedZoneUser" must be a member of group "' + ok_group['id'] + '" to apply this group to batch changes.'))

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2573,4 +2573,4 @@ def test_create_batch_change_for_shared_zone_with_unauthorized_owner_group_id_fa
     }
 
     errors = shared_client.create_batch_change(batch_change_input, status=403)
-    assert_that(errors, is_('User "sharedZoneUser." does not belong to group "' + ok_group['id'] + '". Owner group ID is only required for record set changes in shared zones.'))
+    assert_that(errors, is_('User "sharedZoneUser" is not a member of group "' + ok_group['id'] + '". Owner group ID is only required for record set changes in shared zones.'))

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -25,6 +25,23 @@ sealed trait DomainValidationError {
   def message: String
 }
 
+// The request itself is invalid in this case, so we fail fast
+final case class ChangeLimitExceeded(limit: Int) extends DomainValidationError {
+  def message: String = s"Cannot request more than $limit changes in a single batch change request"
+}
+final case class BatchChangeIsEmpty(limit: Int) extends DomainValidationError {
+  def message: String =
+    s"Batch change contained no changes. Batch change must have at least one change, up to a maximum of $limit changes."
+}
+final case class GroupDoesNotExist(id: String) extends DomainValidationError {
+  def message: String = s"""Group with ID "$id" was not found"""
+}
+final case class NotAMemberOfOwnerGroup(ownerGroupId: String, userName: String)
+    extends DomainValidationError {
+  def message: String =
+    s"""User "$userName" must be a member of group "$ownerGroupId" to apply this group to batch changes."""
+}
+
 final case class InvalidDomainName(param: String) extends DomainValidationError {
   def message: String =
     s"""Invalid domain name: "$param", valid domain names must be letters, numbers, and hyphens, """ +

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
@@ -180,12 +180,12 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
         deleteChange.recordName,
         deleteChange.typ)
       newRecordSet = {
-        val newOwnerGroupId = if (zone.shared && existingRecordSet.ownerGroupId.isEmpty) {
+        val setOwnerGroupId = if (zone.shared && existingRecordSet.ownerGroupId.isEmpty) {
           ownerGroupId
         } else {
           existingRecordSet.ownerGroupId
         }
-        combineAddChanges(addChanges, zone, newOwnerGroupId)
+        combineAddChanges(addChanges, zone, setOwnerGroupId)
       }
       changeIds = deleteChanges.map(_.id) ++ addChanges.map(_.id).toList
     } yield
@@ -223,8 +223,8 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
     for {
       zone <- existingZones.getByName(addChanges.head.zoneName)
       newRecordSet = {
-        val newOwnerGroupId = if (zone.shared) ownerGroupId else None
-        combineAddChanges(addChanges, zone, newOwnerGroupId)
+        val setOwnerGroupId = if (zone.shared) ownerGroupId else None
+        combineAddChanges(addChanges, zone, setOwnerGroupId)
       }
       ids = addChanges.map(_.id)
     } yield RecordSetChangeGenerator.forAdd(newRecordSet, zone, userId, ids.toList)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
@@ -41,7 +41,8 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
   def sendBatchForProcessing(
       batchChange: BatchChange,
       existingZones: ExistingZones,
-      existingRecordSets: ExistingRecordSets): BatchResult[BatchConversionOutput] = {
+      existingRecordSets: ExistingRecordSets,
+      ownerGroupId: Option[String]): BatchResult[BatchConversionOutput] = {
     logger.info(
       s"Converting BatchChange [${batchChange.id}] with SingleChanges [${batchChange.changes.map(_.id)}]")
     for {
@@ -49,7 +50,8 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
         batchChange.changes,
         existingZones,
         existingRecordSets,
-        batchChange.userId).toRightBatchResult
+        batchChange.userId,
+        ownerGroupId).toRightBatchResult
       _ <- allChangesWereConverted(batchChange.changes, recordSetChanges)
       _ <- batchChangeRepo
         .save(batchChange)
@@ -121,7 +123,8 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       changes: List[SingleChange],
       existingZones: ExistingZones,
       existingRecordSets: ExistingRecordSets,
-      userId: String): List[RecordSetChange] = {
+      userId: String,
+      ownerGroupId: Option[String]): List[RecordSetChange] = {
     val grouped = changes.groupBy(_.recordKey)
 
     grouped.toList.flatMap {
@@ -131,7 +134,7 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
         If we move to getting zones from the DB in the converter, we should report status back on changes
         where we can no longer find the zone (edge case - means someone submitted batch and then zone was deleted)
          */
-        combineChanges(groupedChanges, existingZones, existingRecordSets, userId)
+        combineChanges(groupedChanges, existingZones, existingRecordSets, userId, ownerGroupId)
     }
   }
 
@@ -139,7 +142,8 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       changes: List[SingleChange],
       existingZones: ExistingZones,
       existingRecordSets: ExistingRecordSets,
-      userId: String): Option[RecordSetChange] = {
+      userId: String,
+      ownerGroupId: Option[String]): Option[RecordSetChange] = {
     val adds = NonEmptyList.fromList {
       changes.collect {
         case add: SingleAddChange if SupportedBatchChangeRecordTypes.get.contains(add.typ) => add
@@ -153,10 +157,10 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
 
     // Note: deletes are applied before adds by this logic
     (deletes, adds) match {
-      case (None, Some(a)) => generateAddChange(a, existingZones, userId)
+      case (None, Some(a)) => generateAddChange(a, existingZones, userId, ownerGroupId)
       case (Some(d), None) => generateDeleteChange(d, existingZones, existingRecordSets, userId)
       case (Some(d), Some(a)) =>
-        generateUpdateChange(d, a, existingZones, existingRecordSets, userId)
+        generateUpdateChange(d, a, existingZones, existingRecordSets, userId, ownerGroupId)
       case _ => None
     }
   }
@@ -166,7 +170,8 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       addChanges: NonEmptyList[SingleAddChange],
       existingZones: ExistingZones,
       existingRecordSets: ExistingRecordSets,
-      userId: String): Option[RecordSetChange] =
+      userId: String,
+      ownerGroupId: Option[String]): Option[RecordSetChange] =
     for {
       deleteChange <- Some(deleteChanges.head)
       zone <- existingZones.getByName(deleteChange.zoneName)
@@ -174,7 +179,14 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
         deleteChange.zoneId,
         deleteChange.recordName,
         deleteChange.typ)
-      newRecordSet = combineAddChanges(addChanges, zone)
+      newRecordSet = {
+        val newOwnerGroupId = if (zone.shared && existingRecordSet.ownerGroupId.isEmpty) {
+          ownerGroupId
+        } else {
+          existingRecordSet.ownerGroupId
+        }
+        combineAddChanges(addChanges, zone, newOwnerGroupId)
+      }
       changeIds = deleteChanges.map(_.id) ++ addChanges.map(_.id).toList
     } yield
       RecordSetChangeGenerator.forUpdate(
@@ -206,16 +218,23 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
   def generateAddChange(
       addChanges: NonEmptyList[SingleAddChange],
       existingZones: ExistingZones,
-      userId: String): Option[RecordSetChange] =
+      userId: String,
+      ownerGroupId: Option[String]): Option[RecordSetChange] =
     for {
       zone <- existingZones.getByName(addChanges.head.zoneName)
-      newRecordSet = combineAddChanges(addChanges, zone)
+      newRecordSet = {
+        val newOwnerGroupId = if (zone.shared) ownerGroupId else None
+        combineAddChanges(addChanges, zone, newOwnerGroupId)
+      }
       ids = addChanges.map(_.id)
     } yield RecordSetChangeGenerator.forAdd(newRecordSet, zone, userId, ids.toList)
 
   // Combines changes where the RecordData can just be appended to list (A, AAAA, CNAME, PTR)
   // NOTE: CNAME & PTR will only have one data field due to validations, so the combination is fine
-  def combineAddChanges(changes: NonEmptyList[SingleAddChange], zone: Zone): RecordSet = {
+  def combineAddChanges(
+      changes: NonEmptyList[SingleAddChange],
+      zone: Zone,
+      ownerGroupId: Option[String]): RecordSet = {
     val combinedData =
       changes.foldLeft(List[RecordData]())((acc, ch) => ch.recordData :: acc).distinct
     // recordName and typ are shared by all changes passed into this function, can pull those from any change
@@ -228,6 +247,7 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       RecordSetStatus.Pending,
       DateTime.now,
       None,
-      combinedData)
+      combinedData,
+      ownerGroupId = ownerGroupId)
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverterAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverterAlgebra.scala
@@ -29,5 +29,6 @@ trait BatchChangeConverterAlgebra {
   def sendBatchForProcessing(
       batchChange: BatchChange,
       existingZones: ExistingZones,
-      existingRecordSets: ExistingRecordSets): BatchResult[BatchConversionOutput]
+      existingRecordSets: ExistingRecordSets,
+      ownerGroupId: Option[String]): BatchResult[BatchConversionOutput]
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -38,10 +38,10 @@ final case class BatchChangeIsEmpty(limit: Int) extends BatchChangeErrorResponse
 final case class GroupDoesNotExist(id: String) extends BatchChangeErrorResponse {
   def message: String = s"""Group with ID "$id" was not found"""
 }
-final case class UserDoesNotBelongToOwnerGroup(ownerGroupId: String, userName: String)
+final case class NotAMemberOfOwnerGroup(ownerGroupId: String, userName: String)
     extends BatchChangeErrorResponse {
   def message: String =
-    s"""User "$userName." does not belong to group "$ownerGroupId". Owner group ID is only required for """ +
+    s"""User "$userName" is not a member of group "$ownerGroupId". Owner group ID is only required for """ +
       "record set changes in shared zones."
 }
 final case class BatchChangeNotFound(id: String) extends BatchChangeErrorResponse {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -31,12 +31,19 @@ final case class InvalidBatchChangeResponses(
 final case class ChangeLimitExceeded(limit: Int) extends BatchChangeErrorResponse {
   def message: String = s"Cannot request more than $limit changes in a single batch change request"
 }
-
 final case class BatchChangeIsEmpty(limit: Int) extends BatchChangeErrorResponse {
   def message: String =
     s"Batch change contained no changes. Batch change must have at least one change, up to a maximum of $limit changes."
 }
-
+final case class GroupDoesNotExist(id: String) extends BatchChangeErrorResponse {
+  def message: String = s"""Group with ID "$id" was not found"""
+}
+final case class UserDoesNotBelongToOwnerGroup(ownerGroupId: String, userName: String)
+    extends BatchChangeErrorResponse {
+  def message: String =
+    s"""User "$userName." does not belong to group "$ownerGroupId". Owner group ID is only required for """ +
+      "record set changes in shared zones."
+}
 final case class BatchChangeNotFound(id: String) extends BatchChangeErrorResponse {
   def message: String = s"Batch change with id $id cannot be found"
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -41,8 +41,7 @@ final case class GroupDoesNotExist(id: String) extends BatchChangeErrorResponse 
 final case class NotAMemberOfOwnerGroup(ownerGroupId: String, userName: String)
     extends BatchChangeErrorResponse {
   def message: String =
-    s"""User "$userName" is not a member of group "$ownerGroupId". Owner group ID is only required for """ +
-      "record set changes in shared zones."
+    s"""User "$userName" must be a member of group "$ownerGroupId" to apply this group to batch changes."""
 }
 final case class BatchChangeNotFound(id: String) extends BatchChangeErrorResponse {
   def message: String = s"Batch change with id $id cannot be found"

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -16,33 +16,22 @@
 
 package vinyldns.api.domain.batch
 
+import vinyldns.api.domain.DomainValidationError
 import vinyldns.api.domain.batch.BatchChangeInterfaces.ValidatedBatch
 import vinyldns.api.domain.batch.BatchTransformations.ChangeForValidation
 import vinyldns.core.domain.batch.SingleChange
 
 /* Error response options */
 sealed trait BatchChangeErrorResponse
+final case class InvalidBatchChangeInput(errors: List[DomainValidationError])
+    extends BatchChangeErrorResponse
+
 // This separates error by change requested
 final case class InvalidBatchChangeResponses(
     changeRequests: List[ChangeInput],
     changeRequestResponses: ValidatedBatch[ChangeForValidation])
     extends BatchChangeErrorResponse
-// The request itself is invalid in this case, so we fail fast
-final case class ChangeLimitExceeded(limit: Int) extends BatchChangeErrorResponse {
-  def message: String = s"Cannot request more than $limit changes in a single batch change request"
-}
-final case class BatchChangeIsEmpty(limit: Int) extends BatchChangeErrorResponse {
-  def message: String =
-    s"Batch change contained no changes. Batch change must have at least one change, up to a maximum of $limit changes."
-}
-final case class GroupDoesNotExist(id: String) extends BatchChangeErrorResponse {
-  def message: String = s"""Group with ID "$id" was not found"""
-}
-final case class NotAMemberOfOwnerGroup(ownerGroupId: String, userName: String)
-    extends BatchChangeErrorResponse {
-  def message: String =
-    s"""User "$userName" must be a member of group "$ownerGroupId" to apply this group to batch changes."""
-}
+
 final case class BatchChangeNotFound(id: String) extends BatchChangeErrorResponse {
   def message: String = s"Batch change with id $id cannot be found"
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -20,7 +20,10 @@ import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 import vinyldns.core.domain.record.RecordData
 import vinyldns.core.domain.record.RecordType._
 
-final case class BatchChangeInput(comments: Option[String], changes: List[ChangeInput])
+final case class BatchChangeInput(
+    comments: Option[String],
+    changes: List[ChangeInput],
+    ownerGroupId: Option[String] = None)
 
 sealed trait ChangeInput {
   val inputName: String

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -24,7 +24,6 @@ import vinyldns.api.domain.ReverseZoneHelpers.ptrIsInZone
 import vinyldns.api.domain.batch.BatchChangeInterfaces._
 import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain.dns.DnsConversions._
-import vinyldns.api.domain.membership.MembershipValidations._
 import vinyldns.api.domain.{RecordAlreadyExists, ZoneDiscoveryError}
 import vinyldns.api.repository.ApiDataAccessor
 import vinyldns.core.domain.auth.AuthPrincipal
@@ -183,8 +182,8 @@ class BatchChangeService(
 
   def validateCanSeeGroup(ownerGroupId: String, authPrincipal: AuthPrincipal): BatchResult[Unit] =
     IO {
-      if (canSeeGroup(ownerGroupId, authPrincipal).isRight) ().asRight
-      else Left(UserDoesNotBelongToOwnerGroup(ownerGroupId, authPrincipal.signedInUser.userName))
+      if (authPrincipal.isGroupMember(ownerGroupId) || authPrincipal.canEditAll) ().asRight
+      else Left(NotAMemberOfOwnerGroup(ownerGroupId, authPrincipal.signedInUser.userName))
     }.toBatchResult
 
   def zoneDiscovery(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -65,7 +65,7 @@ class BatchChangeService(
       auth: AuthPrincipal): BatchResult[BatchChange] =
     for {
       existingGroup <- getOwnerGroup(batchChangeInput.ownerGroupId)
-      _ <- validateBatchChangeInput(batchChangeInput, existingGroup, auth).toBatchResult
+      _ <- validateBatchChangeInput(batchChangeInput, existingGroup, auth)
       inputValidatedSingleChanges = validateInputChanges(batchChangeInput.changes)
       zoneMap <- getZonesForRequest(inputValidatedSingleChanges).toBatchResult
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -163,7 +163,7 @@ class BatchChangeService(
       ownerGroupId: Option[String],
       authPrincipal: AuthPrincipal): BatchResult[Unit] =
     ownerGroupId match {
-      case None => IO(().asRight).toBatchResult
+      case None => ().toRightBatchResult
       case Some(groupId) =>
         for {
           _ <- validateOwnerGroupExists(groupId)
@@ -180,11 +180,12 @@ class BatchChangeService(
       }
       .toBatchResult
 
-  def validateGroupMembership(ownerGroupId: String, authPrincipal: AuthPrincipal): BatchResult[Unit] =
-    IO {
-      if (authPrincipal.isGroupMember(ownerGroupId) || authPrincipal.canEditAll) ().asRight
-      else Left(NotAMemberOfOwnerGroup(ownerGroupId, authPrincipal.signedInUser.userName))
-    }.toBatchResult
+  def validateGroupMembership(
+      ownerGroupId: String,
+      authPrincipal: AuthPrincipal): BatchResult[Unit] = {
+    if (authPrincipal.isGroupMember(ownerGroupId) || authPrincipal.canEditAll) ().asRight
+    else Left(NotAMemberOfOwnerGroup(ownerGroupId, authPrincipal.signedInUser.userName))
+  }.toBatchResult
 
   def zoneDiscovery(
       changes: ValidatedBatch[ChangeInput],

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -167,7 +167,7 @@ class BatchChangeService(
       case Some(groupId) =>
         for {
           _ <- validateOwnerGroupExists(groupId)
-          _ <- validateCanSeeGroup(groupId, authPrincipal)
+          _ <- validateGroupMembership(groupId, authPrincipal)
         } yield ().asRight
     }
 
@@ -180,7 +180,7 @@ class BatchChangeService(
       }
       .toBatchResult
 
-  def validateCanSeeGroup(ownerGroupId: String, authPrincipal: AuthPrincipal): BatchResult[Unit] =
+  def validateGroupMembership(ownerGroupId: String, authPrincipal: AuthPrincipal): BatchResult[Unit] =
     IO {
       if (authPrincipal.isGroupMember(ownerGroupId) || authPrincipal.canEditAll) ().asRight
       else Left(NotAMemberOfOwnerGroup(ownerGroupId, authPrincipal.signedInUser.userName))

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -17,7 +17,6 @@
 package vinyldns.api.route
 
 import cats.data._
-import cats.implicits._
 import cats.data.Validated._
 import org.json4s.JsonDSL._
 import org.json4s._
@@ -55,7 +54,11 @@ trait BatchChangeJsonProtocol extends JsonValidation {
       val changeList =
         (js \ "changes").required[List[ChangeInput]]("Missing BatchChangeInput.changes")
 
-      ((js \ "comments").optional[String], changeList).mapN(BatchChangeInput)
+      (
+        (js \ "comments").optional[String],
+        changeList,
+        (js \ "ownerGroupId").optional[String]
+      ).mapN(BatchChangeInput)
     }
   }
 
@@ -146,7 +149,8 @@ trait BatchChangeJsonProtocol extends JsonValidation {
         ("createdTimestamp" -> Extraction.decompose(bc.createdTimestamp)) ~
         ("changes" -> Extraction.decompose(bc.changes)) ~
         ("status" -> bc.status.toString) ~
-        ("id" -> bc.id)
+        ("id" -> bc.id) ~
+        ("ownerGroupId" -> bc.ownerGroupId)
   }
 
   case object BatchChangeErrorListSerializer

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -79,16 +79,11 @@ trait BatchChangeRoute extends Directives {
   private def execute[A](f: => EitherT[IO, BatchChangeErrorResponse, A])(rt: A => Route): Route =
     onSuccess(f.value.unsafeToFuture()) {
       case Right(a) => rt(a)
-      case Left(cle: ChangeLimitExceeded) =>
-        complete(StatusCodes.RequestEntityTooLarge, cle.message)
-      case Left(bie: BatchChangeIsEmpty) => complete(StatusCodes.UnprocessableEntity, bie.message)
+      case Left(ibci: InvalidBatchChangeInput) => complete(StatusCodes.BadRequest, ibci)
       case Left(crl: InvalidBatchChangeResponses) => complete(StatusCodes.BadRequest, crl)
       case Left(cnf: BatchChangeNotFound) => complete(StatusCodes.NotFound, cnf.message)
       case Left(una: UserNotAuthorizedError) => complete(StatusCodes.Forbidden, una.message)
       case Left(uct: BatchConversionError) => complete(StatusCodes.BadRequest, uct)
       case Left(uce: UnknownConversionError) => complete(StatusCodes.InternalServerError, uce)
-      case Left(gdne: GroupDoesNotExist) => complete(StatusCodes.BadRequest, gdne.message)
-      case Left(udnbtog: NotAMemberOfOwnerGroup) =>
-        complete(StatusCodes.Forbidden, udnbtog.message)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -88,7 +88,7 @@ trait BatchChangeRoute extends Directives {
       case Left(uct: BatchConversionError) => complete(StatusCodes.BadRequest, uct)
       case Left(uce: UnknownConversionError) => complete(StatusCodes.InternalServerError, uce)
       case Left(gdne: GroupDoesNotExist) => complete(StatusCodes.BadRequest, gdne.message)
-      case Left(udnbtog: UserDoesNotBelongToOwnerGroup) =>
+      case Left(udnbtog: NotAMemberOfOwnerGroup) =>
         complete(StatusCodes.Forbidden, udnbtog.message)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -87,5 +87,8 @@ trait BatchChangeRoute extends Directives {
       case Left(una: UserNotAuthorizedError) => complete(StatusCodes.Forbidden, una.message)
       case Left(uct: BatchConversionError) => complete(StatusCodes.BadRequest, uct)
       case Left(uce: UnknownConversionError) => complete(StatusCodes.InternalServerError, uce)
+      case Left(gdne: GroupDoesNotExist) => complete(StatusCodes.BadRequest, gdne.message)
+      case Left(udnbtog: UserDoesNotBelongToOwnerGroup) =>
+        complete(StatusCodes.Forbidden, udnbtog.message)
     }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -112,7 +112,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     makeSingleAddChange("wrongType", TXTData("Unsupported!"), UNKNOWN)
   )
 
-  private def existingZones = ExistingZones(Set(okZone, zoneShared))
+  private def existingZones = ExistingZones(Set(okZone, sharedZone))
 
   private val aToDelete = RecordSet(
     okZone.id,
@@ -380,7 +380,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
   }
 
   "generateAddChange" should {
-    val singleAddChange = makeSingleAddChange("shared-rs", AData("1.2.3.4"), A, zoneShared)
+    val singleAddChange = makeSingleAddChange("shared-rs", AData("1.2.3.4"), A, sharedZone)
     val ownerGroupId = Some("some-owner-group-id")
 
     "generate record set changes for shared zone without owner group ID if not provided" in {
@@ -418,12 +418,8 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
   }
 
   "generateUpdateChange" should {
-    val addChange = makeSingleAddChange("shared-rs", AData("2.3.4.5"), A, zoneShared)
-    val deleteChange = makeSingleDeleteChange("shared-rs", A, zoneShared)
-    val existingRs = rsOk.copy(
-      name = "shared-rs",
-      records = List(AData("1.2.3.4")),
-      ownerGroupId = Some("existing-owner-group-id"))
+    val addChange = makeSingleAddChange("aaaa", AAAAData("2:3:4:5:6:7:8:9"), AAAA, sharedZone)
+    val deleteChange = makeSingleDeleteChange("aaaa", AAAA, sharedZone)
 
     "not overwrite existing owner group ID for existing record set in shared zone" in {
       val result =
@@ -431,12 +427,12 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
           NonEmptyList.of(deleteChange),
           NonEmptyList.of(addChange),
           existingZones,
-          ExistingRecordSets(List(existingRs)),
+          ExistingRecordSets(List(sharedZoneRecord)),
           okUser.id,
           Some("new-owner-group-id")
         )
       result shouldBe defined
-      result.foreach(_.recordSet.ownerGroupId shouldBe existingRs.ownerGroupId)
+      result.foreach(_.recordSet.ownerGroupId shouldBe sharedZoneRecord.ownerGroupId)
     }
 
     "use specified owner group ID if undefined for existing record set in shared zone" in {
@@ -446,7 +442,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
           NonEmptyList.of(deleteChange),
           NonEmptyList.of(addChange),
           existingZones,
-          ExistingRecordSets(List(existingRs.copy(ownerGroupId = None))),
+          ExistingRecordSets(List(sharedZoneRecord.copy(ownerGroupId = None))),
           okUser.id,
           ownerGroupId
         )
@@ -460,7 +456,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
           NonEmptyList.of(deleteChange.copy(zoneId = okZone.id, zoneName = okZone.name)),
           NonEmptyList.of(addChange.copy(zoneId = okZone.id, zoneName = okZone.name)),
           existingZones,
-          ExistingRecordSets(List(existingRs.copy(ownerGroupId = None))),
+          ExistingRecordSets(List(sharedZoneRecord.copy(ownerGroupId = None, zoneId = okZone.id))),
           okUser.id,
           Some("new-owner-group-id")
         )

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -27,7 +27,12 @@ import vinyldns.api.repository._
 import vinyldns.core.TestMembershipData.okUser
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData.{okZone, _}
-import vinyldns.core.domain.batch.{BatchChange, SingleAddChange, SingleChangeStatus, SingleDeleteChange}
+import vinyldns.core.domain.batch.{
+  BatchChange,
+  SingleAddChange,
+  SingleChangeStatus,
+  SingleDeleteChange
+}
 import vinyldns.core.domain.record.RecordSetChangeType.RecordSetChangeType
 import vinyldns.core.domain.record.RecordType.{RecordType, _}
 import vinyldns.core.domain.record._

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -34,6 +34,7 @@ import vinyldns.api.repository.{
   InMemoryBatchChangeRepository
 }
 import vinyldns.core.TestMembershipData._
+import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.batch.{BatchChange, SingleAddChange, SingleChangeStatus}
 import vinyldns.core.domain.membership.Group
 import vinyldns.core.domain.record.RecordType._
@@ -714,11 +715,11 @@ class BatchChangeServiceSpec
       underTest.validateOwnerGroupId(Some(authGrp.id), auth).value.unsafeRunSync() should be(right)
     }
 
-    "succeed if user is an admin" in {
+    "succeed if user is a super user" in {
       underTest
         .validateOwnerGroupId(
           Some("user-is-not-member"),
-          auth.copy(signedInUser = okUser.copy(isSuper = true)))
+          AuthPrincipal(okUser.copy(isSuper = true), Seq()))
         .value
         .unsafeRunSync() should be(right)
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -203,7 +203,7 @@ class BatchChangeServiceSpec
       val input = BatchChangeInput(None, List(apexAddA), ownerGroupId)
       val result = leftResultOf(underTest.applyBatchChange(input, notAuth).value)
 
-      result shouldBe a[UserDoesNotBelongToOwnerGroup]
+      result shouldBe a[NotAMemberOfOwnerGroup]
     }
 
     "succeed if owner group ID is provided and user is a super user" in {
@@ -762,7 +762,7 @@ class BatchChangeServiceSpec
         .validateOwnerGroupId(Some("user-is-not-member"), auth)
         .value
         .unsafeRunSync() shouldBe
-        Left(UserDoesNotBelongToOwnerGroup("user-is-not-member", auth.signedInUser.userName))
+        Left(NotAMemberOfOwnerGroup("user-is-not-member", auth.signedInUser.userName))
     }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -191,19 +191,21 @@ class BatchChangeServiceSpec
     }
 
     "fail with GroupDoesNotExist if owner group ID is provided for a non-existent group" in {
-      val ownerGroupId = Some("non-existent-group-id")
-      val input = BatchChangeInput(None, List(apexAddA), ownerGroupId)
+      val ownerGroupId = "non-existent-group-id"
+      val input = BatchChangeInput(None, List(apexAddA), Some(ownerGroupId))
       val result = leftResultOf(underTest.applyBatchChange(input, auth).value)
 
-      result shouldBe a[GroupDoesNotExist]
+      result shouldBe InvalidBatchChangeInput(List(GroupDoesNotExist(ownerGroupId)))
     }
 
     "fail with UserDoesNotBelongToOwnerGroup if normal user does not belong to group specified by owner group ID" in {
-      val ownerGroupId = Some("user-is-not-member")
-      val input = BatchChangeInput(None, List(apexAddA), ownerGroupId)
+      val ownerGroupId = "user-is-not-member"
+      val input = BatchChangeInput(None, List(apexAddA), Some(ownerGroupId))
       val result = leftResultOf(underTest.applyBatchChange(input, notAuth).value)
 
-      result shouldBe a[NotAMemberOfOwnerGroup]
+      result shouldBe
+        InvalidBatchChangeInput(
+          List(NotAMemberOfOwnerGroup(ownerGroupId, notAuth.signedInUser.userName)))
     }
 
     "succeed if owner group ID is provided and user is a member of the group" in {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -21,6 +21,7 @@ import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.{ChangeSet, ListRecordSetResults, RecordSet, RecordSetRepository}
 import vinyldns.core.domain.zone.{Zone, ZoneRepository}
 import cats.effect._
+import vinyldns.core.domain.membership.{Group, GroupRepository}
 import vinyldns.core.domain.zone.ZoneRepository.DuplicateZoneError
 
 // Empty implementations let our other test classes just edit with the methods they need
@@ -68,4 +69,19 @@ trait EmptyZoneRepo extends ZoneRepository {
 
   def getZonesByFilters(zoneNames: Set[String]): IO[Set[Zone]] = IO.pure(Set())
 
+}
+
+trait EmptyGroupRepo extends GroupRepository {
+
+  def save(group: Group): IO[Group] = IO.pure(group)
+
+  def delete(group: Group): IO[Group] = IO.pure(group)
+
+  def getGroup(groupId: String): IO[Option[Group]] = IO.pure(None)
+
+  def getGroups(groupIds: Set[String]): IO[Set[Group]] = IO.pure(Set())
+
+  def getGroupByName(groupName: String): IO[Option[Group]] = IO.pure(None)
+
+  def getAllGroups(): IO[Set[Group]] = IO.pure(Set())
 }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -99,6 +99,9 @@ class BatchChangeJsonProtocolSpec
   val addBatchChangeInputWithComment: JObject = ("comments" -> Some("some comment")) ~~
     addChangeList
 
+  val addBatchChangeInputWithOwnerGroupId: JObject = ("ownerGroupId" -> Some("owner-group-id")) ~~
+    addBatchChangeInputWithComment
+
   val addAChangeInput = AddChangeInput("foo.", A, 3600, AData("1.1.1.1"))
 
   val deleteAChangeInput = DeleteChangeInput("foo.", A)
@@ -219,6 +222,16 @@ class BatchChangeJsonProtocolSpec
       result shouldBe BatchChangeInput(
         None,
         List(deleteAChangeInput, addAAAAChangeInput, addCNAMEChangeInput))
+    }
+
+    "successfully serialize valid add change when owner group ID is provided" in {
+      val result = BatchChangeInputSerializer.fromJson(addBatchChangeInputWithOwnerGroupId).value
+
+      result shouldBe BatchChangeInput(
+        Some("some comment"),
+        List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput),
+        Some("owner-group-id")
+      )
     }
 
     "return an error if the changes are not specified" in {
@@ -346,7 +359,8 @@ class BatchChangeJsonProtocolSpec
         ("createdTimestamp" -> decompose(time)) ~
         ("changes" -> decompose(List(add, delete))) ~
         ("status" -> decompose(BatchChangeStatus.Pending)) ~
-        ("id" -> "someId")
+        ("id" -> "someId") ~
+        ("ownerGroupId" -> JNothing)
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -200,7 +200,7 @@ class BatchChangeJsonProtocolSpec
   }
 
   "De-serializing BatchChangeInput from JSON" should {
-    "successfully serialize valid add change data when comment is provided" in {
+    "successfully serialize valid add change data with comment and without owner group ID" in {
       val result = BatchChangeInputSerializer.fromJson(addBatchChangeInputWithComment).value
 
       result shouldBe BatchChangeInput(
@@ -208,7 +208,7 @@ class BatchChangeJsonProtocolSpec
         List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput))
     }
 
-    "successfully serialize valid add change data when no comment is provided" in {
+    "successfully serialize valid add change data without comment and owner group ID" in {
       val result = BatchChangeInputSerializer.fromJson(addChangeList).value
 
       result shouldBe BatchChangeInput(
@@ -216,7 +216,7 @@ class BatchChangeJsonProtocolSpec
         List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput))
     }
 
-    "successfully serialize valid add and delete change data when no comment is provided" in {
+    "successfully serialize valid add and delete change data without comment and owner group ID" in {
       val result = BatchChangeInputSerializer.fromJson(addDeleteChangeList).value
 
       result shouldBe BatchChangeInput(
@@ -224,14 +224,38 @@ class BatchChangeJsonProtocolSpec
         List(deleteAChangeInput, addAAAAChangeInput, addCNAMEChangeInput))
     }
 
-    "successfully serialize valid add change when owner group ID is provided" in {
-      val result = BatchChangeInputSerializer.fromJson(addBatchChangeInputWithOwnerGroupId).value
-
-      result shouldBe BatchChangeInput(
+    "successfully serialize valid add and delete change with comment and owner group ID" in {
+      val batchChange = BatchChangeInput(
         Some("some comment"),
-        List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput),
+        List(
+          deleteAChangeInput,
+          addAChangeInput,
+          addAAAAChangeInput,
+          addCNAMEChangeInput,
+          addPTRChangeInput),
         Some("owner-group-id")
       )
+
+      BatchChangeInputSerializer
+        .fromJson(BatchChangeInputSerializer.toJson(batchChange))
+        .value shouldBe batchChange
+    }
+
+    "successfully serialize valid add and delete change without comment and with owner group ID" in {
+      val batchChange = BatchChangeInput(
+        None,
+        List(
+          deleteAChangeInput,
+          addAChangeInput,
+          addAAAAChangeInput,
+          addCNAMEChangeInput,
+          addPTRChangeInput),
+        Some("owner-group-id")
+      )
+
+      BatchChangeInputSerializer
+        .fromJson(BatchChangeInputSerializer.toJson(batchChange))
+        .value shouldBe batchChange
     }
 
     "return an error if the changes are not specified" in {

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -163,7 +163,7 @@ class BatchChangeRoutingSpec
             IO.pure(Left(GroupDoesNotExist("non-existent-group"))))
         case Some("userDoesNotBelongToOwnerGroup") =>
           EitherT[IO, BatchChangeErrorResponse, BatchChange](
-            IO.pure(Left(UserDoesNotBelongToOwnerGroup("owner-group-id", "user-name"))))
+            IO.pure(Left(NotAMemberOfOwnerGroup("owner-group-id", "user-name"))))
         case Some(_) =>
           EitherT[IO, BatchChangeErrorResponse, BatchChange](IO.pure(Right(genericValidResponse)))
       }

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -37,7 +37,8 @@ object TestZoneData {
   val zoneIp4: Zone = Zone("0.162.198.in-addr.arpa.", "test@test.com", adminGroupId = abcGroup.id)
   val zoneIp6: Zone =
     Zone("1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.", "test@test.com", adminGroupId = abcGroup.id)
-  val zoneShared: Zone = okZone.copy(name = "shared-zone.", shared = true)
+  val zoneShared: Zone =
+    Zone("shared-zone.", "test@test.com", adminGroupId = okGroup.id, shared = true)
 
   val zoneActive: Zone = Zone(
     "some.zone.name.",

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -37,8 +37,6 @@ object TestZoneData {
   val zoneIp4: Zone = Zone("0.162.198.in-addr.arpa.", "test@test.com", adminGroupId = abcGroup.id)
   val zoneIp6: Zone =
     Zone("1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.", "test@test.com", adminGroupId = abcGroup.id)
-  val zoneShared: Zone =
-    Zone("shared-zone.", "test@test.com", adminGroupId = okGroup.id, shared = true)
 
   val zoneActive: Zone = Zone(
     "some.zone.name.",

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -37,6 +37,7 @@ object TestZoneData {
   val zoneIp4: Zone = Zone("0.162.198.in-addr.arpa.", "test@test.com", adminGroupId = abcGroup.id)
   val zoneIp6: Zone =
     Zone("1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.", "test@test.com", adminGroupId = abcGroup.id)
+  val zoneShared: Zone = okZone.copy(name = "shared-zone.", shared = true)
 
   val zoneActive: Zone = Zone(
     "some.zone.name.",

--- a/modules/docs/src/main/tut/api/batchchange-errors.md
+++ b/modules/docs/src/main/tut/api/batchchange-errors.md
@@ -342,50 +342,33 @@ Not all record types are allowed in a DNS reverse zone. The given type is not su
 
 Fail-request errors cause the batch change processing to abort immediately upon encounter.
 
-1. [Batch Change Is Empty](#BatchChangeIsEmpty)
-2. [Change Limit Exceeded](#ChangeLimitExceeded)
-3. [Batch Change Not Found](#BatchChangeNotFound)
-4. [Malformed JSON Errors](#malformed-json-errors)
+1. [Invalid Batch Change Input](#InvalidBatchChangeInput)
+2. [Batch Change Not Found](#BatchChangeNotFound)
+3. [Malformed JSON Errors](#malformed-json-errors)
 
-#### 1. BATCH CHANGE IS EMPTY <a id="BatchChangeIsEmpty" />
+#### 1. INVALID BATCH CHANGE INPUT <a id="InvalidBatchChangeInput" />
 
 ##### HTTP RESPONSE CODE
 
 Code          | description |
  ------------ | :---------- |
-422           | **Unprocessable Entity** - the batch does not contain any changes, thus cannot be processed. |
+400           | **Bad Request** - There is a top-level issue with batch change, aborting batch processing. |
 
-##### ERROR MESSAGE:
+There are a series of different error messages that can be returned with this error code.
+
+##### EXAMPLE ERROR MESSAGES:
 
 ```
 Batch change contained no changes. Batch change must have at least one change, up to a maximum of <limit> changes.
-```
 
-##### DETAILS:
-
-There were no changes found in the [create batch change](../api/create-batchchange) request. A batch must contain at least one change and no more than 20 changes.
-
-
-#### 2. CHANGE LIMIT EXCEEDED <a id="ChangeLimitExceeded" />
-
-##### HTTP RESPONSE CODE
-
-Code          | description |
- ------------ | :---------- |
-413           | **Request Entity Too Large** - the batch size exceeds the maximum number of single changes, currently set to 20. |
-
-##### ERROR MESSAGE:
-
-```
 Cannot request more than <limit> changes in a single batch change request
 ```
 
 ##### DETAILS:
 
-The number of change inputs in the [create batch change](../api/create-batchchange) request exceeds the max change input limit threshold, which is currently set to 20.
+If there are issues with the batch change input data provided in the batch change request, errors will be returned and batch change validations will abort processing.
 
-
-#### 3. BATCH CHANGE NOT FOUND <a id="BatchChangeNotFound" />
+#### 2. BATCH CHANGE NOT FOUND <a id="BatchChangeNotFound" />
 
 ##### HTTP RESPONSE CODE
 
@@ -404,7 +387,7 @@ Batch change with id <id> cannot be found
 The batch ID specified in the [get batch change](../api/get-batchchange) request does not exist.
 
 
-#### 4. MALFORMED JSON ERRORS <a id="malformed-json-errors" />
+#### 3. MALFORMED JSON ERRORS <a id="malformed-json-errors" />
 
 ##### DETAILS:
 


### PR DESCRIPTION
PR 1 of 2. Fixes #342.

Changes in this pull request:
- Update JSON serializers/deserializers to accept/return owner group for batch change.
- Add group validation for:
  1. valid owner group ID
  2. owner group membership in batch service.
- Set owner group ID when applicable in batch change converter:
  - For creates: if zone is shared and owner group ID is provided
  - For updates: if zone is shared and existing record set doesn't have owner group ID set
- Add unit and functional tests