### PR TITLE
Update MySQL information in operator guide documentation

### DIFF
--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -166,9 +166,9 @@ You must have all of the following required API repositories configured in exact
 | ZoneChange  |        X         |       X       |
 
 
-If using DynamoDB, follow the [AWS DynamoDB Setup Guide](setup-dynamodb) first to get the values you need to configure here.
-
 If using MySQL, follow the [MySQL Setup Guide](setup-mysql) first to get the values you need to configure here.
+
+If using DynamoDB, follow the [AWS DynamoDB Setup Guide](setup-dynamodb) first to get the values you need to configure here.
 
 
 ```yaml
@@ -176,6 +176,72 @@ vinyldns {
 
   # this list should include only the datastores being used by your instance
   data-stores = ["mysql", "dynamodb"]
+  
+  mysql {
+    
+    # this is the path to the mysql provider. This should not be edited
+    # from the default in reference.conf
+    class-name = "vinyldns.mysql.repository.MySqlDataStoreProvider"
+    
+    settings {
+      # the name of the database, recommend to leave this as is
+      name = "vinyldns"
+      
+      # the jdbc driver, recommended to leave this as is
+      driver = "org.mariadb.jdbc.Driver"
+  
+      # the URL used to create the schema, typically this will be without the "database" name
+      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+  
+      # the main connection URL
+      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
+  
+      # the user to connect to MySQL
+      user = "root"
+  
+      # the password to connect to MySQL
+      password = "pass"
+  
+      ## see https://github.com/brettwooldridge/HikariCP for more detail on the following fields
+      # the maximum number of connections to scale the connection pool to
+      maximum-pool-size = 20
+  
+      # the maximum number of milliseconds to wait for a connection from the connection pool
+      connection-timeout-millis = 1000
+      
+      # the minimum number of idle connections that HikariCP tries to maintain in the pool
+      minimum-idle = 10
+            
+      # the maximum number of milliseconds that a connection is can sit idle in the pool
+      idle-timeout = 10000
+  
+      # The max lifetime of a connection in a pool.  Should be several seconds shorter than the database imposed connection time limit
+      max-lifetime = 600000
+      
+      # controls whether JMX MBeans are registered
+      register-mbeans = true
+      
+      # my-sql-properties allows you to include any additional mysql performance settings you want.
+      # Note that the properties within my-sql-properties must be camel case!
+      # see https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration for guidance
+      my-sql-properties {
+        prepStmtCacheSize = 300
+        prepStmtCacheSqlLimit = 2048
+        cachePrepStmts = true
+        useServerPrepStmts = true
+        rewriteBatchedStatements = true
+      }
+    }
+    
+    repositories {
+      # all repositories with config sections here will be enabled in mysql
+      zone {
+        # no additional settings for repositories enabled in mysql
+      },
+      batch-change {
+      }
+    }
+  }
   
   dynamodb {
       
@@ -236,72 +302,6 @@ vinyldns {
         table-name = "membershipTest"
         provisioned-reads = 30
         provisioned-writes = 20
-      }
-    }
-  }
-  
-  mysql {
-    
-    # this is the path to the mysql provider. This should not be edited
-    # from the default in reference.conf
-    class-name = "vinyldns.mysql.repository.MySqlDataStoreProvider"
-    
-    settings {
-      # the name of the database, recommend to leave this as is
-      name = "vinyldns"
-      
-      # the jdbc driver, recommended to leave this as is
-      driver = "org.mariadb.jdbc.Driver"
-
-      # the URL used to create the schema, typically this will be without the "database" name
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
-
-      # the main connection URL
-      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
-
-      # the user to connect to MySQL
-      user = "root"
-
-      # the password to connect to MySQL
-      password = "pass"
-
-      ## see https://github.com/brettwooldridge/HikariCP for more detail on the following fields
-      # the maximum number of connections to scale the connection pool to
-      maximum-pool-size = 20
-
-      # the maximum number of milliseconds to wait for a connection from the connection pool
-      connection-timeout-millis = 1000
-      
-      # the minimum number of idle connections that HikariCP tries to maintain in the pool
-      minimum-idle = 10
-            
-      # the maximum number of milliseconds that a connection is can sit idle in the pool
-      idle-timeout = 10000
-
-      # The max lifetime of a connection in a pool.  Should be several seconds shorter than the database imposed connection time limit
-      max-lifetime = 600000
-      
-      # controls whether JMX MBeans are registered
-      register-mbeans = true
-      
-      # my-sql-properties allows you to include any additional mysql performance settings you want.
-      # Note that the properties within my-sql-properties must be camel case!
-      # see https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration for guidance
-      my-sql-properties {
-        prepStmtCacheSize = 300
-        prepStmtCacheSqlLimit = 2048
-        cachePrepStmts = true
-        useServerPrepStmts = true
-        rewriteBatchedStatements = true
-      }
-    }
-    
-    repositories {
-      # all repositories with config sections here will be enabled in mysql
-      zone {
-        # no additional settings for repositories enabled in mysql
-      },
-      batch-change {
       }
     }
   }

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -11,7 +11,7 @@ section: "operator_menu"
 ## Configuration
 - [Configuration Overview](#configuration-overview)
 - [Configuration API Server](#configuring-api-server)
-- [AWS SQS](#aws-sqs)
+- [Queue Configuration](#queue-configuration)
 - [Database Configuration](#database-configuration)
 - [Cryptography](#cryptography-settings)
 - [Additional Configuration Settings](#additional-configuration-settings)

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -150,17 +150,20 @@ VinylDNS supports both DynamoDB and MySQL backends. You can enable all repos in 
 For each backend, you need to configure the table(s) that should be loaded.
 
 You must have all of the following required API repositories configured in exactly one datastore.
-**At the moment, not all repositories are implemented in both datastores, but we are actively working on expanding
-MySQL support to all repositories**:
-- record-set (dynamodb only)
-- record-change (dynamodb only)
-- zone-change (mysql or dynamodb)
-- user (dynamodb only)
-- group (dynamodb only)
-- group-change (dynamodb only)
-- membership (dynamodb only)
-- zone (mysql only)
-- batch-change (mysql only)
+**Some repositories are implemented in DynamoDB, all repositories have MySQL support**:
+
+| Repository | DynamoDB support | MySQL support |
+| :---       |       :---:      |     :---:     |
+| BatchChange  |                 |       X       |
+| Group  |        X         |       X       |
+| GroupChange  |        X         |       X       |
+| Membership  |        X         |       X       |
+| RecordSet |        X         |       X       |
+| RecordSetChange  |        X         |       X       |
+| User  |        X         |       X       |
+| UserChange  |        X         |       X       |
+| Zone  |                 |       X       |
+| ZoneChange  |        X         |       X       |
 
 
 If using DynamoDB, follow the [AWS DynamoDB Setup Guide](setup-dynamodb) first to get the values you need to configure here.

--- a/modules/docs/src/main/tut/operator/pre.md
+++ b/modules/docs/src/main/tut/operator/pre.md
@@ -64,25 +64,9 @@ The `BatchChangeRepository` holds the batch itself and all individual changes th
 * `UserChangeRepository` - Holds changes to users. Currently only used in the portal.
 
 ## Database Types
-### AWS DynamoDB
-VinylDNS has gone through several architecture evolutions.  Along the way, DynamoDB was chosen as the data store due to
-the volume of data at Comcast.  It is an excellent key-value store with extremely high performance characteristics.
-
-VinylDNS uses DynamoDB presently for the following repositories:
-
-1. RecordSetRepository
-1. RecordChangeRepository
-1. ZoneChangeRepository
-1. GroupRepository
-1. UserRepository
-1. MembershipRepository
-1. GroupChangeRepository
-1. UserChangeRepository
-
-Review the [Setup AWS DynamoDB Guide](setup-dynamodb) for more information.
-
 ### MySQL
-VinylDNS currently uses MySQL only for the following repositories:
+VinylDNS has implemented MySQL for all repositories so a MySQL-only instance of VinylDNS is possible. Furthermore, there are two
+repositories that have _only_ been implemented in MySQL:
 
 1. ZoneRepository
 1. BatchChangeRepository
@@ -95,6 +79,26 @@ in DynamoDB in our VinylDNS instance.
 
 Review the [Setup MySQL Guide](setup-mysql) for more information.
 
+### AWS DynamoDB
+VinylDNS has gone through several architecture evolutions.  Along the way, DynamoDB was chosen as the data store due to
+the volume of data at Comcast.  It is an excellent key-value store with extremely high performance characteristics.
+
+VinylDNS has implemented DynamoDB for the following repositories:
+
+1. RecordSetRepository
+1. RecordChangeRepository
+1. ZoneChangeRepository
+1. GroupRepository
+1. UserRepository
+1. MembershipRepository
+1. GroupChangeRepository
+1. UserChangeRepository
+
+Currently using DynamoDB would also require the user to either use MySQL for the batch change and zone repositories or also provide
+an implementation for those repositories in a different data store.
+
+Review the [Setup AWS DynamoDB Guide](setup-dynamodb) for more information.
+
 ## Message Queues
 Most operations that take place in VinylDNS use a message queue.  These operations require high-availability, fault-tolerance
 with retry, and throttling.  The message queue supports these characteristics in VinylDNS.
@@ -104,7 +108,7 @@ fault-tolerance and throttling requirements.
 
 ## Message Queue Types
 ### AWS SQS
-VinylDNS uses AWS SQS as its message queue.  SQS has the following characteristics:
+Our VinylDNS instance uses AWS SQS to fulfill its message queue service needs.  SQS has the following characteristics:
 
 1. High-Availability
 1. Retry - in the event that a message cannot be processed, or if a node fails midstream processing, it will be automatically

--- a/modules/docs/src/main/tut/operator/pre.md
+++ b/modules/docs/src/main/tut/operator/pre.md
@@ -36,7 +36,7 @@ When no zone connection is specified on a zone, the global defaults will be used
 ## Database
 [database]: #database
 
-The VinylDNS database provides implementations in both a `MySQL` / relational and a `NoSQL` / non-relational design.  Instead of having a heavily normalized set of SQL tables
+The VinylDNS database has a `NoSQL` / non-relational design to it.  Instead of having a heavily normalized set of SQL tables
 that surface in the system, VinylDNS relies on `Repositories` where each `Repository` is independent of each one another.
 This allows implementers to best map each `Repository` into the data-store of choice.
 
@@ -61,10 +61,7 @@ The user information will be pulled from LDAP, and inserted into the VinylDNS Us
 * `GroupChangeRepository` - Holds changes to groups and membership
 * `BatchChangeRepository` - VinylDNS allows users to submit multiple record changes _across_ DNS zones at the same time within a `Batch`
 The `BatchChangeRepository` holds the batch itself and all individual changes that executed in the batch.
-* `UserChangeRepository` - Holds changes to users
-
-**Note: The UserChangeRepository is currently only used in the portal, and lives outside of the API.  This will be moved
-alongside the other repositories in the near future.**
+* `UserChangeRepository` - Holds changes to users. Currently only used in the portal.
 
 ## Database Types
 ### AWS DynamoDB

--- a/modules/docs/src/main/tut/operator/pre.md
+++ b/modules/docs/src/main/tut/operator/pre.md
@@ -36,7 +36,7 @@ When no zone connection is specified on a zone, the global defaults will be used
 ## Database
 [database]: #database
 
-The VinylDNS database has a `NoSQL` / non-relational design to it.  Instead of having a heavily normalized set of SQL tables
+The VinylDNS database provides implementations in both a `MySQL` / relational and a `NoSQL` / non-relational design.  Instead of having a heavily normalized set of SQL tables
 that surface in the system, VinylDNS relies on `Repositories` where each `Repository` is independent of each one another.
 This allows implementers to best map each `Repository` into the data-store of choice.
 
@@ -63,7 +63,7 @@ The user information will be pulled from LDAP, and inserted into the VinylDNS Us
 The `BatchChangeRepository` holds the batch itself and all individual changes that executed in the batch.
 * `UserChangeRepository` - Holds changes to users
 
-**Note: The UserChangeRepository is currently only used in the portal, and lives outside of the api.  This will be moved
+**Note: The UserChangeRepository is currently only used in the portal, and lives outside of the API.  This will be moved
 alongside the other repositories in the near future.**
 
 ## Database Types
@@ -93,6 +93,9 @@ VinylDNS currently uses MySQL only for the following repositories:
 Originally, the `ZoneRepository` lived in DynamoDB.  However, the access controls in VinylDNS made it very difficult
 to use DynamoDB as the query interface is limited.  A SQL interface with `JOIN`s was required.
 
+It should also be noted that all of the repositories have also been implemented in MySQL despite most currently running
+in DynamoDB in our VinylDNS instance.
+
 Review the [Setup MySQL Guide](setup-mysql) for more information.
 
 ## Message Queues
@@ -116,6 +119,12 @@ bottlenecks in processing could cause an increase in heap pressure in the API no
 The price to use SQS is in the single digit dollars per month.  VinylDNS can be tuned to run exclusively in the _free tier_.
 
 Review the [Setup AWS SQS Guide](setup-sqs) for more information.
+
+### MySQL
+VinylDNS has also implemented a message queue using MySQL, which incorporates the features that we currently utilize through AWS SQS
+such as changing visibility timeout and re-queuing operations.
+
+Review the [Setup MySQL Guide](setup-mysql) for more information.
 
 ## LDAP
 VinylDNS uses LDAP in order to authenticate users in the **Portal**.  LDAP is **not** used in the API, instead the API uses

--- a/modules/docs/src/main/tut/operator/setup-dynamodb.md
+++ b/modules/docs/src/main/tut/operator/setup-dynamodb.md
@@ -5,8 +5,9 @@ section: "operator_menu"
 ---
 
 # Setup AWS DynamoDB
-[AWS DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html) is the default database
-for _most_ of the data that is stored in VinylDNS.  The following tables are used in VinylDNS:
+[AWS DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html) is currently the default database
+for _most_ of the data that is stored in our instance of VinylDNS. However, all table implementations are available in MySQL
+ (see [Setup MySQL Guide](setup-mysql) for more information). The following tables are present in DynamoDB in our instance of VinylDNS:
 
 * [RecordSet](#recordset-table) - holds record data
 * [RecordSetChange](#recordsetchange-table) - audit history of all changes made to records

--- a/modules/docs/src/main/tut/operator/setup-mysql.md
+++ b/modules/docs/src/main/tut/operator/setup-mysql.md
@@ -5,19 +5,19 @@ section: "operator_menu"
 ---
 
 # Setup MySQL
-VinylDNS stores some tables in MySQL.  The motivation to split databases was due to the Query limitations available
+VinylDNS stores some tables in MySQL.  The motivation to split databases was due to the query limitations available
 in AWS DynamoDB.  Currently, the following tables are present in MySQL
 
 * `zone` - holds zones
 * `zone_access` - holds user or group identifiers that have access to zones
 * `batch_change` - holds batch changes (multiple changes across zones in a single batch)
-* `single_change` - holds individual changes within a batch_change
+* `single_change` - holds individual changes within a `batch_change`
 
 ## Setting up the database
 VinylDNS uses [Flyway](https://flywaydb.org/) to manage SQL migrations.  This means that any database changes, including
 creating the database, adding tables, etc. are all _automatically applied_ when VinylDNS starts up.  You do not need
 to do anything other than giving access to VinylDNS API from your MySQL server instance.  You can view the database
-schema and migrations in the api module [db/migration folder](https://github.com/vinyldns/vinyldns/tree/master/modules/api/src/main/resources/db/migration)
+schema and migrations in the api module [db/migration folder](https://github.com/vinyldns/vinyldns/tree/master/modules/mysql/src/main/resources/db/migration)
 
 VinylDNS uses [HikariCP](https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby) for a high-speed connection
 pool.

--- a/modules/docs/src/main/tut/operator/setup-mysql.md
+++ b/modules/docs/src/main/tut/operator/setup-mysql.md
@@ -5,8 +5,11 @@ section: "operator_menu"
 ---
 
 # Setup MySQL
-VinylDNS stores some tables in MySQL.  The motivation to split databases was due to the query limitations available
-in AWS DynamoDB.  Currently, the following tables are present in MySQL
+Our instance of VinylDNS currently stores some tables in MySQL, though all tables and a queue implementation are available in MySQL. Note
+that the `batch_change` and `zone` tables are _only_ available in MySQL. 
+
+The motivation to split databases was due to the query limitations available in AWS DynamoDB.  Currently, the following tables are present in
+our instance:
 
 * `zone` - holds zones
 * `zone_access` - holds user or group identifiers that have access to zones
@@ -17,7 +20,7 @@ in AWS DynamoDB.  Currently, the following tables are present in MySQL
 VinylDNS uses [Flyway](https://flywaydb.org/) to manage SQL migrations.  This means that any database changes, including
 creating the database, adding tables, etc. are all _automatically applied_ when VinylDNS starts up.  You do not need
 to do anything other than giving access to VinylDNS API from your MySQL server instance.  You can view the database
-schema and migrations in the api module [db/migration folder](https://github.com/vinyldns/vinyldns/tree/master/modules/mysql/src/main/resources/db/migration)
+schema and migrations in the `mysql` module [db/migration folder](https://github.com/vinyldns/vinyldns/tree/master/modules/mysql/src/main/resources/db/migration)
 
 VinylDNS uses [HikariCP](https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby) for a high-speed connection
 pool.


### PR DESCRIPTION
Add information regarding MySQL support and repository implementations.
Fixes #389.

Changes in this pull request:
- Provide information about MySQL support for queue and repositories
- Fix broken migration link
