### PR TITLE
feature flag shared zone info

### DIFF
--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -17,8 +17,10 @@
 package models
 import play.api.Configuration
 
-case class Meta(version: String)
+case class Meta(version: String, shared_display_enabled: Boolean)
 object Meta {
   def apply(config: Configuration): Meta =
-    Meta(config.getOptional[String]("vinyldns.version").getOrElse("unknown"))
+    Meta(
+      config.getOptional[String]("vinyldns.version").getOrElse("unknown"),
+      config.getOptional[Boolean]("shared_display_enabled").getOrElse(false))
 }

--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -17,10 +17,10 @@
 package models
 import play.api.Configuration
 
-case class Meta(version: String, shared_display_enabled: Boolean)
+case class Meta(version: String, sharedDisplayEnabled: Boolean)
 object Meta {
   def apply(config: Configuration): Meta =
     Meta(
       config.getOptional[String]("vinyldns.version").getOrElse("unknown"),
-      config.getOptional[Boolean]("shared_display_enabled").getOrElse(false))
+      config.getOptional[Boolean]("shared-display-enabled").getOrElse(false))
 }

--- a/modules/portal/app/views/zones/zoneDetail.scala.html
+++ b/modules/portal/app/views/zones/zoneDetail.scala.html
@@ -1,4 +1,4 @@
-@(rootAccountName: String, zoneId: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks)
+@(rootAccountName: String, zoneId: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 @import zoneTabs._
 
 @content = {
@@ -49,7 +49,7 @@
                         @manageRecords(request)
                     </div>
                     <div class="tab-pane" id="tab2" ng-controller="ManageZonesController">
-                        @manageZone(request)
+                        @manageZone(request, meta)
                     </div>
                     <div class="tab-pane" id="tab3">
                         @changeHistory(request)

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -46,7 +46,7 @@
                                 </div>
                             </div>
 
-                            @if(meta.shared_display_enabled) {
+                            @if(meta.sharedDisplayEnabled) {
                                 <div class="form-group">
                                     <label class="col-md-3 control-label">Type</label>
                                     <div class="col-md-9">

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -1,4 +1,4 @@
-@(implicit request: play.api.mvc.Request[Any])
+@(implicit request: play.api.mvc.Request[Any], meta: models.Meta)
 
 <div class="alert-wrapper">
     <div ng-repeat="alert in alerts">
@@ -45,6 +45,17 @@
                                     </div>
                                 </div>
                             </div>
+
+                            @if(meta.shared_display_enabled) {
+                                <div class="form-group">
+                                    <label class="col-md-3 control-label">Type</label>
+                                    <div class="col-md-9">
+                                        <div>
+                                            <p class="form-control-static">{{ updateZoneInfo.shared ? "Shared" : "Private" }}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            }
 
                             <div class="form-group" ng-if="isZoneAdmin">
                                 <label class="col-md-3 control-label">Admin Group</label>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -81,7 +81,7 @@
                                     <th>Email</th>
                                     <th>Admin Group</th>
                                     <th>Status</th>
-                                    @if(meta.shared_display_enabled) {
+                                    @if(meta.sharedDisplayEnabled) {
                                         <th>Type</th>
                                     }
                                     <th>Actions</th>
@@ -96,7 +96,7 @@
                                       <span ng-if="!isGroupMember(zone.adminGroupId)" ng-bind="zone.adminGroupName" style="line-height: 0"></span>
                                   </td>
                                   <td ng-bind="zone.status"></td>
-                                  @if(meta.shared_display_enabled) {
+                                  @if(meta.sharedDisplayEnabled) {
                                     <td>{{zone.shared ? "Shared" : "Private"}}</td>
                                   }
                                   <td>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -1,4 +1,4 @@
-@(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks)
+@(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 
 @content = {
 <!-- PAGE CONTENT -->
@@ -81,6 +81,9 @@
                                     <th>Email</th>
                                     <th>Admin Group</th>
                                     <th>Status</th>
+                                    @if(meta.shared_display_enabled) {
+                                        <th>Type</th>
+                                    }
                                     <th>Actions</th>
                                 </tr>
                             </thead>
@@ -93,6 +96,9 @@
                                       <span ng-if="!isGroupMember(zone.adminGroupId)" ng-bind="zone.adminGroupName" style="line-height: 0"></span>
                                   </td>
                                   <td ng-bind="zone.status"></td>
+                                  @if(meta.shared_display_enabled) {
+                                    <td>{{zone.shared ? "Shared" : "Private"}}</td>
+                                  }
                                   <td>
                                     <div class="table-form-group">
                                       <a id="zone-view-{{zone.name}}" type="button" class="btn btn-info btn-rounded"

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -25,5 +25,13 @@ class MetaSpec extends Specification with Mockito {
       val config = Map("vinyldns.version" -> "foo-bar")
       Meta(Configuration.from(config)).version must beEqualTo("foo-bar")
     }
+    "default to false if shared_display_enabled is not found" in {
+      val config = Map("vinyldns.version" -> "foo-bar")
+      Meta(Configuration.from(config)).shared_display_enabled must beFalse
+    }
+    "set to true if shared_display_enabled is true in config" in {
+      val config = Map("shared_display_enabled" -> true)
+      Meta(Configuration.from(config)).shared_display_enabled must beTrue
+    }
   }
 }

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -25,13 +25,13 @@ class MetaSpec extends Specification with Mockito {
       val config = Map("vinyldns.version" -> "foo-bar")
       Meta(Configuration.from(config)).version must beEqualTo("foo-bar")
     }
-    "default to false if shared_display_enabled is not found" in {
+    "default to false if shared-display-enabled is not found" in {
       val config = Map("vinyldns.version" -> "foo-bar")
-      Meta(Configuration.from(config)).shared_display_enabled must beFalse
+      Meta(Configuration.from(config)).sharedDisplayEnabled must beFalse
     }
-    "set to true if shared_display_enabled is true in config" in {
-      val config = Map("shared_display_enabled" -> true)
-      Meta(Configuration.from(config)).shared_display_enabled must beTrue
+    "set to true if shared-display-enabled is true in config" in {
+      val config = Map("shared-display-enabled" -> true)
+      Meta(Configuration.from(config)).sharedDisplayEnabled must beTrue
     }
   }
 }


### PR DESCRIPTION
Fixes #349.

Changes in this pull request:
- add `shared_display_enabled` flag, to be set in the portal config, default is false
- display zone type as "Shared" or "Private" in the main Zones table in the portal and also the Manage Zone tab of an individual zone

To test locally: 
- add `shared_display_enabled = true` in portal module local.conf

<img width="1203" alt="zone_type_in_zones_table" src="https://user-images.githubusercontent.com/4439228/51212244-f5af6200-18e5-11e9-845f-320beb7e83b5.png">

<img width="1202" alt="zone_type_in_manage_zone_tab" src="https://user-images.githubusercontent.com/4439228/51212250-f8aa5280-18e5-11e9-9967-e3db29ac81f7.png">