### PR TITLE
Incorporate owner group validations into delete record set endpoint 

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
@@ -662,9 +662,9 @@ def test_no_delete_access_non_test_zone(shared_zone_test_context):
 
     client.delete_recordset(zone_id, record_delete['id'], status=403)
 
-def test_delete_for_normal_user_not_in_owner_group_in_shared_zone_fails(shared_zone_test_context):
+def test_delete_for_user_not_in_record_owner_group_in_shared_zone_fails(shared_zone_test_context):
     """
-    Test that a normal user cannot delete a record in a shared zone if not part of owner group
+    Test that a user cannot delete a record in a shared zone if not part of record owner group
     """
 
     dummy_client = shared_zone_test_context.dummy_vinyldns_client
@@ -686,9 +686,9 @@ def test_delete_for_normal_user_not_in_owner_group_in_shared_zone_fails(shared_z
             delete_rs = shared_client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=202)
             shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
-def test_delete_for_normal_user_in_owner_group_in_non_shared_zone_fails(shared_zone_test_context):
+def test_delete_for_user_in_record_owner_group_in_non_shared_zone_fails(shared_zone_test_context):
     """
-    Test that a normal user in owner group cannot delete a record in a non-shared zone
+    Test that a user in record owner group cannot delete a record in a non-shared zone
     """
     ok_client = shared_zone_test_context.ok_vinyldns_client
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
@@ -709,35 +709,27 @@ def test_delete_for_normal_user_in_owner_group_in_non_shared_zone_fails(shared_z
             delete_rs = ok_client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=202)
             ok_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
-def test_delete_for_normal_user_in_owner_group_in_shared_zone_succeeds(shared_zone_test_context):
+def test_delete_for_user_in_record_owner_group_in_shared_zone_succeeds(shared_zone_test_context):
     """
-    Test that a normal user in owner group can delete a record in a shared zone
+    Test that a user in record owner group can delete a record in a shared zone
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     ok_client = shared_zone_test_context.ok_vinyldns_client
     shared_zone = shared_zone_test_context.shared_zone
-    create_group = None
+    shared_group = shared_zone_test_context.shared_record_group
 
-    try:
-        new_shared_group = get_group_json("another-shared-group", members=[{ 'id': 'ok' }, { 'id': 'sharedZoneUser' }], admins=[{ 'id': 'ok' }, { 'id': 'sharedZoneUser' }])
-        create_group = shared_client.create_group(new_shared_group, status=200)
+    record_json = get_recordset_json(shared_zone, 'test_shared_bad_user', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_group['id'])
 
-        record_json = get_recordset_json(shared_zone, 'test_shared_bad_user', 'A', [{'address': '1.1.1.1'}], ownergroup_id = create_group['id'])
+    create_rs = shared_client.create_recordset(record_json, status=202)
+    result_rs = shared_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']
 
-        create_rs = shared_client.create_recordset(record_json, status=202)
-        result_rs = shared_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']
-
-        delete_rs = ok_client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=202)
-        # TODO: Update to ok_client once access validation for getRecordSetChange endpoint has been updated to use canViewRecordSet
-        shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
-
-    finally:
-        if create_group:
-            shared_client.delete_group(create_group['id'], status=200)
+    delete_rs = ok_client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=202)
+    # TODO: Update to ok_client once access validation for getRecordSetChange endpoint has been updated to use canViewRecordSet
+    shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
 def test_delete_for_zone_admin_in_shared_zone_succeeds(shared_zone_test_context):
     """
-    Test that a zone admin not in owner group can delete a record in a shared zone
+    Test that a zone admin not in record owner group can delete a record in a shared zone
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     shared_zone = shared_zone_test_context.shared_zone

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -544,3 +544,12 @@ def clear_zoneid_rsid_tuple_list(to_delete, client):
             client.wait_until_recordset_change_status(change, 'Complete')
         except:
             pass
+
+def get_group_json(group_name, email="test@test.com", description="this is a description", members=[{ 'id': 'ok' }], admins=[{ 'id': 'ok' }]):
+    return {
+        'name': group_name,
+        'email': email,
+        'description': description,
+        'members': members,
+        'admins': admins
+    }

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -501,7 +501,7 @@ class RecordSetServiceIntegrationSpec
         Some(group2.id)
     }
 
-    "fail deleting for normal user not in owner group in shared zone" in {
+    "fail deleting for user not in record owner group in shared zone" in {
       val result = leftResultOf(
         testRecordSetService
           .deleteRecordSet(sharedTestRecord.id, sharedTestRecord.zoneId, dummyAuth)
@@ -511,7 +511,7 @@ class RecordSetServiceIntegrationSpec
       result shouldBe a[NotAuthorizedError]
     }
 
-    "fail deleting for normal user in owner group in non-shared zone" in {
+    "fail deleting for user in record owner group in non-shared zone" in {
       val result = leftResultOf(
         testRecordSetService
           .deleteRecordSet(
@@ -524,7 +524,7 @@ class RecordSetServiceIntegrationSpec
       result shouldBe a[NotAuthorizedError]
     }
 
-    "delete successfully for normal user in owner group in shared zone" in {
+    "delete successfully for user in record owner group in shared zone" in {
       val result = testRecordSetService
         .deleteRecordSet(sharedTestRecord.id, sharedTestRecord.zoneId, auth2)
         .value

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -68,16 +68,6 @@ object AccessValidations extends AccessValidationAlgebra {
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit] =
-    ensuring(
-      NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to delete " +
-        s"$recordName.${zone.name}"))(
-      getAccessLevel(auth, recordName, recordType, zone) == AccessLevel.Delete)
-
-  def canDeleteRecordSet(
-      auth: AuthPrincipal,
-      recordName: String,
-      recordType: RecordType,
       zone: Zone,
       recordOwnerGroupId: Option[String]): Either[Throwable, Unit] =
     ensuring(

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -74,6 +74,17 @@ object AccessValidations extends AccessValidationAlgebra {
         s"$recordName.${zone.name}"))(
       getAccessLevel(auth, recordName, recordType, zone) == AccessLevel.Delete)
 
+  def canDeleteRecordSet(
+      auth: AuthPrincipal,
+      recordName: String,
+      recordType: RecordType,
+      zone: Zone,
+      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] =
+    ensuring(
+      NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to delete " +
+        s"$recordName.${zone.name}"))(
+      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) == AccessLevel.Delete)
+
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
@@ -47,7 +47,8 @@ trait AccessValidationAlgebra {
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit]
+      zone: Zone): Either[Throwable, Unit] =
+    canDeleteRecordSet(auth, recordName, recordType, zone, None)
 
   def canDeleteRecordSet(
       auth: AuthPrincipal,

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
@@ -49,6 +49,13 @@ trait AccessValidationAlgebra {
       recordType: RecordType,
       zone: Zone): Either[Throwable, Unit]
 
+  def canDeleteRecordSet(
+      auth: AuthPrincipal,
+      recordName: String,
+      recordType: RecordType,
+      zone: Zone,
+      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
+
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -110,7 +110,7 @@ class RecordSetService(
       zone <- getZone(zoneId)
       existing <- getRecordSet(recordSetId, zone)
       _ <- isNotHighValueDomain(existing, zone).toResult
-      _ <- canDeleteRecordSet(auth, existing.name, existing.typ, zone).toResult
+      _ <- canDeleteRecordSet(auth, existing.name, existing.typ, zone, existing.ownerGroupId).toResult
       _ <- notPending(existing).toResult
       _ <- typeSpecificDeleteValidations(existing, zone).toResult
       change <- RecordSetChangeGenerator.forDelete(existing, zone, Some(auth)).toResult

--- a/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
@@ -319,18 +319,16 @@ class AccessValidationsSpec
     "return a NotAuthorizedError if the user has AccessLevel.NoAccess" in {
       val mockRecordSet = mock[RecordSet]
 
-      val error = leftValue(
-        accessValidationTest
-          .canDeleteRecordSet(userAuthNone, mockRecordSet.name, mockRecordSet.typ, zoneInNone))
+      val error = leftValue(accessValidationTest
+        .canDeleteRecordSet(userAuthNone, mockRecordSet.name, mockRecordSet.typ, zoneInNone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user has AccessLevel.Read" in {
       val mockRecordSet = mock[RecordSet]
 
-      val error = leftValue(
-        accessValidationTest
-          .canDeleteRecordSet(userAuthRead, mockRecordSet.name, mockRecordSet.typ, zoneInRead))
+      val error = leftValue(accessValidationTest
+        .canDeleteRecordSet(userAuthRead, mockRecordSet.name, mockRecordSet.typ, zoneInRead, None))
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -339,7 +337,12 @@ class AccessValidationsSpec
 
       val error = leftValue(
         accessValidationTest
-          .canDeleteRecordSet(userAuthWrite, mockRecordSet.name, mockRecordSet.typ, zoneInWrite))
+          .canDeleteRecordSet(
+            userAuthWrite,
+            mockRecordSet.name,
+            mockRecordSet.typ,
+            zoneInWrite,
+            None))
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -349,7 +352,8 @@ class AccessValidationsSpec
         userAuthDelete,
         mockRecordSet.name,
         mockRecordSet.typ,
-        zoneInDelete) should be(right)
+        zoneInDelete,
+        None) should be(right)
     }
 
     "return a NotAuthorizedError if the user is a test user in a non-test zone" in {
@@ -358,7 +362,7 @@ class AccessValidationsSpec
 
       val error = leftValue(
         accessValidationTest
-          .canDeleteRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, okZone))
+          .canDeleteRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, okZone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -368,7 +372,8 @@ class AccessValidationsSpec
       val zone = okZone.copy(isTest = true)
 
       accessValidationTest
-        .canDeleteRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, zone) should be(right)
+        .canDeleteRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, zone, None) should be(
+        right)
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -16,19 +16,20 @@
 
 package vinyldns.api.domain.record
 
+import cats.effect._
+import cats.scalatest.EitherMatchers
 import org.mockito.Matchers.any
 import org.mockito.Mockito.doReturn
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
-import vinyldns.api.domain.{AccessValidations, HighValueDomainError}
+import vinyldns.api.ResultHelpers
 import vinyldns.api.domain.record.RecordSetHelpers._
 import vinyldns.api.domain.zone._
+import vinyldns.api.domain.{AccessValidations, HighValueDomainError}
 import vinyldns.api.route.ListRecordSetsResponse
-import vinyldns.api.ResultHelpers
-import cats.effect._
 import vinyldns.core.TestMembershipData._
-import vinyldns.core.TestZoneData._
 import vinyldns.core.TestRecordSetData._
+import vinyldns.core.TestZoneData._
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{GroupRepository, ListUsersResults, UserRepository}
 import vinyldns.core.domain.record._
@@ -37,6 +38,7 @@ import vinyldns.core.queue.MessageQueue
 
 class RecordSetServiceSpec
     extends WordSpec
+    with EitherMatchers
     with Matchers
     with MockitoSugar
     with ResultHelpers
@@ -54,6 +56,9 @@ class RecordSetServiceSpec
     .when(mockZoneRepo)
     .getZone(zoneNotAuthorized.id)
   doReturn(IO.unit).when(mockMessageQueue).send(any[RecordSetChange])
+  doReturn(IO.pure(Some(sharedZoneRecord.copy(status = RecordSetStatus.Active))))
+    .when(mockRecordRepo)
+    .getRecordSet(sharedZoneRecord.zoneId, sharedZoneRecord.id)
 
   val underTest = new RecordSetService(
     mockZoneRepo,
@@ -531,6 +536,55 @@ class RecordSetServiceSpec
         leftResultOf(underTest.deleteRecordSet(record.id, okZone.id, okAuth).value)
       result shouldBe InvalidRequest(
         HighValueDomainError(s"high-value-domain.${okZone.name}").message)
+    }
+    "fail for normal user who is not in owner group in shared zone" in {
+      val result =
+        leftResultOf(
+          underTest.deleteRecordSet(sharedZoneRecord.id, sharedZoneRecord.zoneId, dummyAuth).value)
+
+      result shouldBe a[NotAuthorizedError]
+    }
+    "fail for normal user who is in owner group in non-shared zone" in {
+      doReturn(IO.pure(Some(sharedZone.copy(shared = false))))
+        .when(mockZoneRepo)
+        .getZone(sharedZone.id)
+
+      val result =
+        leftResultOf(
+          underTest.deleteRecordSet(sharedZoneRecord.id, sharedZoneRecord.zoneId, okAuth).value)
+
+      result shouldBe a[NotAuthorizedError]
+    }
+    "succeed for normal user in owner group in shared zone" in {
+      doReturn(IO.pure(Some(sharedZone)))
+        .when(mockZoneRepo)
+        .getZone(sharedZone.id)
+
+      val result =
+        underTest
+          .deleteRecordSet(sharedZoneRecord.id, sharedZoneRecord.zoneId, okAuth)
+          .value
+          .unsafeRunSync()
+
+      result should be(right)
+    }
+    "succeed for zone admin in shared zone" in {
+      val result =
+        underTest
+          .deleteRecordSet(sharedZoneRecord.id, sharedZoneRecord.zoneId, sharedAuth)
+          .value
+          .unsafeRunSync()
+
+      result should be(right)
+    }
+    "succeed for super user in shared zone" in {
+      val result =
+        underTest
+          .deleteRecordSet(sharedZoneRecord.id, sharedZoneRecord.zoneId, superUserAuth)
+          .value
+          .unsafeRunSync()
+
+      result should be(right)
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -537,14 +537,14 @@ class RecordSetServiceSpec
       result shouldBe InvalidRequest(
         HighValueDomainError(s"high-value-domain.${okZone.name}").message)
     }
-    "fail for normal user who is not in owner group in shared zone" in {
+    "fail for user who is not in record owner group in shared zone" in {
       val result =
         leftResultOf(
           underTest.deleteRecordSet(sharedZoneRecord.id, sharedZoneRecord.zoneId, dummyAuth).value)
 
       result shouldBe a[NotAuthorizedError]
     }
-    "fail for normal user who is in owner group in non-shared zone" in {
+    "fail for user who is in record owner group in non-shared zone" in {
       doReturn(IO.pure(Some(sharedZone.copy(shared = false))))
         .when(mockZoneRepo)
         .getZone(sharedZone.id)
@@ -555,7 +555,7 @@ class RecordSetServiceSpec
 
       result shouldBe a[NotAuthorizedError]
     }
-    "succeed for normal user in owner group in shared zone" in {
+    "succeed for user in record owner group in shared zone" in {
       doReturn(IO.pure(Some(sharedZone)))
         .when(mockZoneRepo)
         .getZone(sharedZone.id)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -47,17 +47,17 @@ class RecordSetValidationsSpec
     "validRecordTypes" should {
       "return invalid request when adding a PTR record to a forward zone" in {
         val error = leftValue(validRecordTypes(ptrIp4, okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return invalid request when adding a SRV record to an IP4 reverse zone" in {
         val error = leftValue(validRecordTypes(srv, zoneIp4))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return invalid request when adding a SRV record to an IP6 reverse zone" in {
         val error = leftValue(validRecordTypes(srv, zoneIp6))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return ok when adding an acceptable record to a forward zone" in {
@@ -81,7 +81,7 @@ class RecordSetValidationsSpec
       "return invalid request when zone name + record name > 256 characters" in {
         val rs = rsOk.copy(name = "a" * 256)
         val error = leftValue(validRecordNameLength(rs, okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
     }
 
@@ -126,25 +126,25 @@ class RecordSetValidationsSpec
     "isNotDotted" should {
       "return a failure for any record with dotted hosts in forward zones" in {
         val test = aaaa.copy(name = "this.is.a.failure.")
-        leftValue(isNotDotted(test, okZone)) shouldBe a[InvalidRequest]
+        leftValue(isNotDotted(test, okZone)) shouldBe an[InvalidRequest]
       }
 
       "return a failure for any record that is a dotted host ending in the zone name" in {
         val test = aaaa.copy(name = "this.is.a.failure." + okZone.name)
-        leftValue(isNotDotted(test, okZone)) shouldBe a[InvalidRequest]
+        leftValue(isNotDotted(test, okZone)) shouldBe an[InvalidRequest]
       }
 
       "return a failure for a dotted record name that matches a zone name except for a trailing period" in {
         val test = aaaa.copy(name = "boo.hoo.www.comcast.net")
         val zone = okZone.copy(name = "www.comcast.net.")
 
-        leftValue(isNotDotted(test, zone)) shouldBe a[InvalidRequest]
+        leftValue(isNotDotted(test, zone)) shouldBe an[InvalidRequest]
       }
 
       "return a failure for a dotted record name that matches a zone name when the record has a trailing period" in {
         val test = aaaa.copy(name = "boo.hoo.www.comcast.net.")
         val zone = okZone.copy(name = "www.comcast.net")
-        leftValue(isNotDotted(test, zone)) shouldBe a[InvalidRequest]
+        leftValue(isNotDotted(test, zone)) shouldBe an[InvalidRequest]
       }
 
       "return success for any record in a forward zone that is not a dotted host" in {
@@ -165,17 +165,17 @@ class RecordSetValidationsSpec
         "return a failure for any record with dotted hosts in forward zones" in {
           leftValue(
             typeSpecificAddValidations(dottedARecord, List(), okZone)
-          ) shouldBe a[InvalidRequest]
+          ) shouldBe an[InvalidRequest]
         }
         "return a failure for any record with dotted hosts in forward zones (CNAME)" in {
           leftValue(
             typeSpecificAddValidations(dottedARecord.copy(typ = CNAME), List(), okZone)
-          ) shouldBe a[InvalidRequest]
+          ) shouldBe an[InvalidRequest]
         }
         "return a failure for any record with dotted hosts in forward zones (NS)" in {
           leftValue(
             typeSpecificAddValidations(dottedARecord.copy(typ = NS), List(), okZone)
-          ) shouldBe a[InvalidRequest]
+          ) shouldBe an[InvalidRequest]
         }
       }
       "Skip dotted checks on SRV" should {
@@ -252,25 +252,25 @@ class RecordSetValidationsSpec
 
       "return an InvalidRequest if an NS record is '@'" in {
         val error = leftValue(nsValidations(invalidNsApexRs, okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if an NS record is the same as the zone" in {
         val invalid = invalidNsApexRs.copy(name = okZone.name)
         val error = leftValue(nsValidations(invalid, okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if the NS record being updated is '@'" in {
         val valid = invalidNsApexRs.copy(name = "this-is-not-origin-mate")
         val error = leftValue(nsValidations(valid, okZone, Some(invalidNsApexRs)))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if an NS record data is not in the approved server list" in {
         val ns = invalidNsApexRs.copy(records = List(NSData("not.approved.")))
         val error = leftValue(nsValidations(ns, okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
     }
 
@@ -285,12 +285,12 @@ class RecordSetValidationsSpec
       }
       "return an InvalidRequest if a cname record set name is '@'" in {
         val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is same as zone" in {
         val invalid = invalidCnameApexRs.copy(name = okZone.name)
         val error = leftValue(cnameValidations(invalid, List(), okZone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
     }
 
@@ -300,7 +300,7 @@ class RecordSetValidationsSpec
         val record = ptrIp4.copy(name = "252")
 
         val error = leftValue(isNotHighValueDomain(record, zone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return InvalidRequest if a ptr ip6 record matches a High Value Domain" in {
@@ -308,7 +308,7 @@ class RecordSetValidationsSpec
         val record = ptrIp6.copy(name = "f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0")
 
         val error = leftValue(isNotHighValueDomain(record, zone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return InvalidRequest if a non ptr record matches a High Value Domain" in {
@@ -316,7 +316,7 @@ class RecordSetValidationsSpec
         val record = aaaa.copy(name = "high-value-domain")
 
         val error = leftValue(isNotHighValueDomain(record, zone))
-        error shouldBe a[InvalidRequest]
+        error shouldBe an[InvalidRequest]
       }
 
       "return right if record is not a High Value Domain" in {


### PR DESCRIPTION
Pre-req for #342.

Changes in this pull request:
- Update `deleteRecordSet` validation to pass in owner group ID
- Update tests
