### PR TITLE
Karma config updates

### DIFF
--- a/modules/portal/Gruntfile.js
+++ b/modules/portal/Gruntfile.js
@@ -34,9 +34,9 @@ module.exports = function (grunt) {
                 files: {
                     'app/views/main.scala.html': [
                         'public/gentelella/vendors/jquery/dist/jquery.min.js',
-                        'public/javascripts/angular.min.js',
                         'public/gentelella/vendors/bootstrap/dist/js/bootstrap.min.js',
                         'public/javascripts/ui-bootstrap.min.js',
+                        'public/javascripts/angular.min.js',
                         'public/lib/**/*.module.js',
                         'public/lib/**/*.js',
                         'public/app.js',

--- a/modules/portal/app/views/main.scala.html
+++ b/modules/portal/app/views/main.scala.html
@@ -147,8 +147,8 @@
             <!-- START INJECTED DEPENDENCIES -->
             <!-- injector:js -->
             <script src="/public/gentelella/vendors/jquery/dist/jquery.min.js"></script>
-            <script src="/public/javascripts/angular.min.js"></script>
             <script src="/public/gentelella/vendors/bootstrap/dist/js/bootstrap.min.js"></script>
+            <script src="/public/javascripts/angular.min.js"></script>
             <script src="/public/lib/batch-change/batch-change.module.js"></script>
             <script src="/public/lib/batch-change/batch-change-detail.controller.js"></script>
             <script src="/public/lib/batch-change/batch-change-new.controller.js"></script>

--- a/modules/portal/karma.conf.js
+++ b/modules/portal/karma.conf.js
@@ -1,6 +1,9 @@
 // Karma configuration
 // http://karma-runner.github.io/0.10/config/configuration-file.html
 
+const puppeteer = require('puppeteer');
+process.env.CHROME_BIN = puppeteer.executablePath();
+
 module.exports = function(config) {
     config.set({
         // base path, that will be used to resolve files and exclude
@@ -11,9 +14,9 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-            'javascripts/jquery.min.js',
+            'gentelella/vendors/jquery/dist/jquery.min.js',
+            'gentelella/vendors/bootstrap/dist/js/bootstrap.min.js',
             'javascripts/angular.min.js',
-            'javascripts/*.min.js',
             'test_frameworks/*.js',
             'lib/services/**/*.js',
             'lib/controllers/**/*.js',
@@ -37,7 +40,7 @@ module.exports = function(config) {
         
         plugins: [
             'karma-jasmine',
-            'karma-phantomjs-launcher',
+            'karma-chrome-launcher',
             'karma-mocha-reporter'
         ],
 
@@ -61,7 +64,7 @@ module.exports = function(config) {
         // - Safari (only Mac)
         // - PhantomJS
         // - IE (only Windows)
-        browsers: ['PhantomJS'],
+        browsers: ['ChromeHeadless'],
 
         // Continuous Integration mode
         // if true, it capture browsers, run tests and exit

--- a/modules/portal/package.json
+++ b/modules/portal/package.json
@@ -19,7 +19,8 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-copy": "^0.1.0",
-    "grunt-injector": "^1.1.0"
+    "grunt-injector": "^1.1.0",
+    "puppeteer": "^1.11.0"
   },
   "devDependencies": {
     "angular-mocks": "1.6.1",
@@ -28,8 +29,8 @@
     "jasmine-core": "^2.99.1",
     "jasmine-jquery": "2.1.1",
     "jquery": "^3.3.1",
-    "karma": "^2.0.4",
-    "karma-chrome-launcher": "^1.0.1",
+    "karma": "^2.0.5",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.0.2",
     "karma-mocha-reporter": "^2.0.3",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -250,7 +250,7 @@ describe('Controller: RecordsController', function () {
     });
 
     it('isGroupMember returns true if user is a member of a given group', function() {
-        mockGroups = {data: { groups: [
+        this.scope.myGroups = [
             {id: "c8234503-bfda-4b80-897f-d74129051eaa",
                 name: "test",
                 email: "test@test.com",
@@ -258,16 +258,13 @@ describe('Controller: RecordsController', function () {
                 created: "2017-02-15T14:58:31Z",
                 members: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
                 status: "Active"}
-                ],
-            maxItems: 100}};
-
-        this.scope.myGroups = mockGroups.data.groups;
+                ]
 
         expect(this.scope.isGroupMember("c8234503-bfda-4b80-897f-d74129051eaa")).toBe(true);
     });
 
     it('isGroupMember returns true if user is a member of a given group', function() {
-        mockGroups = {data: { groups: [
+        this.scope.myGroups = [
             {id: "c8234503-bfda-4b80-897f-d74129051eaa",
                 name: "test",
                 email: "test@test.com",
@@ -275,10 +272,7 @@ describe('Controller: RecordsController', function () {
                 created: "2017-02-15T14:58:31Z",
                 members: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
                 status: "Active"}
-                ],
-            maxItems: 100}};
-
-        this.scope.myGroups = mockGroups.data.groups;
+                ]
 
         expect(this.scope.isGroupMember("fake")).toBe(false);
     });

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -249,4 +249,37 @@ describe('Controller: RecordsController', function () {
             [expectedZoneId, expectedMaxItems, expectedStartFrom, expectedQuery]);
     });
 
+    it('isGroupMember returns true if user is a member of a given group', function() {
+        mockGroups = {data: { groups: [
+            {id: "c8234503-bfda-4b80-897f-d74129051eaa",
+                name: "test",
+                email: "test@test.com",
+                admins: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                created: "2017-02-15T14:58:31Z",
+                members: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                status: "Active"}
+                ],
+            maxItems: 100}};
+
+        this.scope.myGroups = mockGroups.data.groups;
+
+        expect(this.scope.isGroupMember("c8234503-bfda-4b80-897f-d74129051eaa")).toBe(true);
+    });
+
+    it('isGroupMember returns true if user is a member of a given group', function() {
+        mockGroups = {data: { groups: [
+            {id: "c8234503-bfda-4b80-897f-d74129051eaa",
+                name: "test",
+                email: "test@test.com",
+                admins: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                created: "2017-02-15T14:58:31Z",
+                members: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                status: "Active"}
+                ],
+            maxItems: 100}};
+
+        this.scope.myGroups = mockGroups.data.groups;
+
+        expect(this.scope.isGroupMember("fake")).toBe(false);
+    });
 });


### PR DESCRIPTION
fixes #460 

Was working on some of the front end unit tests and realized PhantomJS doesn't support some functions we use like `find` that are part of ECMAScript2015 because it uses the IE browser https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Browser_compatibility. A long rabbit hole later:
 - I'm using ChromeHeadless instead of PhantomJS 
- had to rearrange the javascript files we pull in 
- had to downgrade the jquery version we use because the Gentellela template we use doesn't support the version we've been using. That weirdly only causes failures in tests 🤷🏽‍♀️ 


Testing steps:

1.  run `npm install`
2. run `grunt unit` from the `modules/portal` directory to run the unit tests