### PR TITLE
portal: add record owner group name to batch form

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -32,9 +32,22 @@
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <div class="form-group">
-                                <label class="h4">Description: </label>
+                                <label class="h5">Description: </label>
                                 <input type="text" class="form-control" ng-model="newBatch.comments">
                             </div>
+                            @if(meta.sharedDisplayEnabled) {
+                            <div class="form-group row">
+                                <div class="col-md-6">
+                                    <label class="h5" for="recordOwnerGroup">Record Owner Group</label>
+                                    <select class="form-control" id="recordOwnerGroup" ng-model="newBatch.ownerGroupId">
+                                        <option></option>
+                                        <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
+                                                ng-selected="updateZoneInfo.adminGroupName == group.name">
+                                            {{group.name}}</option>
+                                    </select>
+                                </div>
+                            </div>
+                            }
                         </div>
                         <div class="panel-body">
                             <h4>Changes</h4>
@@ -156,20 +169,6 @@
                             </table>
                             <button type="button" id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length == batchChangeLimit"><span class="fa fa-plus"></span> Add a Change</button>
                             <span ng-if="newBatch.changes.length == batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</span>
-                            @if(meta.sharedDisplayEnabled) {
-                                <div class="form-group">
-                                    &nbsp;
-                                </div>
-                                <div class="row col-md-6">
-                                    <label for="recordOwnerGroup">Record Owner Group</label>
-                                    <select class="form-control" id="recordOwnerGroup" ng-model="newBatch.ownerGroupId">
-                                        <option></option>
-                                        <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
-                                                ng-selected="updateZoneInfo.adminGroupName == group.name">
-                                            {{group.name}}</option>
-                                    </select>
-                                </div>
-                            }
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -1,4 +1,4 @@
-@(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks)
+@(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 
 @content = {
 <!-- PAGE CONTENT -->
@@ -156,6 +156,20 @@
                             </table>
                             <button type="button" id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length == batchChangeLimit"><span class="fa fa-plus"></span> Add a Change</button>
                             <span ng-if="newBatch.changes.length == batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</span>
+                            @if(meta.sharedDisplayEnabled) {
+                                <div class="form-group">
+                                    &nbsp;
+                                </div>
+                                <div class="row col-md-6">
+                                    <label for="recordOwnerGroup">Record Owner Group</label>
+                                    <select class="form-control" id="recordOwnerGroup" ng-model="newBatch.ownerGroupId">
+                                        <option></option>
+                                        <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
+                                                ng-selected="updateZoneInfo.adminGroupName == group.name">
+                                            {{group.name}}</option>
+                                    </select>
+                                </div>
+                            }
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -21,7 +21,7 @@
         .controller('BatchChangeNewController', function($scope, jsConfig, $log, $location, $timeout, batchChangeService, utilityService, groupsService){
             groupsService.getMyGroups()
                 .then(function (results) {
-                    $scope.myGroups = results['groups'];
+                    $scope.myGroups = results['data']['groups'];
                 })
                 .catch(function (error) {
                     handleError(error, 'groupsService::getMyGroups-failure');

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -19,15 +19,13 @@
 
     angular.module('batch-change')
         .controller('BatchChangeNewController', function($scope, jsConfig, $log, $location, $timeout, batchChangeService, utilityService, groupsService){
-            $scope.load = function(){
-                groupsService.getMyGroupsStored()
-                    .then(function (results) {
-                        $scope.myGroups = results['groups'];
-                    })
-                    .catch(function (error) {
-                        handleError(error, 'groupsService::getMyGroupsStored-failure');
-                    });
-            }
+            groupsService.getMyGroups()
+                .then(function (results) {
+                    $scope.myGroups = results['groups'];
+                })
+                .catch(function (error) {
+                    handleError(error, 'groupsService::getMyGroupsStored-failure');
+                });
 
             $scope.batch = {};
             $scope.newBatch = {comments: "", changes: [{changeType: "Add", type: "A", ttl: 200}]};

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -24,7 +24,7 @@
                     $scope.myGroups = results['groups'];
                 })
                 .catch(function (error) {
-                    handleError(error, 'groupsService::getMyGroupsStored-failure');
+                    handleError(error, 'groupsService::getMyGroups-failure');
                 });
 
             $scope.batch = {};

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -93,7 +93,5 @@
                 var alert = utilityService.failure(error, type);
                 $scope.alerts.push(alert);
             }
-
-            $timeout($scope.load, 0);
         });
 })();

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -19,12 +19,14 @@
 
     angular.module('batch-change')
         .controller('BatchChangeNewController', function($scope, jsConfig, $log, $location, $timeout, batchChangeService, utilityService, groupsService){
-
             $scope.load = function(){
-                groupsService.getMyGroupsStored().then(
-                    function (results) {
+                groupsService.getMyGroupsStored()
+                    .then(function (results) {
                         $scope.myGroups = results['groups'];
                     })
+                    .catch(function (error) {
+                        handleError(error, 'groupsService::getMyGroupsStored-failure');
+                    });
             }
 
             $scope.batch = {};

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -18,7 +18,14 @@
     'use strict';
 
     angular.module('batch-change')
-        .controller('BatchChangeNewController', function($scope, jsConfig, $log, $location, $timeout, batchChangeService, utilityService){
+        .controller('BatchChangeNewController', function($scope, jsConfig, $log, $location, $timeout, batchChangeService, utilityService, groupsService){
+
+            $scope.load = function(){
+                groupsService.getMyGroupsStored().then(
+                    function (results) {
+                        $scope.myGroups = results['groups'];
+                    })
+            }
 
             $scope.batch = {};
             $scope.newBatch = {comments: "", changes: [{changeType: "Add", type: "A", ttl: 200}]};
@@ -86,5 +93,7 @@
                 var alert = utilityService.failure(error, type);
                 $scope.alerts.push(alert);
             }
+
+            $timeout($scope.load, 0);
         });
 })();

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -96,7 +96,9 @@ describe('BatchChange', function(){
             spyOn(batchChangeService, 'createBatchChange').and.returnValue(deferred.promise);
             groupsService.getMyGroups = function() {
                 return $q.when({
-                    groups: "all my groups"
+                    data: {
+                        groups: "all my groups"
+                    }
                 });
             };
 

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -30,7 +30,7 @@ describe('BatchChange', function(){
             module('ngMock')
         });
 
-        beforeEach(inject(function ($rootScope, $controller, $q, batchChangeService, pagingService, utilityService, groupsService) {
+        beforeEach(inject(function ($rootScope, $controller, $q, batchChangeService, pagingService, utilityService) {
             this.rootScope = $rootScope;
             this.scope = $rootScope.$new();
             this.controller = $controller('BatchChangeDetailController', {'$scope': this.scope});
@@ -84,16 +84,29 @@ describe('BatchChange', function(){
             module('ngMock')
         });
 
-        beforeEach(inject(function ($rootScope, $controller, $q, batchChangeService, utilityService) {
+        beforeEach(inject(function ($rootScope, $controller, $q, batchChangeService, utilityService, groupsService) {
             this.rootScope = $rootScope;
             this.scope = $rootScope.$new();
+            this.groupsService = groupsService;
             this.scope.newBatch = {comments: "", changes: [{changeType: "Add", type: "A", ttl: 200}]};
-            this.controller = $controller('BatchChangeNewController', {'$scope': this.scope});
+            this.scope.myGroups = {};
 
             deferred = $q.defer();
 
             spyOn(batchChangeService, 'createBatchChange').and.returnValue(deferred.promise);
+            groupsService.getMyGroups = function() {
+                return $q.when({
+                    groups: "all my groups"
+                });
+            };
+
+            this.controller = $controller('BatchChangeNewController', {'$scope': this.scope});
         }));
+
+        it("test that we properly get user's groups when loading BatchChangeNewController", function(){
+            this.scope.$digest();
+            expect(this.scope.myGroups).toBe("all my groups");
+        });
 
         describe('$scope.addSingleChange', function() {
             it('adds a change to the changes array', function() {

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -19,7 +19,8 @@ describe('BatchChange', function(){
     beforeEach(function () {
         module('batch-change'),
         module('service.utility'),
-        module('service.paging')
+        module('service.paging'),
+        module('service.groups')
     });
 
     var deferred;
@@ -29,7 +30,7 @@ describe('BatchChange', function(){
             module('ngMock')
         });
 
-        beforeEach(inject(function ($rootScope, $controller, $q, batchChangeService, pagingService, utilityService) {
+        beforeEach(inject(function ($rootScope, $controller, $q, batchChangeService, pagingService, utilityService, groupsService) {
             this.rootScope = $rootScope;
             this.scope = $rootScope.$new();
             this.controller = $controller('BatchChangeDetailController', {'$scope': this.scope});


### PR DESCRIPTION
Fixes #343 .

Changes in this pull request:
- add drop down menu in the batch change form to select the record owner group that will be applied to new and unowned records in shared zones 
- this is in the feature flag so `shared-display-enabled = true` should be added to local.conf or reference.conf to view
- we aren't adding an messaging around the field at this time, we'll do all the portal messaging in a separate issue/pr.
- batch change validations aren't merged in yet so the batch change will be accepted whether the owner group is set or not
