### PR TITLE
Batch change owner group validations

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2777,9 +2777,9 @@ def test_create_batch_change_validation_without_owner_group_id(shared_zone_test_
             delete_result = shared_client.delete_recordset(shared_zone['id'], rsId, status=202)
             shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
-def test_create_batch_delete_record_for_normal_user_in_owner_group_succeeds(shared_zone_test_context):
+def test_create_batch_delete_record_for_unassociated_user_in_owner_group_succeeds(shared_zone_test_context):
     """
-    Test delete change in batch for a record in a shared zone for a normal user belonging to the record owner group succeeds
+    Test delete change in batch for a record in a shared zone for an unassociated user belonging to the record owner group succeeds
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     ok_client = shared_zone_test_context.ok_vinyldns_client
@@ -2803,9 +2803,9 @@ def test_create_batch_delete_record_for_normal_user_in_owner_group_succeeds(shar
     assert_change_success_response_values(completed_batch['changes'], zone=shared_zone, index=0, record_name="shared-delete",
                                           input_name="shared-delete.shared.", record_data=None, change_type="DeleteRecordSet")
 
-def test_create_batch_delete_record_for_normal_user_not_in_owner_group_fails(shared_zone_test_context):
+def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fails(shared_zone_test_context):
     """
-    Test delete change in batch for a record in a shared zone for a normal user not belonging to the record owner group fails
+    Test delete change in batch for a record in a shared zone for an unassociated user not belonging to the record owner group fails
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     dummy_client = shared_zone_test_context.dummy_vinyldns_client

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2410,7 +2410,8 @@ def test_user_validation_ownership(shared_zone_test_context):
             get_change_A_AAAA_json("update-test-batch.shared.", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json("update-test-batch.shared.", address="1.1.1.1"),
             get_change_A_AAAA_json("delete-test-batch.shared.", change_type="DeleteRecordSet"),
-        ]
+        ],
+        "ownerGroupId": "shared-zone-group"
     }
 
     response = client.create_batch_change(batch_change_input, status=400)
@@ -2441,7 +2442,8 @@ def test_user_validation_shared(shared_zone_test_context):
             get_change_A_AAAA_json("update-test-batch.non.test.shared.", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json("update-test-batch.non.test.shared.", address="1.1.1.1"),
             get_change_A_AAAA_json("delete-test-batch.non.test.shared.", change_type="DeleteRecordSet")
-        ]
+        ],
+        "ownerGroupId": shared_zone_test_context.ok_group['id']
     }
 
     response = client.create_batch_change(batch_change_input, status=400)

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1427,7 +1427,8 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=["Record \"delete-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="update-nonexistent.ok.", record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="AAAA", record_data="1::1",)
+        assert_failed_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="AAAA", record_data="1::1",
+                                               error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[11], input_name="delete-unauthorized.dummy.", record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["User \"ok\" is not authorized."])
         assert_failed_change_in_error_response(response[12], input_name="update-unauthorized.dummy.", record_type="AAAA", record_data="1::1",
@@ -1649,7 +1650,8 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=['Record "non-existent-delete.ok." Does Not Exist: cannot delete a record that does not exist.'])
         assert_failed_change_in_error_response(response[11], input_name="non-existent-update.ok.", record_type="CNAME", change_type="DeleteRecordSet",
                                                error_messages=['Record "non-existent-update.ok." Does Not Exist: cannot delete a record that does not exist.'])
-        assert_successful_change_in_error_response(response[12], input_name="non-existent-update.ok.", record_type="CNAME", record_data="test.com.")
+        assert_failed_change_in_error_response(response[12], input_name="non-existent-update.ok.", record_type="CNAME", record_data="test.com.",
+                                               error_messages=['Record "non-existent-update.ok." Does Not Exist: cannot delete a record that does not exist.'])
         assert_failed_change_in_error_response(response[13], input_name="delete-unauthorized.dummy.", record_type="CNAME", change_type="DeleteRecordSet",
                                                error_messages=['User "ok" is not authorized.'])
         assert_failed_change_in_error_response(response[14], input_name="update-unauthorized.dummy.", record_type="CNAME", change_type="DeleteRecordSet",
@@ -1893,7 +1895,8 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist
         assert_failed_change_in_error_response(response[11], input_name="192.0.2.199", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"192.0.2.199\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[12], ttl=300, input_name="192.0.2.200", record_type="PTR", record_data="has-updated.ptr.")
+        assert_failed_change_in_error_response(response[12], ttl=300, input_name="192.0.2.200", record_type="PTR", record_data="has-updated.ptr.",
+                                                   error_messages=["Record \"192.0.2.200\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[13], input_name="192.0.2.200", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"192.0.2.200\" Does Not Exist: cannot delete a record that does not exist."])
 
@@ -2040,7 +2043,8 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist, failure on update with double add
         assert_failed_change_in_error_response(response[7], input_name="fd69:27cc:fe91::60", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"fd69:27cc:fe91::60\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[8], ttl=300, input_name="fd69:27cc:fe91::65", record_type="PTR", record_data="has-updated.ptr.")
+        assert_failed_change_in_error_response(response[8], ttl=300, input_name="fd69:27cc:fe91::65", record_type="PTR", record_data="has-updated.ptr.",
+                                                   error_messages=["Record \"fd69:27cc:fe91::65\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="fd69:27cc:fe91::65", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"fd69:27cc:fe91::65\" Does Not Exist: cannot delete a record that does not exist."])
         assert_successful_change_in_error_response(response[10], input_name="fd69:27cc:fe91::1122", record_type="PTR", change_type="DeleteRecordSet")
@@ -2203,7 +2207,8 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=["Record \"delete-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[7], input_name="update-nonexistent.ok.", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[8], input_name="update-nonexistent.ok.", record_type="TXT", record_data="test",)
+        assert_failed_change_in_error_response(response[8], input_name="update-nonexistent.ok.", record_type="TXT", record_data="test",
+                                               error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="delete-unauthorized.dummy.", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["User \"ok\" is not authorized."])
         assert_failed_change_in_error_response(response[10], input_name="update-unauthorized.dummy.", record_type="TXT", record_data="test",
@@ -2378,7 +2383,8 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=["Record \"delete-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="update-nonexistent.ok.", record_type="MX", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="MX", record_data={"preference": 1000, "exchange": "foo.bar."},)
+        assert_failed_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="MX", record_data={"preference": 1000, "exchange": "foo.bar."},
+                                               error_messages=['Record "update-nonexistent.ok." Does Not Exist: cannot delete a record that does not exist.'])
         assert_failed_change_in_error_response(response[11], input_name="delete-unauthorized.dummy.", record_type="MX", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["User \"ok\" is not authorized."])
         assert_failed_change_in_error_response(response[12], input_name="update-unauthorized.dummy.", record_type="MX", record_data={"preference": 1000, "exchange": "foo.bar."},
@@ -2859,3 +2865,39 @@ def test_create_batch_delete_record_for_zone_admin_not_in_owner_group_succeeds(s
 
     assert_change_success_response_values(completed_batch['changes'], zone=shared_zone, index=0, record_name="shared-delete",
                                           input_name="shared-delete.shared.", record_data=None, change_type="DeleteRecordSet")
+
+def test_create_batch_update_record_in_shared_zone_for_unassociated_user_in_owner_group_succeeds(shared_zone_test_context):
+    """
+    Test update change in batch for a record for a user belonging to record owner group succeeds
+    """
+    shared_client = shared_zone_test_context.shared_zone_vinyldns_client
+    ok_client = shared_zone_test_context.ok_vinyldns_client
+    shared_zone = shared_zone_test_context.shared_zone
+    shared_record_group = shared_zone_test_context.shared_record_group
+    create_rs = None
+
+    shared_update = get_recordset_json(shared_zone, "mx", "MX", [{"preference": 1, "exchange": "foo.bar."}], 200, shared_record_group['id'])
+
+    batch_change_input = {
+        "changes": [
+            get_change_MX_json("mx.shared.", ttl=300),
+            get_change_MX_json("mx.shared.", change_type="DeleteRecordSet")
+        ]
+    }
+
+    try:
+        create_rs = shared_client.create_recordset(shared_update, status=202)
+        shared_client.wait_until_recordset_change_status(create_rs, 'Complete')
+
+        result = ok_client.create_batch_change(batch_change_input, status=202)
+        completed_batch = ok_client.wait_until_batch_change_completed(result)
+
+        assert_change_success_response_values(completed_batch['changes'], zone=shared_zone, index=0, record_name="mx", ttl=300,
+                                              record_type="MX", input_name="mx.shared.", record_data={'preference': 1, 'exchange': 'foo.bar.'})
+        assert_change_success_response_values(completed_batch['changes'], zone=shared_zone, index=1, record_name="mx",
+                                              record_type="MX", input_name="mx.shared.", record_data=None, change_type="DeleteRecordSet")
+
+    finally:
+        if create_rs:
+            delete_rs = shared_client.delete_recordset(shared_zone['id'], create_rs['recordSet']['id'], status=202)
+            shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1853,6 +1853,26 @@ def test_create_with_owner_group_in_shared_zone_by_acl_passes(shared_zone_test_c
             delete_result = shared_zone_test_context.shared_zone_vinyldns_client.delete_recordset(zone['id'], create_rs['id'], status=202)
             shared_zone_test_context.shared_zone_vinyldns_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
+def test_create_in_shared_zone_without_owner_group_id_succeeds(shared_zone_test_context):
+    """
+    Test that creating a record in a shared zone without and owner group ID specified succeeds
+    """
+    dummy_client = shared_zone_test_context.dummy_vinyldns_client
+    shared_client = shared_zone_test_context.shared_zone_vinyldns_client
+    zone = shared_zone_test_context.shared_zone
+    create_rs = None
+
+    record_json = get_recordset_json(zone, 'test_shared_no_owner_group', 'A', [{'address': '1.1.1.1'}])
+
+    try:
+        create_response = dummy_client.create_recordset(record_json, status=202)
+        create_rs = shared_client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
+        assert_that(create_rs, is_not(has_key('ownerGroupId')))
+
+    finally:
+        if create_rs:
+            delete_result = dummy_client.delete_recordset(create_rs['zoneId'], create_rs['id'], status=202)
+            shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 def test_create_in_shared_zone_by_unassociated_user_succeeds(shared_zone_test_context):
     """

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1855,7 +1855,7 @@ def test_create_with_owner_group_in_shared_zone_by_acl_passes(shared_zone_test_c
 
 def test_create_in_shared_zone_without_owner_group_id_succeeds(shared_zone_test_context):
     """
-    Test that creating a record in a shared zone without and owner group ID specified succeeds
+    Test that creating a record in a shared zone without an owner group ID specified succeeds
     """
     dummy_client = shared_zone_test_context.dummy_vinyldns_client
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
@@ -1876,7 +1876,7 @@ def test_create_in_shared_zone_without_owner_group_id_succeeds(shared_zone_test_
 
 def test_create_in_shared_zone_by_unassociated_user_succeeds(shared_zone_test_context):
     """
-    Test that creating a record in a shared zone by a normal user succeeds
+    Test that creating a record in a shared zone by an unassociated user succeeds
     """
 
     dummy_client = shared_zone_test_context.dummy_vinyldns_client

--- a/modules/api/functional_test/live_tests/recordsets/get_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/get_recordset_test.py
@@ -160,7 +160,7 @@ def test_get_recordset_from_shared_zone(shared_zone_test_context):
 
 def test_get_unowned_recordset_from_shared_zone(shared_zone_test_context):
     """
-    Test getting an unowned recordset with no admin rights fails
+    Test getting an unowned recordset with no admin rights succeeds
     """
     client = shared_zone_test_context.shared_zone_vinyldns_client
     result_rs = None
@@ -173,7 +173,7 @@ def test_get_unowned_recordset_from_shared_zone(shared_zone_test_context):
 
         # Get the recordset we just made and verify
         ok_client = shared_zone_test_context.ok_vinyldns_client
-        ok_client.get_recordset(result_rs['zoneId'], result_rs['id'], status=403)
+        ok_client.get_recordset(result_rs['zoneId'], result_rs['id'], status=200)
 
     finally:
         if result_rs:

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -2087,7 +2087,7 @@ def test_update_owner_group_from_admin_in_shared_zone_passes(shared_zone_test_co
 
 def test_update_from_unassociated_user_in_shared_zone_succeeds(shared_zone_test_context):
     """
-    Test that normal user updating record without existing owner group ID in shared zone succeeds
+    Test that an unassociated user updating record without existing owner group ID in shared zone succeeds
     """
 
     ok_client = shared_zone_test_context.ok_vinyldns_client

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -2085,9 +2085,9 @@ def test_update_owner_group_from_admin_in_shared_zone_passes(shared_zone_test_co
             shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
-def test_update_from_unassociated_user_in_shared_zone_fails(shared_zone_test_context):
+def test_update_from_unassociated_user_in_shared_zone_succeeds(shared_zone_test_context):
     """
-    Test that updating with a user that does not have write access fails in a shared zone
+    Test that normal user updating record without existing owner group ID in shared zone succeeds
     """
 
     ok_client = shared_zone_test_context.ok_vinyldns_client
@@ -2103,8 +2103,9 @@ def test_update_from_unassociated_user_in_shared_zone_fails(shared_zone_test_con
 
         update = create_rs
         update['ttl'] = update['ttl'] + 100
-        error = ok_client.update_recordset(update, status=403)
-        assert_that(error, is_('User ok does not have access to update test-shared-success.shared.'))
+        update_response = ok_client.update_recordset(update, status=202)
+        update_rs = shared_client.wait_until_recordset_change_status(update_response, 'Complete')
+        assert_that(update_rs, is_not(has_key('ownerGroupId')))
 
     finally:
         if create_rs:

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -75,17 +75,6 @@ object AccessValidations extends AccessValidationAlgebra {
         s"$recordName.${zone.name}"))(
       getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) == AccessLevel.Delete)
 
-  def canDeleteRecordSet(
-      auth: AuthPrincipal,
-      recordName: String,
-      recordType: RecordType,
-      zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] =
-    ensuring(
-      NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to delete " +
-        s"$recordName.${zone.name}"))(
-      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) == AccessLevel.Delete)
-
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -75,6 +75,17 @@ object AccessValidations extends AccessValidationAlgebra {
         s"$recordName.${zone.name}"))(
       getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) == AccessLevel.Delete)
 
+  def canDeleteRecordSet(
+      auth: AuthPrincipal,
+      recordName: String,
+      recordType: RecordType,
+      zone: Zone,
+      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] =
+    ensuring(
+      NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to delete " +
+        s"$recordName.${zone.name}"))(
+      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) == AccessLevel.Delete)
+
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -184,7 +184,7 @@ object AccessValidations extends AccessValidationAlgebra {
     case testUser if testUser.isTestUser && !zone.isTest => AccessLevel.NoAccess
     case admin if admin.canEditAll || admin.isGroupMember(zone.adminGroupId) =>
       AccessLevel.Delete
-    case recordOwner if zone.shared && recordOwnerGroupId.exists(recordOwner.isGroupMember) =>
+    case recordOwner if zone.shared && recordOwnerGroupId.forall(recordOwner.isGroupMember) =>
       AccessLevel.Delete
     case supportUser if supportUser.canReadAll =>
       val aclAccess = getAccessFromAcl(auth, recordName, recordType, zone)

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
@@ -47,20 +47,6 @@ trait AccessValidationAlgebra {
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit] =
-    canDeleteRecordSet(auth, recordName, recordType, zone, None)
-
-  def canDeleteRecordSet(
-      auth: AuthPrincipal,
-      recordName: String,
-      recordType: RecordType,
-      zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
-
-  def canDeleteRecordSet(
-      auth: AuthPrincipal,
-      recordName: String,
-      recordType: RecordType,
       zone: Zone,
       recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidationsAlgebra.scala
@@ -57,6 +57,13 @@ trait AccessValidationAlgebra {
       zone: Zone,
       recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
 
+  def canDeleteRecordSet(
+      auth: AuthPrincipal,
+      recordName: String,
+      recordType: RecordType,
+      zone: Zone,
+      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
+
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -123,8 +123,8 @@ final case class CnameIsNotUniqueError(name: String, typ: RecordType)
       s"""Existing record with name "$name" and type "$typ" conflicts with this record."""
 }
 
-final case class UserIsNotAuthorized(user: String) extends DomainValidationError {
-  def message: String = s"""User "$user" is not authorized."""
+final case class UserIsNotAuthorized(userId: String) extends DomainValidationError {
+  def message: String = s"""User "$userId" is not authorized."""
 }
 
 final case class RecordNameNotUniqueInBatch(name: String, typ: RecordType)

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -143,4 +143,10 @@ final case class HighValueDomainError(name: String) extends DomainValidationErro
   def message: String =
     s"""Record name "$name" is configured as a High Value Domain, so it cannot be modified."""
 }
+
+final case class MissingOwnerGroupId(recordName: String, zoneName: String)
+    extends DomainValidationError {
+  def message: String =
+    s"""Zone "$zoneName" is a shared zone, so owner group ID must be specified for record "$recordName"."""
+}
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -123,8 +123,8 @@ final case class CnameIsNotUniqueError(name: String, typ: RecordType)
       s"""Existing record with name "$name" and type "$typ" conflicts with this record."""
 }
 
-final case class UserIsNotAuthorized(userId: String) extends DomainValidationError {
-  def message: String = s"""User "$userId" is not authorized."""
+final case class UserIsNotAuthorized(userName: String) extends DomainValidationError {
+  def message: String = s"""User "$userName" is not authorized."""
 }
 
 final case class RecordNameNotUniqueInBatch(name: String, typ: RecordType)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -70,7 +70,11 @@ class BatchChangeService(
       zoneMap <- getZonesForRequest(inputValidatedSingleChanges).toBatchResult
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)
       recordSets <- getExistingRecordSets(changesWithZones).toBatchResult
-      validatedSingleChanges = validateChangesWithContext(changesWithZones, recordSets, auth)
+      validatedSingleChanges = validateChangesWithContext(
+        changesWithZones,
+        recordSets,
+        auth,
+        batchChangeInput.ownerGroupId)
       changeForConversion <- buildResponse(batchChangeInput, validatedSingleChanges, auth).toBatchResult
       conversionResult <- batchChangeConverter.sendBatchForProcessing(
         changeForConversion,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -198,8 +198,7 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
       case _ => ().validNel
     }
 
-    val validations = typedValidations |+|
-      userCanUpdateRecordSet(change, auth, batchOwnerGroupId) |+|
+    val validations = typedValidations |+| userCanAddRecordSet(change, auth) |+|
       ownerGroupProvidedIfNeeded(
         change,
         existingRecordSets.get(change.zone.id, change.recordName, change.inputChange.typ),

--- a/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/AccessValidationsSpec.scala
@@ -490,6 +490,18 @@ class AccessValidationsSpec
       result shouldBe AccessLevel.Delete
     }
 
+    "return AccessLevel.Delete if the record is unowned and the zone is shared" in {
+      val recordOwnerAuth = AuthPrincipal(dummyUser.copy(isSupport = true), Seq())
+      val result =
+        accessValidationTest.getAccessLevel(
+          recordOwnerAuth,
+          sharedZoneRecordNoOwnerGroup.name,
+          sharedZoneRecordNoOwnerGroup.typ,
+          sharedZone,
+          sharedZoneRecordNoOwnerGroup.ownerGroupId)
+      result shouldBe AccessLevel.Delete
+    }
+
     "return the result of getAccessLevel if the user is a record owner but zone is not shared" in {
       val result =
         accessValidationTest.getAccessLevel(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -502,7 +502,8 @@ class BatchChangeValidationsSpec
 
   property(
     "validateChangesWithContext: should fail for update if user does not have sufficient access") {
-    val readAcl = ACLRule(accessLevel = AccessLevel.Read, userId = Some(notAuth.userId))
+    val readAcl =
+      ACLRule(accessLevel = AccessLevel.Read, userId = Some(notAuth.signedInUser.userName))
     val existingRecord = rsOk.copy(zoneId = okZone.id, name = "update", ttl = 300)
     val addUpdateA = AddChangeForValidation(
       okZone.addACLRule(readAcl),
@@ -518,8 +519,10 @@ class BatchChangeValidationsSpec
       notAuth,
       None)
 
-    result(0) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
-    result(1) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
+    result(0) should haveInvalid[DomainValidationError](
+      UserIsNotAuthorized(notAuth.signedInUser.userName))
+    result(1) should haveInvalid[DomainValidationError](
+      UserIsNotAuthorized(notAuth.signedInUser.userName))
   }
 
   property("validateChangesWithContext: should fail for update if record does not exist") {
@@ -881,7 +884,8 @@ class BatchChangeValidationsSpec
           notAuth,
           None)
 
-      result(0) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
+      result(0) should haveInvalid[DomainValidationError](
+        UserIsNotAuthorized(notAuth.signedInUser.userName))
     }
   }
 
@@ -1017,7 +1021,8 @@ class BatchChangeValidationsSpec
       notAuth,
       None)
 
-    result(0) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
+    result(0) should haveInvalid[DomainValidationError](
+      UserIsNotAuthorized(notAuth.signedInUser.userName))
   }
 
   property("""validateChangesWithContext: should properly process batch that contains
@@ -1531,7 +1536,7 @@ class BatchChangeValidationsSpec
       None)
 
     result(0) should
-      haveInvalid[DomainValidationError](UserIsNotAuthorized(dummyAuth.signedInUser.id))
+      haveInvalid[DomainValidationError](UserIsNotAuthorized(dummyAuth.signedInUser.userName))
   }
 
   property(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -402,7 +402,8 @@ class BatchChangeValidationsSpec
         duplicateNameCname.validNel,
         duplicateNamePTR.validNel),
       ExistingRecordSets(existingRsList),
-      okAuth
+      okAuth,
+      None
     )
 
     result(0) shouldBe valid
@@ -429,7 +430,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -449,7 +451,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
-      notAuth)
+      notAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -470,7 +473,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
-      notAuth)
+      notAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
     result(1) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
@@ -488,7 +492,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) should haveInvalid[DomainValidationError](
@@ -509,7 +514,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addA.validNel, deleteCname.validNel),
       ExistingRecordSets(List(existingCname)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -528,7 +534,8 @@ class BatchChangeValidationsSpec
         val result = validateChangesWithContext(
           List(input.validNel),
           ExistingRecordSets(newRecordSetList),
-          okAuth)
+          okAuth,
+          None)
 
         result(0) should haveInvalid[DomainValidationError](
           CnameIsNotUniqueError(input.inputChange.inputName, RecordType.CNAME))
@@ -539,7 +546,11 @@ class BatchChangeValidationsSpec
   property("validateChangesWithContext: should succeed if all inputs are good") {
     forAll(validAddChangeForValidationGen) { input: AddChangeForValidation =>
       val result =
-        validateChangesWithContext(List(input.validNel), ExistingRecordSets(recordSetList), okAuth)
+        validateChangesWithContext(
+          List(input.validNel),
+          ExistingRecordSets(recordSetList),
+          okAuth,
+          None)
 
       result(0) shouldBe valid
     }
@@ -552,7 +563,8 @@ class BatchChangeValidationsSpec
         val result = validateChangesWithContext(
           List(input.validNel),
           ExistingRecordSets(recordSetList),
-          okAuth)
+          okAuth,
+          None)
         result(0) shouldBe valid
       }
     }
@@ -567,7 +579,8 @@ class BatchChangeValidationsSpec
       val result = validateChangesWithContext(
         List(input.validNel),
         ExistingRecordSets(existingRecordSetList),
-        okAuth)
+        okAuth,
+        None)
 
       result(0) should haveInvalid[DomainValidationError](
         RecordAlreadyExists(input.inputChange.inputName))
@@ -589,7 +602,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addCname.validNel, deleteA.validNel),
       ExistingRecordSets(newRecordSetList),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -606,7 +620,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addCname.validNel),
       ExistingRecordSets(newRecordSetList),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](
       CnameIsNotUniqueError(addCname.inputChange.inputName, existingA.typ))
@@ -631,7 +646,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addCname.validNel, deletePtr.validNel),
       ExistingRecordSets(List(existingRecordPTR)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -652,7 +668,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addCname.validNel),
       ExistingRecordSets(List(existingRecordPTR)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](
       CnameIsNotUniqueError(addCname.inputChange.inputName, existingRecordPTR.typ))
@@ -675,7 +692,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addA.validNel, addAAAA.validNel, addCname.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -699,7 +717,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addA.validNel, addAAAA.validNel, addDuplicateCname.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) shouldBe valid
@@ -726,7 +745,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addA.validNel, addCname.validNel, addDuplicateCname.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) should haveInvalid[DomainValidationError](
@@ -754,7 +774,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addA.validNel, addPtr.validNel, addDuplicatePtr.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result.map(_ shouldBe valid)
   }
@@ -766,7 +787,11 @@ class BatchChangeValidationsSpec
       "valid",
       AddChangeInput("valid.ok.", RecordType.A, 30, AData("1.1.1.1")))
     val result =
-      validateChangesWithContext(List(addA.validNel), ExistingRecordSets(recordSetList), okAuth)
+      validateChangesWithContext(
+        List(addA.validNel),
+        ExistingRecordSets(recordSetList),
+        okAuth,
+        None)
 
     result(0) shouldBe valid
   }
@@ -780,7 +805,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addA.validNel),
       ExistingRecordSets(recordSetList),
-      AuthPrincipal(superUser, Seq.empty))
+      AuthPrincipal(superUser, Seq.empty),
+      None)
 
     result(0) shouldBe valid
   }
@@ -793,7 +819,11 @@ class BatchChangeValidationsSpec
       AddChangeInput("valid.ok.", RecordType.A, 30, AData("1.1.1.1"))
     )
     val result =
-      validateChangesWithContext(List(addA.validNel), ExistingRecordSets(recordSetList), notAuth)
+      validateChangesWithContext(
+        List(addA.validNel),
+        ExistingRecordSets(recordSetList),
+        notAuth,
+        None)
 
     result(0) shouldBe valid
   }
@@ -803,7 +833,11 @@ class BatchChangeValidationsSpec
       |is not a superuser, doesn't have group admin access, or doesn't have necessary ACL rule""".stripMargin) {
     forAll(validAddChangeForValidationGen) { input: AddChangeForValidation =>
       val result =
-        validateChangesWithContext(List(input.validNel), ExistingRecordSets(recordSetList), notAuth)
+        validateChangesWithContext(
+          List(input.validNel),
+          ExistingRecordSets(recordSetList),
+          notAuth,
+          None)
 
       result(0) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
     }
@@ -822,7 +856,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addCname.validNel, addPtr.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](
       RecordNameNotUniqueInBatch("existing.ok.", RecordType.CNAME))
@@ -839,7 +874,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel),
       ExistingRecordSets(List(existingDeleteRecord)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
   }
@@ -852,7 +888,11 @@ class BatchChangeValidationsSpec
       "record-does-not-exist",
       DeleteChangeInput("record-does-not-exist.ok.", RecordType.A))
     val result =
-      validateChangesWithContext(List(deleteA.validNel), ExistingRecordSets(recordSetList), okAuth)
+      validateChangesWithContext(
+        List(deleteA.validNel),
+        ExistingRecordSets(recordSetList),
+        okAuth,
+        None)
 
     result(0) should haveInvalid[DomainValidationError](
       RecordDoesNotExist(deleteA.inputChange.inputName))
@@ -871,7 +911,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel),
       ExistingRecordSets(List(existingDeleteRecord)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
   }
@@ -884,7 +925,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel),
       ExistingRecordSets(List(existingDeleteRecord)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
   }
@@ -897,7 +939,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel),
       ExistingRecordSets(List(existingDeleteRecord)),
-      AuthPrincipal(superUser, Seq.empty))
+      AuthPrincipal(superUser, Seq.empty),
+      None)
     result(0) shouldBe valid
   }
 
@@ -912,7 +955,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel),
       ExistingRecordSets(List(existingDeleteRecord)),
-      notAuth)
+      notAuth,
+      None)
 
     result(0) shouldBe valid
   }
@@ -928,7 +972,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel),
       ExistingRecordSets(List(existingDeleteRecord)),
-      notAuth)
+      notAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](UserIsNotAuthorized(notAuth.userId))
   }
@@ -970,7 +1015,8 @@ class BatchChangeValidationsSpec
         addA.validNel,
         deleteCname.validNel),
       ExistingRecordSets(List(existingA, existingCname)),
-      okAuth
+      okAuth,
+      None
     )
 
     result(0) shouldBe valid
@@ -1006,7 +1052,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteA.validNel, addA.validNel, addAAAA.validNel, addCname.validNel, addPtr.validNel),
       ExistingRecordSets(List(existingA)),
-      okAuth)
+      okAuth,
+      None)
     result.map(_ shouldBe valid)
   }
 
@@ -1033,7 +1080,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteCname.validNel, addA.validNel, addAAAA.validNel, addPtr.validNel),
       ExistingRecordSets(List(existingCname)),
-      okAuth)
+      okAuth,
+      None)
     result.map(_ shouldBe valid)
   }
 
@@ -1051,7 +1099,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteCname.validNel, addCname.validNel),
       ExistingRecordSets(List(existingCname)),
-      okAuth)
+      okAuth,
+      None)
     result.map(_ shouldBe valid)
   }
 
@@ -1078,7 +1127,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteUpdateCname.validNel, addUpdateCname.validNel, addCname.validNel),
       ExistingRecordSets(List(existingCname)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
     result(1) should haveInvalid[DomainValidationError](
@@ -1106,7 +1156,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deletePtr.validNel, addCname.validNel),
       ExistingRecordSets(List(existingPtr)),
-      okAuth)
+      okAuth,
+      None)
     result.map(_ shouldBe valid)
   }
 
@@ -1129,7 +1180,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deletePtr.validNel, addPtr.validNel),
       ExistingRecordSets(List(existingPtr)),
-      okAuth)
+      okAuth,
+      None)
     result.map(_ shouldBe valid)
   }
 
@@ -1156,7 +1208,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteUpdatePtr.validNel, addUpdatePtr.validNel, addPtr.validNel),
       ExistingRecordSets(List(existingPtr)),
-      okAuth)
+      okAuth,
+      None)
 
     result.map(_ shouldBe valid)
   }
@@ -1196,7 +1249,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addTxt.validNel),
       ExistingRecordSets(List(existingTxt)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](RecordAlreadyExists("name-conflict."))
   }
@@ -1214,7 +1268,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addTxt.validNel, addTxt2.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](
       RecordNameNotUniqueInBatch("name-conflict.", RecordType.TXT))
@@ -1239,7 +1294,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addTxt.validNel, addTxt2.validNel),
       ExistingRecordSets(List(existingTxt)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) should haveInvalid[DomainValidationError](
       RecordNameNotUniqueInBatch("name-conflict.", RecordType.TXT))
@@ -1264,7 +1320,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addTxt.validNel, addTxt2.validNel),
       ExistingRecordSets(List(existingTxt)),
-      okAuth)
+      okAuth,
+      None)
 
     result(0) shouldBe valid
   }
@@ -1311,7 +1368,11 @@ class BatchChangeValidationsSpec
       AddChangeInput("name-conflict", RecordType.MX, 300, MXData(1, "foo.bar.")))
 
     val result =
-      validateChangesWithContext(List(addMX.validNel), ExistingRecordSets(List(existingMX)), okAuth)
+      validateChangesWithContext(
+        List(addMX.validNel),
+        ExistingRecordSets(List(existingMX)),
+        okAuth,
+        None)
     result(0) should haveInvalid[DomainValidationError](RecordAlreadyExists("name-conflict."))
   }
 
@@ -1328,7 +1389,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(addMx.validNel, addMx2.validNel),
       ExistingRecordSets(List()),
-      okAuth)
+      okAuth,
+      None)
     result(0) shouldBe valid
   }
 
@@ -1350,7 +1412,8 @@ class BatchChangeValidationsSpec
     val result = validateChangesWithContext(
       List(deleteMx.validNel, addMx.validNel),
       ExistingRecordSets(List(existingMx)),
-      okAuth)
+      okAuth,
+      None)
     result(0) shouldBe valid
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -540,9 +540,31 @@ class BatchChangeValidationsSpec
       okAuth,
       None)
 
-    result(0) shouldBe valid
+    result(0) should haveInvalid[DomainValidationError](
+      RecordDoesNotExist(deleteUpdateA.inputChange.inputName))
     result(1) should haveInvalid[DomainValidationError](
       RecordDoesNotExist(deleteUpdateA.inputChange.inputName))
+  }
+
+  property(
+    """validateChangesWithContext: should succeed for update in shared zone if user belongs to record
+             | owner group""".stripMargin) {
+    val existingRecord =
+      sharedZoneRecord.copy(name = "mx", typ = RecordType.MX, records = List(MXData(200, "mx")))
+    val addUpdateA = AddChangeForValidation(
+      sharedZone,
+      "mx",
+      AddChangeInput("mx.shared.", RecordType.MX, 300, MXData(200, "mx")))
+    val deleteUpdateA =
+      DeleteChangeForValidation(sharedZone, "mx", DeleteChangeInput("mx.shared.", RecordType.MX))
+    val result = validateChangesWithContext(
+      List(addUpdateA.validNel, deleteUpdateA.validNel),
+      ExistingRecordSets(List(existingRecord)),
+      okAuth,
+      None)
+
+    result(0) shouldBe valid
+    result(1) shouldBe valid
   }
 
   property("""validateChangesWithContext: should succeed adding a record

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -655,18 +655,33 @@ class RecordSetServiceSpec
     }
 
     "fail when the account is not authorized for the record" in {
-      doReturn(IO.pure(Some(sharedZoneRecordNoOwnerGroup)))
+      doReturn(IO.pure(Some(sharedZoneRecordNotFoundOwnerGroup)))
         .when(mockRecordRepo)
-        .getRecordSet(sharedZone.id, sharedZoneRecordNoOwnerGroup.id)
+        .getRecordSet(sharedZone.id, sharedZoneRecordNotFoundOwnerGroup.id)
 
       doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(any[String])
 
       val result =
         leftResultOf(
           underTest
-            .getRecordSet(sharedZoneRecordNoOwnerGroup.id, sharedZone.id, okAuth)
+            .getRecordSet(sharedZoneRecordNotFoundOwnerGroup.id, sharedZone.id, okAuth)
             .value)
       result shouldBe a[NotAuthorizedError]
+    }
+
+    "succeed when a record in a shared zone has no owner group ID" in {
+      doReturn(IO.pure(Some(sharedZoneRecordNoOwnerGroup)))
+        .when(mockRecordRepo)
+        .getRecordSet(sharedZone.id, sharedZoneRecordNoOwnerGroup.id)
+
+      doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(any[String])
+
+      val result = underTest
+        .getRecordSet(sharedZoneRecordNoOwnerGroup.id, sharedZone.id, okAuth)
+        .value
+        .unsafeRunSync()
+
+      result should be(right)
     }
 
     "fail if the user is only in the recordSet owner group but the zone is not shared" in {


### PR DESCRIPTION
Fixes #342.
Add context validations for batch change. Branched off of #454 (from commit `c789fac`).

Changes in this pull request:
- Implement batch change validations
- Update access validations to accept requests when `ownerGroupId` is not defined in existing record set
- Added functional and unit tests
