### PR TITLE
Update getRecordSetChange access validation

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
@@ -494,7 +494,7 @@ def test_user_cannot_delete_record_with_write_txt_read_all(shared_zone_test_cont
         # dummy should be able to add the RS
         new_rs = get_recordset_json(ok_zone, "www-user-cant-delete", "TXT", [{'text':'should-work'}])
         rs_change = dummy_client.create_recordset(new_rs, status=202)
-        created_rs = client.wait_until_recordset_change_status(rs_change, 'Complete')['recordSet']
+        created_rs = dummy_client.wait_until_recordset_change_status(rs_change, 'Complete')['recordSet']
         verify_recordset(created_rs, new_rs)
 
         #dummy cannot delete the RS

--- a/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
@@ -724,8 +724,7 @@ def test_delete_for_user_in_record_owner_group_in_shared_zone_succeeds(shared_zo
     result_rs = shared_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']
 
     delete_rs = ok_client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=202)
-    # TODO: Update to ok_client once access validation for getRecordSetChange endpoint has been updated to use canViewRecordSet
-    shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
+    ok_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
 def test_delete_for_zone_admin_in_shared_zone_succeeds(shared_zone_test_context):
     """

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -163,13 +163,18 @@ class RecordSetService(
       authPrincipal: AuthPrincipal): Result[RecordSetChange] =
     for {
       zone <- getZone(zoneId)
-      _ <- canSeeZone(authPrincipal, zone).toResult
       change <- recordChangeRepository
         .getRecordSetChange(zone.id, changeId)
         .orFail(
           RecordSetChangeNotFoundError(
             s"Unable to find record set change with id $changeId in zone ${zone.name}"))
         .toResult[RecordSetChange]
+      _ <- canViewRecordSet(
+        authPrincipal,
+        change.recordSet.name,
+        change.recordSet.typ,
+        zone,
+        change.recordSet.ownerGroupId).toResult
     } yield change
 
   def listRecordSetChanges(

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -852,6 +852,17 @@ class RecordSetServiceSpec
       actual shouldBe pendingCreateAAAA
     }
 
+    "return the record set change if the user is in the record owner group in a shared zone" in {
+      doReturn(IO.pure(Some(pendingCreateSharedRecord)))
+        .when(mockRecordChangeRepo)
+        .getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id)
+
+      val actual: RecordSetChange =
+        rightResultOf(
+          underTest.getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id, okAuth).value)
+      actual shouldBe pendingCreateSharedRecord
+    }
+
     "return a RecordSetChangeNotFoundError if it is not found" in {
       doReturn(IO.pure(None))
         .when(mockRecordChangeRepo)
@@ -862,8 +873,26 @@ class RecordSetServiceSpec
     }
 
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
+      doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
+      doReturn(IO.pure(Some(pendingCreateAAAA)))
+        .when(mockRecordChangeRepo)
+        .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
+
       val error = leftResultOf(
-        underTest.getRecordSetChange(zoneNotAuthorized.id, pendingCreateAAAA.id, dummyAuth).value)
+        underTest.getRecordSetChange(zoneActive.id, pendingCreateAAAA.id, dummyAuth).value)
+
+      error shouldBe a[NotAuthorizedError]
+    }
+
+    "return a NotAuthorizedError if the user is in the record owner group but the zone is not shared" in {
+      doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(zoneNotAuthorized.id)
+      doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone)))
+        .when(mockRecordChangeRepo)
+        .getRecordSetChange(zoneNotAuthorized.id, pendingCreateSharedRecordNotSharedZone.id)
+
+      val error = leftResultOf(underTest
+        .getRecordSetChange(zoneNotAuthorized.id, pendingCreateSharedRecordNotSharedZone.id, okAuth)
+        .value)
 
       error shouldBe a[NotAuthorizedError]
     }

--- a/modules/core/src/test/scala/vinyldns/core/TestRecordSetData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestRecordSetData.scala
@@ -249,6 +249,10 @@ object TestRecordSetData {
   val completeCreateNS: RecordSetChange =
     pendingCreateNS.copy(status = RecordSetChangeStatus.Complete)
 
+  val pendingCreateSharedRecord: RecordSetChange = makeTestAddChange(sharedZoneRecord, sharedZone)
+  val pendingCreateSharedRecordNotSharedZone: RecordSetChange =
+    makeTestAddChange(notSharedZoneRecordWithOwnerGroup, zoneNotAuthorized)
+
   /* CHANGESETS */
   val pendingChangeSet: ChangeSet = ChangeSet(Seq(pendingCreateAAAA, pendingCreateCNAME))
 


### PR DESCRIPTION
Fixes #453.

Changes in this pull request:
- use canViewRecordSet validation instead of canSeeZone validation
- add unit tests in RecordSetServiceSpec
- ~~updated one func test to illustrate that a user in the record owner group of a record in a shared zone can view a related record set change. put that in a separate commit that doesn't need to be merged since i know @mitruly intends to test that in #454 https://github.com/vinyldns/vinyldns/pull/454/files#diff-8f6bb5f233fd1e5366e4831da659d5d8R727~~
- update `test_user_cannot_delete_record_with_write_txt_read_all` func test to confirm a user without admin rights can still get a record set change if they have other valid record access. 
