### PR TITLE
make shared zone ids unique across runs

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
@@ -679,7 +679,7 @@ def test_delete_for_user_not_in_record_owner_group_in_shared_zone_fails(shared_z
         result_rs = shared_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']
 
         error = dummy_client.delete_recordset(shared_zone['id'], result_rs['id'], status=403)
-        assert_that(error, is_('User dummy does not have access to delete test-shared-bad-user.shared.'))
+        assert_that(error, is_('User dummy does not have access to delete test-shared-del-nonog.shared.'))
 
     finally:
         if result_rs:
@@ -702,7 +702,7 @@ def test_delete_for_user_in_record_owner_group_in_non_shared_zone_fails(shared_z
         result_rs = ok_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']
 
         error = shared_client.delete_recordset(ok_zone['id'], result_rs['id'], status=403)
-        assert_that(error, is_('User sharedZoneUser does not have access to delete test-shared-bad-user.ok.'))
+        assert_that(error, is_('User sharedZoneUser does not have access to delete test-non-shared-del-og.ok.'))
 
     finally:
         if result_rs:

--- a/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/delete_recordset_test.py
@@ -672,7 +672,7 @@ def test_delete_for_user_not_in_record_owner_group_in_shared_zone_fails(shared_z
     shared_zone = shared_zone_test_context.shared_zone
     result_rs = None
 
-    record_json = get_recordset_json(shared_zone, 'test_shared_bad_user', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_zone_test_context.shared_record_group['id'])
+    record_json = get_recordset_json(shared_zone, 'test_shared_del_nonog', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_zone_test_context.shared_record_group['id'])
 
     try:
         create_rs = shared_client.create_recordset(record_json, status=202)
@@ -695,7 +695,7 @@ def test_delete_for_user_in_record_owner_group_in_non_shared_zone_fails(shared_z
     ok_zone = shared_zone_test_context.ok_zone
     result_rs = None
 
-    record_json = get_recordset_json(ok_zone, 'test_shared_bad_user', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_zone_test_context.shared_record_group['id'])
+    record_json = get_recordset_json(ok_zone, 'test_non_shared_del_og', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_zone_test_context.shared_record_group['id'])
 
     try:
         create_rs = ok_client.create_recordset(record_json, status=202)
@@ -718,7 +718,7 @@ def test_delete_for_user_in_record_owner_group_in_shared_zone_succeeds(shared_zo
     shared_zone = shared_zone_test_context.shared_zone
     shared_group = shared_zone_test_context.shared_record_group
 
-    record_json = get_recordset_json(shared_zone, 'test_shared_bad_user', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_group['id'])
+    record_json = get_recordset_json(shared_zone, 'test_shared_del_og', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_group['id'])
 
     create_rs = shared_client.create_recordset(record_json, status=202)
     result_rs = shared_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']
@@ -734,7 +734,7 @@ def test_delete_for_zone_admin_in_shared_zone_succeeds(shared_zone_test_context)
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
     shared_zone = shared_zone_test_context.shared_zone
 
-    record_json = get_recordset_json(shared_zone, 'test_shared_bad_user', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_zone_test_context.shared_record_group['id'])
+    record_json = get_recordset_json(shared_zone, 'test_shared_del_admin', 'A', [{'address': '1.1.1.1'}], ownergroup_id = shared_zone_test_context.shared_record_group['id'])
 
     create_rs = shared_client.create_recordset(record_json, status=202)
     result_rs = shared_client.wait_until_recordset_change_status(create_rs, 'Complete')['recordSet']

--- a/modules/api/functional_test/live_tests/shared_zone_test_context.py
+++ b/modules/api/functional_test/live_tests/shared_zone_test_context.py
@@ -266,10 +266,14 @@ class SharedZoneTestContext(object):
                 }, status=202)
             self.ds_zone = ds_zone_change['zone']
 
-            shared_zone_change = self.set_up_shared_zone('shared-zone')
+            get_shared_zones = self.shared_zone_vinyldns_client.list_zones(status=200)['zones']
+            shared_zone = [zone for zone in get_shared_zones if zone["name"] == "shared."]
+            non_test_shared_zone = [zone for zone in get_shared_zones if zone["name"] == "non.test.shared."]
+
+            shared_zone_change = self.set_up_shared_zone(shared_zone[0]["id"])
             self.shared_zone = shared_zone_change['zone']
 
-            non_test_shared_zone_change = self.set_up_shared_zone('non-test-shared-zone')
+            non_test_shared_zone_change = self.set_up_shared_zone(non_test_shared_zone[0]["id"])
             self.non_test_shared_zone = non_test_shared_zone_change['zone']
 
             # wait until our zones are created

--- a/modules/api/functional_test/live_tests/shared_zone_test_context.py
+++ b/modules/api/functional_test/live_tests/shared_zone_test_context.py
@@ -267,13 +267,13 @@ class SharedZoneTestContext(object):
             self.ds_zone = ds_zone_change['zone']
 
             get_shared_zones = self.shared_zone_vinyldns_client.list_zones(status=200)['zones']
-            shared_zone = [zone for zone in get_shared_zones if zone["name"] == "shared."]
-            non_test_shared_zone = [zone for zone in get_shared_zones if zone["name"] == "non.test.shared."]
+            shared_zone = [zone for zone in get_shared_zones if zone['name'] == "shared."]
+            non_test_shared_zone = [zone for zone in get_shared_zones if zone['name'] == "non.test.shared."]
 
-            shared_zone_change = self.set_up_shared_zone(shared_zone[0]["id"])
+            shared_zone_change = self.set_up_shared_zone(shared_zone[0]['id'])
             self.shared_zone = shared_zone_change['zone']
 
-            non_test_shared_zone_change = self.set_up_shared_zone(non_test_shared_zone[0]["id"])
+            non_test_shared_zone_change = self.set_up_shared_zone(non_test_shared_zone[0]['id'])
             self.non_test_shared_zone = non_test_shared_zone_change['zone']
 
             # wait until our zones are created

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -161,7 +161,6 @@ object TestDataLoader {
   final val sharedZone = Zone(
     name = "shared.",
     email = "email",
-    id = "shared-zone",
     adminGroupId = sharedZoneGroup.id,
     shared = true,
     isTest = true
@@ -172,7 +171,6 @@ object TestDataLoader {
   final val nonTestSharedZone = Zone(
     name = "non.test.shared.",
     email = "email",
-    id = "non-test-shared-zone",
     adminGroupId = sharedZoneGroup.id,
     shared = true
   )


### PR DESCRIPTION
maintenance thing - because we are using the same ids always for the shared zones, one failed run can corrupt the database. pulled that out, just getting those zones by a list