### PR TITLE
portal: add record owner group to record modals

### DIFF
--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -2,7 +2,7 @@
 
     <!-- START ACCORDION -->
     <!-- START RECENT RECORDSET CHANGES TABLE PANEL -->
-<div class="panel panel-default x_panel">
+<div class="panel panel-default x_panel" ng-init="sharedDisplayEnabled = @meta.sharedDisplayEnabled">
     <div class="panel-heading">
         <h3 class="panel-title">
             <a class="collapse-link">

--- a/modules/portal/public/app.js
+++ b/modules/portal/public/app.js
@@ -2,7 +2,8 @@ angular.module('vinyldns', [
     'services.module',
     'controllers.module',
     'directives.module',
-    'batch-change'
+    'batch-change',
+    'constants'
 ])
     .config(function ($httpProvider, $animateProvider, $logProvider) {
         $httpProvider

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -20,7 +20,8 @@ describe('BatchChange', function(){
         module('batch-change'),
         module('service.utility'),
         module('service.paging'),
-        module('service.groups')
+        module('service.groups'),
+        module('constants')
     });
 
     var deferred;

--- a/modules/portal/public/lib/constants.js
+++ b/modules/portal/public/lib/constants.js
@@ -17,6 +17,5 @@
 angular
     .module('constants', [])
     .constant('jsConfig', {
-        batchChangeLimit: 20,
-        sharedDisplayEnabled: false
+        batchChangeLimit: 20
     });

--- a/modules/portal/public/lib/constants.js
+++ b/modules/portal/public/lib/constants.js
@@ -17,5 +17,6 @@
 angular
     .module('batch-change')
     .constant('jsConfig', {
-        batchChangeLimit: 20
+        batchChangeLimit: 20,
+        sharedDisplayEnabled: false
     });

--- a/modules/portal/public/lib/constants.js
+++ b/modules/portal/public/lib/constants.js
@@ -15,7 +15,7 @@
  */
 
 angular
-    .module('batch-change')
+    .module('constants', [])
     .constant('jsConfig', {
         batchChangeLimit: 20,
         sharedDisplayEnabled: false

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -261,7 +261,6 @@ angular.module('controller.records', [])
     function createRecordSet(record) {
         var payload = recordsService.toVinylRecord(record);
         payload.zoneId = $scope.zoneId;
-        payload.ownerGroupId = record.ownerGroupId;
         return recordsService
             .createRecordSet($scope.zoneId, payload)
             .then(recordSetSuccess("Create Record"))

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -15,7 +15,7 @@
  */
 
 angular.module('controller.records', [])
-    .controller('RecordsController', function ($scope, $timeout, $log, recordsService, groupsService, pagingService, utilityService, $q) {
+    .controller('RecordsController', function ($scope, jsConfig, $timeout, $log, recordsService, groupsService, pagingService, utilityService, $q) {
 
     /**
       * Scope data initial setup
@@ -62,6 +62,8 @@ angular.module('controller.records', [])
     };
 
     $scope.isZoneAdmin = false;
+
+    $scope.sharedDisplayEnabled = jsConfig.sharedDisplayEnabled;
 
     // paging status for recordsets
     var recordsPaging = pagingService.getNewPagingParams(100);
@@ -256,6 +258,7 @@ angular.module('controller.records', [])
     function createRecordSet(record) {
         var payload = recordsService.toVinylRecord(record);
         payload.zoneId = $scope.zoneId;
+        payload.ownerGroupId = record.ownerGroupId;
         return recordsService
             .createRecordSet($scope.zoneId, payload)
             .then(recordSetSuccess("Create Record"))
@@ -267,6 +270,7 @@ angular.module('controller.records', [])
     function updateRecordSet(record) {
         var payload = recordsService.toVinylRecord(record);
         payload.zoneId = $scope.zoneId;
+        payload.ownerGroupId = record.ownerGroupId;
         return recordsService
             .updateRecordSet($scope.zoneId, record.id, payload)
             .then(recordSetSuccess("Update Record"))

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -270,7 +270,9 @@ angular.module('controller.records', [])
     function updateRecordSet(record) {
         var payload = recordsService.toVinylRecord(record);
         payload.zoneId = $scope.zoneId;
-        payload.ownerGroupId = record.ownerGroupId;
+        if (record.ownerGroupId) {
+            payload.ownerGroupId = record.ownerGroupId;
+        }
         return recordsService
             .updateRecordSet($scope.zoneId, record.id, payload)
             .then(recordSetSuccess("Update Record"))

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -182,6 +182,9 @@ angular.module('controller.records', [])
     $scope.clearRecord = function(record) {
         record.ttl = undefined;
         record.data = undefined;
+        if ($scope.sharedDisplayEnabled) {
+            record.ownerGroupId = undefined;
+        }
     };
 
     $scope.getZoneStatusLabel = function() {

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -15,7 +15,7 @@
  */
 
 angular.module('controller.records', [])
-    .controller('RecordsController', function ($scope, jsConfig, $timeout, $log, recordsService, groupsService, pagingService, utilityService, $q) {
+    .controller('RecordsController', function ($scope, $timeout, $log, recordsService, groupsService, pagingService, utilityService, $q) {
 
     /**
       * Scope data initial setup
@@ -63,8 +63,6 @@ angular.module('controller.records', [])
 
     $scope.isZoneAdmin = false;
 
-    $scope.sharedDisplayEnabled = jsConfig.sharedDisplayEnabled;
-
     // paging status for recordsets
     var recordsPaging = pagingService.getNewPagingParams(100);
 
@@ -81,7 +79,9 @@ angular.module('controller.records', [])
             action: $scope.recordModalState.CONFIRM_DELETE,
             title: "Delete record",
             basics: $scope.recordModalParams.readOnly,
-            details: $scope.recordModalParams.readOnly
+            details: $scope.recordModalParams.readOnly,
+            sharedZone: $scope.zoneInfo.shared,
+            sharedDisplayEnabled: $scope.sharedDisplayEnabled
         };
         $("#record_modal").modal("show");
     };
@@ -99,7 +99,9 @@ angular.module('controller.records', [])
             action: $scope.recordModalState.CREATE,
             title: "Create record",
             basics: $scope.recordModalParams.editable,
-            details: $scope.recordModalParams.editable
+            details: $scope.recordModalParams.editable,
+            sharedZone: $scope.zoneInfo.shared,
+            sharedDisplayEnabled: $scope.sharedDisplayEnabled
         };
         $scope.addRecordForm.$setPristine();
         $("#record_modal").modal("show");
@@ -112,7 +114,9 @@ angular.module('controller.records', [])
             action: $scope.recordModalState.UPDATE,
             title: "Update record",
             basics: $scope.recordModalParams.readOnly,
-            details: $scope.recordModalParams.editable
+            details: $scope.recordModalParams.editable,
+            sharedZone: $scope.zoneInfo.shared,
+            sharedDisplayEnabled: $scope.sharedDisplayEnabled
         };
         $scope.addRecordForm.$setPristine();
         $("#record_modal").modal("show");
@@ -133,7 +137,9 @@ angular.module('controller.records', [])
             action: $scope.recordModalState.VIEW_DETAILS,
             title: "Record Info",
             basics: $scope.recordModalParams.readOnly,
-            details: $scope.recordModalParams.readOnly
+            details: $scope.recordModalParams.readOnly,
+            sharedZone: $scope.zoneInfo.shared,
+            sharedDisplayEnabled: $scope.sharedDisplayEnabled
         };
         $("#record_modal").modal("show");
     };
@@ -182,7 +188,7 @@ angular.module('controller.records', [])
     $scope.clearRecord = function(record) {
         record.ttl = undefined;
         record.data = undefined;
-        if ($scope.sharedDisplayEnabled) {
+        if ($scope.sharedDisplayEnabled && $scope.zoneInfo.shared) {
             record.ownerGroupId = undefined;
         }
     };

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -23,6 +23,7 @@ describe('Controller: RecordsController', function () {
         module('service.utility'),
         module('directives.modals.record.module'),
         module('controller.records')
+        module('constants')
     });
     beforeEach(inject(function ($rootScope, $controller, $httpBackend, $q, groupsService, recordsService, pagingService) {
         this.rootScope = $rootScope;

--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -240,6 +240,9 @@ angular.module('service.records', [])
                     break;
                 default:
             }
+            if (record.ownerGroupId) {
+                newRecord.ownerGroupId = record.ownerGroupId
+            }
             return newRecord;
         };
 

--- a/modules/portal/public/templates/record-modal.html
+++ b/modules/portal/public/templates/record-modal.html
@@ -314,6 +314,16 @@
                 </modal-invalid>
             </modal-element>
 
+            <modal-element label="Record Owner Group" ng-if="sharedDisplayEnabled">
+                <select class="form-control"
+                        ng-model="currentRecord.ownerGroupId"
+                        ng-disabled="recordModal.details.readOnly">
+                    <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
+                            ng-selected="currentRecord.ownerGroupId == group.name">
+                        {{group.name}}</option>
+                </select>
+            </modal-element>
+
         </modal-body>
         <modal-footer>
             <span ng-if="recordModal.action == recordModalState.CREATE">

--- a/modules/portal/public/templates/record-modal.html
+++ b/modules/portal/public/templates/record-modal.html
@@ -314,13 +314,13 @@
                 </modal-invalid>
             </modal-element>
 
-            <modal-element label="Record Owner Group" ng-if="sharedDisplayEnabled">
+            <modal-element label="Record Owner Group" ng-if="recordModal.sharedDisplayEnabled && recordModal.sharedZone">
                 <select class="form-control"
                         ng-model="currentRecord.ownerGroupId"
                         ng-disabled="recordModal.details.readOnly">
                     <option value=""></option>
                     <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
-                            ng-selected="currentRecord.ownerGroupId == group.name">
+                            ng-selected="currentRecord.ownerGroupId == group.id">
                         {{group.name}}</option>
                 </select>
             </modal-element>

--- a/modules/portal/public/templates/record-modal.html
+++ b/modules/portal/public/templates/record-modal.html
@@ -318,6 +318,7 @@
                 <select class="form-control"
                         ng-model="currentRecord.ownerGroupId"
                         ng-disabled="recordModal.details.readOnly">
+                    <option value=""></option>
                     <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
                             ng-selected="currentRecord.ownerGroupId == group.name">
                         {{group.name}}</option>


### PR DESCRIPTION
Fixes #468

Changes in this pull request:
- added a jsConfig value to hide the portal additions. since the modal file isn't scala it can't use the scala feature flag we set up.
- Adds record owner group selection in all of the record modals.
