### PR TITLE
portal: add record owner group in batch changes detail view

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -33,8 +33,18 @@
         </div>
         <div class="row">
             <div class="col-md-12">
-                <h5>Created: {{batch.createdTimestamp}}</h5>
-                <h5 ng-if="batch.comments">Description: {{batch.comments}}</h5>
+                <p><strong>Created:</strong> {{batch.createdTimestamp}}</p>
+                <p ng-if="batch.comments"><strong>Description:</strong> {{batch.comments}}</p>
+                @if(meta.sharedDisplayEnabled) {
+                    <p ng-if="batch.ownerGroupName"><strong>Record Owner Group:</strong> {{batch.ownerGroupName}}</p>
+                    <p ng-if="batch.ownerGroupId && !batch.ownerGroupName">
+                        <strong>Record Owner Group:</strong>
+                        <span class="text-danger" data-toggle="tooltip" data-placement="top"
+                              title="Group with ID {{batch.ownerGroupId}} no longer exists.">
+                            <span class="fa fa-warning"></span> Group deleted
+                        </span>
+                    </p>
+                }
             </div>
         </div>
         <br>


### PR DESCRIPTION
Fixes #356 .

This is currently branched off #459 

Changes in this pull request:
- display record owner group name below description in batch change details view
- if the group no longer exists display "Group deleted" with tooltip that includes the group ID at the time the group was set in the batch change.

![record owner group in batch change detail view](https://user-images.githubusercontent.com/4439228/52221934-4d4f4680-2870-11e9-9400-f237ae449613.png)

![deleted record owner group in batch change detail view](https://user-images.githubusercontent.com/4439228/52221936-504a3700-2870-11e9-84e0-b51b22b07e40.png)


Review notes:
- enable sharedDisplayEnabled in local.conf or reference.conf 