### PR TITLE
correctly clear ownerGroupId in new batch change form

### DIFF
--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -56,6 +56,9 @@
                 $scope.processing = true;
 
                 var payload = $scope.newBatch;
+                if (!$scope.newBatch.ownerGroupId) {
+                     delete payload.ownerGroupId
+                }
 
                 function success(response) {
                     var alert = utilityService.success('Successfully Created Batch Change', response, 'createBatchChange: createBatchChange successful');


### PR DESCRIPTION
Fixes #481.

Changes in this pull request:
- correctly remove the ownerGroupId value in a new batch change. It was trying to send an empty attribute if a user selects a group then unselects a group, but we shouldn't send the attribute at all if the value is an empty string or doesn't exist.
