### PR TITLE
Fix IPv4 PTR zone discovery

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1819,6 +1819,7 @@ def test_ipv4_ptr_record_when_zone_discovery_only_finds_mismatched_delegated_zon
     }
 
     try:
+        # delete classless base zone (2.0.192.in-addr.arpa); only remaining zone is delegated zone (192/30.2.0.192.in-addr.arpa)
         ok_client.delete_zone(classless_base_zone['id'], status=202)
         ok_client.wait_until_zone_deleted(classless_base_zone['id'])
         response = ok_client.create_batch_change(batch_change_input, status=400)
@@ -1826,6 +1827,7 @@ def test_ipv4_ptr_record_when_zone_discovery_only_finds_mismatched_delegated_zon
                                                error_messages=['Zone Discovery Failed: zone for "192.0.2.1" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS.'])
 
     finally:
+        # re-create classless base zone and update zone info in shared_zone_test_context for use in future tests
          zone_create_change = ok_client.create_zone(shared_zone_test_context.classless_base_zone_json, status=202)
          shared_zone_test_context.classless_base_zone = zone_create_change['zone']
          ok_client.wait_until_zone_exists(zone_create_change)

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1805,6 +1805,31 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
         clear_recordset_list(to_delete, client)
 
 
+def test_ipv4_ptr_record_when_zone_discovery_only_finds_mismatched_delegated_zone_fails(shared_zone_test_context):
+    """
+    Test IPv4 PTR record discovery for only delegated zones that do not match the record name fails
+    """
+    ok_client = shared_zone_test_context.ok_vinyldns_client
+    classless_base_zone = shared_zone_test_context.classless_base_zone
+
+    batch_change_input = {
+        "changes": [
+            get_change_PTR_json("192.0.2.1")
+        ]
+    }
+
+    try:
+        ok_client.delete_zone(classless_base_zone['id'], status=202)
+        ok_client.wait_until_zone_deleted(classless_base_zone['id'])
+        response = ok_client.create_batch_change(batch_change_input, status=400)
+        assert_failed_change_in_error_response(response[0], input_name="192.0.2.1", record_type="PTR", record_data="test.com.",
+                                               error_messages=['Zone Discovery Failed: zone for "192.0.2.1" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS.'])
+
+    finally:
+         zone_create_change = ok_client.create_zone(shared_zone_test_context.classless_base_zone_json, status=202)
+         shared_zone_test_context.classless_base_zone = zone_create_change['zone']
+         ok_client.wait_until_zone_exists(zone_create_change)
+
 def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
     """
     Test all update and delete validations performed on ipv4 PTR records submitted in batch changes

--- a/modules/api/functional_test/live_tests/shared_zone_test_context.py
+++ b/modules/api/functional_test/live_tests/shared_zone_test_context.py
@@ -142,26 +142,28 @@ class SharedZoneTestContext(object):
             )
             self.ip4_reverse_zone = ip4_reverse_zone_change['zone']
 
+            self.classless_base_zone_json = {
+                'name': '2.0.192.in-addr.arpa.',
+                'email': 'test@test.com',
+                'shared': False,
+                'adminGroupId': self.ok_group['id'],
+                'isTest': True,
+                'connection': {
+                    'name': 'classless-base.',
+                    'keyName': VinylDNSTestContext.dns_key_name,
+                    'key': VinylDNSTestContext.dns_key,
+                    'primaryServer': VinylDNSTestContext.dns_ip
+                },
+                'transferConnection': {
+                    'name': 'classless-base.',
+                    'keyName': VinylDNSTestContext.dns_key_name,
+                    'key': VinylDNSTestContext.dns_key,
+                    'primaryServer': VinylDNSTestContext.dns_ip
+                }
+            }
+
             classless_base_zone_change = self.ok_vinyldns_client.create_zone(
-                {
-                    'name': '2.0.192.in-addr.arpa.',
-                    'email': 'test@test.com',
-                    'shared': False,
-                    'adminGroupId': self.ok_group['id'],
-                    'isTest': True,
-                    'connection': {
-                        'name': 'classless-base.',
-                        'keyName': VinylDNSTestContext.dns_key_name,
-                        'key': VinylDNSTestContext.dns_key,
-                        'primaryServer': VinylDNSTestContext.dns_ip
-                    },
-                    'transferConnection': {
-                        'name': 'classless-base.',
-                        'keyName': VinylDNSTestContext.dns_key_name,
-                        'key': VinylDNSTestContext.dns_key,
-                        'primaryServer': VinylDNSTestContext.dns_ip
-                    }
-                }, status=202
+                self.classless_base_zone_json, status=202
             )
             self.classless_base_zone = classless_base_zone_change['zone']
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/AccessValidations.scala
@@ -185,7 +185,8 @@ object AccessValidations extends AccessValidationAlgebra {
     case testUser if testUser.isTestUser && !zone.isTest => AccessLevel.NoAccess
     case admin if admin.canEditAll || admin.isGroupMember(zone.adminGroupId) =>
       AccessLevel.Delete
-    case recordOwner if zone.shared && sharedRecordAccess(recordOwner, recordType, recordOwnerGroupId) =>
+    case recordOwner
+        if zone.shared && sharedRecordAccess(recordOwner, recordType, recordOwnerGroupId) =>
       AccessLevel.Delete
     case supportUser if supportUser.canReadAll =>
       val aclAccess = getAccessFromAcl(auth, recordName, recordType, zone)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -224,13 +224,13 @@ class BatchChangeService(
     val recordName = change.inputName.split('.').takeRight(1).mkString
     val validZones = zoneMap.getipv4PTRMatches(change.inputName).filter(ptrIsInZone(_, recordName, PTR).isRight)
 
-    if (validZones.isEmpty) {
-      ZoneDiscoveryError(change.inputName).invalidNel
-    } else {
-      val zone =
-        if (validZones.size > 1) validZones.find(zn => zn.name.contains("/")).get
-        else validZones.head
-      ChangeForValidation(zone, recordName, change).validNel
+    val zone = {
+      if (validZones.size > 1) validZones.find(zn => zn.name.contains("/"))
+      else validZones.headOption
+    }
+    zone match {
+      case Some(z) => ChangeForValidation(z, recordName, change).validNel
+      case None => ZoneDiscoveryError(change.inputName).invalidNel
     }
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -222,12 +222,12 @@ class BatchChangeService(
       change: ChangeInput,
       zoneMap: ExistingZones): SingleValidation[ChangeForValidation] = {
     val zones = zoneMap.getipv4PTRMatches(change.inputName)
+    val recordName = change.inputName.split('.').takeRight(1).mkString
+    val validZones = zones.filter(zn => ptrIsInZone(zn, recordName, PTR).isRight)
 
-    if (zones.isEmpty)
+    if (validZones.isEmpty) {
       ZoneDiscoveryError(change.inputName).invalidNel
-    else {
-      val recordName = change.inputName.split('.').takeRight(1).mkString
-      val validZones = zones.filter(zn => ptrIsInZone(zn, recordName, PTR).isRight)
+    } else {
       val zone =
         if (validZones.size > 1) validZones.find(zn => zn.name.contains("/")).get
         else validZones.head

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -221,9 +221,8 @@ class BatchChangeService(
   def ptrIpv4ZoneDiscovery(
       change: ChangeInput,
       zoneMap: ExistingZones): SingleValidation[ChangeForValidation] = {
-    val zones = zoneMap.getipv4PTRMatches(change.inputName)
     val recordName = change.inputName.split('.').takeRight(1).mkString
-    val validZones = zones.filter(zn => ptrIsInZone(zn, recordName, PTR).isRight)
+    val validZones = zoneMap.getipv4PTRMatches(change.inputName).filter(ptrIsInZone(_, recordName, PTR).isRight)
 
     if (validZones.isEmpty) {
       ZoneDiscoveryError(change.inputName).invalidNel

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -222,7 +222,8 @@ class BatchChangeService(
       change: ChangeInput,
       zoneMap: ExistingZones): SingleValidation[ChangeForValidation] = {
     val recordName = change.inputName.split('.').takeRight(1).mkString
-    val validZones = zoneMap.getipv4PTRMatches(change.inputName).filter(ptrIsInZone(_, recordName, PTR).isRight)
+    val validZones =
+      zoneMap.getipv4PTRMatches(change.inputName).filter(ptrIsInZone(_, recordName, PTR).isRight)
 
     val zone = {
       if (validZones.size > 1) validZones.find(zn => zn.name.contains("/"))

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -86,7 +86,7 @@ class BatchChangeServiceSpec
   private val onlyApexZone = Zone("only.apex.exists.", "email", id = "onlyApex")
   private val onlyBaseZone = Zone("only.base.", "email", id = "onlyBase")
   private val ptrZone = Zone("55.144.10.in-addr.arpa.", "email", id = "nonDelegatedPTR")
-  private val delegatedPTRZone = Zone("64/25.55.144.10.in-addr.arpa.", "email", id = "delegatedPTR")
+  private val delegatedPTRZone = Zone("64/25.55.144.10.in-addr.arpa.", "email", id = "delegatedPTR") /**/
   private val otherPTRZone = Zone("56.144.10.in-addr.arpa.", "email", id = "otherPTR")
 
   private val apexAddForVal = AddChangeForValidation(apexZone, "apex.test.com.", apexAddA)
@@ -538,6 +538,14 @@ class BatchChangeServiceSpec
       val result = underTest.zoneDiscovery(List(ptrAdd.validNel), ExistingZones(Set(apexZone)))
 
       result.head should haveInvalid[DomainValidationError](ZoneDiscoveryError("10.144.55.11"))
+    }
+
+    "return an error for PTR if there are zone matches for the IP but no match on the record name" in {
+      val result = underTest.zoneDiscovery(
+        List(ptrAdd.validNel),
+        ExistingZones(Set(delegatedPTRZone.copy(name = "192/30.55.144.10.in-addr.arpa."))))
+
+      result.head should haveInvalid[DomainValidationError](ZoneDiscoveryError(ptrAdd.inputName))
     }
 
     "map the batch change input to the delegated PTR zone for PTR records (ipv6)" in {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -86,7 +86,7 @@ class BatchChangeServiceSpec
   private val onlyApexZone = Zone("only.apex.exists.", "email", id = "onlyApex")
   private val onlyBaseZone = Zone("only.base.", "email", id = "onlyBase")
   private val ptrZone = Zone("55.144.10.in-addr.arpa.", "email", id = "nonDelegatedPTR")
-  private val delegatedPTRZone = Zone("64/25.55.144.10.in-addr.arpa.", "email", id = "delegatedPTR") /**/
+  private val delegatedPTRZone = Zone("64/25.55.144.10.in-addr.arpa.", "email", id = "delegatedPTR")
   private val otherPTRZone = Zone("56.144.10.in-addr.arpa.", "email", id = "otherPTR")
 
   private val apexAddForVal = AddChangeForValidation(apexZone, "apex.test.com.", apexAddA)


### PR DESCRIPTION
Fixes #480. Properly handle internal server error when PTRv4 zone discovery fails.

Changes in this pull request:
- Cover scenario where initial zone discovery finds potentially matching zones but fails on finding a record name match for IPv4 record