### PR TITLE
Fix MySqlUserRepository Logging

### DIFF
--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
@@ -31,7 +31,7 @@ class MySqlUserRepository(cryptoAlgebra: CryptoAlgebra)
     with Monitored
     with ProtobufConversions {
 
-  private final val logger = LoggerFactory.getLogger(classOf[MySqlZoneChangeRepository])
+  private final val logger = LoggerFactory.getLogger(classOf[MySqlUserRepository])
 
   private final val PUT_USER =
     sql"""


### PR DESCRIPTION
The logger for MySqlUserRepository referenced a different repository class.

Changes in this pull request:
- MySqlUserRepository logs as the correct class
