### PR TITLE
Expand input_name column in single_change table

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2928,31 +2928,3 @@ def test_create_batch_update_record_in_shared_zone_for_unassociated_user_in_owne
         if create_rs:
             delete_rs = shared_client.delete_recordset(shared_zone['id'], create_rs['recordSet']['id'], status=202)
             shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
-
-def test_create_batch_record_with_max_label_length_succeeds(shared_zone_test_context):
-    """
-    Test creating a change in batch with a record containing the max label length (63) should succeed
-    """
-    parent_zone = shared_zone_test_context.parent_zone
-    ok_client = shared_zone_test_context.ok_vinyldns_client
-    rs_name = "a"*63
-    to_delete = []
-
-    batch_change_input = {
-        "changes": [
-            get_change_A_AAAA_json(rs_name + ".parent.com.")
-        ]
-    }
-
-    try:
-        result = ok_client.create_batch_change(batch_change_input, status=202)
-        completed_batch = ok_client.wait_until_batch_change_completed(result)
-
-        record_set_list = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
-        to_delete = set(record_set_list) # set here because multiple items in the batch combine to one RS
-
-        assert_change_success_response_values(result['changes'], zone=parent_zone, index=0, record_name=rs_name,
-                                              input_name=rs_name + ".parent.com.", record_data="1.1.1.1")
-
-    finally:
-        clear_zoneid_rsid_tuple_list(to_delete, ok_client)

--- a/modules/api/src/it/scala/vinyldns/api/domain/batch/BatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/batch/BatchChangeRepositoryIntegrationSpec.scala
@@ -1,0 +1,52 @@
+package vinyldns.api.domain.batch
+
+import org.joda.time.DateTime
+import org.scalatest.{Matchers, WordSpecLike}
+import vinyldns.api.MySqlApiIntegrationSpec
+import vinyldns.core.TestMembershipData._
+import vinyldns.core.domain.batch.{BatchChange, SingleAddChange, SingleChangeStatus}
+import vinyldns.core.domain.record.{AData, RecordType}
+import vinyldns.mysql.MySqlIntegrationSpec
+
+class BatchChangeRepositoryIntegrationSpec
+    extends MySqlApiIntegrationSpec
+    with MySqlIntegrationSpec
+    with Matchers
+    with WordSpecLike {
+
+  import vinyldns.api.domain.DomainValidations._
+
+  "MySqlBatchChangeRepository" should {
+    "successfully save single change with max-length input name" in {
+      val batchChange = BatchChange(
+        okUser.id,
+        okUser.userName,
+        None,
+        DateTime.now,
+        List(
+          SingleAddChange(
+            "some-zone-id",
+            "zone-name",
+            "record-name",
+            "a" * HOST_MAX_LENGTH,
+            RecordType.A,
+            300,
+            AData("1.1.1.1"),
+            SingleChangeStatus.Pending,
+            None,
+            None,
+            None))
+      )
+
+      val f = for {
+        saveBatchChangeResult <- batchChangeRepository.save(batchChange)
+        getSingleChangesResult <- batchChangeRepository.getSingleChanges(
+          batchChange.changes.map(_.id))
+      } yield (saveBatchChangeResult, getSingleChangesResult)
+      val (saveResponse, singleChanges) = f.unsafeRunSync()
+
+      saveResponse shouldBe batchChange
+      singleChanges.foreach(_.inputName.length shouldBe HOST_MAX_LENGTH)
+    }
+  }
+}

--- a/modules/api/src/it/scala/vinyldns/api/domain/batch/BatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/batch/BatchChangeRepositoryIntegrationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package vinyldns.api.domain.batch
 
 import org.joda.time.DateTime

--- a/modules/mysql/src/main/resources/db/migration/V3.12__BatchChangeExpandInputName.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.12__BatchChangeExpandInputName.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+ALTER TABLE single_change MODIFY input_name VARCHAR(255) NOT NULL;


### PR DESCRIPTION
Expand `input_name` column from `VARCHAR(45)` to `VARCHAR(255)`. Fixes #462.

Changes in this pull request:
- Add migration script for `input_name` column expansion
- Add functional test for max label length creation in batch change
