### PR TITLE
portal ptr correspondence

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -56,7 +56,7 @@
                                 <tr>
                                     <th>#</th>
                                     <th class="col-md-2">Change Type</th>
-                                    <th class="col-md-1">Record Type</th>
+                                    <th>Record Type</th>
                                     <th>Input Name</th>
                                     <th class="col-md-1">TTL</th>
                                     <th>Record Data</th>
@@ -73,8 +73,10 @@
                                         </select>
                                     </td>
                                     <td>
-                                        <select class="form-control" ng-model="change.type" >
-                                            <option value="A" selected>A</option>
+                                        <select class="form-control" ng-model="change.type">
+                                            <option value="A+PTR" selected>A+PTR</option>
+                                            <option>AAAA+PTR</option>
+                                            <option>A</option>
                                             <option>AAAA</option>
                                             <option>CNAME</option>
                                             <option>PTR</option>
@@ -101,10 +103,23 @@
                                     </td>
                                     <!--TTL based on change type-->
                                     <!--record data name based on record type and change type-->
-                                    <td ng-if="change.changeType=='DeleteRecordSet'">
+                                    <td ng-if="change.changeType=='DeleteRecordSet' && change.type!='A+PTR' && change.type!='AAAA+PTR'">
                                         <input class="form-control" placeholder="" disabled/>
                                     </td>
-
+                                    <td ng-if="change.type=='A+PTR'">
+                                        <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" required="string" class="form-control" placeholder="e.g. 1.1.1.1" ipv4>
+                                        <p ng-show="createBatchChangeForm.$submitted">
+                                            <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
+                                            <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.ipv4" class="batch-change-error-help">must be a valid IPv4 Address!</span>
+                                        </p>
+                                    </td>
+                                    <td ng-if="change.type=='AAAA+PTR'">
+                                        <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" required="string" class="form-control" placeholder="e.g. fd69:27cc:fe91::60" ipv6>
+                                        <p ng-show="createBatchChangeForm.$submitted">
+                                            <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
+                                            <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.ipv6" class="batch-change-error-help">must be a valid IPv6 Address!</span>
+                                        </p>
+                                    </td>
                                     <td ng-if="change.type=='A' && change.changeType=='Add'">
                                         <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. 1.1.1.1" ng-disabled="change.changeType=='DeleteRecordSet'" ipv4>
                                         <p ng-show="createBatchChangeForm.$submitted">

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -182,8 +182,8 @@
                                 </tr>
                                 </tbody>
                             </table>
-                            <button type="button" id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length == batchChangeLimit"><span class="fa fa-plus"></span> Add a Change</button>
-                            <span ng-if="newBatch.changes.length == batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</span>
+                            <button type="button" id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length >= batchChangeLimit"><span class="fa fa-plus"></span> Add a Change</button>
+                            <span ng-if="newBatch.changes.length >= batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</span>
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -59,14 +59,11 @@
                      delete payload.ownerGroupId
                 }
 
-
                 function formatData(payload) {
-                    var i;
-                    for (i = 0; i < payload.changes.length; i++) {
+                    for (var i = 0; i < payload.changes.length; i++) {
                         var entry = payload.changes[i]
                         if(entry.type == 'A+PTR' || entry.type == 'AAAA+PTR') {
                             entry.type = entry.type.slice(0, -4);
-                            payload.changes[i] = entry;
                             var newEntry = {changeType: entry.changeType, type: "PTR", ttl: entry.ttl, inputName: entry.record.address, record: {ptrdname: entry.inputName}}
                             payload.changes.splice(i+1, 0, newEntry)
                         }

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -114,7 +114,7 @@ describe('BatchChange', function(){
             it('adds a change to the changes array', function() {
                this.scope.addSingleChange();
 
-               expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A", ttl: 200}, {changeType: "Add", type: "A", ttl: 200}]})
+               expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}, {changeType: "Add", type: "A+PTR", ttl: 200}]})
             });
         });
 


### PR DESCRIPTION
Fixes #510.

Changes in this pull request:
- Add "A+PTR" and "AAAA+PTR" record types in the new batch change form, "A+PTR" is now the default option, and "AAA+PTR" is second.
- On submit, re-format the batch change data to split the "A+PTR" or "AAAA+PTR" entries into two entries, one for the forward record and one for the reverse record.

Screenshot: new record types in record type menu
<img width="1521" alt="record type menu" src="https://user-images.githubusercontent.com/4439228/53519198-c07b5f80-3aa0-11e9-8cf6-01b9eb2d9bdc.png">

Screenshot: data entered in form for A+PTR record type
<img width="1526" alt="data entry" src="https://user-images.githubusercontent.com/4439228/53519093-772b1000-3aa0-11e9-8650-8f371bdb0246.png">

Screenshot: on submission attempt the entry is split into 2 entries, if there are any errors they appear on the relevant entry
<img width="1529" alt="screen shot 2019-02-27 at 2 49 01 pm" src="https://user-images.githubusercontent.com/4439228/53519045-58c51480-3aa0-11e9-87fe-af537fe95b75.png">


Screenshot: batch change detail, shows the split forward and reverse records
<img width="1530" alt="batch change detail" src="https://user-images.githubusercontent.com/4439228/53518928-13084c00-3aa0-11e9-8ba6-5b32144ee6f5.png">

Some testing suggestions:
Load zones: `1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.`, `2.0.192.in-addr.arpa.`, and `ok.`

In a new batch change form:
"Add" "A+PTR" "a.ok." "200" "192.0.2.4"
"Add" "AAAA+PTR" "aaaa.ok." "200" "fd69:27cc:fe91::2"
"DeleteRecordSet" "AAAA+PTR" "a.ok." "200" "192.0.2.4"
"DeleteRecordSet" "A+PTR" "aaaa.ok." "200" "fd69:27cc:fe91::2"

To test batch change record limit you'll need to add 20 entries (or whatever your limit is set at) with at least one of them being an "A+PTR" or "AAAA+PTR", when you confirm the submission it will convert to 21 records and report an error that the limit is exceeded.

