### PR TITLE
Fix wait condition for zone update/delete functional tests

### DIFF
--- a/modules/api/functional_test/live_tests/zones/delete_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/delete_zone_test.py
@@ -35,7 +35,7 @@ def test_delete_zone_success(shared_zone_test_context):
         }
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
-        client.wait_until_zone_exists(result)
+        client.wait_until_zone_active(result_zone['id'])
 
         client.delete_zone(result_zone['id'], status=202)
         client.wait_until_zone_deleted(result_zone['id'])
@@ -76,7 +76,7 @@ def test_delete_zone_twice(shared_zone_test_context):
         }
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
-        client.wait_until_zone_exists(result)
+        client.wait_until_zone_active(result_zone['id'])
 
         client.delete_zone(result_zone['id'], status=202)
         client.wait_until_zone_deleted(result_zone['id'])

--- a/modules/api/functional_test/live_tests/zones/update_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/update_zone_test.py
@@ -43,7 +43,7 @@ def test_update_zone_success(shared_zone_test_context):
         }
         result = client.create_zone(zone, status=202)
         result_zone = result['zone']
-        client.wait_until_zone_exists(result)
+        client.wait_until_zone_active(result_zone['id'])
 
         result_zone['email'] = 'foo@bar.com'
         result_zone['acl']['rules'] = [acl_rule]

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -707,25 +707,12 @@ class VinylDNSClient(object):
 
         assert_that(response, is_(404))
 
+    #TODO Replace calls to this method with wait_until_zone_active and remove
     def wait_until_zone_exists(self, zone_change, **kwargs):
         """
-        Waits a period of time for the zone creation to complete.
-
-        :param zone_change: the create zone change for the zone that has been created.
-        :param kw: Additional parameters for the http request
-        :return: True when the zone creation is complete False if the timeout expires
+        Shim method to invoke wait_until_zone_active
         """
-        zone_id = zone_change[u'zone'][u'id']
-        retries = MAX_RETRIES
-        url = urljoin(self.index_url, u'/zones/{0}'.format(zone_id))
-        response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, status=(200, 404), **kwargs)
-        while response != 200 and retries > 0:
-            url = urljoin(self.index_url, u'/zones/{0}'.format(zone_id))
-            response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, status=(200, 404), **kwargs)
-            retries -= 1
-            time.sleep(RETRY_WAIT)
-
-        return response == 200
+        self.wait_until_zone_active(zone_change[u'zone'][u'id'])
 
     def wait_until_zone_active(self, zone_id):
         """

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -705,7 +705,7 @@ class VinylDNSClient(object):
             retries -= 1
             time.sleep(RETRY_WAIT)
 
-        return response == 404
+        assert_that(response, is_(404))
 
     def wait_until_zone_exists(self, zone_change, **kwargs):
         """
@@ -772,8 +772,7 @@ class VinylDNSClient(object):
 
         # Wait until each zone is gone
         for zone_id in zone_ids:
-            success = self.wait_until_zone_deleted(zone_id)
-            assert_that(success, is_(True))
+            self.wait_until_zone_deleted(zone_id)
 
     def wait_until_recordset_change_status(self, rs_change, expected_status):
         """


### PR DESCRIPTION
With a bit of latency in environments that are processing requests, it is possible to encounter a race condition when waiting for a zone create to finish. Resolves #515.

Changes in this pull request:
- Update `wait_until_zone_deleted` into a hard stopper by forcing assertions
- Update zone update/delete tests to wait for zone active status, rather than sync
