### PR TITLE
Sync users against LDAP (in the portal)

### DIFF
--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -18,12 +18,13 @@ package controllers
 
 import java.util
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import controllers.LdapAuthenticator.LdapByDomainAuthenticator
 import controllers.VinylDNS.UserDetails
 import javax.naming.directory._
 import javax.naming.Context
+import vinyldns.core.domain.membership.User
 import vinyldns.core.health.HealthCheck._
 
 import scala.collection.JavaConverters._
@@ -178,6 +179,8 @@ final case class LdapServiceException(errorMessage: String)
     extends LdapException(s"Encountered error communicating with LDAP service: $errorMessage")
 final case class InvalidCredentials(username: String)
     extends LdapException(s"Provided credentials were invalid for user [$username].")
+final case class NoLdapSearchDomainsConfigured()
+    extends LdapException("No LDAP search domains were configured so user lookup is impossible.")
 
 /**
   * Top level ldap authenticator that tries authenticating on multiple domains. Authentication is
@@ -190,6 +193,9 @@ class LdapAuthenticator(
     authenticator: LdapByDomainAuthenticator,
     serviceAccount: ServiceAccount)
     extends Authenticator {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   /**
     * Attempts to search for user in specified LDAP domains. Attempts all LDAP domains that are specified in order; in
@@ -226,10 +232,16 @@ class LdapAuthenticator(
     }
 
   def authenticate(username: String, password: String): Either[LdapException, LdapUserDetails] =
-    findUserDetails(searchBase, username, authenticator.authenticate(_, username, password), true)
+    // Need to check domains here due to recursive nature of findUserDetails
+    if (searchBase.isEmpty) Left(NoLdapSearchDomainsConfigured())
+    else
+      findUserDetails(searchBase, username, authenticator.authenticate(_, username, password), true)
 
   def lookup(username: String): Either[LdapException, LdapUserDetails] =
-    findUserDetails(searchBase, username, authenticator.lookup(_, username, serviceAccount), true)
+    // Need to check domains here due to recursive nature of findUserDetails
+    if (searchBase.isEmpty) Left(NoLdapSearchDomainsConfigured())
+    else
+      findUserDetails(searchBase, username, authenticator.lookup(_, username, serviceAccount), true)
 
   def healthCheck(): HealthCheck =
     IO {
@@ -240,11 +252,24 @@ class LdapAuthenticator(
         case _ => ().asRight
       }
     }.asHealthCheck
+
+  // List[User] => List[Either[LdapException, LdapUserDetails]] => List[User]
+  def getUsersNotInLdap(users: List[User]): IO[List[User]] =
+    users
+      .map { u =>
+        IO(lookup(u.userName)).map {
+          case Left(_: UserDoesNotExistException) => Some(u) // Only grab users that do not exist
+          case _ => None
+        }
+      }
+      .parSequence
+      .map(_.flatten)
 }
 
 trait Authenticator {
   def authenticate(username: String, password: String): Either[LdapException, LdapUserDetails]
   def lookup(username: String): Either[LdapException, LdapUserDetails]
+  def getUsersNotInLdap(usernames: List[User]): IO[List[User]]
   def healthCheck(): HealthCheck
 }
 
@@ -282,6 +307,9 @@ class TestAuthenticator(authenticator: Authenticator) extends Authenticator {
     }
 
   def healthCheck(): HealthCheck = authenticator.healthCheck()
+
+  def getUsersNotInLdap(users: List[User]): IO[List[User]] =
+    authenticator.getUsersNotInLdap(users)
 }
 
 case class LdapSearchDomain(organization: String, domainName: String)

--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -93,8 +93,6 @@ object LdapAuthenticator {
   private[controllers] object LdapByDomainAuthenticator {
     def apply(settings: Settings): LdapByDomainAuthenticator =
       new LdapByDomainAuthenticator(settings, createContext(settings))
-
-    def apply(): LdapByDomainAuthenticator = LdapByDomainAuthenticator(Settings)
   }
 
   /**

--- a/modules/portal/app/controllers/Settings.scala
+++ b/modules/portal/app/controllers/Settings.scala
@@ -26,6 +26,7 @@ import pureconfig.module.catseffect.loadConfigF
 import vinyldns.core.repository.DataStoreConfig
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 // $COVERAGE-OFF$
 class Settings(private val config: Configuration) {
@@ -41,6 +42,13 @@ class Settings(private val config: Configuration) {
   val ldapCtxFactory: String = config.get[String]("LDAP.context.initialContextFactory")
   val ldapSecurityAuthentication: String = config.get[String]("LDAP.context.securityAuthentication")
   val ldapProviderUrl: URI = new URI(config.get[String]("LDAP.context.providerUrl"))
+
+  val ldapSyncEnabled: Boolean =
+    config.getOptional[Boolean]("LDAP.user-sync.enabled").getOrElse(false)
+  val ldapSyncPollingInterval: FiniteDuration = config
+    .getOptional[Int]("LDAP.user-sync.hours-polling-interval")
+    .getOrElse(24)
+    .hours
 
   val portalTestLogin: Boolean = config.getOptional[Boolean]("portal.test_login").getOrElse(false)
 

--- a/modules/portal/app/controllers/repository/PortalDataAccessor.scala
+++ b/modules/portal/app/controllers/repository/PortalDataAccessor.scala
@@ -18,8 +18,10 @@ package controllers.repository
 
 import vinyldns.core.domain.membership.{UserChangeRepository, UserRepository}
 import vinyldns.core.repository.DataAccessor
+import vinyldns.core.task.TaskRepository
 
 final case class PortalDataAccessor(
     userRepository: UserRepository,
-    userChangeRepository: UserChangeRepository)
+    userChangeRepository: UserChangeRepository,
+    taskRepository: TaskRepository)
     extends DataAccessor

--- a/modules/portal/app/controllers/repository/PortalDataAccessorProvider.scala
+++ b/modules/portal/app/controllers/repository/PortalDataAccessorProvider.scala
@@ -22,6 +22,7 @@ import vinyldns.core.domain.membership.{UserChangeRepository, UserRepository}
 import vinyldns.core.repository.DataStoreLoader.getRepoOf
 import vinyldns.core.repository.RepositoryName._
 import vinyldns.core.repository.{DataAccessorProvider, DataStore, DataStoreConfig}
+import vinyldns.core.task.TaskRepository
 
 // $COVERAGE-OFF$
 object PortalDataAccessorProvider extends DataAccessorProvider[PortalDataAccessor] {
@@ -32,7 +33,8 @@ object PortalDataAccessorProvider extends DataAccessorProvider[PortalDataAccesso
       dataStores: List[(DataStoreConfig, DataStore)]): ValidatedNel[String, PortalDataAccessor] =
     (
       getRepoOf[UserRepository](dataStores, user),
-      getRepoOf[UserChangeRepository](dataStores, userChange)
+      getRepoOf[UserChangeRepository](dataStores, userChange),
+      getRepoOf[TaskRepository](dataStores, task)
     ).mapN(PortalDataAccessor)
 }
 // $COVERAGE-ON$

--- a/modules/portal/app/modules/VinylDNSModule.scala
+++ b/modules/portal/app/modules/VinylDNSModule.scala
@@ -72,7 +72,7 @@ class VinylDNSModule(environment: Environment, configuration: Configuration)
             new UserAccountAccessor(repositories.userRepository, repositories.userChangeRepository),
             auth)
           .start
-      } else IO.pure(()).start
+      } else IO.unit
     } yield {
       bind(classOf[CryptoAlgebra]).toInstance(crypto)
       bind(classOf[Authenticator]).toInstance(auth)

--- a/modules/portal/app/tasks/TaskHandler.scala
+++ b/modules/portal/app/tasks/TaskHandler.scala
@@ -35,17 +35,14 @@ class TaskHandler @Inject()(taskRepository: TaskRepository) {
   private val logger: Logger = LoggerFactory.getLogger("TaskHandler")
   private implicit val t: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
 
-  def fetchAndClaimTask(taskName: String, pollingInterval: FiniteDuration): IO[Unit] = {
-    print(s"task name: $taskName; polling interval: $pollingInterval\n\n")
+  def fetchAndClaimTask(taskName: String, pollingInterval: FiniteDuration): IO[Unit] =
     taskRepository.claimTask(taskName, pollingInterval).flatMap {
       case true =>
         IO(logger.info(s"Successfully found and claimed task [$taskName]."))
       case false =>
         val claimError = NoTaskToClaim(taskName)
-        logger.info(claimError.message)
         IO.raiseError(claimError)
     }
-  }
 
   def runSyncTask(
       taskName: String,
@@ -61,7 +58,7 @@ class TaskHandler @Inject()(taskRepository: TaskRepository) {
     } yield ()
 
     syncRun.handleErrorWith { err =>
-      IO(logger.error(s"Encountered task error for [$taskName]", err))
+      IO(logger.info(s"Encountered task error for [$taskName]", err))
     }
   }
 

--- a/modules/portal/app/tasks/TaskHandler.scala
+++ b/modules/portal/app/tasks/TaskHandler.scala
@@ -54,7 +54,7 @@ class TaskHandler @Inject()(taskRepository: TaskRepository) {
       _ <- IO(logger.info(s"Fetched and claimed task [$taskName]."))
       _ <- UserSyncTask
         .syncUsers(userAccountAccessor, authenticator)
-        .handleError(e => IO(logger.error("Encountered error syncing task", e)))
+        .handleErrorWith(e => IO(logger.error("Encountered error syncing task", e)))
       _ <- taskRepository.releaseTask(taskName)
       _ <- IO(logger.info(s"Released task [$taskName]."))
     } yield ()

--- a/modules/portal/app/tasks/TaskHandler.scala
+++ b/modules/portal/app/tasks/TaskHandler.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import controllers.{Authenticator, Settings, UserAccountAccessor}
+import fs2.Stream
+import javax.inject.{Inject, Singleton}
+import org.slf4j.{Logger, LoggerFactory}
+import vinyldns.core.task._
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class NoTaskToClaim(taskName: String) extends Throwable {
+  def message: String = s"No available task [$taskName] to claim."
+}
+
+@Singleton
+class TaskHandler @Inject()(taskRepository: TaskRepository) {
+  private val logger: Logger = LoggerFactory.getLogger("TaskHandler")
+  private implicit val t: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+
+  def fetchAndClaimTask(taskName: String, pollingInterval: FiniteDuration): IO[Unit] =
+    taskRepository.claimTask(taskName, pollingInterval).flatMap {
+      case true =>
+        IO(logger.info(s"Successfully found and claimed task [$taskName]."))
+      case false =>
+        val claimError = NoTaskToClaim(taskName)
+        logger.info(claimError.message)
+        IO.raiseError(claimError)
+    }
+
+  def runSyncTask(
+      taskName: String,
+      pollingInterval: FiniteDuration,
+      userAccountAccessor: UserAccountAccessor,
+      authenticator: Authenticator): IO[Unit] =
+    for {
+      _ <- fetchAndClaimTask(taskName, pollingInterval)
+      _ <- IO(logger.info(s"Fetched and claimed task [$taskName]."))
+      _ <- UserSyncTask.syncUsers(userAccountAccessor, authenticator).handleError(_ => ())
+      _ <- taskRepository.releaseTask(taskName)
+      _ <- IO(logger.info(s"Released task [$taskName]."))
+    } yield ()
+
+  def startTaskStream(
+      settings: Settings,
+      userAccountAccessor: UserAccountAccessor,
+      authenticator: Authenticator): Stream[IO, Unit] = {
+    import UserSyncTask._
+    import settings._
+
+    def runTaskStream(): Stream[IO, Unit] =
+      Stream
+        .awakeEvery[IO](ldapSyncPollingInterval)
+        .evalMap[IO, Unit](
+          _ =>
+            runSyncTask(
+              SYNC_USER_TASK_NAME,
+              ldapSyncPollingInterval,
+              userAccountAccessor,
+              authenticator))
+        .handleErrorWith { error =>
+          logger.error("Encountered error sending sync job", error)
+          runTaskStream()
+        }
+
+    runTaskStream()
+  }
+
+  def run(
+      settings: Settings,
+      userAccountAccessor: UserAccountAccessor,
+      authenticator: Authenticator): IO[Unit] =
+    startTaskStream(settings, userAccountAccessor, authenticator).compile.drain
+}

--- a/modules/portal/app/tasks/TaskHandler.scala
+++ b/modules/portal/app/tasks/TaskHandler.scala
@@ -52,7 +52,9 @@ class TaskHandler @Inject()(taskRepository: TaskRepository) {
     val syncRun = for {
       _ <- fetchAndClaimTask(taskName, pollingInterval)
       _ <- IO(logger.info(s"Fetched and claimed task [$taskName]."))
-      _ <- UserSyncTask.syncUsers(userAccountAccessor, authenticator).handleError(_ => ())
+      _ <- UserSyncTask
+        .syncUsers(userAccountAccessor, authenticator)
+        .handleError(e => IO(logger.error("Encountered error syncing task", e)))
       _ <- taskRepository.releaseTask(taskName)
       _ <- IO(logger.info(s"Released task [$taskName]."))
     } yield ()

--- a/modules/portal/app/tasks/TaskHandler.scala
+++ b/modules/portal/app/tasks/TaskHandler.scala
@@ -35,7 +35,8 @@ class TaskHandler @Inject()(taskRepository: TaskRepository) {
   private val logger: Logger = LoggerFactory.getLogger("TaskHandler")
   private implicit val t: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
 
-  def fetchAndClaimTask(taskName: String, pollingInterval: FiniteDuration): IO[Unit] =
+  def fetchAndClaimTask(taskName: String, pollingInterval: FiniteDuration): IO[Unit] = {
+    print(s"task name: $taskName; polling interval: $pollingInterval\n\n")
     taskRepository.claimTask(taskName, pollingInterval).flatMap {
       case true =>
         IO(logger.info(s"Successfully found and claimed task [$taskName]."))
@@ -44,6 +45,7 @@ class TaskHandler @Inject()(taskRepository: TaskRepository) {
         logger.info(claimError.message)
         IO.raiseError(claimError)
     }
+  }
 
   def runSyncTask(
       taskName: String,

--- a/modules/portal/app/tasks/UserSyncTask.scala
+++ b/modules/portal/app/tasks/UserSyncTask.scala
@@ -23,19 +23,19 @@ import vinyldns.core.domain.membership.LockStatus
 
 object UserSyncTask {
   val SYNC_USER_TASK_NAME = "user_sync"
-  private val log: Logger = LoggerFactory.getLogger("Task")
+  private val log: Logger = LoggerFactory.getLogger("UserSyncTask")
 
   def syncUsers(
       userAccountAccessor: UserAccountAccessor,
       authenticator: Authenticator): IO[Unit] = {
-    log.info("Initiating user sync")
+    log.error("Initiating user sync")
     for {
       allUsers <- userAccountAccessor.getAllUsers
       activeUsers = allUsers.filter(u => u.lockStatus != LockStatus.Locked && !u.isTest)
       nonActiveUsers <- authenticator.getUsersNotInLdap(activeUsers)
       lockedUsers <- userAccountAccessor.lockUsers(nonActiveUsers)
       _ <- IO(
-        log.info(
+        log.error(
           s"Users locked: ${lockedUsers.map(_.userName)}. Total locked: ${lockedUsers.size}"))
     } yield ()
   }

--- a/modules/portal/app/tasks/UserSyncTask.scala
+++ b/modules/portal/app/tasks/UserSyncTask.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import cats.effect.IO
+import controllers.{Authenticator, UserAccountAccessor}
+import org.slf4j.{Logger, LoggerFactory}
+import vinyldns.core.domain.membership.LockStatus
+
+object UserSyncTask {
+  val SYNC_USER_TASK_NAME = "user_sync"
+  private val log: Logger = LoggerFactory.getLogger("Task")
+
+  def syncUsers(
+      userAccountAccessor: UserAccountAccessor,
+      authenticator: Authenticator): IO[Unit] = {
+    log.info("Initiating user sync")
+    for {
+      allUsers <- userAccountAccessor.getAllUsers
+      activeUsers = allUsers.filter(u => u.lockStatus != LockStatus.Locked && !u.isTest)
+      nonActiveUsers <- authenticator.getUsersNotInLdap(activeUsers)
+      lockedUsers <- userAccountAccessor.lockUsers(nonActiveUsers)
+      _ <- IO(
+        log.info(
+          s"Users locked: ${lockedUsers.map(_.userName)}. Total locked: ${lockedUsers.size}"))
+    } yield ()
+  }
+}

--- a/modules/portal/conf/application.conf
+++ b/modules/portal/conf/application.conf
@@ -13,6 +13,9 @@ mysql {
     user {
       # no additional settings for now
     }
+    task {
+      # no additional settings for now
+    }
   }
 }
 

--- a/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
@@ -167,6 +167,13 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
           response must beLeft
         }
       }
+
+      "return an error if no LDAP search domains are provided" in {
+        val noDomainsLdapAuthenticator =
+          new LdapAuthenticator(List(), mock[LdapByDomainAuthenticator], mock[ServiceAccount])
+
+        noDomainsLdapAuthenticator.authenticate("someUserName", "somePassword") must beLeft
+      }
     }
     ".lookup" should {
       "lookup first with 1st domain" in {
@@ -188,6 +195,13 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
 
         "and return details if authenticated" in {
           response must beRight
+        }
+
+        "return an error if no LDAP search domains are provided" in {
+          val noDomainsLdapAuthenticator =
+            new LdapAuthenticator(List(), mock[LdapByDomainAuthenticator], mock[ServiceAccount])
+
+          noDomainsLdapAuthenticator.lookup("someUserName") must beLeft
         }
       }
 

--- a/modules/portal/test/tasks/TaskHandlerSpec.scala
+++ b/modules/portal/test/tasks/TaskHandlerSpec.scala
@@ -91,19 +91,23 @@ class TaskHandlerSpec extends Specification with Mockito {
           mockAuthenticator)
         .unsafeRunSync() must beEqualTo(())
     }
-    "stop process flow if task cannot be claimed" in {
+    "catch error and return unit if there is no task to claim" in {
       taskHandler
         .runSyncTask(
           badTaskName,
           mockSettings.ldapSyncPollingInterval,
           mockUserAccountAccessor,
           mockAuthenticator)
-        .unsafeRunSync() must throwA[NoTaskToClaim]
+        .unsafeRunSync() must beEqualTo(())
     }
   }
 
   "run" should {
     "run the task stream" in {
+      mockTaskRepository
+        .claimTask("user_sync", 50.millis)
+        .returns(IO.pure(true))
+
       taskHandler
         .run(mockSettings, mockUserAccountAccessor, mockAuthenticator)
         .unsafeRunTimed(mockSettings.ldapSyncPollingInterval * 2) must beNone

--- a/modules/portal/test/tasks/TaskHandlerSpec.scala
+++ b/modules/portal/test/tasks/TaskHandlerSpec.scala
@@ -25,7 +25,7 @@ import vinyldns.core.task.TaskRepository
 
 import scala.concurrent.duration._
 
-class UserSyncTaskHandlerSpec extends Specification with Mockito {
+class TaskHandlerSpec extends Specification with Mockito {
   implicit val cs: ContextShift[IO] =
     IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
 
@@ -81,7 +81,7 @@ class UserSyncTaskHandlerSpec extends Specification with Mockito {
     }
   }
 
-  "doTask" should {
+  "runSyncTask" should {
     "process entire flow if fetchAndClaimTask succeeds" in {
       taskHandler
         .runSyncTask(
@@ -99,6 +99,14 @@ class UserSyncTaskHandlerSpec extends Specification with Mockito {
           mockUserAccountAccessor,
           mockAuthenticator)
         .unsafeRunSync() must throwA[NoTaskToClaim]
+    }
+  }
+
+  "run" should {
+    "run the task stream" in {
+      taskHandler
+        .run(mockSettings, mockUserAccountAccessor, mockAuthenticator)
+        .unsafeRunTimed(mockSettings.ldapSyncPollingInterval * 2) must beNone
     }
   }
 }

--- a/modules/portal/test/tasks/UserSyncTaskHandlerSpec.scala
+++ b/modules/portal/test/tasks/UserSyncTaskHandlerSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import cats.effect.{ContextShift, IO}
+import controllers.{Authenticator, Settings, UserAccountAccessor}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import vinyldns.core.domain.membership.{LockStatus, User}
+import vinyldns.core.task.TaskRepository
+
+import scala.concurrent.duration._
+
+class UserSyncTaskHandlerSpec extends Specification with Mockito {
+  implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
+
+  private val notAuthUser: User = User("not-authorized", "accessKey", "secretKey")
+  private val lockedNotAuthUser: User = notAuthUser.copy(lockStatus = LockStatus.Locked)
+  private val goodTaskName = "good_task"
+  private val badTaskName = "bad_task"
+
+  val mockAuthenticator: Authenticator = {
+    val mockObject = mock[Authenticator]
+    mockObject.getUsersNotInLdap(List(notAuthUser)).returns(IO(List(notAuthUser)))
+    mockObject
+  }
+
+  val mockUserAccountAccessor: UserAccountAccessor = {
+    val mockObject = mock[UserAccountAccessor]
+    mockObject.getAllUsers.returns(IO(List(notAuthUser)))
+    mockObject
+      .lockUsers(List(notAuthUser))
+      .returns(IO(List(lockedNotAuthUser)))
+    mockObject
+  }
+
+  val mockSettings: Settings = {
+    val mockObject = mock[Settings]
+    mockObject.ldapSyncPollingInterval.returns(50.millis)
+    mockObject
+  }
+
+  val mockTaskRepository: TaskRepository = {
+    val mockObject = mock[TaskRepository]
+    mockObject.claimTask(goodTaskName, mockSettings.ldapSyncPollingInterval).returns(IO.pure(true))
+    mockObject
+      .claimTask(badTaskName, mockSettings.ldapSyncPollingInterval)
+      .returns(IO.pure(false))
+    mockObject
+      .releaseTask(goodTaskName)
+      .returns(IO.unit)
+    mockObject
+  }
+  val taskHandler = new TaskHandler(mockTaskRepository)
+
+  "fetchAndClaimTask" should {
+    "fetch and claim the task if it is unclaimed" in {
+      taskHandler
+        .fetchAndClaimTask(goodTaskName, mockSettings.ldapSyncPollingInterval)
+        .unsafeRunSync() must beEqualTo(())
+    }
+    "return a NoTaskToClaim error is there are issues" in {
+      taskHandler
+        .fetchAndClaimTask(badTaskName, mockSettings.ldapSyncPollingInterval)
+        .unsafeRunSync() must throwA[NoTaskToClaim]
+    }
+  }
+
+  "doTask" should {
+    "process entire flow if fetchAndClaimTask succeeds" in {
+      taskHandler
+        .runSyncTask(
+          goodTaskName,
+          mockSettings.ldapSyncPollingInterval,
+          mockUserAccountAccessor,
+          mockAuthenticator)
+        .unsafeRunSync() must beEqualTo(())
+    }
+    "stop process flow if task cannot be claimed" in {
+      taskHandler
+        .runSyncTask(
+          badTaskName,
+          mockSettings.ldapSyncPollingInterval,
+          mockUserAccountAccessor,
+          mockAuthenticator)
+        .unsafeRunSync() must throwA[NoTaskToClaim]
+    }
+  }
+}

--- a/modules/portal/test/tasks/UserSyncTaskSpec.scala
+++ b/modules/portal/test/tasks/UserSyncTaskSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import cats.effect.IO
+import controllers.{Authenticator, UserAccountAccessor}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import vinyldns.core.domain.membership._
+
+import scala.concurrent.duration._
+
+class UserSyncTaskSpec extends Specification with Mockito {
+  val notAuthUser: User = User("not-authorized", "accessKey", "secretKey")
+  val lockedNotAuthUser: User = notAuthUser.copy(lockStatus = LockStatus.Locked)
+  val mockAuthenticator: Authenticator = {
+    val mockObject = mock[Authenticator]
+    mockObject.getUsersNotInLdap(List(notAuthUser)).returns(IO(List(notAuthUser)))
+    mockObject
+  }
+
+  val mockUserAccountAccessor: UserAccountAccessor = {
+    val mockObject = mock[UserAccountAccessor]
+    mockObject.getAllUsers.returns(IO(List(notAuthUser)))
+    mockObject
+      .lockUsers(List(notAuthUser))
+      .returns(IO(List(lockedNotAuthUser)))
+    mockObject
+  }
+
+  "SyncUserTask" should {
+    "successfully lock unauthorized, non-test users" in {
+      UserSyncTask
+        .syncUsers(mockUserAccountAccessor, mockAuthenticator)
+        .unsafeRunSync() must beEqualTo(())
+    }
+
+    "successfully process if no users are found" in {
+      UserSyncTask
+        .syncUsers(mockUserAccountAccessor, mockAuthenticator)
+        .unsafeRunSync() must beEqualTo(())
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   lazy val awsV = "1.11.423"
   lazy val jaxbV = "2.3.0"
   lazy val ip4sV = "1.1.1"
+  lazy val fs2V = "1.0.0"
 
   lazy val apiDependencies = Seq(
     "com.typesafe.akka"         %% "akka-http"                      % akkaHttpV,
@@ -38,7 +39,7 @@ object Dependencies {
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "org.scodec"                %% "scodec-bits"                    % scodecV,
     "org.slf4j"                 %  "slf4j-api"                      % "1.7.25",
-    "co.fs2"                    %% "fs2-core"                       % "1.0.0",
+    "co.fs2"                    %% "fs2-core"                       % fs2V,
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
     "io.prometheus"             % "simpleclient_hotspot"            % prometheusV,
@@ -109,6 +110,7 @@ object Dependencies {
     "com.typesafe.play"         %% "play-ahc-ws"                    % playV,
     "com.typesafe.play"         %% "play-specs2"                    % playV % "test",
     "com.nimbusds"              % "oauth2-oidc-sdk"                 % "6.5",
-    "com.nimbusds"              % "nimbus-jose-jwt"                 % "7.0"
+    "com.nimbusds"              % "nimbus-jose-jwt"                 % "7.0",
+    "co.fs2"                    %% "fs2-core"                       % fs2V
   )
 }


### PR DESCRIPTION
Manage user locking via LDAP syncing. Fixes #523.

Changes in this pull request:
- Create `TaskHandler` to handle process flow for tasks (implemented via FS2 `Stream`)
- Create simple table to handle task contention for distributed portal setup