### PR TITLE
Add ownerGroupId to mysql recordset table

### DIFF
--- a/modules/mysql/src/main/resources/db/migration/V3.13__RecordSetOwnerGroup.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.13__RecordSetOwnerGroup.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+ALTER TABLE recordset ADD COLUMN owner_group_id CHAR(36) NULL;
+CREATE INDEX owner_group_id_index ON recordset (owner_group_id);

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -57,10 +57,10 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     """.stripMargin
 
   private val INSERT_RECORDSET =
-    sql"INSERT IGNORE INTO recordset(id, zone_id, name, type, data, fqdn) VALUES (?, ?, ?, ?, ?, ?)"
+    sql"INSERT IGNORE INTO recordset(id, zone_id, name, type, data, fqdn, owner_group_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
 
   private val UPDATE_RECORDSET =
-    sql"UPDATE recordset SET zone_id = ?, name = ?, type = ?, data = ?, fqdn = ? WHERE id = ?"
+    sql"UPDATE recordset SET zone_id = ?, name = ?, type = ?, data = ?, fqdn = ?, owner_group_id = ? WHERE id = ?"
 
   private val DELETE_RECORDSET =
     sql"DELETE FROM recordset WHERE id = ?"
@@ -92,6 +92,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             fromRecordType(oldRs.typ),
             toPB(oldRs).toByteArray,
             toFQDN(change.zone.name, oldRs.name),
+            oldRs.ownerGroupId,
             oldRs.id)
         }
       }
@@ -114,7 +115,8 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             i.recordSet.name,
             fromRecordType(i.recordSet.typ),
             toPB(i.recordSet).toByteArray,
-            toFQDN(i.zone.name, i.recordSet.name)
+            toFQDN(i.zone.name, i.recordSet.name),
+            i.recordSet.ownerGroupId
           )
         }
 
@@ -126,6 +128,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             fromRecordType(u.recordSet.typ),
             toPB(u.recordSet).toByteArray,
             toFQDN(u.zone.name, u.recordSet.name),
+            u.recordSet.ownerGroupId,
             u.recordSet.id)
         }
 


### PR DESCRIPTION
Fixes #426 .

Changes in this pull request:
- Added a new alter query under migrations section
- Updated MySqlRecordSetRepository to include the optional new field `owner-group-id` 
- Integration tests