### PR TITLE
batch change use getRecordSetsByFQDNs

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -552,8 +552,8 @@ def test_create_batch_change_failed(shared_zone_test_context):
         # these records already exist in the backend, but are not synced in zone
         dns_add(shared_zone_test_context.ok_zone, "backend-foo", 200, "A", "1.2.3.4")
         dns_add(shared_zone_test_context.ok_zone, "backend-already-exists", 200, "A", "1.2.3.4")
-        dns_add(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", 200, "PTR", "test.com.")
-        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "193", 200, "PTR", "test.com")
+        dns_add(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", 200, "PTR", "another-test.com")
+        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "193", 200, "PTR", "another-test.com")
         result = client.create_batch_change(batch_change_input, status=202)
         completed_batch = client.wait_until_batch_change_completed(result)
 

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -542,16 +542,18 @@ def test_create_batch_change_failed(shared_zone_test_context):
         "comments": "this is optional",
         "changes": [
             get_change_A_AAAA_json("backend-foo.ok.", address="4.5.6.7"),
-            get_change_A_AAAA_json("backend-already-exists.ok.", address="4.5.6.7")
+            get_change_A_AAAA_json("backend-already-exists.ok.", address="4.5.6.7"),
+            get_change_PTR_json("fd69:27cc:fe91::1234"),
+            get_change_PTR_json("192.0.2.196")
         ]
     }
 
     try:
-        # both of these records already exist in the backend, but are not synced in zone
+        # these records already exist in the backend, but are not synced in zone
         dns_add(shared_zone_test_context.ok_zone, "backend-foo", 200, "A", "1.2.3.4")
         dns_add(shared_zone_test_context.ok_zone, "backend-already-exists", 200, "A", "1.2.3.4")
-        dns_add(shared_zone_test_context.ip6_reverse_zone, "fd69:27cc:fe91::1234", 200, "PTR", "test.com.")
-        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "194", 200, "PTR", "another-test.com.")
+        dns_add(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", 200, "PTR", "test.com.")
+        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "196", 200, "PTR", "test.com")
         result = client.create_batch_change(batch_change_input, status=202)
         completed_batch = client.wait_until_batch_change_completed(result)
 
@@ -560,9 +562,8 @@ def test_create_batch_change_failed(shared_zone_test_context):
     finally:
         dns_delete(shared_zone_test_context.ok_zone, "backend-foo", "A")
         dns_delete(shared_zone_test_context.ok_zone, "backend-already-exists", "A")
-        dns_delete(shared_zone_test_context.ok_zone, "fd69:27cc:fe91::1234", "PTR")
-        dns_delete(shared_zone_test_context.ok_zone, "194", "PTR")
-
+        dns_delete(shared_zone_test_context.classless_zone_delegation_zone, "196", "PTR")
+        dns_delete(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR")
 
 def test_empty_batch_fails(shared_zone_test_context):
     """

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -550,6 +550,8 @@ def test_create_batch_change_failed(shared_zone_test_context):
         # both of these records already exist in the backend, but are not synced in zone
         dns_add(shared_zone_test_context.ok_zone, "backend-foo", 200, "A", "1.2.3.4")
         dns_add(shared_zone_test_context.ok_zone, "backend-already-exists", 200, "A", "1.2.3.4")
+        dns_add(shared_zone_test_context.ip6_reverse_zone, "fd69:27cc:fe91::1234", 200, "PTR", "test.com.")
+        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "194", 200, "PTR", "another-test.com.")
         result = client.create_batch_change(batch_change_input, status=202)
         completed_batch = client.wait_until_batch_change_completed(result)
 
@@ -558,6 +560,8 @@ def test_create_batch_change_failed(shared_zone_test_context):
     finally:
         dns_delete(shared_zone_test_context.ok_zone, "backend-foo", "A")
         dns_delete(shared_zone_test_context.ok_zone, "backend-already-exists", "A")
+        dns_delete(shared_zone_test_context.ok_zone, "fd69:27cc:fe91::1234", "PTR")
+        dns_delete(shared_zone_test_context.ok_zone, "194", "PTR")
 
 
 def test_empty_batch_fails(shared_zone_test_context):

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -544,7 +544,7 @@ def test_create_batch_change_failed(shared_zone_test_context):
             get_change_A_AAAA_json("backend-foo.ok.", address="4.5.6.7"),
             get_change_A_AAAA_json("backend-already-exists.ok.", address="4.5.6.7"),
             get_change_PTR_json("fd69:27cc:fe91::1234"),
-            get_change_PTR_json("192.0.2.196")
+            get_change_PTR_json("192.0.2.193")
         ]
     }
 
@@ -553,7 +553,7 @@ def test_create_batch_change_failed(shared_zone_test_context):
         dns_add(shared_zone_test_context.ok_zone, "backend-foo", 200, "A", "1.2.3.4")
         dns_add(shared_zone_test_context.ok_zone, "backend-already-exists", 200, "A", "1.2.3.4")
         dns_add(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", 200, "PTR", "test.com.")
-        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "196", 200, "PTR", "test.com")
+        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "193", 200, "PTR", "test.com")
         result = client.create_batch_change(batch_change_input, status=202)
         completed_batch = client.wait_until_batch_change_completed(result)
 
@@ -562,7 +562,7 @@ def test_create_batch_change_failed(shared_zone_test_context):
     finally:
         dns_delete(shared_zone_test_context.ok_zone, "backend-foo", "A")
         dns_delete(shared_zone_test_context.ok_zone, "backend-already-exists", "A")
-        dns_delete(shared_zone_test_context.classless_zone_delegation_zone, "196", "PTR")
+        dns_delete(shared_zone_test_context.classless_zone_delegation_zone, "193", "PTR")
         dns_delete(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR")
 
 def test_empty_batch_fails(shared_zone_test_context):

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -155,9 +155,9 @@ class BatchChangeService(
   def getExistingRecordSets(
       changes: ValidatedBatch[ChangeForValidation]): IO[ExistingRecordSets] = {
     val uniqueGets = changes.getValid.map(change => change.inputChange.inputName).toSet
-    val allSeq = recordSetRepository.getRecordSetsByFQDNs(uniqueGets)
+    val allRecordSets = recordSetRepository.getRecordSetsByFQDNs(uniqueGets)
 
-    allSeq.map(lst => ExistingRecordSets(lst))
+    allRecordSets.map(lst => ExistingRecordSets(lst))
   }
 
   def getOwnerGroup(ownerGroupId: Option[String]): BatchResult[Option[Group]] = {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -130,6 +130,8 @@ class BatchChangeServiceSpec
     makeRS(nonApexAddForVal.zone.name, nonApexAddForVal.recordName, TXT)
 
   object TestRecordSetRepo extends EmptyRecordSetRepo {
+    val dbRecordSets: Set[(RecordSet, String)] =
+      Set((existingApex, "apex.test.com."), (existingNonApex, "non-apex.test.com."))
 
     override def getRecordSetsByName(zoneId: String, name: String): IO[List[RecordSet]] =
       IO.pure {
@@ -139,6 +141,13 @@ class BatchChangeServiceSpec
           case (_, _) => List()
         }
       }
+
+    override def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] =
+      IO.pure(
+        dbRecordSets
+          .filter(rn => names.contains(rn._2))
+          .map(r => r._1)
+          .toList)
   }
 
   object AlwaysExistsZoneRepo extends EmptyZoneRepo {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -156,12 +156,18 @@ class BatchChangeServiceSpec
       }
 
     override def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] =
-      IO.pure(
+      IO.pure {
         dbRecordSets
-          .filter(rn => names.contains(rn._2))
-          .map(r => r._1)
-          .toList)
-  }
+          .filter {
+            case (_, fqdn) =>
+              names.contains(fqdn)
+          }
+          .map {
+            case (rs, _) => rs
+          }
+          .toList
+      }
+}
 
   object AlwaysExistsZoneRepo extends EmptyZoneRepo {
     override def getZonesByNames(zoneNames: Set[String]): IO[Set[Zone]] = {

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -839,7 +839,9 @@ class MembershipServiceSpec
       }
 
       "return an InvalidGroupRequestError when a group for deletion is admin of a zone" in {
-        doReturn(IO.pure(Some("somerecordsetid"))).when(mockRecordSetRepo).getFirstOwnedRecordByGroup(okGroup.id)
+        doReturn(IO.pure(Some("somerecordsetid")))
+          .when(mockRecordSetRepo)
+          .getFirstOwnedRecordByGroup(okGroup.id)
 
         val error = leftResultOf(underTest.isNotRecordOwnerGroup(okGroup).value)
         error shouldBe an[InvalidGroupRequestError]
@@ -855,7 +857,9 @@ class MembershipServiceSpec
       }
 
       "return an InvalidGroupRequestError when a group has an ACL rule in a zone" in {
-        doReturn(IO.pure(Some("someZoneId"))).when(mockZoneRepo).getFirstOwnedZoneAclGroupId(okGroup.id)
+        doReturn(IO.pure(Some("someZoneId")))
+          .when(mockZoneRepo)
+          .getFirstOwnedZoneAclGroupId(okGroup.id)
 
         val error = leftResultOf(underTest.isNotInZoneAclRule(okGroup).value)
         error shouldBe an[InvalidGroupRequestError]


### PR DESCRIPTION
right now recordsets are searched by zone id and recordset name, the getRecordSetsByFQDNs function will allow for batch gets using the input name that was directly input into the batch request
