### PR TITLE
Delete group - Check if ownerGroupId is in any recordSet

### DIFF
--- a/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
@@ -226,6 +226,14 @@ def test_list_batch_change_summaries_with_deleted_record_owner_group_passes(shar
         record_set_list = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
         record_to_delete = set(record_set_list)
 
+        #delete records and owner group
+        temp = record_to_delete.copy()
+        for result_rs in temp:
+            delete_result = client.delete_recordset(result_rs[0], result_rs[1], status=202)
+            client.wait_until_recordset_change_status(delete_result, 'Complete')
+            record_to_delete.remove(result_rs)
+        temp.clear()
+
         # delete group
         client.delete_group(group_to_delete['id'], status=200)
 

--- a/modules/api/functional_test/live_tests/zone_history_context.py
+++ b/modules/api/functional_test/live_tests/zone_history_context.py
@@ -159,7 +159,6 @@ class ZoneHistoryContext(object):
         result =  self.client.delete_recordset(self.zone['id'], rs['id'], status=202)
         return result, result['recordSet']
 
-
     def confirm_member_in_group(self, client, group):
         retries = 2
         success = group in client.list_all_my_groups(status=200)

--- a/modules/api/functional_test/live_tests/zones/sync_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/sync_zone_test.py
@@ -95,6 +95,7 @@ def test_sync_zone_success(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
     zone_name = 'sync-test'
     updated_rs_id = None
+    check_rs = None
 
     zone = {
         'name': zone_name,
@@ -216,6 +217,11 @@ def test_sync_zone_success(shared_zone_test_context):
                 client.wait_until_recordset_change_status(change, 'Complete')
 
     finally:
+        # reset the ownerGroupId for foo record
+        if check_rs:
+            check_rs['ownerGroupId'] = None
+            update_response = client.update_recordset(check_rs, status=202)
+            client.wait_until_recordset_change_status(update_response, 'Complete')
         if 'id' in zone:
             dns_update(zone, 'foo', 38400, 'A', '2.2.2.2')
             dns_delete(zone, 'newrs', 'A')

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -89,8 +89,8 @@ class MembershipService(
     for {
       existingGroup <- getExistingGroup(groupId)
       _ <- canEditGroup(existingGroup, authPrincipal).toResult
-      _ <- isAZoneAdmin(existingGroup)
-      _ <- isOwnerGroup(existingGroup)
+      _ <- isZoneAdmin(existingGroup)
+      _ <- isRecordOwnerGroup(existingGroup)
       _ <- groupChangeRepo
         .save(GroupChange.forDelete(existingGroup, authPrincipal))
         .toResult[GroupChange]
@@ -237,7 +237,7 @@ class MembershipService(
       }
       .toResult
 
-  def isAZoneAdmin(group: Group): Result[Unit] =
+  def isZoneAdmin(group: Group): Result[Unit] =
     zoneRepo
       .getZonesByAdminGroupId(group.id)
       .map { zones =>
@@ -247,13 +247,13 @@ class MembershipService(
       }
       .toResult
 
-  def isOwnerGroup(group: Group): Result[Unit] =
+  def isRecordOwnerGroup(group: Group): Result[Unit] =
     recordSetRepo
-      .isNotAOwnerGroupId(group.id)
+      .isRecordOwnerGroup(group.id)
       .map { rs =>
         ensuring(
           InvalidGroupRequestError(s"${group.name} is the owner for a record. Cannot delete.")) {
-          rs
+          !rs
         }
       }
       .toResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -249,11 +249,12 @@ class MembershipService(
 
   def isNotRecordOwnerGroup(group: Group): Result[Unit] =
     recordSetRepo
-      .getRecordSetOwnerGroup(group.id)
-      .map { rs =>
+      .getFirstOwnedRecordByGroup(group.id)
+      .map { rsId =>
         ensuring(
-          InvalidGroupRequestError(s"${group.name} is the owner for a record set $rs. Cannot delete.")){
-          rs.isEmpty
+          InvalidGroupRequestError(
+            s"${group.name} is the owner for record set $rsId. Cannot delete.")) {
+          rsId.isEmpty
         }
       }
       .toResult

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -118,7 +118,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored {
             val dottedRecords = changes
               .filter { chg =>
                 chg.recordSet.name != zone.name && chg.recordSet.name.contains(".") &&
-                  chg.recordSet.typ != RecordType.SRV
+                chg.recordSet.typ != RecordType.SRV
               }
               .map(_.recordSet.name)
               .mkString(", ")

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSConfigSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSConfigSpec.scala
@@ -38,7 +38,11 @@ class VinylDNSConfigSpec extends WordSpec with Matchers {
           .find(_.className == "vinyldns.mysql.repository.MySqlDataStoreProvider")
           .get
 
-      mysqlConfig.repositories.keys should contain theSameElementsAs Set(zone, batchChange, user, recordSet)
+      mysqlConfig.repositories.keys should contain theSameElementsAs Set(
+        zone,
+        batchChange,
+        user,
+        recordSet)
     }
     "assign the correct dynamodb repositories" in {
       val dynamodbConfig =

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -780,7 +780,7 @@ class MembershipServiceSpec
       "return true when a group for deletion is not the admin of a zone" in {
         doReturn(IO.pure(List())).when(mockZoneRepo).getZonesByAdminGroupId(okGroup.id)
 
-        val result = awaitResultOf(underTest.groupCanBeDeleted(okGroup).value)
+        val result = awaitResultOf(underTest.isAZoneAdmin(okGroup).value)
         result should be(right)
       }
 
@@ -789,7 +789,7 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getZonesByAdminGroupId(okGroup.id)
 
-        val error = leftResultOf(underTest.groupCanBeDeleted(okGroup).value)
+        val error = leftResultOf(underTest.isAZoneAdmin(okGroup).value)
         error shouldBe a[InvalidGroupRequestError]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -428,9 +428,9 @@ class MembershipServiceSpec
         doReturn(IO.pure(Set[String]()))
           .when(mockMembershipRepo)
           .removeMembers(anyString, any[Set[String]])
-        doReturn(IO.pure(false))
+        doReturn(IO.pure(""))
           .when(mockRecordSetRepo)
-          .isRecordOwnerGroup(anyString)
+          .getRecordSetOwnerGroup(anyString)
 
         val result: Group = rightResultOf(underTest.deleteGroup("ok", okAuth).value)
         result shouldBe okGroup.copy(status = GroupStatus.Deleted)
@@ -482,7 +482,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
         doReturn(IO.pure(false))
           .when(mockRecordSetRepo)
-          .isRecordOwnerGroup(anyString())
+          .getRecordSetOwnerGroup(anyString())
         val error = leftResultOf(underTest.deleteGroup("ok", okAuth).value)
 
         error shouldBe a[InvalidGroupRequestError]
@@ -799,11 +799,11 @@ class MembershipServiceSpec
       }
     }
 
-    "isZoneAdmin" should {
+    "isNotZoneAdmin" should {
       "return true when a group for deletion is not the admin of a zone" in {
         doReturn(IO.pure(List())).when(mockZoneRepo).getZonesByAdminGroupId(okGroup.id)
 
-        val result = awaitResultOf(underTest.isZoneAdmin(okGroup).value)
+        val result = awaitResultOf(underTest.isNotZoneAdmin(okGroup).value)
         result should be(right)
       }
 
@@ -812,23 +812,23 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getZonesByAdminGroupId(okGroup.id)
 
-        val error = leftResultOf(underTest.isZoneAdmin(okGroup).value)
+        val error = leftResultOf(underTest.isNotZoneAdmin(okGroup).value)
         error shouldBe a[InvalidGroupRequestError]
       }
     }
 
-    "isOwnerGroup" should {
+    "isNotRecordOwnerGroup" should {
       "return true when a group for deletion is not the admin of a zone" in {
-        doReturn(IO.pure(false)).when(mockRecordSetRepo).isRecordOwnerGroup(okGroup.id)
+        doReturn(IO.pure("")).when(mockRecordSetRepo).getRecordSetOwnerGroup(okGroup.id)
 
-        val result = awaitResultOf(underTest.isRecordOwnerGroup(okGroup).value)
+        val result = awaitResultOf(underTest.isNotRecordOwnerGroup(okGroup).value)
         result should be(right)
       }
 
       "return an InvalidGroupRequestError when a group for deletion is admin of a zone" in {
-        doReturn(IO.pure(true)).when(mockRecordSetRepo).isRecordOwnerGroup(okGroup.id)
+        doReturn(IO.pure("someId")).when(mockRecordSetRepo).getRecordSetOwnerGroup(okGroup.id)
 
-        val error = leftResultOf(underTest.isRecordOwnerGroup(okGroup).value)
+        val error = leftResultOf(underTest.isNotRecordOwnerGroup(okGroup).value)
         error shouldBe a[InvalidGroupRequestError]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -428,9 +428,9 @@ class MembershipServiceSpec
         doReturn(IO.pure(Set[String]()))
           .when(mockMembershipRepo)
           .removeMembers(anyString, any[Set[String]])
-        doReturn(IO.pure(true))
+        doReturn(IO.pure(false))
           .when(mockRecordSetRepo)
-          .isNotAOwnerGroupId(anyString)
+          .isRecordOwnerGroup(anyString)
 
         val result: Group = rightResultOf(underTest.deleteGroup("ok", okAuth).value)
         result shouldBe okGroup.copy(status = GroupStatus.Deleted)
@@ -482,7 +482,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
         doReturn(IO.pure(false))
           .when(mockRecordSetRepo)
-          .isNotAOwnerGroupId(anyString())
+          .isRecordOwnerGroup(anyString())
         val error = leftResultOf(underTest.deleteGroup("ok", okAuth).value)
 
         error shouldBe a[InvalidGroupRequestError]
@@ -799,11 +799,11 @@ class MembershipServiceSpec
       }
     }
 
-    "isAZoneAdmin" should {
+    "isZoneAdmin" should {
       "return true when a group for deletion is not the admin of a zone" in {
         doReturn(IO.pure(List())).when(mockZoneRepo).getZonesByAdminGroupId(okGroup.id)
 
-        val result = awaitResultOf(underTest.isAZoneAdmin(okGroup).value)
+        val result = awaitResultOf(underTest.isZoneAdmin(okGroup).value)
         result should be(right)
       }
 
@@ -812,23 +812,23 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getZonesByAdminGroupId(okGroup.id)
 
-        val error = leftResultOf(underTest.isAZoneAdmin(okGroup).value)
+        val error = leftResultOf(underTest.isZoneAdmin(okGroup).value)
         error shouldBe a[InvalidGroupRequestError]
       }
     }
 
     "isOwnerGroup" should {
       "return true when a group for deletion is not the admin of a zone" in {
-        doReturn(IO.pure(true)).when(mockRecordSetRepo).isNotAOwnerGroupId(okGroup.id)
+        doReturn(IO.pure(false)).when(mockRecordSetRepo).isRecordOwnerGroup(okGroup.id)
 
-        val result = awaitResultOf(underTest.isOwnerGroup(okGroup).value)
+        val result = awaitResultOf(underTest.isRecordOwnerGroup(okGroup).value)
         result should be(right)
       }
 
       "return an InvalidGroupRequestError when a group for deletion is admin of a zone" in {
-        doReturn(IO.pure(false)).when(mockRecordSetRepo).isNotAOwnerGroupId(okGroup.id)
+        doReturn(IO.pure(true)).when(mockRecordSetRepo).isRecordOwnerGroup(okGroup.id)
 
-        val error = leftResultOf(underTest.isOwnerGroup(okGroup).value)
+        val error = leftResultOf(underTest.isRecordOwnerGroup(okGroup).value)
         error shouldBe a[InvalidGroupRequestError]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -50,7 +50,7 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] = IO.pure(List())
 
-  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean] = IO.pure(true)
+  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean] = IO.pure(true)
 }
 
 trait EmptyZoneRepo extends ZoneRepository {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -50,7 +50,7 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] = IO.pure(List())
 
-  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String] = IO.pure("")
+  def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]] = IO.pure(None)
 }
 
 trait EmptyZoneRepo extends ZoneRepository {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -50,7 +50,7 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] = IO.pure(List())
 
-  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean] = IO.pure(true)
+  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String] = IO.pure("")
 }
 
 trait EmptyZoneRepo extends ZoneRepository {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -49,6 +49,8 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
   def getRecordSetCount(zoneId: String): IO[Int] = IO.pure(0)
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] = IO.pure(List())
+
+  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean] = IO.pure(true)
 }
 
 trait EmptyZoneRepo extends ZoneRepository {

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -40,5 +40,5 @@ trait RecordSetRepository extends Repository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]]
 
-  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean]
+  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean]
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -40,5 +40,5 @@ trait RecordSetRepository extends Repository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]]
 
-  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean]
+  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String]
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -40,5 +40,5 @@ trait RecordSetRepository extends Repository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]]
 
-  def getRecordSetByOwnerGroupId(ownerGroupId: String): IO[List[RecordSet]]
+  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean]
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -39,4 +39,6 @@ trait RecordSetRepository extends Repository {
   def getRecordSetsByName(zoneId: String, name: String): IO[List[RecordSet]]
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]]
+
+  def getRecordSetByOwnerGroupId(ownerGroupId: String): IO[List[RecordSet]]
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -40,5 +40,5 @@ trait RecordSetRepository extends Repository {
 
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]]
 
-  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String]
+  def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]]
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -244,11 +244,11 @@ class DynamoDBRecordSetRepository private[repository] (
       )
     }
 
-  override def getRecordSetByOwnerGroupId(ownerGroupId: String): IO[List[RecordSet]] =
-    monitor("repo.RecordSet.getRecordSetByOwnerGroupId") {
+  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean] =
+    monitor("repo.RecordSet.isNotAOwnerGroupId") {
       IO.raiseError(
         UnsupportedDynamoDBRepoFunction(
-          "getRecordSetByOwnerGroupId is not supported by VinylDNS DynamoDB RecordSetRepository"
+          "isNotAOwnerGroupId is not supported by VinylDNS DynamoDB RecordSetRepository"
         )
       )
     }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -244,11 +244,11 @@ class DynamoDBRecordSetRepository private[repository] (
       )
     }
 
-  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String] =
-    monitor("repo.RecordSet.isNotAOwnerGroupId") {
+  def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]] =
+    monitor("repo.RecordSet.getFirstOwnedRecordByGroup") {
       IO.raiseError(
         UnsupportedDynamoDBRepoFunction(
-          s"isRecordOwnerGroup is not supported by VinylDNS DynamoDB RecordSetRepository id=${ownerGroupId}"
+          s"getFirstOwnedRecordByGroup is not supported by VinylDNS DynamoDB RecordSetRepository id=$ownerGroupId"
         )
       )
     }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -244,11 +244,11 @@ class DynamoDBRecordSetRepository private[repository] (
       )
     }
 
-  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean] =
+  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean] =
     monitor("repo.RecordSet.isNotAOwnerGroupId") {
       IO.raiseError(
         UnsupportedDynamoDBRepoFunction(
-          "isNotAOwnerGroupId is not supported by VinylDNS DynamoDB RecordSetRepository"
+          s"isRecordOwnerGroup is not supported by VinylDNS DynamoDB RecordSetRepository id=${ownerGroupId}"
         )
       )
     }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -244,7 +244,7 @@ class DynamoDBRecordSetRepository private[repository] (
       )
     }
 
-  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean] =
+  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String] =
     monitor("repo.RecordSet.isNotAOwnerGroupId") {
       IO.raiseError(
         UnsupportedDynamoDBRepoFunction(

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -243,4 +243,13 @@ class DynamoDBRecordSetRepository private[repository] (
         )
       )
     }
+
+  override def getRecordSetByOwnerGroupId(ownerGroupId: String): IO[List[RecordSet]] =
+    monitor("repo.RecordSet.getRecordSetByOwnerGroupId") {
+      IO.raiseError(
+        UnsupportedDynamoDBRepoFunction(
+          "getRecordSetByOwnerGroupId is not supported by VinylDNS DynamoDB RecordSetRepository"
+        )
+      )
+    }
 }

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
@@ -396,11 +396,11 @@ class DynamoDBRecordSetRepositorySpec
     }
   }
 
-  "DynamoDBRecordSetRepository.getRecordSetOwnerGroup" should {
+  "DynamoDBRecordSetRepository.getRecordSetIdOwnerGroup" should {
     "return an error if used" in {
       val store = new TestDynamoRecordSetRepo
       an[UnsupportedDynamoDBRepoFunction] should be thrownBy store
-        .getRecordSetOwnerGroup("someId")
+        .getFirstOwnedRecordByGroup("someId")
         .unsafeRunSync()
     }
   }

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
@@ -395,4 +395,13 @@ class DynamoDBRecordSetRepositorySpec
         .unsafeRunSync()
     }
   }
+
+  "DynamoDBRecordSetRepository.isRecordOwnerGroup" should {
+    "return an error if used" in {
+      val store = new TestDynamoRecordSetRepo
+      a[UnsupportedDynamoDBRepoFunction] should be thrownBy store
+        .isRecordOwnerGroup("someId")
+        .unsafeRunSync()
+    }
+  }
 }

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
@@ -390,17 +390,17 @@ class DynamoDBRecordSetRepositorySpec
   "DynamoDBRecordSetRepository.getRecordSetsByFQDNs" should {
     "return an error if used" in {
       val store = new TestDynamoRecordSetRepo
-      a[UnsupportedDynamoDBRepoFunction] should be thrownBy store
+      an[UnsupportedDynamoDBRepoFunction] should be thrownBy store
         .getRecordSetsByFQDNs(Set("test"))
         .unsafeRunSync()
     }
   }
 
-  "DynamoDBRecordSetRepository.isRecordOwnerGroup" should {
+  "DynamoDBRecordSetRepository.getRecordSetOwnerGroup" should {
     "return an error if used" in {
       val store = new TestDynamoRecordSetRepo
-      a[UnsupportedDynamoDBRepoFunction] should be thrownBy store
-        .isRecordOwnerGroup("someId")
+      an[UnsupportedDynamoDBRepoFunction] should be thrownBy store
+        .getRecordSetOwnerGroup("someId")
         .unsafeRunSync()
     }
   }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -479,8 +479,8 @@ class MySqlRecordSetRepositoryIntegrationSpec
     }
   }
 
-  "isRecordOwnerGroup" should {
-    "return recordset id when groupid is ownerGroupId for the record set" in {
+  "getRecordSetIdOwnerGroup" should {
+    "return id for the first recordSet owned by the ownerGroupId" in {
       val addChange = makeTestAddChange(ds.copy(ownerGroupId = Some("someOwner")), okZone)
       val testRecord = addChange.recordSet
       val dbCalls = for {
@@ -490,13 +490,13 @@ class MySqlRecordSetRepositoryIntegrationSpec
 
       dbCalls.unsafeRunSync()
 
-      val result = repo.getRecordSetOwnerGroup("someOwner").unsafeRunSync()
-      result shouldBe ds.id
+      val result = repo.getFirstOwnedRecordByGroup("someOwner").unsafeRunSync()
+      result shouldBe Some(testRecord.id)
     }
 
     "return empty string when no record set has the id as ownerGroupId" in {
-      val result = repo.getRecordSetOwnerGroup("notFound").unsafeRunSync()
-      result shouldBe ""
+      val result = repo.getFirstOwnedRecordByGroup("notFound").unsafeRunSync()
+      result shouldBe None
     }
   }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -478,4 +478,25 @@ class MySqlRecordSetRepositoryIntegrationSpec
       result2 should contain theSameElementsAs List(change1.recordSet, change2.recordSet)
     }
   }
+
+  "isRecordOwnerGroup" should {
+    "return true when id is ownerGroupId for a record set" in {
+      val addChange = makeTestAddChange(ds.copy(ownerGroupId = Some("someOwner")), okZone)
+      val testRecord = addChange.recordSet
+      val dbCalls = for {
+        _ <- repo.apply(ChangeSet(addChange))
+        get <- repo.getRecordSet(testRecord.zoneId, testRecord.id)
+      } yield get
+
+      dbCalls.unsafeRunSync()
+
+      val result = repo.isRecordOwnerGroup("someOwner").unsafeRunSync()
+      result shouldBe true
+    }
+
+    "return false when no record set has the id as ownerGroupId" in {
+      val result = repo.isRecordOwnerGroup("notFound").unsafeRunSync()
+      result shouldBe false
+    }
+  }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -480,7 +480,7 @@ class MySqlRecordSetRepositoryIntegrationSpec
   }
 
   "isRecordOwnerGroup" should {
-    "return true when id is ownerGroupId for a record set" in {
+    "return recordset id when groupid is ownerGroupId for the record set" in {
       val addChange = makeTestAddChange(ds.copy(ownerGroupId = Some("someOwner")), okZone)
       val testRecord = addChange.recordSet
       val dbCalls = for {
@@ -490,13 +490,13 @@ class MySqlRecordSetRepositoryIntegrationSpec
 
       dbCalls.unsafeRunSync()
 
-      val result = repo.isRecordOwnerGroup("someOwner").unsafeRunSync()
-      result shouldBe true
+      val result = repo.getRecordSetOwnerGroup("someOwner").unsafeRunSync()
+      result shouldBe ds.id
     }
 
-    "return false when no record set has the id as ownerGroupId" in {
-      val result = repo.isRecordOwnerGroup("notFound").unsafeRunSync()
-      result shouldBe false
+    "return empty string when no record set has the id as ownerGroupId" in {
+      val result = repo.getRecordSetOwnerGroup("notFound").unsafeRunSync()
+      result shouldBe ""
     }
   }
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -74,7 +74,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
 
   private val GET_RECORDSET_BY_OWNERID =
     sql"""
-      |SELECT data
+      |SELECT id
       |  FROM recordset
       |WHERE owner_group_id = {ownerGroupId}
       |LIMIT 1
@@ -284,16 +284,16 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       }
     }
 
-  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean] =
+  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String] =
     monitor("repo.RecordSet.isRecordOwnerGroup") {
       IO {
         DB.readOnly { implicit s =>
           GET_RECORDSET_BY_OWNERID
             .bindByName('ownerGroupId -> ownerGroupId)
-            .map(toRecordSet)
-            .list()
+            .map(_.string(1))
+            .single
             .apply()
-            .nonEmpty
+            .getOrElse("")
         }
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -74,9 +74,10 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
 
   private val GET_RECORDSET_BY_OWNERID =
     sql"""
-      |SELECT data
+      |SELECT id
       |FROM recordset
       |WHERE owner_group_id = {ownerGroupId}
+      |LIMIT 1
     """.stripMargin
 
   def apply(changeSet: ChangeSet): IO[ChangeSet] =
@@ -283,7 +284,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       }
     }
 
-  def getRecordSetByOwnerGroupId(ownerGroupId: String): IO[List[RecordSet]] =
+  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean] =
     monitor("repo.RecordSet.getRecordSetByOwnerGroupId") {
       IO {
         DB.readOnly { implicit s =>
@@ -292,6 +293,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             .map(toRecordSet)
             .list()
             .apply()
+            .isEmpty
         }
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -74,8 +74,8 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
 
   private val GET_RECORDSET_BY_OWNERID =
     sql"""
-      |SELECT id
-      |FROM recordset
+      |SELECT data
+      |  FROM recordset
       |WHERE owner_group_id = {ownerGroupId}
       |LIMIT 1
     """.stripMargin
@@ -284,8 +284,8 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       }
     }
 
-  def isNotAOwnerGroupId(ownerGroupId: String): IO[Boolean] =
-    monitor("repo.RecordSet.getRecordSetByOwnerGroupId") {
+  def isRecordOwnerGroup(ownerGroupId: String): IO[Boolean] =
+    monitor("repo.RecordSet.isRecordOwnerGroup") {
       IO {
         DB.readOnly { implicit s =>
           GET_RECORDSET_BY_OWNERID
@@ -293,7 +293,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             .map(toRecordSet)
             .list()
             .apply()
-            .isEmpty
+            .nonEmpty
         }
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -284,8 +284,8 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       }
     }
 
-  def getRecordSetOwnerGroup(ownerGroupId: String): IO[String] =
-    monitor("repo.RecordSet.isRecordOwnerGroup") {
+  def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]] =
+    monitor("repo.RecordSet.getFirstOwnedRecordByGroup") {
       IO {
         DB.readOnly { implicit s =>
           GET_RECORDSET_BY_OWNERID
@@ -293,7 +293,6 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             .map(_.string(1))
             .single
             .apply()
-            .getOrElse("")
         }
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -72,6 +72,13 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       | WHERE fqdn
     """.stripMargin
 
+  private val GET_RECORDSET_BY_OWNERID =
+    sql"""
+      |SELECT data
+      |FROM recordset
+      |WHERE owner_group_id = {ownerGroupId}
+    """.stripMargin
+
   def apply(changeSet: ChangeSet): IO[ChangeSet] =
     monitor("repo.RecordSet.apply") {
 
@@ -272,6 +279,19 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
               .list()
               .apply()
           }
+        }
+      }
+    }
+
+  def getRecordSetByOwnerGroupId(ownerGroupId: String): IO[List[RecordSet]] =
+    monitor("repo.RecordSet.getRecordSetByOwnerGroupId") {
+      IO {
+        DB.readOnly { implicit s =>
+          GET_RECORDSET_BY_OWNERID
+            .bindByName('ownerGroupId -> ownerGroupId)
+            .map(toRecordSet)
+            .list()
+            .apply()
         }
       }
     }


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- check if ownerGroupId is not in any recordset before deleting group
