### PR TITLE
correctly handle txt record data

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1517,6 +1517,7 @@ def test_create_long_txt_record_succeeds(shared_zone_test_context):
     try:
         rs_create = client.create_recordset(long_txt_rs, status=202)
         rs = client.wait_until_recordset_change_status(rs_create, 'Complete')['recordSet']
+        assert_that(rs['records'][0]['text'], is_(record_data))
     finally:
         try:
             delete_result = client.delete_recordset(rs['zoneId'], rs['id'], status=202)

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1507,6 +1507,23 @@ def test_create_record_with_existing_cname_wildcard_succeed(shared_zone_test_con
                 pass
 
 
+def test_create_long_txt_record_succeeds(shared_zone_test_context):
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    zone = shared_zone_test_context.system_test_zone
+    record_data = 'a' * 64763
+    long_txt_rs = get_recordset_json(zone, 'long-txt-record', 'TXT', [{'text': record_data}])
+
+    try:
+        rs_create = client.create_recordset(long_txt_rs, status=202)
+        rs = client.wait_until_recordset_change_status(rs_create, 'Complete')['recordSet']
+    finally:
+        try:
+            delete_result = client.delete_recordset(rs['zoneId'], rs['id'], status=202)
+            client.wait_until_recordset_change_status(delete_result, 'Complete')
+        except:
+            pass
+
 def test_dotted_host_create_fails(shared_zone_test_context):
     """
     Tests that a dotted host recordset create fails

--- a/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
@@ -274,7 +274,7 @@ trait DnsConversions {
 
   def fromTXTRecord(r: DNS.TXTRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(TXTData(data.getStrings.asScala.mkString(",")))
+      List(TXTData(data.getStrings.asScala.mkString("")))
     }
 
   def toDnsRecords(recordSet: RecordSet, zoneName: String): Either[Throwable, List[DNS.Record]] =
@@ -346,17 +346,18 @@ trait DnsConversions {
           new DNS.SPFRecord(recordName, DNS.DClass.IN, ttl, text)
 
         case TXTData(text) =>
-          new DNS.TXTRecord(recordName, DNS.DClass.IN, ttl, text)
+          val texts = text.grouped(255).toList
+          new DNS.TXTRecord(recordName, DNS.DClass.IN, ttl, texts.asJava)
       }
     }
 
-  def toDnsRRset(recordSet: RecordSet, zoneName: String): Either[Throwable, DNS.RRset] =
-    Either.catchNonFatal {
-      val dnsRecordSet = new DNS.RRset()
-      toDnsRecords(recordSet, zoneName).map(_.foreach(dnsRecordSet.addRR))
-
+  def toDnsRRset(recordSet: RecordSet, zoneName: String): Either[Throwable, DNS.RRset] = {
+    val dnsRecordSet = new DNS.RRset()
+    toDnsRecords(recordSet, zoneName).map { thing =>
+      thing.foreach(dnsRecordSet.addRR)
       dnsRecordSet
     }
+  }
 
   def toDnsRecordType(typ: RecordType): Integer = typ match {
     case RecordType.A => DNS.Type.A

--- a/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
@@ -353,8 +353,8 @@ trait DnsConversions {
 
   def toDnsRRset(recordSet: RecordSet, zoneName: String): Either[Throwable, DNS.RRset] = {
     val dnsRecordSet = new DNS.RRset()
-    toDnsRecords(recordSet, zoneName).map { thing =>
-      thing.foreach(dnsRecordSet.addRR)
+    toDnsRecords(recordSet, zoneName).map { record =>
+      record.foreach(dnsRecordSet.addRR)
       dnsRecordSet
     }
   }

--- a/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
@@ -274,7 +274,7 @@ trait DnsConversions {
 
   def fromTXTRecord(r: DNS.TXTRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(TXTData(data.getStrings.asScala.mkString("")))
+      List(TXTData(data.getStrings.asScala.mkString))
     }
 
   def toDnsRecords(recordSet: RecordSet, zoneName: String): Either[Throwable, List[DNS.Record]] =

--- a/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
@@ -126,7 +126,7 @@ class DnsConversionsSpec
     List(SPFData("spf")))
   private val testLongSPF = RecordSet(
     testZone.id,
-    "spf-record",
+    "long-spf-record",
     RecordType.SPF,
     200,
     RecordSetStatus.Active,
@@ -160,6 +160,15 @@ class DnsConversionsSpec
     DateTime.now,
     None,
     List(TXTData("text")))
+  private val testLongTXT = RecordSet(
+    testZone.id,
+    "long-txt-record",
+    RecordType.TXT,
+    200,
+    RecordSetStatus.Active,
+    DateTime.now,
+    None,
+    List(TXTData("a" * 64763)))
   private val testAt = RecordSet(
     testZone.id,
     "vinyldns.",
@@ -346,6 +355,11 @@ class DnsConversionsSpec
       verifyMatch(result, testTXT)
     }
 
+    "convert long TXT record set" in {
+      val result = rightValue(toDnsRRset(testLongTXT, testZoneName))
+      verifyMatch(result, testLongTXT)
+    }
+
     "fail to convert a bad SPF record set" in {
       val result = leftValue(toDnsRRset(testLongSPF, testZoneName))
       result shouldBe a[java.lang.IllegalArgumentException]
@@ -455,6 +469,9 @@ class DnsConversionsSpec
     }
     "convert to/from RecordType TXT" in {
       verifyMatch(testTXT, roundTrip(testTXT))
+    }
+    "convert to/from RecordType TXT long TXT record data" in {
+      verifyMatch(testLongTXT, roundTrip(testLongTXT))
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
@@ -151,6 +151,15 @@ class DnsConversionsSpec
     DateTime.now,
     None,
     List(TXTData("text")))
+  private val tooLongTXT = RecordSet(
+    testZone.id,
+    "txt-record",
+    RecordType.TXT,
+    200,
+    RecordSetStatus.Active,
+    DateTime.now,
+    None,
+    List(TXTData("a" * 64764)))
   private val testAt = RecordSet(
     testZone.id,
     "vinyldns.",
@@ -335,6 +344,11 @@ class DnsConversionsSpec
     "convert TXT record set" in {
       val result = rightValue(toDnsRRset(testTXT, testZoneName))
       verifyMatch(result, testTXT)
+    }
+
+    "fail to convert a bad TXT record set" in {
+      val result = leftValue(toDnsRRset(tooLongTXT, testZoneName))
+      result shouldBe a[java.lang.IllegalArgumentException]
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
@@ -124,6 +124,15 @@ class DnsConversionsSpec
     DateTime.now,
     None,
     List(SPFData("spf")))
+  private val testLongSPF = RecordSet(
+    testZone.id,
+    "spf-record",
+    RecordType.SPF,
+    200,
+    RecordSetStatus.Active,
+    DateTime.now,
+    None,
+    List(SPFData("s" * 256)))
   private val testSRV = RecordSet(
     testZone.id,
     "srv-record",
@@ -151,15 +160,6 @@ class DnsConversionsSpec
     DateTime.now,
     None,
     List(TXTData("text")))
-  private val tooLongTXT = RecordSet(
-    testZone.id,
-    "txt-record",
-    RecordType.TXT,
-    200,
-    RecordSetStatus.Active,
-    DateTime.now,
-    None,
-    List(TXTData("a" * 64764)))
   private val testAt = RecordSet(
     testZone.id,
     "vinyldns.",
@@ -346,8 +346,8 @@ class DnsConversionsSpec
       verifyMatch(result, testTXT)
     }
 
-    "fail to convert a bad TXT record set" in {
-      val result = leftValue(toDnsRRset(tooLongTXT, testZoneName))
+    "fail to convert a bad SPF record set" in {
+      val result = leftValue(toDnsRRset(testLongSPF, testZoneName))
       result shouldBe a[java.lang.IllegalArgumentException]
     }
   }


### PR DESCRIPTION
Fixes #563.

Changes in this pull request:
- group TXT record data as a list of 255 character length strings
- also updated the `toDnsRRset` so it doesn't swallow errors 
