### PR TITLE
upgrade to scala 2.12.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 
 scala:
   - 2.12.7
+  - 2.12.8
 
 python:
   - 2.7

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ def scalaStyleSettings: Seq[Def.Setting[_]] = scalaStyleCompile ++ scalaStyleTes
 // settings that should be inherited by all projects
 lazy val sharedSettings = Seq(
   organization := "vinyldns",
-  scalaVersion := "2.12.7",
+  scalaVersion := "2.12.8",
   organizationName := "Comcast Cable Communications Management, LLC",
   startYear := Some(2018),
   licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),


### PR DESCRIPTION
Pretty much ready to submit a pr with the scala js portal rewrite I've been working on. That branch is feature flagged and adds a `/v2` route to the existing portal when the flag is turned on

scala js has a known bug with 2.12.17 so want to get this first commit in first to make sure travis is good with 2.12.18 
