### PR TITLE
remove old scala version from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 
 scala:
-  - 2.12.7
   - 2.12.8
 
 python:


### PR DESCRIPTION
additional tweak for #569.

Changes in this pull request:
- remove scala version 2.12.7 from travis.yml
