### PR TITLE
increase batch change limit default to 1000

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -189,7 +189,7 @@ vinyldns {
     }
   ]
 
-  batch-change-limit = 20
+  batch-change-limit = 1000
 
   # FQDNs / IPs that cannot be modified via VinylDNS
   # regex-list used for all record types except PTR

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -576,23 +576,7 @@ def test_empty_batch_fails(shared_zone_test_context):
     }
 
     errors = shared_zone_test_context.ok_vinyldns_client.create_batch_change(batch_change_input, status=400)['errors']
-    assert_that(errors, contains("Batch change contained no changes. Batch change must have at least one change, up to a maximum of 20 changes."))
-
-
-def test_create_batch_exceeding_change_limit_fails(shared_zone_test_context):
-    """
-    Test that creating a batch exceeding the change limit fails with ChangeLimitExceeded
-    """
-    client = shared_zone_test_context.ok_vinyldns_client
-    batch_change_input = {
-        "changes": []
-    }
-    for x in range(100):
-        batch_change_input['changes'].append(get_change_A_AAAA_json("ok.", address=("1.2.3." + str(x))))
-
-    errors = client.create_batch_change(batch_change_input, status=400)['errors']
-    assert_that(errors, contains("Cannot request more than 20 changes in a single batch change request"))
-
+    assert_that(errors[0], contains_string("Batch change contained no changes. Batch change must have at least one change, up to a maximum of"))
 
 def test_create_batch_change_without_changes_fails(shared_zone_test_context):
     """

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -88,7 +88,7 @@ vinyldns {
 
   sync-delay = 10000 # 10 second delay for resyncing zone
 
-  batch-change-limit = 20 # Max change limit per batch request
+  batch-change-limit = 1000 # Max change limit per batch request
 
   # this key is used in order to encrypt/decrypt DNS TSIG keys.  We use this dummy one for test purposes, this
   # should be overridden with a real value that is hidden for production deployment

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -101,5 +101,5 @@ vinyldns {
     primaryServer = "127.0.0.1:19001"
   }
 
-  batch-change-limit = 20
+  batch-change-limit = 1000
 }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -53,7 +53,7 @@ class BatchChangeRoutingSpec
   object TestData {
     import vinyldns.api.domain.batch.ChangeInputType._
 
-    val batchChangeLimit = 20
+    val batchChangeLimit = 1000
 
     /* Builds BatchChange response */
     def createBatchChangeResponse(

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -132,7 +132,7 @@ vinyldns {
 
   # the max number of changes in a single batch change.  Change carefully as this has performance
   # implications
-  batch-change-limit = 20
+  batch-change-limit = 1000
 }
 
 # Akka settings, these should not need to be modified unless you know akka http really well.

--- a/modules/docs/src/main/tut/api/create-batchchange.md
+++ b/modules/docs/src/main/tut/api/create-batchchange.md
@@ -102,7 +102,7 @@ Code          | description |
 202           | **Accepted** - The batch change is queued and is returned in the response body. |
 400           | **Bad Request** - Error in the batch change. See [Batch Change Errors](../api/batchchange-errors) page. |
 403           | **Forbidden** - The user does not have the access required to perform the action. |
-413           | **Request Entity Too Large** - Cannot request more than 20 changes in a single batch change request. |
+413           | **Request Entity Too Large** - Cannot request more than <limit> changes in a single batch change request. |
 422           | **Unprocessable Entity** - the batch does not contain any changes, thus cannot be processed. |
 
 A batch change goes through numerous validations before it is processed. This results in corresponding BadRequest or error responses. View the full list of batch change errors [here](../api/batchchange-errors).

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -570,7 +570,7 @@ vinyldns {
 
   # the max number of changes in a single batch change.  Change carefully as this has performance
   # implications
-  batch-change-limit = 20
+  batch-change-limit = 1000
 }
 
 # Akka settings, these should not need to be modified unless you know akka http really well.

--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -23,6 +23,6 @@ object Meta {
     Meta(
       config.getOptional[String]("vinyldns.version").getOrElse("unknown"),
       config.getOptional[Boolean]("shared-display-enabled").getOrElse(false),
-      config.getOptional[Int]("batch-change-limit").getOrElse(20)
+      config.getOptional[Int]("batch-change-limit").getOrElse(1000)
     )
 }

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -37,9 +37,9 @@ class MetaSpec extends Specification with Mockito {
       val config = Map("batch-change-limit" -> 21)
       Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(21)
     }
-    "default to 20 if batch-change-limit is not found" in {
+    "default to 1000 if batch-change-limit is not found" in {
       val config = Map("vinyldns.version" -> "foo-bar")
-      Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(20)
+      Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(1000)
     }
   }
 }


### PR DESCRIPTION
follow-up to #509.

now that we've migrated recordsets to mysql and get existing recordsets more efficiently we can increase the batch change limit.

Changes in this pull request:
- set default batch-change-limit to 1000
- remove tests that check for specific limit (every instance of VinylDNS doesn't have to have the same batch change limit!)
