### PR TITLE
use getRecordSetsByName

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -161,6 +161,10 @@ class BatchChangeServiceSpec
         (zoneId, name) match {
           case ("apex", "apex.test.com.") => List(existingApex)
           case ("base", "non-apex") => List(existingNonApex)
+          case ("nonDelegatedPTR", "11") => List(existingPtr)
+          case ("delegatedPTR", "193") => List(existingPtrDelegated)
+          case ("ipv6PTR", "9.2.3.8.2.4.0.0.0.0.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0") =>
+            List(existingPtrV6)
           case (_, _) => List()
         }
       }


### PR DESCRIPTION
reverts part of #539

Changes in this pull request:
- use getRecordSetsByName instead of getRecordSetsByFQDNs
