### PR TITLE
remove PTRs from create batch func test

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -542,9 +542,7 @@ def test_create_batch_change_failed(shared_zone_test_context):
         "comments": "this is optional",
         "changes": [
             get_change_A_AAAA_json("backend-foo.ok.", address="4.5.6.7"),
-            get_change_A_AAAA_json("backend-already-exists.ok.", address="4.5.6.7"),
-            get_change_PTR_json("fd69:27cc:fe91::1234"),
-            get_change_PTR_json("192.0.2.193")
+            get_change_A_AAAA_json("backend-already-exists.ok.", address="4.5.6.7")
         ]
     }
 
@@ -552,8 +550,6 @@ def test_create_batch_change_failed(shared_zone_test_context):
         # these records already exist in the backend, but are not synced in zone
         dns_add(shared_zone_test_context.ok_zone, "backend-foo", 200, "A", "1.2.3.4")
         dns_add(shared_zone_test_context.ok_zone, "backend-already-exists", 200, "A", "1.2.3.4")
-        dns_add(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", 200, "PTR", "another-test.com")
-        dns_add(shared_zone_test_context.classless_zone_delegation_zone, "193", 200, "PTR", "another-test.com")
         result = client.create_batch_change(batch_change_input, status=202)
         completed_batch = client.wait_until_batch_change_completed(result)
 
@@ -562,8 +558,6 @@ def test_create_batch_change_failed(shared_zone_test_context):
     finally:
         dns_delete(shared_zone_test_context.ok_zone, "backend-foo", "A")
         dns_delete(shared_zone_test_context.ok_zone, "backend-already-exists", "A")
-        dns_delete(shared_zone_test_context.classless_zone_delegation_zone, "193", "PTR")
-        dns_delete(shared_zone_test_context.ip6_reverse_zone, "4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR")
 
 def test_empty_batch_fails(shared_zone_test_context):
     """


### PR DESCRIPTION
partial reversion of #539.

Changes in this pull request:
- remove the PTR records in the func test "test_create_batch_change_failed"
