### PR TITLE
Remove distinct from zone sql queries

### DIFF
--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -197,7 +197,7 @@ class MySqlZoneRepositoryIntegrationSpec
       )
 
       f.unsafeRunSync()
-      repo.listZones(okUserAuth).unsafeRunSync() should contain theSameElementsAs testZones
+      repo.listZones(okUserAuth).unsafeRunSync() should contain allElementsOf testZones
 
       // dummy user only has access to one zone
       repo.listZones(dummyAuth).unsafeRunSync() should contain only testZones.head
@@ -299,7 +299,7 @@ class MySqlZoneRepositoryIntegrationSpec
       )
       addACL.unsafeRunSync()
 
-      repo.listZones(okUserAuth).unsafeRunSync() should contain theSameElementsAs zones
+      repo.listZones(okUserAuth).unsafeRunSync() should contain allElementsOf zones
 
       // dummy user only has access to first zone
       repo.listZones(dummyAuth).unsafeRunSync() should contain only zones.head
@@ -309,7 +309,7 @@ class MySqlZoneRepositoryIntegrationSpec
       repo.save(revoked).unsafeRunSync()
 
       // ok user can still access zones
-      repo.listZones(okUserAuth).unsafeRunSync() should contain theSameElementsAs Seq(revoked, zones(1))
+      repo.listZones(okUserAuth).unsafeRunSync() should contain allElementsOf Seq(revoked, zones(1))
 
       // dummy user can not access the revoked zone
       repo.listZones(dummyAuth).unsafeRunSync() shouldBe empty

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -98,14 +98,14 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
 
   private final val GET_ZONES_BY_ADMIN_GROUP_ID =
     sql"""
-       |SELECT DISTINCT id, data
+       |SELECT data
        |  FROM zone z
        | WHERE z.admin_group_id = (?)
         """.stripMargin
 
   private final val BASE_ZONE_SEARCH_SQL =
     """
-      |SELECT DISTINCT z.id, z.data, z.name
+      |SELECT z.data
       |  FROM zone z
        """.stripMargin
 
@@ -117,7 +117,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
 
   private final val GET_ZONE_ACCESS_BY_ADMIN_GROUP_ID =
     sql"""
-         |SELECT DISTINCT zone_id
+         |SELECT zone_id
          |  FROM zone_access z
          | WHERE z.accessor_id = (?)
          | LIMIT 1
@@ -219,7 +219,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             zoneNameFilter,
             offset,
             pageSize)
-            .map(extractZone(2))
+            .map(extractZone(1))
             .list()
             .apply()
         }
@@ -230,7 +230,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
     monitor("repo.ZoneJDBC.getZonesByAdminGroupId") {
       IO {
         DB.readOnly { implicit s =>
-          GET_ZONES_BY_ADMIN_GROUP_ID.bind(adminGroupId).map(extractZone(2)).list().apply()
+          GET_ZONES_BY_ADMIN_GROUP_ID.bind(adminGroupId).map(extractZone(1)).list().apply()
         }
       }
     }


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- Removed `DISTINCT` from GET_ZONES_BY_ADMIN_GROUP_ID
- Removed `DISTINCT` from BASE_ZONE_SEARCH_SQL
- Removed `DISTINCT` from GET_ZONE_ACCESS_BY_ADMIN_GROUP_ID