### PR TITLE
Chunk up zone sync logging and drop records prior to deserialization into RecordSet model

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
@@ -34,7 +34,7 @@ trait ZoneViewLoader {
 }
 
 object DnsZoneViewLoader extends DnsConversions {
-  private implicit val logger: Logger = LoggerFactory.getLogger("vinyldns.engine.ZoneSyncHandler")
+  private implicit val logger: Logger = LoggerFactory.getLogger("vinyldns.api.domain.zone.DnsZoneViewLoader")
 
   def dnsZoneTransfer(zone: Zone): ZoneTransferIn = {
     val conn =

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
@@ -34,7 +34,7 @@ trait ZoneViewLoader {
 }
 
 object DnsZoneViewLoader extends DnsConversions {
-  private implicit val logger: Logger = LoggerFactory.getLogger("vinyldns.api.domain.zone.DnsZoneViewLoader")
+  private val logger: Logger = LoggerFactory.getLogger("vinyldns.api.domain.zone.DnsZoneViewLoader")
 
   def dnsZoneTransfer(zone: Zone): ZoneTransferIn = {
     val conn =

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
@@ -81,18 +81,8 @@ case class DnsZoneViewLoader(zone: Zone, zoneTransfer: Zone => ZoneTransferIn)
           val dnsZoneName = zoneDnsName(zone.name)
 
           if (droppedRecords.nonEmpty) {
-            droppedRecords
-              .grouped(1000)
-              .foreach { droppedGroup =>
-                val droppedInfo = droppedGroup
-                  .map(record =>
-                    relativize(record.getName, dnsZoneName) + " " + fromDnsRecordType(
-                      record.getType))
-                  .mkString(", ")
-
-                logger.warn(
-                  s"Zone sync for zone [$dnsZoneName] dropped ${droppedGroup.length} recordsets: $droppedInfo")
-              }
+            logger.warn(
+              s"Zone sync for zone [$dnsZoneName] dropped ${droppedRecords.length} unsupported record sets")
           }
 
           val recordSets = supportedRecords.map(toRecordSet(_, dnsZoneName, zone.id))

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -101,14 +101,6 @@ class ZoneSyncHandlerSpec
     created = DateTime.now,
     records = List(AData("4.4.4.4"))
   )
-  private val testRecordUnknown = RecordSet(
-    zoneId = testZone.id,
-    name = "jkl",
-    typ = RecordType.UNKNOWN,
-    ttl = 100,
-    status = RecordSetStatus.Active,
-    created = DateTime.now,
-    records = List())
 
   private val testReversePTR = RecordSet(
     zoneId = testReverseZone.id,
@@ -407,17 +399,16 @@ class ZoneSyncHandlerSpec
       result.zone.latestSync shouldBe defined
     }
 
-    "filters out unknown record types but allow dotted hosts" in {
+    "allow dotted hosts" in {
       val captor = ArgumentCaptor.forClass(classOf[ChangeSet])
       val testVinylDNSView = mock[ZoneView]
 
-      val unknownChange = RecordSetChangeGenerator.forAdd(testRecordUnknown, testZone)
       val dottedChange = RecordSetChangeGenerator.forAdd(testRecordDotted, testZone)
       val okDottedChange = RecordSetChangeGenerator.forAdd(testRecordDottedOk, testZone)
       val expectedChanges = Seq(okDottedChange, dottedChange)
       val correctChangeSet = testChangeSet.copy(changes = expectedChanges)
 
-      doReturn(List(unknownChange, dottedChange, okDottedChange))
+      doReturn(List(dottedChange, okDottedChange))
         .when(testVinylDNSView)
         .diff(any[ZoneView])
       doReturn(() => IO(testVinylDNSView)).when(mockVinylDNSLoader).load


### PR DESCRIPTION
Fixes #581.

Changes in this pull request:
- Group logging into smaller chunks
- Move record drop logic from `ZoneSyncHandler` to `DnsZoneViewLoader` (prior to deserialization of `DNS.Record` type to VinylDNS' `RecordSet` model)