### PR TITLE
Allow dotted hosts for TXT records

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1525,9 +1525,9 @@ def test_create_long_txt_record_succeeds(shared_zone_test_context):
         except:
             pass
 
-def test_dotted_host_create_fails(shared_zone_test_context):
+def test_txt_dotted_host_create_succeeds(shared_zone_test_context):
     """
-    Tests that a dotted host recordset create fails
+    Tests that a TXT dotted host recordset create succeeds
     """
     client = shared_zone_test_context.ok_vinyldns_client
     new_rs = {
@@ -1537,12 +1537,20 @@ def test_dotted_host_create_fails(shared_zone_test_context):
         'ttl': 100,
         'records': [
             {
-                'text': 'should fail'
+                'text': 'should pass'
             }
         ]
     }
-    error = client.create_recordset(new_rs, status=422)
-    assert_that(error, is_('Record with name record-with.dot is a dotted host which is illegal in this zone ok.'))
+    rs_result = None
+
+    try:
+        rs_create = client.create_recordset(new_rs, status=202)
+        rs_result = client.wait_until_recordset_change_status(rs_create, 'Complete')['recordSet']
+
+    finally:
+        if rs_result:
+            delete_result = client.delete_recordset(rs_result['zoneId'], rs_result['id'], status=202)
+            client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
 def test_ns_create_for_admin_group_succeeds(shared_zone_test_context):

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -1669,7 +1669,7 @@ def test_ns_update_for_unapproved_server_fails(shared_zone_test_context):
 
 def test_update_to_txt_dotted_host_succeeds(shared_zone_test_context):
     """
-    Tests that a dotted host record set update succeeds
+    Tests that a TXT dotted host record set update succeeds
     """
     result_rs = None
     ok_zone = shared_zone_test_context.ok_zone

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -1667,20 +1667,21 @@ def test_ns_update_for_unapproved_server_fails(shared_zone_test_context):
             client.delete_recordset(ns_rs['zoneId'], ns_rs['id'], status=(202,404))
             client.wait_until_recordset_deleted(ns_rs['zoneId'], ns_rs['id'])
 
-def test_update_to_dotted_host_fails(shared_zone_test_context):
+def test_update_to_txt_dotted_host_succeeds(shared_zone_test_context):
     """
-    Tests that a dotted host record set update fails
+    Tests that a dotted host record set update succeeds
     """
     result_rs = None
     ok_zone = shared_zone_test_context.ok_zone
     client = shared_zone_test_context.ok_vinyldns_client
+
     try:
         result_rs = seed_text_recordset(client, "update_with_dots", ok_zone)
-
         result_rs['name'] = "update_with.dots"
 
-        error = client.update_recordset(result_rs, status=422)
-        assert_that(error, is_('Record with name update_with.dots is a dotted host which is illegal in this zone ok.'))
+        update_rs = client.update_recordset(result_rs, status=202)
+        result_rs = client.wait_until_recordset_change_status(update_rs, 'Complete')['recordSet']
+
     finally:
         if result_rs:
             delete_result = client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=202)

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -92,7 +92,7 @@ object RecordSetValidations {
       case NS => nsValidations(newRecordSet, zone)
       case SOA => soaValidations(newRecordSet, zone)
       case PTR => ptrValidations(newRecordSet, zone)
-      case SRV | TXT => ().asRight // SRV does not go through dotted host check
+      case SRV | TXT => ().asRight // SRV and TXT do not go through dotted host check
       case DS => dsValidations(newRecordSet, existingRecordsWithName, zone)
       case _ => isNotDotted(newRecordSet, zone)
     }
@@ -107,7 +107,7 @@ object RecordSetValidations {
       case NS => nsValidations(newRecordSet, zone, Some(oldRecordSet))
       case SOA => soaValidations(newRecordSet, zone)
       case PTR => ptrValidations(newRecordSet, zone)
-      case SRV | TXT => ().asRight // SRV does not go through dotted host check
+      case SRV | TXT => ().asRight // SRV and TXT do not go through dotted host check
       case DS => dsValidations(newRecordSet, existingRecordsWithName, zone)
       case _ => isNotDotted(newRecordSet, zone)
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -92,7 +92,7 @@ object RecordSetValidations {
       case NS => nsValidations(newRecordSet, zone)
       case SOA => soaValidations(newRecordSet, zone)
       case PTR => ptrValidations(newRecordSet, zone)
-      case SRV => ().asRight // SRV does not go through dotted host check
+      case SRV | TXT => ().asRight // SRV does not go through dotted host check
       case DS => dsValidations(newRecordSet, existingRecordsWithName, zone)
       case _ => isNotDotted(newRecordSet, zone)
     }
@@ -107,7 +107,7 @@ object RecordSetValidations {
       case NS => nsValidations(newRecordSet, zone, Some(oldRecordSet))
       case SOA => soaValidations(newRecordSet, zone)
       case PTR => ptrValidations(newRecordSet, zone)
-      case SRV => ().asRight // SRV does not go through dotted host check
+      case SRV | TXT => ().asRight // SRV does not go through dotted host check
       case DS => dsValidations(newRecordSet, existingRecordsWithName, zone)
       case _ => isNotDotted(newRecordSet, zone)
     }

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -118,7 +118,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored {
             val dottedRecords = changes
               .filter { chg =>
                 chg.recordSet.name != zone.name && chg.recordSet.name.contains(".") &&
-                chg.recordSet.typ != RecordType.SRV
+                chg.recordSet.typ != RecordType.SRV && chg.recordSet.typ != RecordType.TXT
               }
               .map(_.recordSet.name)
               .mkString(", ")


### PR DESCRIPTION
Changes in this pull request:
- Allow dotted hosts for `TXT` records
- Update functional tests
