### PR TITLE
Expose get zone by name route in the API

### DIFF
--- a/modules/api/functional_test/live_tests/zones/get_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/get_zone_test.py
@@ -87,3 +87,32 @@ def test_get_zone_includes_acl_display_name(shared_zone_test_context):
     assert_that(acl, has_item(user_acl_rule))
     assert_that(acl, has_item(group_acl_rule))
     assert_that(len(acl), is_(2))
+
+def test_get_zone_by_name(shared_zone_test_context):
+    """
+    Test get an existing zone by name
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    result = client.get_zone_by_name(shared_zone_test_context.system_test_zone['name'], status=200)['zone']
+
+    assert_that(result['id'], is_(shared_zone_test_context.system_test_zone['id']))
+    assert_that(result['name'], is_(shared_zone_test_context.system_test_zone['name']))
+    assert_that(result['adminGroupName'], is_(shared_zone_test_context.ok_group['name']))
+
+def test_get_zone_by_name_fails_without_access(shared_zone_test_context):
+    """
+    Test get an existing zone by name without access
+    """
+    client = shared_zone_test_context.dummy_vinyldns_client
+
+    client.get_zone_by_name(shared_zone_test_context.ok_zone['name'], status=403)
+
+
+def test_get_zone_by_name_returns_404_when_not_found(shared_zone_test_context):
+    """
+    Test get an existing zone returns a 404 when the zone is not found
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    client.get_zone_by_name("zone_name_does_not_exist", status=404)

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -387,6 +387,17 @@ class VinylDNSClient(object):
 
         return data
 
+    def get_zone_by_name(self, zone_name, **kwargs):
+        """
+        Gets a zone for the given zone name
+        :param zone_name: the name of the zone to retrieve
+        :return: the zone, or will 404 if not found
+        """
+        url = urljoin(self.index_url, u'/zones/name/{0}'.format(zone_name))
+        response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, **kwargs)
+
+        return data
+
     def list_zone_changes(self, zone_id, start_from=None, max_items=None, **kwargs):
         """
         Gets the zone changes for the given zone id

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -34,6 +34,8 @@ trait ZoneServiceAlgebra {
 
   def getZone(zoneId: String, auth: AuthPrincipal): Result[ZoneInfo]
 
+  def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo]
+
   def listZones(
       authPrincipal: AuthPrincipal,
       nameFilter: Option[String],

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -71,6 +71,11 @@ trait ZoneRoute extends Directives {
           complete(StatusCodes.OK, GetZoneResponse(zone))
         }
       } ~
+      (get & path("zones" / "name" / Segment) & monitor("Endpoint.getZoneByName")) { zoneName =>
+        execute(zoneService.getZoneByName(zoneName, authPrincipal)) { zone =>
+          complete(StatusCodes.OK, GetZoneResponse(zone))
+        }
+      } ~
       (delete & path("zones" / Segment) & monitor("Endpoint.deleteZone")) { id =>
         execute(zoneService.deleteZone(id, authPrincipal)) { chg =>
           complete(StatusCodes.Accepted, chg)

--- a/modules/docs/src/main/resources/microsite/data/menu.yml
+++ b/modules/docs/src/main/resources/microsite/data/menu.yml
@@ -114,8 +114,11 @@ options:
     - title: Delete Zone
       url: api/delete-zone.html
       menu_section: zoneapireference
-    - title: Get Zone
-      url: api/get-zone.html
+    - title: Get Zone by ID
+      url: api/get-zone-by-id.html
+      menu_section: zoneapireference
+    - title: Get Zone by Name
+      url: api/get-zone-by-name.html
       menu_section: zoneapireference
     - title: List / Search Zone
       url: api/list-zones.html

--- a/modules/docs/src/main/tut/api/get-zone-by-id.md
+++ b/modules/docs/src/main/tut/api/get-zone-by-id.md
@@ -1,0 +1,61 @@
+---
+layout: docs
+title: "Get Zone by ID"
+section: "api"
+---
+
+# Get Zone by ID
+
+Retrieves a zone with the matching zone ID
+
+#### HTTP REQUEST
+
+> GET /zones/{zoneId}
+
+#### HTTP RESPONSE TYPES
+
+Code          | description |
+ ------------ | :---------- |
+200           | **OK** - Successful lookup, the zone is returned in the response body |
+401           | **Unauthorized** - The authentication information provided is invalid.  Typically the request was not signed properly, or the access key and secret used to sign the request are incorrect |
+403           | **Forbidden** - The user does not have the access required to perform the action |
+404           | **Not Found** - Zone not found |
+
+#### HTTP RESPONSE ATTRIBUTES
+
+name          | type          | description |
+ ------------ | ------------- | :---------- |
+zone          | map          | refer to [zone model](../api/zone-model) |
+
+#### EXAMPLE RESPONSE
+
+```
+{
+  "zone": {
+    "status": "Active",
+    "account": "6baa85ad-267f-44ff-b535-818b7d7a2467",
+    "name": "system-test.",
+    "created": "2016-12-28T18:12:09Z",
+    "adminGroupId": "6baa85ad-267f-44ff-b535-818b7d7a2467",
+    "email": "test@example.com",
+    "connection": {
+      "primaryServer": "127.0.0.1:5301",
+      "keyName": "vinyl.",
+      "name": "system-test.",
+      "key": "OBF:1:B2cetOaRf1YAABAAek/w22XyKAleCRjA/hZO9fkNtNufPIRWTYHXviAk9GjrfcFOG9nNuB=="
+    },
+    "transferConnection": {
+      "primaryServer": "127.0.0.1:5301",
+      "keyName": "vinyl.",
+      "name": "system-test.",
+      "key": "OBF:1:PNt2k1nYkC0AABAAePpNMrDp+4C4GDbicWWlAqB5c4mKoKhvfpiWY1PfuRCVzSAeXydztB=="
+    },
+    "shared": true,
+    "acl": {
+      "rules": []
+    },
+    "id": "0f2fcece-b4ee-4982-b671-e5946f7db81d",
+    "latestSync": "2016-12-16T15:27:26Z"
+  }
+}
+```

--- a/modules/docs/src/main/tut/api/get-zone-by-name.md
+++ b/modules/docs/src/main/tut/api/get-zone-by-name.md
@@ -1,16 +1,16 @@
 ---
 layout: docs
-title: "Get Zone"
+title: "Get Zone by Name"
 section: "api"
 ---
 
-# Get Zone
+# Get Zone by Name
 
-Retrieves a zone with the matching zone id
+Retrieves a zone with the matching zone name
 
 #### HTTP REQUEST
 
-> GET /zones/{zoneId}
+> GET /zones/name/{zoneName}
 
 #### HTTP RESPONSE TYPES
 


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- Added a route to `ZoneRouting` `GET /zones/name/<segment>`
- Added a new method to `ZoneService`to `getZonesByName`
- Unit and Integrations tests
- Functional tests