### PR TITLE
Enable shared zone toggle for zone admins that are also support users

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -71,10 +71,10 @@ class ZoneValidations(syncDelayMillis: Int) {
       case None => ().asRight
     }
 
-  // Validates that the zone is either not shared or shared and the user is a super user
+  // Validates that the zone is either not shared or shared and the user is a super or support user
   def validateSharedZoneAuthorized(zoneShared: Boolean, user: User): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized to create shared zones."))(
-      !zoneShared || user.isSuper)
+      !zoneShared || user.isSuper || user.isSupport)
 
   // Validates that the zone shared status has not been changed, or changed and the user is a super user
   def validateSharedZoneAuthorized(
@@ -84,5 +84,5 @@ class ZoneValidations(syncDelayMillis: Int) {
     ensuring(
       NotAuthorizedError(
         s"Not authorized to update zone shared status from $currentShared to $updateShared."))(
-      currentShared == updateShared || user.isSuper)
+      currentShared == updateShared || user.isSuper || user.isSupport)
 }

--- a/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
@@ -36,6 +36,7 @@ object TestMembershipData {
 
   val dummyUser = User("dummyName", "dummyAccess", "dummySecret")
   val superUser = User("super", "superAccess", "superSecret", isSuper = true)
+  val supportUser = User("support", "supportAccess", "supportSecret", isSupport = true)
   val lockedUser = User("locked", "lockedAccess", "lockedSecret", lockStatus = LockStatus.Locked)
   val sharedZoneUser = User("sharedZoneAdmin", "sharedAccess", "sharedSecret")
 
@@ -115,6 +116,8 @@ object TestMembershipData {
   val notAuth: AuthPrincipal = AuthPrincipal(User("not", "auth", "secret"), Seq.empty)
 
   val sharedAuth: AuthPrincipal = AuthPrincipal(sharedZoneUser, Seq(abcGroup.id))
+
+  val supportUserAuth: AuthPrincipal = AuthPrincipal(supportUser, Seq(okGroup.id))
 
   val superUserAuth = AuthPrincipal(superUser, Seq.empty)
 


### PR DESCRIPTION
Currently, only super users can toggle the shared flag for zone creates/updates. We need more flexibility and don't want to open it up to all zone admins, so a middle ground is a zone admin that is also a support user.

Changes in this pull request:
- Enable functionality
- Create unit tests
