### PR TITLE
Lookup zone by name with trailing dot

### DIFF
--- a/modules/api/functional_test/live_tests/zones/get_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/get_zone_test.py
@@ -100,6 +100,18 @@ def test_get_zone_by_name(shared_zone_test_context):
     assert_that(result['name'], is_(shared_zone_test_context.system_test_zone['name']))
     assert_that(result['adminGroupName'], is_(shared_zone_test_context.ok_group['name']))
 
+def test_get_zone_by_name_without_trailing_dot_succeeds(shared_zone_test_context):
+    """
+    Test get an existing zone by name succeeds when trailing dot is omitted
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    result = client.get_zone_by_name(shared_zone_test_context.system_test_zone['name'][:-1], status=200)['zone']
+
+    assert_that(result['id'], is_(shared_zone_test_context.system_test_zone['id']))
+    assert_that(result['name'], is_(shared_zone_test_context.system_test_zone['name']))
+    assert_that(result['adminGroupName'], is_(shared_zone_test_context.ok_group['name']))
+
 def test_get_zone_by_name_fails_without_access(shared_zone_test_context):
     """
     Test get an existing zone by name without access

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -19,8 +19,9 @@ package vinyldns.api.domain.zone
 import cats.implicits._
 import vinyldns.api.Interfaces
 import vinyldns.api.domain.AccessValidationAlgebra
-import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.api.domain.dns.DnsConversions._
 import vinyldns.api.repository.ApiDataAccessor
+import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
 import vinyldns.core.domain.zone._
 import vinyldns.core.queue.MessageQueue
@@ -239,13 +240,13 @@ class ZoneService(
   def getZoneOrFail(zoneId: String): Result[Zone] =
     zoneRepository
       .getZone(zoneId)
-      .orFail(ZoneNotFoundError(s"Zone with id $zoneId does not exists"))
+      .orFail(ZoneNotFoundError(s"Zone with ID $zoneId does not exist"))
       .toResult[Zone]
 
   def getZoneByNameOrFail(zoneName: String): Result[Zone] =
     zoneRepository
-      .getZoneByName(zoneName)
-      .orFail(ZoneNotFoundError(s"Zone with name $zoneName does not exists"))
+      .getZoneByName(zoneDnsName(zoneName).toString)
+      .orFail(ZoneNotFoundError(s"Zone with name $zoneName does not exist"))
       .toResult[Zone]
 
   def validateZoneConnectionIfChanged(newZone: Zone, existingZone: Zone): Result[Unit] =


### PR DESCRIPTION
Changes in this pull request:
- Relativize `getZoneByName` lookup to ensure trailing dot
- Update unit and functional tests
