### PR TITLE
make sure zone name is fully qualified in getByZoneName

### DIFF
--- a/modules/api/functional_test/live_tests/zones/get_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/get_zone_test.py
@@ -100,6 +100,18 @@ def test_get_zone_by_name(shared_zone_test_context):
     assert_that(result['name'], is_(shared_zone_test_context.system_test_zone['name']))
     assert_that(result['adminGroupName'], is_(shared_zone_test_context.ok_group['name']))
 
+def test_get_zone_by_name_without_trailing_dot_succeeds(shared_zone_test_context):
+    """
+    Test get an existing zone by name without including trailing dot
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    result = client.get_zone_by_name("system-test", status=200)['zone']
+
+    assert_that(result['id'], is_(shared_zone_test_context.system_test_zone['id']))
+    assert_that(result['name'], is_(shared_zone_test_context.system_test_zone['name']))
+    assert_that(result['adminGroupName'], is_(shared_zone_test_context.ok_group['name']))
+
 def test_get_zone_by_name_fails_without_access(shared_zone_test_context):
     """
     Test get an existing zone by name without access

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -121,13 +121,15 @@ class ZoneService(
       groupName <- getGroupName(zone.adminGroupId)
     } yield ZoneInfo(zone, aclInfo, groupName)
 
-  def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo] =
+  def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo] = {
+    val qualifiedName = if (zoneName.endsWith(".")) zoneName else s"$zoneName."
     for {
-      zone <- getZoneByNameOrFail(zoneName)
+      zone <- getZoneByNameOrFail(qualifiedName)
       _ <- canSeeZone(auth, zone).toResult
       aclInfo <- getZoneAclDisplay(zone.acl)
       groupName <- getGroupName(zone.adminGroupId)
     } yield ZoneInfo(zone, aclInfo, groupName)
+  }
 
   def listZones(
       authPrincipal: AuthPrincipal,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -24,6 +24,7 @@ import vinyldns.api.repository.ApiDataAccessor
 import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
 import vinyldns.core.domain.zone._
 import vinyldns.core.queue.MessageQueue
+import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 
 object ZoneService {
   def apply(
@@ -121,15 +122,13 @@ class ZoneService(
       groupName <- getGroupName(zone.adminGroupId)
     } yield ZoneInfo(zone, aclInfo, groupName)
 
-  def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo] = {
-    val qualifiedName = if (zoneName.endsWith(".")) zoneName else s"$zoneName."
+  def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo] =
     for {
-      zone <- getZoneByNameOrFail(qualifiedName)
+      zone <- getZoneByNameOrFail(ensureTrailingDot(zoneName))
       _ <- canSeeZone(auth, zone).toResult
       aclInfo <- getZoneAclDisplay(zone.acl)
       groupName <- getGroupName(zone.adminGroupId)
     } yield ZoneInfo(zone, aclInfo, groupName)
-  }
 
   def listZones(
       authPrincipal: AuthPrincipal,

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -101,7 +101,7 @@ trait DnsJsonProtocol extends JsonValidation {
         (js \ "id").required[String]("Missing Zone.id"),
         (js \ "name")
           .required[String]("Missing Zone.name")
-          .map(name => if (name.endsWith(".")) name else s"$name."),
+          .map(ensureTrailingDot),
         (js \ "email").required[String]("Missing Zone.email"),
         (js \ "connection").optional[ZoneConnection],
         (js \ "transferConnection").optional[ZoneConnection],

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -407,7 +407,7 @@ class ZoneServiceSpec
     }
 
     "return a zone by name with failure when no zone is found" in {
-      doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName("someZoneName")
+      doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName("someZoneName.")
 
       val error = leftResultOf(underTest.getZoneByName("someZoneName", okAuth).value)
       error shouldBe a[ZoneNotFoundError]
@@ -422,7 +422,7 @@ class ZoneServiceSpec
       doReturn(IO.pure(Some(abcGroup))).when(mockGroupRepo).getGroup(anyString)
 
       val expectedZoneInfo = ZoneInfo(abcZone, ZoneACLInfo(Set()), abcGroup.name)
-      val result = underTest.getZoneByName(abcZone.name, abcAuth).value.unsafeRunSync()
+      val result = underTest.getZoneByName("abc.zone.recordsets", abcAuth).value.unsafeRunSync()
       result.right.value shouldBe expectedZoneInfo
     }
   }


### PR DESCRIPTION
tweak to #588

Changes in this pull request:
- make sure the given zone name is fully qualified (i.e. ends in  ".") before looking up the zone
