### PR TITLE
set default streams in mainFlow

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -273,7 +273,8 @@ class CommandHandlerSpec
             count,
             100.millis,
             stop,
-            connections
+            connections,
+            1
           )
           .take(1)
 


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- In the CommandHandler set the number of concurrent message batches as a parameter, default to 4 
- In the ComnandHandlerSpec test "main flow should process successfully" set the number of concurrent message batches to 1 to keep the test results consistent
