### PR TITLE
portal: add getZoneByName API route

### DIFF
--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -370,6 +370,15 @@ class VinylDNS @Inject()(
     // $COVERAGE-ON$
   }
 
+  def getZoneByName(name: String): Action[AnyContent] = userAction.async { implicit request =>
+    val vinyldnsRequest =
+      new VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"zones/name/$name")
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+  }
+
   def syncZone(id: String): Action[AnyContent] = userAction.async { implicit request =>
     // $COVERAGE-OFF$
     val vinyldnsRequest =

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -25,6 +25,7 @@ POST          /regenerate-creds                  @controllers.VinylDNS.regenerat
 
 GET           /api/zones                         @controllers.VinylDNS.getZones
 GET           /api/zones/:id                     @controllers.VinylDNS.getZone(id: String)
+GET           /api/zones/name/:name              @controllers.VinylDNS.getZoneByName(name: String)
 POST          /api/zones                         @controllers.VinylDNS.addZone
 PUT           /api/zones/:id                     @controllers.VinylDNS.updateZone(id: String)
 DELETE        /api/zones/:id                     @controllers.VinylDNS.deleteZone(id: String)

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -180,9 +180,10 @@ trait TestApplicationData { this: Mockito =>
   )
 
   val hobbitZoneId = "uuid-abcdef-12345"
+  val hobbitZoneName = "hobbits"
   val hobbitZone: JsValue = Json.parse(s"""{
       | "id":             "${hobbitZoneId}",
-      | "name":           "hobbits",
+      | "name":           "${hobbitZoneName}",
       | "email":          "hobbitAdmin@shire.me",
       | "status":         "Active",
       | "account":        "system",

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -133,7 +133,7 @@ trait TestApplicationData { this: Mockito =>
 
   val hobbitGroupId = "uuid-12345-abcdef"
   val hobbitGroup: JsValue = Json.parse(s"""{
-       | "id":          "${hobbitGroupId}",
+       | "id":          "$hobbitGroupId",
        | "name":        "hobbits",
        | "email":       "hobbitAdmin@shire.me",
        | "description": "Hobbits of the shire",
@@ -173,7 +173,7 @@ trait TestApplicationData { this: Mockito =>
 
   val hobbitGroupMembers: JsValue = Json.parse(
     s"""{
-       | "members": [ ${frodoJsonString} ],
+       | "members": [ $frodoJsonString ],
        | "maxItems": 100
        |}
      """.stripMargin
@@ -182,14 +182,14 @@ trait TestApplicationData { this: Mockito =>
   val hobbitZoneId = "uuid-abcdef-12345"
   val hobbitZoneName = "hobbits"
   val hobbitZone: JsValue = Json.parse(s"""{
-      | "id":             "${hobbitZoneId}",
-      | "name":           "${hobbitZoneName}",
+      | "id":             "$hobbitZoneId",
+      | "name":           "$hobbitZoneName",
       | "email":          "hobbitAdmin@shire.me",
       | "status":         "Active",
       | "account":        "system",
       | "shared":         false,
       | "adminGroupName": "hobbits",
-      | "adminGroupId":   "${hobbitGroupId}"
+      | "adminGroupId":   "$hobbitGroupId"
       | }
     """.stripMargin)
 
@@ -200,13 +200,13 @@ trait TestApplicationData { this: Mockito =>
       | "account":        "system",
       | "shared":         false,
       | "adminGroupName": "hobbits",
-      | "adminGroupId":   "${hobbitGroupId}"
+      | "adminGroupId":   "$hobbitGroupId"
       | }
     """.stripMargin)
 
   val hobbitRecordSetId = "uuid-record-12345"
   val hobbitRecordSet: JsValue = Json.parse(s"""{
-      | "zoneId":        "${hobbitZoneId}",
+      | "zoneId":        "$hobbitZoneId",
       | "name":          "ok",
       | "typ":           "${RecordType.A}",
       | "ttl":           "200",

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -1745,7 +1745,7 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
     ".getZoneByName" should {
       "return ok (200) if the zone is found" in new WithApplication(app) {
         Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
-          case backendGET(p"/zones/name/${hobbitZoneName}") =>
+          case backendGET(p"/zones/name/$hobbitZoneName") =>
             defaultActionBuilder {
               Results.Ok(hobbitZone)
             }

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -1742,6 +1742,122 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
       }
     }
 
+    ".getZoneByName" should {
+      "return ok (200) if the zone is found" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendGET(p"/zones/name/${hobbitZoneName}") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitZone)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val mockUserAccessor = mock[UserAccountAccessor]
+            mockUserAccessor.get(anyString).returns(IO.pure(Some(frodoUser)))
+            mockUserAccessor.getUserByKey(anyString).returns(IO.pure(Some(frodoUser)))
+            val underTest =
+              TestVinylDNS(
+                testConfigLdap,
+                mockLdapAuthenticator,
+                mockUserAccessor,
+                client,
+                components,
+                crypto)
+            val result =
+              underTest.getZoneByName(hobbitZoneName)(
+                FakeRequest(GET, s"/zones/name/$hobbitZoneName")
+                  .withSession(
+                    "username" -> frodoUser.userName,
+                    "accessKey" -> frodoUser.accessKey))
+
+            status(result) must beEqualTo(OK)
+            hasCacheHeaders(result)
+            contentAsJson(result) must beEqualTo(hobbitZone)
+          }
+        }
+      }
+      "return a not found (404) if the zone does not exist" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendGET(p"/zones/name/not-hobbits") =>
+            defaultActionBuilder {
+              Results.NotFound
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val mockUserAccessor = mock[UserAccountAccessor]
+            mockUserAccessor.get(anyString).returns(IO.pure(Some(frodoUser)))
+            mockUserAccessor.getUserByKey(anyString).returns(IO.pure(Some(frodoUser)))
+            val underTest =
+              TestVinylDNS(
+                testConfigLdap,
+                mockLdapAuthenticator,
+                mockUserAccessor,
+                client,
+                components,
+                crypto)
+            val result =
+              underTest.getZoneByName("not-hobbits")(FakeRequest(GET, "/zones/name/not-hobbits")
+                .withSession("username" -> frodoUser.userName, "accessKey" -> frodoUser.accessKey))
+
+            status(result) must beEqualTo(NOT_FOUND)
+            hasCacheHeaders(result)
+          }
+        }
+      }
+      "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendGET(p"/zones/name/$hobbitZoneName") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitZone)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockUserAccessor,
+              client,
+              components,
+              crypto)
+            val result =
+              underTest.getZoneByName(hobbitZoneName)(
+                FakeRequest(GET, s"/api/zones/name/$hobbitZoneName"))
+
+            status(result) mustEqual 401
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              "You are not logged in. Please login to continue.")
+          }
+        }
+      }
+      "return forbidden (403) if user account is locked" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendGET(p"/zones/name/$hobbitZoneName") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitZone)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockLockedUserAccessor,
+              client,
+              components,
+              crypto)
+            val result = underTest.getZoneByName(hobbitZoneName)(
+              FakeRequest(GET, s"/api/zones/name/$hobbitZoneName").withSession(
+                "username" -> lockedFrodoUser.userName,
+                "accessKey" -> lockedFrodoUser.accessKey))
+
+            status(result) mustEqual 403
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              s"User account for `${lockedFrodoUser.userName}` is locked.")
+          }
+        }
+      }
+    }
+
     ".syncZone" should {
       "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
         Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {


### PR DESCRIPTION
Supports #588

Changes in this pull request:
- add an API route in the portal for getZoneByName (`/api/zones/name/:name`)

