### PR TITLE
Expose backendId for zones

### DIFF
--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -68,6 +68,15 @@
                                 </div>
                             </div>
 
+                            <div class="form-group">
+                                <label class="col-md-3 control-label">DNS Backend ID (optional)</label>
+                                <div class="col-md-9">
+                                    <div>
+                                        <input id="zone-update-backendID" type="text" ng-model="updateZoneInfo.backendId" class="form-control" ng-disabled="!isZoneAdmin"/>
+                                    </div>
+                                </div>
+                            </div>
+
                         </div>
                         <div class="col-md-6">
 
@@ -178,6 +187,7 @@
                                         ng-click="clearUpdateTransferConnection()" type="button">Clear Connection</button>
                             </div>
                         </div>
+
                     </div>
                 </div>
 

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -80,6 +80,7 @@
                                     <th>Name</th>
                                     <th>Email</th>
                                     <th>Admin Group</th>
+                                    <th>Backend ID</th>
                                     <th>Status</th>
                                     @if(meta.sharedDisplayEnabled) {
                                         <th>Type</th>
@@ -95,6 +96,7 @@
                                       <a ng-if="isGroupMember(zone.adminGroupId)" ng-bind="zone.adminGroupName" href="/groups/{{zone.adminGroupId}}"></a>
                                       <span ng-if="!isGroupMember(zone.adminGroupId)" ng-bind="zone.adminGroupName" style="line-height: 0"></span>
                                   </td>
+                                  <td ng-bind="zone.backendId"></td>
                                   <td ng-bind="zone.status"></td>
                                   @if(meta.sharedDisplayEnabled) {
                                     <td>{{zone.shared ? "Shared" : "Private"}}</td>

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -145,6 +145,7 @@ angular.module('controller.manageZones', [])
         var zone = angular.copy($scope.updateZoneInfo);
         zone = zonesService.normalizeZoneDates(zone);
         zone = zonesService.setConnectionKeys(zone);
+        zone = zonesService.checkBackendId(zone);
         $scope.currentManageZoneState = $scope.manageZoneState.UPDATE;
         $scope.updateZone(zone, 'Zone Update');
     };

--- a/modules/portal/public/lib/controllers/controller.manageZones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.spec.js
@@ -64,6 +64,8 @@ describe('Controller: ManageZonesController', function () {
             .and.stub();
         var setConnectionKeys = spyOn(this.zonesService, 'setConnectionKeys')
             .and.stub();
+        var checkBackendId = spyOn(this.zonesService, 'checkBackendId')
+                    .and.stub();
         var updateZone = spyOn(this.scope, 'updateZone')
             .and.stub();
 

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -96,6 +96,13 @@ angular.module('service.zones', [])
             return zone;
         };
 
+        this.checkBackendId = function(zone) {
+            if (zone.backendId === ''){
+                zone.backendId = undefined;
+            }
+            return zone;
+        };
+
         this.toApiIso = function(date) {
             /* when we parse the DateTimes from the api it gets turned into javascript readable format
              * instead of just staying the way it is, so for now converting it back to ISO format on the fly,

--- a/modules/portal/public/mocks/mockZoneSubmit.json
+++ b/modules/portal/public/mocks/mockZoneSubmit.json
@@ -7,5 +7,6 @@
     "key":"abc123",
     "primaryServer":"1.2.3.4"
   },
-  "shared":false
+  "shared":false,
+  "backendId":"testBackendID"
 }

--- a/modules/portal/public/templates/zoneconnection-modal.html
+++ b/modules/portal/public/templates/zoneconnection-modal.html
@@ -33,6 +33,26 @@
             </modal-element>
 
             <div class="dns-connection-form">
+                <h4>Optional DNS server connection settings</h4>
+                <hr>
+                <span class="help-block">
+                    If none of the following options are filled, default connection settings are used.
+                </span>
+            </div>
+
+            <div class="dns-connection-form">
+                <h4>DNS Zone Backend ID (Optional)</h4>
+                <hr>
+            </div>
+            <modal-element label="Backend Id">
+                <input id="zone-backendId" type="text" ng-model="currentZone.backendId" name="backendIdVal" class="form-control"/>
+                <span class="help-block">
+                    The ID for a pre-configured DNS connection configuration. Please contact your DNS admin team
+                    if a configuration exists.
+                </span>
+            </modal-element>
+
+            <div class="dns-connection-form">
                 <h4>DNS Server (Optional)</h4>
                 <hr>
             </div>
@@ -91,6 +111,7 @@
                     would be used to connect to server <i>bind-01.sys.example.net</i> on port 5300
                 </span>
             </modal-element>
+
         </modal-body>
         <modal-footer>
             <button type="button" class="btn btn-default pull-left" ng-click="resetCurrentZone()">Clear Form</button>


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- Add `backendId` to zone creation as an optional
- Add `backendId` to manage zone page
