### PR TITLE
WIP: Query all zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ release.version
 .ensime_cache
 package-lock.json
 *trustStore.jks
+.bloop
+.metals

--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -107,6 +107,7 @@ def list_zones_context(request):
 
     return ctx
 
+
 def test_list_zones_success(list_zones_context):
     """
     Test that we can retrieve a list of zones
@@ -118,6 +119,20 @@ def test_list_zones_success(list_zones_context):
     assert_that(retrieved, has_item(has_entry('name', 'list-zones-test-searched-1.')))
     assert_that(retrieved, has_item(has_entry('adminGroupName', 'list-zones-group')))
     assert_that(retrieved, has_item(has_entry('backendId', 'func-test-backend')))
+
+
+def test_list_zones_search_all(list_zones_context, shared_zone_test_context):
+    """
+    Test that we can retrieve a list of zones even ones we do not have access to
+    """
+    dummy_zone_name = shared_zone_test_context.dummy_zone['name']
+    result = list_zones_context.client.list_zones(name_filter=dummy_zone_name, search_all=True, status=200)
+    retrieved = result['zones']
+    assert_that(retrieved, has_length(1))
+
+    result = list_zones_context.client.list_zones(name_filter=dummy_zone_name, search_all=False, status=200)
+    retrieved = result['zones']
+    assert_that(retrieved, has_length(0))
 
 
 def test_list_zones_max_items_100(list_zones_context):

--- a/modules/api/functional_test/live_tests/zones/update_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/update_zone_test.py
@@ -569,11 +569,13 @@ def test_delete_acl_removes_permissions(shared_zone_test_context):
     ok_zone = ok_client.get_zone(shared_zone_test_context.ok_zone['id'])['zone']
 
     ok_view = ok_client.list_zones()['zones']
-    assert_that(ok_view, has_item(ok_zone))    # ok can see ok_zone
+    ok_view_ids = [z['id'] for z in ok_view]
+    assert_that(ok_view_ids, has_item(ok_zone['id']))    # ok can see ok_zone
 
     # verify dummy cannot see ok_zone
     dummy_view = dummy_client.list_zones()['zones']
-    assert_that(dummy_view, is_not(has_item(ok_zone))) # cannot view zone
+    dummy_view_ids = [z['id'] for z in dummy_view]
+    assert_that(dummy_view_ids, is_not(has_item(ok_zone['id'])))  # cannot view zone
 
     # add acl rule
     acl_rule = {
@@ -588,11 +590,13 @@ def test_delete_acl_removes_permissions(shared_zone_test_context):
     verify_acl_rule_is_present_once(acl_rule, ok_zone['acl'])
 
     ok_view = ok_client.list_zones()['zones']
-    assert_that(ok_view, has_item(ok_zone))    # ok can still see ok_zone
+    ok_view_ids = [z['id'] for z in ok_view]
+    assert_that(ok_view_ids, has_item(ok_zone['id']))    # ok can still see ok_zone
 
     # verify dummy can see ok_zone
     dummy_view = dummy_client.list_zones()['zones']
-    assert_that(dummy_view, has_item(ok_zone)) # can view zone
+    dummy_view_ids = [z['id'] for z in dummy_view]
+    assert_that(dummy_view_ids, has_item(ok_zone['id']))  # can view zone
 
     # delete acl rule
     result = ok_client.delete_zone_acl_rule_with_wait(shared_zone_test_context.ok_zone['id'], acl_rule, status=202)
@@ -600,11 +604,13 @@ def test_delete_acl_removes_permissions(shared_zone_test_context):
     verify_acl_rule_is_not_present(acl_rule, ok_zone['acl'])
 
     ok_view = ok_client.list_zones()['zones']
-    assert_that(ok_view, has_item(ok_zone))    # ok can still see ok_zone
+    ok_view_ids = [z['id'] for z in ok_view]
+    assert_that(ok_view_ids, has_item(ok_zone['id']))     # ok can still see ok_zone
 
     # verify dummy can not see ok_zone
     dummy_view = dummy_client.list_zones()['zones']
-    assert_that(dummy_view, is_not(has_item(ok_zone))) # cannot view zone
+    dummy_view_ids = [z['id'] for z in dummy_view]
+    assert_that(dummy_view_ids, is_not(has_item(ok_zone['id'])))  # cannot view zone
 
 
 def test_update_reverse_v4_zone(shared_zone_test_context):

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -444,7 +444,7 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, **kwargs)
         return data
 
-    def list_zones(self, name_filter=None, start_from=None, max_items=None, **kwargs):
+    def list_zones(self, name_filter=None, start_from=None, max_items=None, search_all=False, **kwargs):
         """
         Gets a list of zones that currently exist
         :return: a list of zones
@@ -460,6 +460,9 @@ class VinylDNSClient(object):
 
         if max_items:
             query.append(u'maxItems=' + str(max_items))
+
+        if search_all:
+            query.append(u'searchAll=' + str(search_all))
 
         if query:
             url = url + u'?' + u'&'.join(query)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -81,10 +81,11 @@ case class ZoneSummaryInfo(
     adminGroupId: String,
     adminGroupName: String,
     latestSync: Option[DateTime],
-    backendId: Option[String])
+    backendId: Option[String],
+    hasAccess: Boolean)
 
 object ZoneSummaryInfo {
-  def apply(zone: Zone, groupName: String): ZoneSummaryInfo =
+  def apply(zone: Zone, groupName: String, hasAccess: Boolean = true): ZoneSummaryInfo =
     ZoneSummaryInfo(
       name = zone.name,
       email = zone.email,
@@ -100,7 +101,8 @@ object ZoneSummaryInfo {
       adminGroupId = zone.adminGroupId,
       adminGroupName = groupName,
       latestSync = zone.latestSync,
-      zone.backendId
+      zone.backendId,
+      hasAccess
     )
 }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -66,6 +66,11 @@ object ZoneInfo {
     )
 }
 
+object ZoneAccessLevel extends Enumeration {
+  type ZoneAccessLevel = Value
+  val ReadOnly, ACLAccess, ZoneAdmin, SuperUser = Value
+}
+
 case class ZoneSummaryInfo(
     name: String,
     email: String,
@@ -81,11 +86,10 @@ case class ZoneSummaryInfo(
     adminGroupId: String,
     adminGroupName: String,
     latestSync: Option[DateTime],
-    backendId: Option[String],
-    hasAccess: Boolean)
+    backendId: Option[String])
 
 object ZoneSummaryInfo {
-  def apply(zone: Zone, groupName: String, hasAccess: Boolean = true): ZoneSummaryInfo =
+  def apply(zone: Zone, groupName: String): ZoneSummaryInfo =
     ZoneSummaryInfo(
       name = zone.name,
       email = zone.email,
@@ -101,8 +105,7 @@ object ZoneSummaryInfo {
       adminGroupId = zone.adminGroupId,
       adminGroupName = groupName,
       latestSync = zone.latestSync,
-      zone.backendId,
-      hasAccess
+      zone.backendId
     )
 }
 
@@ -205,7 +208,8 @@ case class ListZonesResponse(
     nameFilter: Option[String],
     startFrom: Option[String] = None,
     nextId: Option[String] = None,
-    maxItems: Int = 100)
+    maxItems: Int = 100,
+    searchAll: Boolean = false)
 
 // Errors
 case class InvalidRequest(msg: String) extends Throwable(msg)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -66,11 +66,6 @@ object ZoneInfo {
     )
 }
 
-object ZoneAccessLevel extends Enumeration {
-  type ZoneAccessLevel = Value
-  val ReadOnly, ACLAccess, ZoneAdmin, SuperUser = Value
-}
-
 case class ZoneSummaryInfo(
     name: String,
     email: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -134,9 +134,15 @@ class ZoneService(
       authPrincipal: AuthPrincipal,
       nameFilter: Option[String] = None,
       startFrom: Option[String] = None,
-      maxItems: Int = 100): Result[ListZonesResponse] = {
+      maxItems: Int = 100,
+      searchAll: Boolean = false): Result[ListZonesResponse] = {
     for {
-      listZonesResult <- zoneRepository.listZones(authPrincipal, nameFilter, startFrom, maxItems)
+      listZonesResult <- zoneRepository.listZones(
+        authPrincipal,
+        nameFilter,
+        startFrom,
+        maxItems,
+        searchAll)
       zones = listZonesResult.zones
       groupIds = zones.map(_.adminGroupId).toSet
       groups <- groupRepository.getGroups(groupIds)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -40,7 +40,8 @@ trait ZoneServiceAlgebra {
       authPrincipal: AuthPrincipal,
       nameFilter: Option[String],
       startFrom: Option[String],
-      maxItems: Int): Result[ListZonesResponse]
+      maxItems: Int,
+      searchAll: Boolean): Result[ListZonesResponse]
 
   def listZoneChanges(
       zoneId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -53,14 +53,21 @@ trait ZoneRoute extends Directives {
         parameters(
           "nameFilter".?,
           "startFrom".as[String].?,
-          "maxItems".as[Int].?(DEFAULT_MAX_ITEMS)) {
-          (nameFilter: Option[String], startFrom: Option[String], maxItems: Int) =>
+          "maxItems".as[Int].?(DEFAULT_MAX_ITEMS),
+          "searchAll".as[Boolean].?(false)
+        ) {
+          (
+              nameFilter: Option[String],
+              startFrom: Option[String],
+              maxItems: Int,
+              searchAll: Boolean) =>
             {
               handleRejections(invalidQueryHandler) {
                 validate(
                   0 < maxItems && maxItems <= MAX_ITEMS_LIMIT,
                   s"maxItems was $maxItems, maxItems must be between 0 and $MAX_ITEMS_LIMIT") {
-                  execute(zoneService.listZones(authPrincipal, nameFilter, startFrom, maxItems)) {
+                  execute(zoneService
+                    .listZones(authPrincipal, nameFilter, startFrom, maxItems, searchAll)) {
                     result =>
                       complete(StatusCodes.OK, result)
                   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -510,9 +510,6 @@ class ZoneServiceSpec
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
-      doReturn(IO.pure(resultZoneIds))
-        .when(mockZoneRepo)
-        .getAccess(any[Seq[String]], any[AuthPrincipal])
 
       val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
@@ -530,9 +527,6 @@ class ZoneServiceSpec
         .when(mockZoneRepo)
         .listZones(abcAuth, None, None, 100, false)
       doReturn(IO.pure(Set(okGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
-      doReturn(IO.pure(resultZoneIds))
-        .when(mockZoneRepo)
-        .getAccess(any[Seq[String]], any[AuthPrincipal])
 
       val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
       val expectedZones =
@@ -553,9 +547,6 @@ class ZoneServiceSpec
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
-      doReturn(IO.pure(resultZoneIds))
-        .when(mockZoneRepo)
-        .getAccess(any[Seq[String]], any[AuthPrincipal])
 
       val result: ListZonesResponse =
         rightResultOf(underTest.listZones(abcAuth, maxItems = 2).value)
@@ -582,9 +573,6 @@ class ZoneServiceSpec
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
-      doReturn(IO.pure(resultZoneIds))
-        .when(mockZoneRepo)
-        .getAccess(any[Seq[String]], any[AuthPrincipal])
 
       val result: ListZonesResponse =
         rightResultOf(underTest.listZones(abcAuth, nameFilter = Some("foo"), maxItems = 2).value)
@@ -604,9 +592,6 @@ class ZoneServiceSpec
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
-      doReturn(IO.pure(resultZoneIds))
-        .when(mockZoneRepo)
-        .getAccess(any[Seq[String]], any[AuthPrincipal])
 
       val result: ListZonesResponse =
         rightResultOf(underTest.listZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value)
@@ -630,10 +615,6 @@ class ZoneServiceSpec
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
-
-      doReturn(IO.pure(resultZoneIds))
-        .when(mockZoneRepo)
-        .getAccess(any[Seq[String]], any[AuthPrincipal])
 
       val result: ListZonesResponse =
         rightResultOf(underTest.listZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value)

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -502,8 +502,6 @@ class ZoneServiceSpec
     }
 
     "return the appropriate zones" in {
-      val resultZones = List(abcZone, xyzZone)
-      val resultZoneIds = resultZones.map(_.id)
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone))))
         .when(mockZoneRepo)
         .listZones(abcAuth, None, None, 100, false)
@@ -521,7 +519,6 @@ class ZoneServiceSpec
 
     "return Unknown group name if zone admin group cannot be found" in {
       val resultZones = List(abcZone, xyzZone)
-      val resultZoneIds = resultZones.map(_.id)
 
       doReturn(IO.pure(ListZonesResults(resultZones)))
         .when(mockZoneRepo)
@@ -540,7 +537,6 @@ class ZoneServiceSpec
 
     "set the nextId appropriately" in {
       val resultZones = List(abcZone, xyzZone)
-      val resultZoneIds = resultZones.map(_.id)
       doReturn(IO.pure(ListZonesResults(resultZones, maxItems = 2, nextId = Some("zone2."))))
         .when(mockZoneRepo)
         .listZones(abcAuth, None, None, 2, false)
@@ -559,7 +555,6 @@ class ZoneServiceSpec
 
     "set the nameFilter when provided" in {
       val resultZones = List(abcZone, xyzZone)
-      val resultZoneIds = resultZones.map(_.id)
 
       doReturn(
         IO.pure(
@@ -584,7 +579,6 @@ class ZoneServiceSpec
 
     "set the startFrom when provided" in {
       val resultZones = List(abcZone, xyzZone)
-      val resultZoneIds = resultZones.map(_.id)
 
       doReturn(IO.pure(ListZonesResults(resultZones, startFrom = Some("zone4."), maxItems = 2)))
         .when(mockZoneRepo)
@@ -600,9 +594,7 @@ class ZoneServiceSpec
     }
 
     "set the nextId to be the current result set size plus the start from" in {
-
       val resultZones = List(abcZone, xyzZone)
-      val resultZoneIds = resultZones.map(_.id)
       doReturn(
         IO.pure(
           ListZonesResults(

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -77,9 +77,6 @@ trait EmptyZoneRepo extends ZoneRepository {
   def getZonesByFilters(zoneNames: Set[String]): IO[Set[Zone]] = IO.pure(Set())
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]] = IO.pure(None)
-
-  def getAccess(zones: Seq[String], authPrincipal: AuthPrincipal): IO[Seq[String]] =
-    IO.pure(Seq.empty)
 }
 
 trait EmptyGroupRepo extends GroupRepository {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -67,7 +67,8 @@ trait EmptyZoneRepo extends ZoneRepository {
       authPrincipal: AuthPrincipal,
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
-      maxItems: Int = 100): IO[ListZonesResults] = IO.pure(ListZonesResults())
+      maxItems: Int = 100,
+      searchAll: Boolean = false): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]] = IO.pure(List())
 
@@ -76,6 +77,9 @@ trait EmptyZoneRepo extends ZoneRepository {
   def getZonesByFilters(zoneNames: Set[String]): IO[Set[Zone]] = IO.pure(Set())
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]] = IO.pure(None)
+
+  def getAccess(zones: Seq[String], authPrincipal: AuthPrincipal): IO[Seq[String]] =
+    IO.pure(Seq.empty)
 }
 
 trait EmptyGroupRepo extends GroupRepository {

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -220,7 +220,8 @@ class ZoneRoutingSpec
         authPrincipal: AuthPrincipal,
         nameFilter: Option[String],
         startFrom: Option[String],
-        maxItems: Int): Result[ListZonesResponse] = {
+        maxItems: Int,
+        searchAll: Boolean): Result[ListZonesResponse] = {
 
       val outcome = (authPrincipal, nameFilter, startFrom, maxItems) match {
         case (_, None, Some("zone3."), 3) =>

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
@@ -21,4 +21,5 @@ case class ListZonesResults(
     nextId: Option[String] = None,
     startFrom: Option[String] = None,
     maxItems: Int = 100,
-    zonesFilter: Option[String] = None)
+    zonesFilter: Option[String] = None,
+    searchAll: Boolean = false)

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
@@ -43,8 +43,7 @@ final case class Zone(
     adminGroupId: String = "system",
     latestSync: Option[DateTime] = None,
     isTest: Boolean = false,
-    backendId: Option[String] = None,
-    userHasAccess: Boolean = true) { // <-- note, this is hacky as it has nothing to do with the zone
+    backendId: Option[String] = None) {
   val isIPv4: Boolean = name.endsWith("in-addr.arpa.")
   val isIPv6: Boolean = name.endsWith("ip6.arpa.")
   val isReverse: Boolean = isIPv4 || isIPv6

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
@@ -43,7 +43,8 @@ final case class Zone(
     adminGroupId: String = "system",
     latestSync: Option[DateTime] = None,
     isTest: Boolean = false,
-    backendId: Option[String] = None) {
+    backendId: Option[String] = None,
+    userHasAccess: Boolean = true) { // <-- note, this is hacky as it has nothing to do with the zone
   val isIPv4: Boolean = name.endsWith("in-addr.arpa.")
   val isIPv6: Boolean = name.endsWith("ip6.arpa.")
   val isReverse: Boolean = isIPv4 || isIPv6

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -43,8 +43,6 @@ trait ZoneRepository extends Repository {
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]]
-
-  def getAccess(zones: Seq[String], authPrincipal: AuthPrincipal): IO[Seq[String]]
 }
 
 object ZoneRepository {

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -43,6 +43,8 @@ trait ZoneRepository extends Repository {
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]]
+
+  def getAccess(zones: Seq[String], authPrincipal: AuthPrincipal): IO[Seq[String]]
 }
 
 object ZoneRepository {

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -37,7 +37,8 @@ trait ZoneRepository extends Repository {
       authPrincipal: AuthPrincipal,
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
-      maxItems: Int = 100): IO[ListZonesResults]
+      maxItems: Int = 100,
+      searchAll: Boolean = false): IO[ListZonesResults]
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]
 

--- a/modules/docs/src/main/tut/api/list-zones.md
+++ b/modules/docs/src/main/tut/api/list-zones.md
@@ -10,7 +10,7 @@ Retrieves the list of zones a user has access to.  The zone name is only sorted 
 
 #### HTTP REQUEST
 
-> GET /zones?nameFilter={yoursearchhere}&startFrom={response.nextId}&maxItems={1 - 100}
+> GET /zones?nameFilter={yoursearchhere}&startFrom={response.nextId}&maxItems={1 - 100}&searchAll={true | false}
 
 #### HTTP REQUEST PARAMS
 
@@ -36,6 +36,7 @@ zones         | Array of [Zones](../api/zone-model#zone-attributes) | An array o
 startFrom     | *any*         | (optional) The startFrom parameter that was sent in on the HTTP request.  Will not be present if the startFrom parameter was not sent |
 nextId        | *any*         | (optional) The identifier to be passed in as the *startFrom* parameter to retrieve the next page of results.  If there are no results left, this field will not be present.
 maxItems      | int           | The maxItems parameter that was sent in on the HTTP request.  This will be 100 if not sent. |
+searchAll     | boolean       | The searchAll parameter that was sent in on the HTTP request.  This will be 100 if not sent. |
 
 #### EXAMPLE RESPONSE
 
@@ -113,6 +114,7 @@ maxItems      | int           | The maxItems parameter that was sent in on the H
       "latestSync": "2016-12-16T15:27:26Z"
     }
   ],
-  "maxItems": 100
+  "maxItems": 100,
+  "searchAll": false
 }
 ```

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -288,6 +288,21 @@ class MySqlZoneRepositoryIntegrationSpec
       f.unsafeRunSync().zones shouldBe empty
     }
 
+    "return zones if user is not authorized but searchAll is true" in {
+      val unauthorized = AuthPrincipal(
+        signedInUser = User("not-authorized", "not-authorized", "not-authorized"),
+        memberGroupIds = Seq.empty
+      )
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          zones <- repo.listZones(unauthorized, searchAll = true)
+        } yield zones
+
+      f.unsafeRunSync().zones should contain theSameElementsAs testZones
+    }
+
     "not return zones when access is revoked" in {
       // ok user can access both zones, dummy can only access first zone
       val zones = testZones.take(2)

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -110,7 +110,7 @@
                                   }
                                   <td>
                                     <div class="table-form-group">
-                                      <a ng-if="zone.hasAccess" id="zone-view-{{zone.name}}" type="button" class="btn btn-info btn-rounded"
+                                      <a id="zone-view-{{zone.name}}" type="button" class="btn btn-info btn-rounded"
                                       ng-href="/zones/{{ zone.id }}">
                                         View
                                       </a>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -42,14 +42,23 @@
 
                         <!-- SEARCH BOX -->
                         <div class="pull-right">
-                            <form class="input-group" ng-submit="refreshZones()">
-                                <div class="input-group">
-                                    <span class="input-group-btn">
-                                        <button id="zone-search-button" type="submit" class="btn btn-primary btn-left-round">
-                                          <span class="fa fa-search"></span>
-                                        </button>
-                                    </span>
-                                    <input id="zone-search-text" ng-model="query" type="text" class="form-control"  placeholder="Zone Name"/>
+                            <form class="form-inline" ng-submit="refreshZones()">
+                                <div class="form-group" style="padding-left: 10px;">
+                                    <label class="check">
+                                        <input type="checkbox"
+                                               ng-model="searchAll" name="searchAll"
+                                               class="icheckbox_minimal-grey"/>
+                                        Search All Zones?</label>
+                                </div>
+                                <div class="form-group" style="padding-left: 10px;">
+                                    <div class="input-group">
+                                        <span class="input-group-btn">
+                                            <button id="zone-search-button" type="submit" class="btn btn-primary btn-left-round">
+                                              <span class="fa fa-search"></span>
+                                            </button>
+                                        </span>
+                                        <input id="zone-search-text" ng-model="query" type="text" class="form-control"  placeholder="Zone Name"/>
+                                    </div>
                                 </div>
                             </form>
                         </div>
@@ -101,7 +110,7 @@
                                   }
                                   <td>
                                     <div class="table-form-group">
-                                      <a id="zone-view-{{zone.name}}" type="button" class="btn btn-info btn-rounded"
+                                      <a ng-if="zone.hasAccess" id="zone-view-{{zone.name}}" type="button" class="btn btn-info btn-rounded"
                                       ng-href="/zones/{{ zone.id }}">
                                         View
                                       </a>

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -23,6 +23,7 @@ angular.module('controller.zones', [])
     $scope.hasZones = false; // Re-assigned each time zones are fetched without a query
 
     $scope.query = "";
+    $scope.searchAll = false;
 
     // Paging status for zone sets
     var zonesPaging = pagingService.getNewPagingParams(100);
@@ -79,7 +80,7 @@ angular.module('controller.zones', [])
         }
 
         return zonesService
-            .getZones(zonesPaging.maxItems, undefined, $scope.query)
+            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchAll)
             .then(success)
             .catch(function (error) {
                 handleError(error, 'zonesService::getZones-failure');
@@ -154,7 +155,7 @@ angular.module('controller.zones', [])
     $scope.prevPage = function () {
         var startFrom = pagingService.getPrevStartFrom(zonesPaging);
         return zonesService
-            .getZones(zonesPaging.maxItems, startFrom, $scope.query)
+            .getZones(zonesPaging.maxItems, startFrom, $scope.query, $scope.searchAll)
             .then(function(response) {
                 zonesPaging = pagingService.prevPageUpdate(response.data.nextId, zonesPaging);
                 updateZoneDisplay(response.data.zones);
@@ -166,7 +167,7 @@ angular.module('controller.zones', [])
 
     $scope.nextPage = function () {
         return zonesService
-            .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query)
+            .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query, $scope.searchAll)
             .then(function(response) {
                 var zoneSets = response.data.zones;
                 zonesPaging = pagingService.nextPageUpdate(zoneSets, response.data.nextId, zonesPaging);

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -74,12 +74,13 @@ describe('Controller: ZonesController', function () {
         var expectedMaxItems = 100;
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
+        var expectedSearchAll = false;
 
         this.scope.nextPage();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-          [expectedMaxItems, expectedStartFrom, expectedQuery]);
+          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchAll]);
     });
 
     it('prevPage should call getZones with the correct parameters', function () {
@@ -90,18 +91,19 @@ describe('Controller: ZonesController', function () {
         var expectedMaxItems = 100;
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
+        var expectedSearchAll = false;
 
         this.scope.prevPage();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchAll]);
 
         this.scope.nextPage();
         this.scope.prevPage();
 
         expect(getZoneSets.calls.count()).toBe(3);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchAll]);
     });
 });

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -19,14 +19,15 @@
 angular.module('service.zones', [])
     .service('zonesService', function ($http, groupsService, $log, utilityService) {
 
-        this.getZones = function (limit, startFrom, query) {
+        this.getZones = function (limit, startFrom, query, searchAll) {
             if (query == "") {
                 query = null;
             }
             var params = {
                 "maxItems": limit,
                 "startFrom": startFrom,
-                "nameFilter": query
+                "nameFilter": query,
+                "searchAll": searchAll
             };
             var url = groupsService.urlBuilder("/api/zones", params);
             return $http.get(url);


### PR DESCRIPTION
Allows a user to search across all zones in the system.

* Added a `searchAll` flag to the list zones route, service, and repository methods
* Added a new `getAccess` method to the `ZoneRepository` to determine which zones a user actually has access to
* Added a `hasAccess` flag to the `ZoneSummaryInfo` type that is returned that indicates if a user has access to the zone
* Updated the `ZoneService` to check for access before building the `ZoneSummaryInfo`
* Updated the portal to consider whether a user has access when displaying the zones in the zones page
* Updated the portal to add a check box to allow for "search all"
