### PR TITLE
only show abandon zone button to zone admins

### DIFF
--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -306,8 +306,8 @@
                     </td>
                     @if(meta.sharedDisplayEnabled) {
                         <td ng-if="zoneInfo.shared">
-                            <a ng-if="record.ownerGroupName && isGroupMember(record.ownerGroupId)" ng-bind="record.ownerGroupName" href="/groups/{{record.ownerGroupId}}"></a>
-                            <span ng-if="record.ownerGroupName && !isGroupMember(record.ownerGroupId)" ng-bind="record.ownerGroupName"></span>
+                            <a ng-if="record.ownerGroupName && canAccessGroup(record.ownerGroupId)" ng-bind="record.ownerGroupName" href="/groups/{{record.ownerGroupId}}"></a>
+                            <span ng-if="record.ownerGroupName && !canAccessGroup(record.ownerGroupId)" ng-bind="record.ownerGroupName"></span>
                             <span ng-if="!record.ownerGroupId">Unowned</span>
                             <span ng-if="record.ownerGroupId && !record.ownerGroupName" class="text-danger" data-toggle="tooltip" data-placement="top"
                                   title="Group with ID {{record.ownerGroupId}} no longer exists."><span class="fa fa-warning"></span> Group deleted</span>

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -67,7 +67,7 @@
         <div class="btn-group">
             <button id="refresh-records-button" class="btn btn-default" ng-click="refreshRecords()"><span class="fa fa-refresh"></span> Refresh</button>
             <button id="create-record-button" class="btn btn-default" ng-click="createRecord()"><span class="fa fa-plus"></span> Create Record Set</button>
-            <button id="zone-sync-button" class="btn btn-default mb-control" ng-hide="!isZoneAdmin" data-toggle="modal" data-target="#mb-sync"><span class="fa fa-exchange"></span> Sync Zone</button>
+            <button id="zone-sync-button" class="btn btn-default mb-control" ng-if="isZoneAdmin" data-toggle="modal" data-target="#mb-sync"><span class="fa fa-exchange"></span> Sync Zone</button>
         </div>
 
         <div>

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -198,17 +198,25 @@
 
             </div>
             <div class="form-group panel-footer" ng-if="isZoneAdmin">
-                <div class="col-md-12">
-                    <span ng-if="currentManageZoneState == manageZoneState.UPDATE">
-                        <button id="zone-update-button" type="button"
-                                ng-disabled="!objectsDiffer(updateZoneInfo, zoneInfo) && updateZoneInfo.hiddenKey == '' &&
-                                             updateZoneInfo.hiddenTransferKey == ''"
-                                class="btn btn-primary pull-right"
-                                ng-click="clickUpdateZone()">Update Zone</button>
-                        <button type="button" class="btn btn-primary" ng-click="refreshZone()"
-                                ng-disabled="!objectsDiffer(updateZoneInfo, zoneInfo) && updateZoneInfo.hiddenKey == '' &&
-                                             updateZoneInfo.hiddenTransferKey == ''">Reset</button>
-                    </span>
+                <div class="col-md-3">
+                    <button ng-if="currentManageZoneState == manageZoneState.UPDATE" type="button" class="btn btn-primary" ng-click="refreshZone()"
+                            ng-disabled="!objectsDiffer(updateZoneInfo, zoneInfo) && updateZoneInfo.hiddenKey == '' &&
+                                         updateZoneInfo.hiddenTransferKey == ''">
+                        Reset
+                    </button>
+                </div>
+                <div class="vinyldns-flex-right">
+                    <button ng-if="currentManageZoneState == manageZoneState.UPDATE" id="zone-update-button" type="button"
+                            ng-disabled="!objectsDiffer(updateZoneInfo, zoneInfo) && updateZoneInfo.hiddenKey == '' &&
+                                         updateZoneInfo.hiddenTransferKey == ''"
+                            class="btn btn-primary"
+                            ng-click="clickUpdateZone()">
+                        Update Zone
+                    </button>
+                    <button id="zone-delete-{{zone.name}}" class="btn btn-danger btn-rounded mb-control"
+                            ng-click="confirmDeleteZone();">
+                        Abandon Zone
+                    </button>
 
                     <span class="update-zone-msg" ng-if="currentManageZoneState == manageZoneState.CONFIRM_UPDATE">
                         <span>Are you sure you want to update this zone?&emsp;</span>
@@ -224,7 +232,7 @@
     <!-- END ZONE INFO FORM -->
 
     <!-- START ACL TABLE -->
-<div class="panel panel-default" ng-if="isZoneAdmin">
+<div class="panel panel-default">
 
     <div class="panel-heading">
         <h3 class="panel-title">
@@ -237,7 +245,7 @@
             <button id="refresh-acl-rules-button" class="btn btn-default" ng-click="refreshZone()">
                 <span class="fa fa-refresh"></span> Refresh
             </button>
-            <button id="create-acl-rule-button" class="btn btn-default" ng-click="clickCreateAclRule()">
+            <button ng-if="isZoneAdmin" id="create-acl-rule-button" class="btn btn-default" ng-click="clickCreateAclRule()">
                 <span class="fa fa-plus"></span> Create ACL Rule
             </button>
         </div>
@@ -281,7 +289,7 @@
                     </td>
 
                     <td>
-                        <span>
+                        <span ng-if="isZoneAdmin">
                             <button class="btn btn-info btn-sm" id="update-acl-rule-button-{{$index}}"
                                 ng-click="clickUpdateAclRule($index)">
                                 Update
@@ -460,3 +468,34 @@
     </modal>
 </form>
     <!-- END ACL MODAL -->
+
+<div class="modal fade in" id="delete_zone_connection_modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span>
+                </button>
+                <div class="modal-title">Abandon Zone?</div>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to abandon the <strong>{{zoneInfo.name}}</strong> zone? This will disconnect the zone from Vinyl,
+                    but recordsets will still exist unless deleted from
+                    <a ng-href="/zones/{{zoneInfo.id}}">
+                        <strong>Manage Records</strong></a></p>
+            </div>
+            <div class="modal-footer">
+                <form name="deleteZoneConnectionForm" ng-submit="deleteZoneConnection()" role="form" class="form-horizontal" novalidate>
+                    <button type="submit" id="zone-delete-yes-button"
+                            class="btn btn-danger pull-right"
+                            ng-click="submitDeleteZone(zoneInfo.id)">
+                        Abandon
+                    </button>
+                    <button type="button" class="btn btn-primary"
+                            data-dismiss="modal">
+                        Close
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -232,7 +232,7 @@
     <!-- END ZONE INFO FORM -->
 
     <!-- START ACL TABLE -->
-<div class="panel panel-default">
+<div class="panel panel-default" ng-if="canReadZone">
 
     <div class="panel-heading">
         <h3 class="panel-title">

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -92,8 +92,8 @@
                                   <td ng-bind="zone.name"></td>
                                   <td ng-bind="zone.email"></td>
                                   <td>
-                                      <a ng-if="isGroupMember(zone.adminGroupId)" ng-bind="zone.adminGroupName" href="/groups/{{zone.adminGroupId}}"></a>
-                                      <span ng-if="!isGroupMember(zone.adminGroupId)" ng-bind="zone.adminGroupName" style="line-height: 0"></span>
+                                      <a ng-if="canAccessGroup(zone.adminGroupId)" ng-bind="zone.adminGroupName" href="/groups/{{zone.adminGroupId}}"></a>
+                                      <span ng-if="!canAccessGroup(zone.adminGroupId)" ng-bind="zone.adminGroupName" style="line-height: 0"></span>
                                   </td>
                                   <td ng-bind="zone.status"></td>
                                   @if(meta.sharedDisplayEnabled) {
@@ -107,7 +107,8 @@
                                       </a>
                                       <button id="zone-delete-{{zone.name}}"
                                       class="btn btn-danger btn-rounded mb-control"
-                                      ng-click="confirmDeleteZone(zone);">
+                                      ng-click="confirmDeleteZone(zone);"
+                                      ng-if="isZoneAdmin(zone.adminGroupId)">
                                         Abandon
                                       </button>
                                     </div>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -105,12 +105,6 @@
                                       ng-href="/zones/{{ zone.id }}">
                                         View
                                       </a>
-                                      <button id="zone-delete-{{zone.name}}"
-                                      class="btn btn-danger btn-rounded mb-control"
-                                      ng-click="confirmDeleteZone(zone);"
-                                      ng-if="isZoneAdmin(zone.adminGroupId)">
-                                        Abandon
-                                      </button>
                                     </div>
                                   </td>
                                 </tr>
@@ -144,37 +138,6 @@
 <!-- END PAGE CONTENT -->
 
 <zoneconnection></zoneconnection>
-
-<div class="modal fade in" id="delete_zone_connection_modal">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span>
-              </button>
-                <div class="modal-title">Abandon Zone?</div>
-            </div>
-            <div class="modal-body">
-                <p>Are you sure you want to abandon the <strong>{{currentZone.name}}</strong> zone? This will disconnect the zone from Vinyl,
-                but recordsets will still exist unless deleted from
-                <a ng-href="/zones/{{currentZone.id}}">
-                <strong>Manage Records</strong></a></p>
-            </div>
-            <div class="modal-footer">
-                <form name="deleteZoneConnectionForm" ng-submit="deleteZoneConnection()" role="form" class="form-horizontal" novalidate>
-                    <button type="submit" id="zone-delete-yes-button"
-                    class="btn btn-danger pull-right"
-                    ng-click="submitDeleteZone(currentZone.id)">
-                      Abandon
-                    </button>
-                    <button type="button" class="btn btn-primary"
-                    ng-click="cancel()">
-                      Close
-                    </button>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
 }
 
 @plugins = {

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -396,3 +396,8 @@ input[type="file"] {
 .batch-change-csv-label {
     cursor: pointer;
 }
+
+.vinyldns-flex-right {
+    display: flex;
+    justify-content: flex-end;
+}

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -83,6 +83,27 @@ angular.module('controller.manageZones', [])
         $scope.currentManageZoneState = $scope.manageZoneState.UPDATE;
     };
 
+    $scope.confirmDeleteZone = function() {
+        $("#delete_zone_connection_modal").modal("show");
+    };
+
+    $scope.submitDeleteZone = function() {
+        zonesService.delZone($scope.zoneInfo.id)
+            .then(function (response) {
+                $("#delete_zone_connection_modal").modal("hide");
+                var msg = response.statusText + " (HTTP "+response.status+"): " + response.data.changeType + " zone '" + response.data.zone.name + "'";
+                $scope.alerts.push({type: "success", content: msg});
+                $timeout(function(){
+                    location.href = "/zones";
+                 }, 2000);
+            })
+            .catch(function (error) {
+                $("#delete_zone_connection_modal").modal("hide");
+                $scope.zoneError = true;
+                handleError(error, 'zonesService::sendZone-failure');
+            });
+    };
+
     /**
      * Acl modal control functions
      */

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -576,7 +576,6 @@ angular.module('controller.records', [])
     }
 
     function profileFailure(results) {
-        $scope.profile = $scope.profile || {};
         handleError(results, 'profileService::getAuthenticatedUserData-catch');
     }
 

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -41,6 +41,7 @@ angular.module('controller.records', [])
     $scope.recordsetChanges = {};
     $scope.currentRecord = {};
     $scope.zoneInfo = {};
+    $scope.profile = {};
 
     var loadZonesPromise;
     var loadRecordsPromise;
@@ -69,14 +70,6 @@ angular.module('controller.records', [])
     };
 
     $scope.isZoneAdmin = false;
-
-    profileService.getAuthenticatedUserData().then(function (results) {
-        if (results.data) {
-            $scope.profile = results.data
-        }
-    }, function () {
-        $scope.profile = $scope.profile || {};
-    });
 
     // paging status for recordsets
     var recordsPaging = pagingService.getNewPagingParams(100);
@@ -575,9 +568,24 @@ angular.module('controller.records', [])
             });
     };
 
+    function profileSuccess(results) {
+        if (results.data) {
+            $scope.profile = results.data;
+            $log.log('profileService::getAuthenticatedUserData-success');
+        }
+    }
+
+    function profileFailure(results) {
+        $scope.profile = $scope.profile || {};
+        handleError(results, 'profileService::getAuthenticatedUserData-catch');
+    }
+
     loadZonesPromise = $timeout($scope.refreshZone, 0);
     loadRecordsPromise = $timeout($scope.refreshRecords, 0);
     $timeout($scope.refreshRecordChangesPreview, 0);
     $timeout($scope.refreshRecordChanges, 0);
 
+    profileService.getAuthenticatedUserData()
+        .then(profileSuccess, profileFailure)
+        .catch(profileFailure);
 });

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -371,7 +371,7 @@ angular.module('controller.records', [])
     }
 
     $scope.canAccessGroup = function(groupId) {
-        $scope.myGroupIds.indexOf(groupId) > -1
+        return $scope.myGroupIds.indexOf(groupId) > -1
     };
 
     /**

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -352,6 +352,7 @@ angular.module('controller.records', [])
         .then(
             function (results) {
                 $scope.myGroups = results.groups;
+                $scope.myGroupIds = results.groups.map(function(grp) {return grp['id']});
                 determineAdmin()
             })
         .catch(function (error){
@@ -361,8 +362,7 @@ angular.module('controller.records', [])
 
     function determineAdmin(){
         var groupMember;
-        var groupIds = $scope.myGroups.map(function(grp) {return grp['id']});
-        var theGroupIndex = groupIds.indexOf($scope.zoneInfo.adminGroupId);
+        var theGroupIndex = $scope.myGroupIds.indexOf($scope.zoneInfo.adminGroupId);
         if (theGroupIndex > -1) {
             var groupMemberIds = $scope.myGroups[theGroupIndex].members.map(function(member) {return member['id']});
             groupMember = groupMemberIds.indexOf($scope.profile.id) > -1;
@@ -371,10 +371,7 @@ angular.module('controller.records', [])
     }
 
     $scope.canAccessGroup = function(groupId) {
-        var groupMember = $scope.myGroups.find(function(group) {
-            return groupId === group.id;
-        });
-        return groupMember !== undefined
+        $scope.myGroupIds.indexOf(groupId) > -1
     };
 
     /**

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -364,8 +364,8 @@ angular.module('controller.records', [])
         var groupIds = $scope.myGroups.map(function(grp) {return grp['id']});
         var theGroupIndex = groupIds.indexOf($scope.zoneInfo.adminGroupId);
         if (theGroupIndex > -1) {
-            var stuff = $scope.myGroups[theGroupIndex].members.map(function(member) {return member['id']});
-            groupMember = stuff.indexOf($scope.profile.id) > -1;
+            var groupMemberIds = $scope.myGroups[theGroupIndex].members.map(function(member) {return member['id']});
+            groupMember = groupMemberIds.indexOf($scope.profile.id) > -1;
         }
         $scope.isZoneAdmin = groupMember || $scope.profile.isSuper
     }

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -70,6 +70,7 @@ angular.module('controller.records', [])
     };
 
     $scope.isZoneAdmin = false;
+    $scope.canReadZone = false;
 
     // paging status for recordsets
     var recordsPaging = pagingService.getNewPagingParams(100);
@@ -361,17 +362,26 @@ angular.module('controller.records', [])
     }
 
     function determineAdmin(){
+        $scope.isZoneAdmin = $scope.profile.isSuper || isInAdminGroup()
+        $scope.canReadZone = canReadZone()
+    }
+
+    function isInAdminGroup() {
         var groupMember;
         var theGroupIndex = $scope.myGroupIds.indexOf($scope.zoneInfo.adminGroupId);
         if (theGroupIndex > -1) {
             var groupMemberIds = $scope.myGroups[theGroupIndex].members.map(function(member) {return member['id']});
             groupMember = groupMemberIds.indexOf($scope.profile.id) > -1;
         }
-        $scope.isZoneAdmin = groupMember || $scope.profile.isSuper
+        return groupMember
     }
 
-    $scope.canAccessGroup = function(groupId) {
-        return $scope.myGroupIds.indexOf(groupId) > -1
+    function canReadZone() {
+        return $scope.myGroupIds.indexOf($scope.zoneInfo.adminGroupId) > -1;
+    }
+
+    function canAccessGroup(groupId) {
+        return $scope.myGroupIds.indexOf(groupId) > -1;
     };
 
     /**

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -15,7 +15,7 @@
  */
 
 angular.module('controller.records', [])
-    .controller('RecordsController', function ($scope, $timeout, $log, recordsService, groupsService, pagingService, utilityService, $q) {
+    .controller('RecordsController', function ($scope, $timeout, $log, recordsService, groupsService, pagingService, profileService, utilityService, $q) {
 
     /**
       * Scope data initial setup
@@ -69,6 +69,14 @@ angular.module('controller.records', [])
     };
 
     $scope.isZoneAdmin = false;
+
+    profileService.getAuthenticatedUserData().then(function (results) {
+        if (results.data) {
+            $scope.profile = results.data
+        }
+    }, function () {
+        $scope.profile = $scope.profile || {};
+    });
 
     // paging status for recordsets
     var recordsPaging = pagingService.getNewPagingParams(100);
@@ -359,11 +367,18 @@ angular.module('controller.records', [])
     }
 
     function determineAdmin(){
-        var groupIds = $scope.myGroups.map(function(grp) {return grp['id']});
-        $scope.isZoneAdmin = groupIds.indexOf($scope.zoneInfo.adminGroupId) > -1;
+        var groupMember;
+        $scope.myGroups.find(function(group) {
+            if ($scope.zoneInfo.adminGroupId === group.id) {
+                group.members.find(function(member){
+                    return groupMember = $scope.profile.id === member.id;
+                });
+            };
+        });
+        $scope.isZoneAdmin = groupMember || $scope.profile.isSuper
     }
 
-    $scope.isGroupMember = function(groupId) {
+    $scope.canAccessGroup = function(groupId) {
         var groupMember = $scope.myGroups.find(function(group) {
             return groupId === group.id;
         });

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -367,13 +367,13 @@ angular.module('controller.records', [])
     }
 
     function isInAdminGroup() {
-        var groupMember;
+        var groupMember = false;
         var theGroupIndex = $scope.myGroupIds.indexOf($scope.zoneInfo.adminGroupId);
         if (theGroupIndex > -1) {
             var groupMemberIds = $scope.myGroups[theGroupIndex].members.map(function(member) {return member['id']});
             groupMember = groupMemberIds.indexOf($scope.profile.id) > -1;
         }
-        return groupMember
+        return groupMember;
     }
 
     function canReadZone() {

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -368,13 +368,12 @@ angular.module('controller.records', [])
 
     function determineAdmin(){
         var groupMember;
-        $scope.myGroups.find(function(group) {
-            if ($scope.zoneInfo.adminGroupId === group.id) {
-                group.members.find(function(member){
-                    return groupMember = $scope.profile.id === member.id;
-                });
-            };
-        });
+        var groupIds = $scope.myGroups.map(function(grp) {return grp['id']});
+        var theGroupIndex = groupIds.indexOf($scope.zoneInfo.adminGroupId);
+        if (theGroupIndex > -1) {
+            var stuff = $scope.myGroups[theGroupIndex].members.map(function(member) {return member['id']});
+            groupMember = stuff.indexOf($scope.profile.id) > -1;
+        }
         $scope.isZoneAdmin = groupMember || $scope.profile.isSuper
     }
 

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -122,12 +122,14 @@ describe('Controller: RecordsController', function () {
             maxItems: 100}};
 
         this.scope.zoneInfo = {};
+        this.scope.profile = {id: "7096b806-c12a-4171-ba13-7fabb523acee", isSuper: false};
         spyOn(this.recordsService, 'getZone')
             .and.stub()
             .and.returnValue(this.q.when({ data: {zone: mockZone}}));
         spyOn(this.groupsService, 'getMyGroups')
             .and.stub()
             .and.returnValue(this.q.when(mockGroups));
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
         this.scope.refreshZone();
         this.scope.$digest();
 
@@ -160,12 +162,94 @@ describe('Controller: RecordsController', function () {
             maxItems: 100}};
 
         this.scope.zoneInfo = {};
+        this.scope.profile = {id: "notAdmin", isSuper: false};
         spyOn(this.recordsService, 'getZone')
             .and.stub()
             .and.returnValue(this.q.when({ data: {zone: mockZone}}));
         spyOn(this.groupsService, 'getMyGroups')
             .and.stub()
             .and.returnValue(this.q.when(mockGroups));
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
+        this.scope.refreshZone();
+        this.scope.$digest();
+
+        expect(this.scope.zoneInfo).toEqual(mockZone);
+        expect(this.scope.isZoneAdmin).toBe(false);
+    });
+
+    it('refreshZone updates zoneInfo and isZoneAdmin when user is a super user', function() {
+        mockZone = {
+            name: "dummy.",
+            email: "test@test.com",
+            status: "Active",
+            created: "2017-02-15T14:58:39Z",
+            account: "c8234503-bfda-4b80-897f-d74129051eaa",
+            acl: {rules: []},
+            adminGroupId: "c8234503-bfda-4b80-897f-d74129051eaa",
+            id: "c5c87405-2ec8-4e03-b2dc-c6758a5d9666",
+            shared: false,
+            status: "Active"
+        };
+        mockGroups = {data: { groups: [
+            {id: "some-other-id",
+                name: "test",
+                email: "test@test.com",
+                admins: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                created: "2017-02-15T14:58:31Z",
+                members: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                status: "Active"}
+        ],
+            maxItems: 100}};
+
+        this.scope.zoneInfo = {};
+        this.scope.profile = {id: "notAdmin", isSuper: true};
+        spyOn(this.recordsService, 'getZone')
+            .and.stub()
+            .and.returnValue(this.q.when({ data: {zone: mockZone}}));
+        spyOn(this.groupsService, 'getMyGroups')
+            .and.stub()
+            .and.returnValue(this.q.when(mockGroups));
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
+        this.scope.refreshZone();
+        this.scope.$digest();
+
+        expect(this.scope.zoneInfo).toEqual(mockZone);
+        expect(this.scope.isZoneAdmin).toBe(true);
+    });
+
+    it('refreshZone updates zoneInfo and isZoneAdmin when user is a support user only', function() {
+        mockZone = {
+            name: "dummy.",
+            email: "test@test.com",
+            status: "Active",
+            created: "2017-02-15T14:58:39Z",
+            account: "c8234503-bfda-4b80-897f-d74129051eaa",
+            acl: {rules: []},
+            adminGroupId: "c8234503-bfda-4b80-897f-d74129051eaa",
+            id: "c5c87405-2ec8-4e03-b2dc-c6758a5d9666",
+            shared: false,
+            status: "Active"
+        };
+        mockGroups = {data: { groups: [
+            {id: "some-other-id",
+                name: "test",
+                email: "test@test.com",
+                admins: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                created: "2017-02-15T14:58:31Z",
+                members: [{id: "7096b806-c12a-4171-ba13-7fabb523acee"}],
+                status: "Active"}
+        ],
+            maxItems: 100}};
+
+        this.scope.zoneInfo = {};
+        this.scope.profile = {id: "notAdmin", isSupport: true, isSuper: false};
+        spyOn(this.recordsService, 'getZone')
+            .and.stub()
+            .and.returnValue(this.q.when({ data: {zone: mockZone}}));
+        spyOn(this.groupsService, 'getMyGroups')
+            .and.stub()
+            .and.returnValue(this.q.when(mockGroups));
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
         this.scope.refreshZone();
         this.scope.$digest();
 

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -20,11 +20,12 @@ describe('Controller: RecordsController', function () {
         module('service.groups'),
         module('service.records'),
         module('service.paging'),
+        module('service.profile'),
         module('service.utility'),
         module('directives.modals.record.module'),
         module('controller.records')
     });
-    beforeEach(inject(function ($rootScope, $controller, $httpBackend, $q, groupsService, recordsService, pagingService) {
+    beforeEach(inject(function ($rootScope, $controller, $httpBackend, $q, groupsService, recordsService, pagingService, profileService) {
         this.rootScope = $rootScope;
         this.scope = this.rootScope.$new();
         this.$httpBackend = $httpBackend;
@@ -32,6 +33,7 @@ describe('Controller: RecordsController', function () {
         this.groupsService = groupsService;
         this.recordsService = recordsService;
         this.pagingService = pagingService;
+        this.profileService = profileService;
         this.q = $q;
     }));
 

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -242,7 +242,7 @@ describe('Controller: RecordsController', function () {
             maxItems: 100}};
 
         this.scope.zoneInfo = {};
-        this.scope.profile = {id: "notAdmin", isSupport: true, isSuper: false};
+        this.scope.profile = {id: "notAdmin", isSuper: false};
         spyOn(this.recordsService, 'getZone')
             .and.stub()
             .and.returnValue(this.q.when({ data: {zone: mockZone}}));

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -69,11 +69,10 @@ angular.module('controller.zones', [])
     };
 
     $scope.isZoneAdmin = function(groupId) {
-        var groupMember;
-        $scope.myGroups.find(function(group) {
+        var groupMember = $scope.myGroups.find(function(group) {
             if (groupId === group.id) {
-                group.members.find(function(member){
-                    return groupMember = $scope.profile.id === member.id;
+                return group.members.find(function(member){
+                    return $scope.profile.id === member.id;
                 });
             };
         });

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -77,7 +77,7 @@ angular.module('controller.zones', [])
                 });
             };
         });
-        return groupMember !== undefined || $scope.profile.isSuper
+        return groupMember || $scope.profile.isSuper
     };
 
     /* Refreshes zone data set and then re-displays */

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -51,6 +51,7 @@ angular.module('controller.zones', [])
     groupsService.getMyGroups().then(function (results) {
         if (results.data) {
             $scope.myGroups = results.data.groups;
+            $scope.myGroupIds = results.data.groups.map(function(grp) {return grp['id']});
         }
         $scope.resetCurrentZone();
     });
@@ -62,21 +63,7 @@ angular.module('controller.zones', [])
     });
 
     $scope.canAccessGroup = function(groupId) {
-        var groupAccess = $scope.myGroups.find(function(group) {
-            return groupId === group.id;
-        });
-        return groupAccess !== undefined
-    };
-
-    $scope.isZoneAdmin = function(groupId) {
-        var groupMember = $scope.myGroups.find(function(group) {
-            if (groupId === group.id) {
-                return group.members.find(function(member){
-                    return $scope.profile.id === member.id;
-                });
-            };
-        });
-        return groupMember || $scope.profile.isSuper
+        return $scope.myGroupIds.indexOf(groupId) > -1;
     };
 
     /* Refreshes zone data set and then re-displays */
@@ -134,30 +121,6 @@ angular.module('controller.zones', [])
                 handleError(error, 'zonesService::sendZone-failure');
                 $scope.processing = false;
             });
-    };
-
-    $scope.confirmDeleteZone = function (zoneInfo) {
-        $scope.currentZone = zoneInfo;
-        $("#delete_zone_connection_modal").modal("show");
-    };
-
-    $scope.submitDeleteZone = function (id) {
-        zonesService.delZone(id)
-            .then(function () {
-                $("#delete_zone_connection_modal").modal("hide");
-                $scope.refreshZones();
-            })
-            .catch(function (error) {
-                $("#delete_zone_connection_modal").modal("hide");
-                $scope.zoneError = true;
-                handleError(error, 'zonesService::sendZone-failure');
-            });
-    };
-
-    $scope.cancel = function () {
-        $scope.resetCurrentZone();
-        $("#modal_zone_connect").modal("hide");
-        $("#delete_zone_connection_modal").modal("hide");
     };
 
     function handleError(error, type) {

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -63,7 +63,7 @@ angular.module('controller.zones', [])
     });
 
     $scope.canAccessGroup = function(groupId) {
-        return $scope.myGroupIds.indexOf(groupId) > -1;
+        $scope.myGroupIds.indexOf(groupId) > -1;
     };
 
     /* Refreshes zone data set and then re-displays */

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -61,11 +61,23 @@ angular.module('controller.zones', [])
         }
     });
 
-    $scope.isGroupMember = function(groupId) {
-        var groupMember = $scope.myGroups.find(function(group) {
+    $scope.canAccessGroup = function(groupId) {
+        var groupAccess = $scope.myGroups.find(function(group) {
             return groupId === group.id;
         });
-        return groupMember !== undefined
+        return groupAccess !== undefined
+    };
+
+    $scope.isZoneAdmin = function(groupId) {
+        var groupMember;
+        $scope.myGroups.find(function(group) {
+            if (groupId === group.id) {
+                group.members.find(function(member){
+                    return groupMember = $scope.profile.id === member.id;
+                });
+            };
+        });
+        return groupMember !== undefined || $scope.profile.isSuper
     };
 
     /* Refreshes zone data set and then re-displays */

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -63,7 +63,7 @@ angular.module('controller.zones', [])
     });
 
     $scope.canAccessGroup = function(groupId) {
-        $scope.myGroupIds.indexOf(groupId) > -1;
+        return $scope.myGroupIds.indexOf(groupId) > -1;
     };
 
     /* Refreshes zone data set and then re-displays */

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -41,7 +41,7 @@ describe('Controller: ZonesController', function () {
         groupsService.getMyGroups = function() {
             return $q.when({
                 data: {
-                    groups: "all my groups"
+                    groups: [{id: "all my groups"}]
                 }
             });
         };
@@ -63,7 +63,7 @@ describe('Controller: ZonesController', function () {
 
     it('test that we properly get users groups when loading ZonesController', function(){
         this.scope.$digest();
-        expect(this.scope.myGroups).toBe("all my groups");
+        expect(this.scope.myGroups).toEqual([{id: "all my groups"}]);
     });
 
     it('nextPage should call getZones with the correct parameters', function () {


### PR DESCRIPTION
Fixes #606.

Changes in this pull request:
- only show the Abandon zone button to zone admins (members of the group that owns the zone and super users)
- note: support users don't have the ability to change zones so shouldn't see the button
- renamed `isGroupMember` function to `canAccessGroup` that applies to zone admins, support users and super users. This is used to determine if the group name should be linked to in the Zones table.
- added `isZoneAdmin` function that applies to zone admins and super users. This is used to to determine if the Abandon zone button is visible.
