### PR TITLE
Update backend ID functional test to be more flexible

### DIFF
--- a/modules/api/functional_test/live_tests/zones/get_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/get_zone_test.py
@@ -141,4 +141,4 @@ def test_get_zone_backend_ids(shared_zone_test_context):
     """
     client = shared_zone_test_context.ok_vinyldns_client
     response = client.get_backend_ids(status = 200)
-    assert_that(response, is_([u'func-test-backend']))
+    assert_that(response, has_item(u'func-test-backend'))


### PR DESCRIPTION
In one of our functional tests, we check that the only backend ID returned is the test `func-test-backend` ID. The test needs to be more flexible so that loading more backend IDs should not fail this test.