### PR TITLE
delete recordsets from repo on zone delete

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -185,7 +185,7 @@ object CommandHandler {
       connections: ConfiguredDnsConnections)(implicit timer: Timer[IO]): IO[Unit] = {
     // Handlers for each type of change request
     val zoneChangeHandler =
-      ZoneChangeHandler(zoneRepo, zoneChangeRepo)
+      ZoneChangeHandler(zoneRepo, zoneChangeRepo, recordSetRepo)
     val recordChangeHandler =
       RecordSetChangeHandler(recordSetRepo, recordChangeRepo, batchChangeRepo)
     val zoneSyncHandler =

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
@@ -70,7 +70,7 @@ class ZoneChangeHandlerSpec extends WordSpec with Matchers with MockitoSugar {
     val deleteChange = change.copy(changeType = ZoneChangeType.Delete)
 
     doReturn(IO.pure(Right(deleteChange.zone))).when(mockZoneRepo).save(deleteChange.zone)
-    doReturn(IO.pure(1))
+    doReturn(IO.pure(()))
       .when(mockRecordSetRepo)
       .deleteRecordSetsInZone(deleteChange.zone.id, deleteChange.zone.name)
     doReturn(IO.pure(deleteChange)).when(mockChangeRepo).save(any[ZoneChange])

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
@@ -23,26 +23,25 @@ import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.TestZoneData.zoneChangePending
+import vinyldns.core.domain.record.RecordSetRepository
 import vinyldns.core.domain.zone.ZoneRepository.DuplicateZoneError
-import vinyldns.core.domain.zone.{
-  ZoneChange,
-  ZoneChangeRepository,
-  ZoneChangeStatus,
-  ZoneRepository
-}
+import vinyldns.core.domain.zone._
 
 class ZoneChangeHandlerSpec extends WordSpec with Matchers with MockitoSugar {
 
-  "ZoneChangeHandler" should {
-    "save the zone change and zone" in {
-      val mockZoneRepo = mock[ZoneRepository]
-      val mockChangeRepo = mock[ZoneChangeRepository]
-      val change = zoneChangePending
+  trait Fixture {
+    val mockZoneRepo = mock[ZoneRepository]
+    val mockChangeRepo = mock[ZoneChangeRepository]
+    val mockRecordSetRepo = mock[RecordSetRepository]
+    val change = zoneChangePending
+    val test = ZoneChangeHandler(mockZoneRepo, mockChangeRepo, mockRecordSetRepo)
+  }
 
+  "ZoneChangeHandler" should {
+    "save the zone change and zone" in new Fixture {
       doReturn(IO.pure(Right(change.zone))).when(mockZoneRepo).save(change.zone)
       doReturn(IO.pure(change)).when(mockChangeRepo).save(any[ZoneChange])
 
-      val test = ZoneChangeHandler(mockZoneRepo, mockChangeRepo)
       test(change).unsafeRunSync()
 
       val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
@@ -53,15 +52,10 @@ class ZoneChangeHandlerSpec extends WordSpec with Matchers with MockitoSugar {
     }
   }
 
-  "save the zone change as failed if the zone does not save" in {
-    val mockZoneRepo = mock[ZoneRepository]
-    val mockChangeRepo = mock[ZoneChangeRepository]
-    val change = zoneChangePending
-
+  "save the zone change as failed if the zone does not save" in new Fixture {
     doReturn(IO.pure(Left(DuplicateZoneError("message")))).when(mockZoneRepo).save(change.zone)
     doReturn(IO.pure(change)).when(mockChangeRepo).save(any[ZoneChange])
 
-    val test = ZoneChangeHandler(mockZoneRepo, mockChangeRepo)
     test(change).unsafeRunSync()
 
     val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
@@ -70,5 +64,41 @@ class ZoneChangeHandlerSpec extends WordSpec with Matchers with MockitoSugar {
     val savedChange = changeCaptor.getValue
     savedChange.status shouldBe ZoneChangeStatus.Failed
     savedChange.systemMessage shouldBe Some("Zone with name \"message\" already exists.")
+  }
+
+  "save a delete zone change as synced if recordset delete succeeds" in new Fixture {
+    val deleteChange = change.copy(changeType = ZoneChangeType.Delete)
+
+    doReturn(IO.pure(Right(deleteChange.zone))).when(mockZoneRepo).save(deleteChange.zone)
+    doReturn(IO.pure(1))
+      .when(mockRecordSetRepo)
+      .deleteRecordSetsInZone(deleteChange.zone.id, deleteChange.zone.name)
+    doReturn(IO.pure(deleteChange)).when(mockChangeRepo).save(any[ZoneChange])
+
+    test(deleteChange).unsafeRunSync()
+
+    val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
+    verify(mockChangeRepo).save(changeCaptor.capture())
+
+    val savedChange = changeCaptor.getValue
+    savedChange.status shouldBe ZoneChangeStatus.Synced
+  }
+
+  "save a delete zone change as synced if recordset delete fails" in new Fixture {
+    val deleteChange = change.copy(changeType = ZoneChangeType.Delete)
+
+    doReturn(IO.pure(Right(deleteChange.zone))).when(mockZoneRepo).save(deleteChange.zone)
+    doReturn(IO.raiseError(new Throwable("error")))
+      .when(mockRecordSetRepo)
+      .deleteRecordSetsInZone(deleteChange.zone.id, deleteChange.zone.name)
+    doReturn(IO.pure(deleteChange)).when(mockChangeRepo).save(any[ZoneChange])
+
+    test(deleteChange).unsafeRunSync()
+
+    val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
+    verify(mockChangeRepo).save(changeCaptor.capture())
+
+    val savedChange = changeCaptor.getValue
+    savedChange.status shouldBe ZoneChangeStatus.Synced
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -52,7 +52,7 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
 
   def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]] = IO.pure(None)
 
-  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int] = IO(0)
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Unit] = IO(())
 }
 
 trait EmptyZoneRepo extends ZoneRepository {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -51,6 +51,8 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]] = IO.pure(List())
 
   def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]] = IO.pure(None)
+
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int] = IO(0)
 }
 
 trait EmptyZoneRepo extends ZoneRepository {
@@ -74,7 +76,6 @@ trait EmptyZoneRepo extends ZoneRepository {
   def getZonesByFilters(zoneNames: Set[String]): IO[Set[Zone]] = IO.pure(Set())
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]] = IO.pure(None)
-
 }
 
 trait EmptyGroupRepo extends GroupRepository {

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -41,4 +41,6 @@ trait RecordSetRepository extends Repository {
   def getRecordSetsByFQDNs(names: Set[String]): IO[List[RecordSet]]
 
   def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]]
+
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int]
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -42,5 +42,5 @@ trait RecordSetRepository extends Repository {
 
   def getFirstOwnedRecordByGroup(ownerGroupId: String): IO[Option[String]]
 
-  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int]
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Unit]
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -252,4 +252,15 @@ class DynamoDBRecordSetRepository private[repository] (
         )
       )
     }
+
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int] =
+    monitor("repo.RecordSet.deleteRecordSetsInZone") {
+      IO.raiseError(
+        UnsupportedDynamoDBRepoFunction(
+          s"""deleteRecordSetsInZone(zoneid=$zoneId, zoneName=$zoneName)
+             |is not supported by VinylDNS DynamoDB RecordSetRepository""".stripMargin
+            .replaceAll("\n", " ")
+        )
+      )
+    }
 }

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepository.scala
@@ -253,7 +253,7 @@ class DynamoDBRecordSetRepository private[repository] (
       )
     }
 
-  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int] =
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Unit] =
     monitor("repo.RecordSet.deleteRecordSetsInZone") {
       IO.raiseError(
         UnsupportedDynamoDBRepoFunction(

--- a/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
+++ b/modules/dynamodb/src/test/scala/vinyldns/dynamodb/repository/DynamoDBRecordSetRepositorySpec.scala
@@ -404,4 +404,13 @@ class DynamoDBRecordSetRepositorySpec
         .unsafeRunSync()
     }
   }
+
+  "DynamoDBRecordSetRepository.deleteRecordSetsInZone" should {
+    "return an error if used" in {
+      val store = new TestDynamoRecordSetRepo
+      an[UnsupportedDynamoDBRepoFunction] should be thrownBy store
+        .deleteRecordSetsInZone("zoneId", "zoneName")
+        .unsafeRunSync()
+    }
+  }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -508,15 +508,15 @@ class MySqlRecordSetRepositoryIntegrationSpec
       repo.getRecordSetCount(okZone.id).unsafeRunSync() shouldBe 20
       repo.getRecordSetCount(abcZone.id).unsafeRunSync() shouldBe 10
 
-      repo.deleteRecordSetsInZone(okZone.id, okZone.name).unsafeRunSync() shouldBe 20
+      repo.deleteRecordSetsInZone(okZone.id, okZone.name).unsafeRunSync() should not be a[Throwable]
 
       repo.getRecordSetCount(okZone.id).unsafeRunSync() shouldBe 0
       repo.getRecordSetCount(abcZone.id).unsafeRunSync() shouldBe 10
     }
 
-    "return 0 if there is nothing to delete" in {
+    "not fail if there is nothing to delete" in {
       repo.getRecordSetCount(okZone.id).unsafeRunSync() shouldBe 0
-      repo.deleteRecordSetsInZone(okZone.id, okZone.name).unsafeRunSync() shouldBe 0
+      repo.deleteRecordSetsInZone(okZone.id, okZone.name).unsafeRunSync() should not be a[Throwable]
     }
   }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -499,4 +499,24 @@ class MySqlRecordSetRepositoryIntegrationSpec
       result shouldBe None
     }
   }
+
+  "deleteRecordSetsInZone" should {
+    "delete recordsets from table with matching zone id" in {
+      insert(okZone, 20)
+      insert(abcZone, 10)
+
+      repo.getRecordSetCount(okZone.id).unsafeRunSync() shouldBe 20
+      repo.getRecordSetCount(abcZone.id).unsafeRunSync() shouldBe 10
+
+      repo.deleteRecordSetsInZone(okZone.id, okZone.name).unsafeRunSync() shouldBe 20
+
+      repo.getRecordSetCount(okZone.id).unsafeRunSync() shouldBe 0
+      repo.getRecordSetCount(abcZone.id).unsafeRunSync() shouldBe 10
+    }
+
+    "return 0 if there is nothing to delete" in {
+      repo.getRecordSetCount(okZone.id).unsafeRunSync() shouldBe 0
+      repo.deleteRecordSetsInZone(okZone.id, okZone.name).unsafeRunSync() shouldBe 0
+    }
+  }
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -303,7 +303,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       }
     }
 
-  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Int] =
+  def deleteRecordSetsInZone(zoneId: String, zoneName: String): IO[Unit] =
     monitor("repo.RecordSet.deleteRecordSetsInZone") {
       IO {
         val numDeleted = DB.localTx { implicit s =>
@@ -313,7 +313,6 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             .apply()
         }
         logger.info(s"Deleted $numDeleted records from zone $zoneName (zone id: $zoneId)")
-        numDeleted
       }.handleErrorWith { error =>
         logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId)", error)
         IO.raiseError(error)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -312,7 +312,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             .update()
             .apply()
         }
-        logger.info(s"Deleted $numDeleted from zone $zoneName (zone id: $zoneId)")
+        logger.info(s"Deleted $numDeleted records from zone $zoneName (zone id: $zoneId)")
         numDeleted
       }.handleErrorWith { error =>
         logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId)", error)


### PR DESCRIPTION
When VinylDNS accepts a zone delete it removes the zone from the zone database but not the zone's recordsets from the recordset database. This orphans recordsets in the repo that turn into junk data. Even if someone reconnected to the zone the zone will have a new ID and duplicate all its recordsets in the recordset repo.

* Added logic to ZoneChangeHandler such that on a successful zone delete it will call a function to delete all recordsets with that zone id
* The ZoneChangeHandler will process the successful delete zone change even if the recordset delete fails
* Recordsets are NOT deleted from the DNS backend, just the recordsets table 