### PR TITLE
Include `*.csv` files in the built microsite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -406,7 +406,8 @@ lazy val docSettings = Seq(
   micrositeGithubToken := sys.env.get("SBT_MICROSITES_PUBLISH_TOKEN"),
   ghpagesNoJekyll := false,
   fork in tut := true,
-  micrositeEditButton := Some(MicrositeEditButton("Improve this page", "/edit/master/modules/docs/src/main/tut/{{ page.path }}"))
+  micrositeEditButton := Some(MicrositeEditButton("Improve this page", "/edit/master/modules/docs/src/main/tut/{{ page.path }}")),
+  includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json" | "*.csv"
 )
 
 lazy val docs = (project in file("modules/docs"))


### PR DESCRIPTION
Changes in this pull request:

 * Include `.csv` files as part of the ones to be included when building the site.

This is needed due to an [sbt-microsites setting](https://github.com/47deg/sbt-microsites/blob/0a8387363c2c87179c433ca406fd85d428ece6dc/src/main/scala/microsites/MicrositesPlugin.scala#L113) where only some extensions are included as part the built microsite.
