### PR TITLE
group duplicate zones in listZones query

### DIFF
--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -197,7 +197,7 @@ class MySqlZoneRepositoryIntegrationSpec
       )
 
       f.unsafeRunSync()
-      repo.listZones(okUserAuth).unsafeRunSync().zones should contain allElementsOf testZones
+      repo.listZones(okUserAuth).unsafeRunSync().zones should contain theSameElementsAs testZones
 
       // dummy user only has access to one zone
       repo.listZones(dummyAuth).unsafeRunSync().zones should contain only testZones.head

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -237,8 +237,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             sb.append(filters.mkString(" AND "))
           }
 
-          sb.append(s" GROUP BY z.id ")
-          sb.append(s" ORDER BY z.name ASC ")
+          sb.append(s" GROUP BY z.name ")
           sb.append(s" LIMIT $maxItems")
 
           val query = sb.toString

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -237,6 +237,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             sb.append(filters.mkString(" AND "))
           }
 
+          sb.append(s" GROUP BY z.id ")
           sb.append(s" ORDER BY z.name ASC ")
           sb.append(s" LIMIT $maxItems")
 


### PR DESCRIPTION
Fixes #614

Changes in this pull request:
- Group zones by ID instead of returning all zones to prevent duplicates
- Update spec to use `contain theSameElementsAs` instead of `contain allElementsOf` so duplicate zones in the response would fail
