### PR TITLE
improve shell script language

### DIFF
--- a/bin/docker-up-api-server.sh
+++ b/bin/docker-up-api-server.sh
@@ -44,7 +44,7 @@ do
         echo "Succeeded in connecting to VinylDNS API!"
         break
     else
-        echo "Retrying Again" >&2
+        echo "Retrying" >&2
 
         let RETRY-=1
         sleep 1

--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -25,7 +25,7 @@ function wait_for_url {
 			echo "Succeeded in connecting to ${URL}!"
 			break
 		else
-			echo "Retrying Again" >&2
+			echo "Retrying" >&2
 
 			let RETRY-=1
 			sleep 1

--- a/docker/api/run.sh
+++ b/docker/api/run.sh
@@ -32,7 +32,7 @@ do
     then
         break
     else
-        echo "Retrying Again" >&2
+        echo "Retrying" >&2
 
         let RETRY-=1
         sleep "$SLEEP_DURATION"

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -26,7 +26,7 @@ do
     then
         break
     else
-        echo "Retrying Again" >&2
+        echo "Retrying" >&2
 
         let RETRY-=1
         sleep "$SLEEP_DURATION"

--- a/modules/api/src/universal/bin/wait-for-dependencies.sh
+++ b/modules/api/src/universal/bin/wait-for-dependencies.sh
@@ -13,7 +13,7 @@ do
     then
         break
     else
-        echo "Retrying Again" >&2
+        echo "Retrying" >&2
 
         let RETRY-=1
         sleep .5

--- a/modules/portal/dist/wait-for-dependencies.sh
+++ b/modules/portal/dist/wait-for-dependencies.sh
@@ -18,7 +18,7 @@ do
     then
         break
     else
-        echo "Retrying Again" >&2
+        echo "Retrying" >&2
 
         let RETRY-=1
         sleep .5


### PR DESCRIPTION
Various shell scripts print "Retrying Again," when re-attempting some action.
The message can be rephrased to "Retrying" (or even "Trying Again")
to be more accurate and simple (and maybe a bit less like "ATM machine" ;) ).