### PR TITLE
Add Notifier to Vinyl core

### DIFF
--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -18,13 +18,11 @@ package vinyldns.core.notifier
 
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
-import scala.concurrent.ExecutionContext
 import org.slf4j.LoggerFactory
 
-final case class AllNotifiers(notifiers: List[Notifier]) extends Notifier {
+final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: ContextShift[IO]) {
 
   private val logger = LoggerFactory.getLogger("AllNotifiers")
-  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   def notify(notification: Notification[_]): IO[Unit] =
     for {

--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+
+import cats.effect.{ContextShift, IO}
+import cats.implicits._
+import scala.concurrent.ExecutionContext
+import org.slf4j.LoggerFactory
+
+final case class AllNotifiers(notifiers: List[Notifier]) extends Notifier {
+
+  private val logger = LoggerFactory.getLogger("AllNotifiers")
+  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  def notify(notification: Notification[_]): IO[Unit] =
+    for {
+      _ <- notifiers.parTraverse(notify(_, notification))
+    } yield ()
+
+  def notify(notifier: Notifier, notification: Notification[_]): IO[Unit] =
+    notifier.notify(notification).handleErrorWith { e =>
+      IO { logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e) }
+    }
+}

--- a/modules/core/src/main/scala/vinyldns/core/notifier/Notification.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/Notification.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+
+final case class Notification[A](change: A)

--- a/modules/core/src/main/scala/vinyldns/core/notifier/Notifier.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/Notifier.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+
+import cats.effect.IO
+
+trait Notifier {
+
+  def notify(notification: Notification[_]): IO[Unit]
+
+}

--- a/modules/core/src/main/scala/vinyldns/core/notifier/NotifierConfig.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/NotifierConfig.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+import com.typesafe.config.Config
+
+final case class NotifierConfig(className: String, settings: Config)

--- a/modules/core/src/main/scala/vinyldns/core/notifier/NotifierLoader.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/NotifierLoader.scala
@@ -18,12 +18,14 @@ package vinyldns.core.notifier
 import vinyldns.core.domain.membership.UserRepository
 import cats.effect.IO
 import cats.implicits._
+import cats.effect.ContextShift
 
 object NotifierLoader {
 
-  def loadAll(configs: List[NotifierConfig], userRepository: UserRepository): IO[Notifier] =
+  def loadAll(configs: List[NotifierConfig], userRepository: UserRepository)(
+      implicit cs: ContextShift[IO]): IO[AllNotifiers] =
     for {
-      notifiers <- configs.traverse[IO, Notifier](load(_, userRepository))
+      notifiers <- configs.parTraverse(load(_, userRepository))
     } yield AllNotifiers(notifiers)
 
   def load(config: NotifierConfig, userRepository: UserRepository): IO[Notifier] =

--- a/modules/core/src/main/scala/vinyldns/core/notifier/NotifierLoader.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/NotifierLoader.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+import vinyldns.core.domain.membership.UserRepository
+import cats.effect.IO
+import cats.implicits._
+
+object NotifierLoader {
+
+  def loadAll(configs: List[NotifierConfig], userRepository: UserRepository): IO[Notifier] =
+    for {
+      notifiers <- configs.traverse[IO, Notifier](load(_, userRepository))
+    } yield AllNotifiers(notifiers)
+
+  def load(config: NotifierConfig, userRepository: UserRepository): IO[Notifier] =
+    for {
+      provider <- IO(
+        Class
+          .forName(config.className)
+          .getDeclaredConstructor()
+          .newInstance()
+          .asInstanceOf[NotifierProvider])
+      notifier <- provider.load(config, userRepository)
+    } yield notifier
+
+}

--- a/modules/core/src/main/scala/vinyldns/core/notifier/NotifierProvider.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/NotifierProvider.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+import vinyldns.core.domain.membership.UserRepository
+import cats.effect.IO
+
+trait NotifierProvider {
+  def load(config: NotifierConfig, userRepository: UserRepository): IO[Notifier]
+}

--- a/modules/core/src/test/scala/vinyldns/core/notifier/AllNotifiersSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/notifier/AllNotifiersSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+
+import cats.scalatest.{EitherMatchers, EitherValues, ValidatedMatchers}
+import org.scalatest.mockito._
+import org.scalatest.{Matchers, WordSpec}
+import org.mockito.Mockito._
+import cats.effect.IO
+
+class AllNotifiersSpec
+    extends WordSpec
+    with Matchers
+    with MockitoSugar
+    with EitherValues
+    with EitherMatchers
+    with ValidatedMatchers {
+
+  val mockNotifiers = List.fill(3)(mock[Notifier])
+
+  "notifier" should {
+    "notify all contained notifiers" in {
+
+      val notifier = AllNotifiers(mockNotifiers)
+
+      val notification = Notification("anything")
+
+      mockNotifiers.foreach { mock =>
+        reset(mock)
+        when(mock.notify(notification)).thenReturn(IO.unit)
+      }
+
+      notifier.notify(notification)
+
+      mockNotifiers.foreach(verify(_).notify(notification))
+    }
+
+    "suppress errors from notifiers" in {
+      val notifier = AllNotifiers(mockNotifiers)
+
+      val notification = Notification("anything")
+
+      mockNotifiers.foreach { mock =>
+        reset(mock)
+        when(mock.notify(notification)).thenReturn(IO.unit)
+      }
+
+      when(mockNotifiers(2).notify(notification)).thenReturn(IO.raiseError(new Exception("fail")))
+
+      notifier.notify(notification).unsafeRunSync()
+
+      mockNotifiers.foreach(verify(_).notify(notification))
+    }
+  }
+
+}

--- a/modules/core/src/test/scala/vinyldns/core/notifier/NotifierLoaderSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/notifier/NotifierLoaderSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.notifier
+
+import cats.scalatest.{EitherMatchers, EitherValues, ValidatedMatchers}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.mockito._
+import org.scalatest.{Matchers, WordSpec}
+import vinyldns.core.domain.membership.UserRepository
+import cats.effect.IO
+import org.mockito.Mockito._
+
+import scala.collection.JavaConverters._
+
+object Mocks extends MockitoSugar {
+  val mockUserRepository: UserRepository = mock[UserRepository]
+}
+
+object MockNotifierProvider extends MockitoSugar {
+
+  val mockNotifier: Notifier = mock[Notifier]
+
+}
+
+class MockNotifierProvider extends NotifierProvider {
+
+  def load(config: NotifierConfig, userRepo: UserRepository) =
+    IO.pure(MockNotifierProvider.mockNotifier)
+}
+
+class FailingProvider extends NotifierProvider {
+
+  def load(config: NotifierConfig, userRepo: UserRepository) =
+    IO.raiseError(new IllegalStateException("always failing"))
+
+}
+
+class NotifierLoaderSpec
+    extends WordSpec
+    with Matchers
+    with MockitoSugar
+    with EitherValues
+    with EitherMatchers
+    with ValidatedMatchers {
+
+  val placeholderConfig: Config = ConfigFactory.parseMap(Map[String, String]().asJava)
+  val goodConfig = NotifierConfig("vinyldns.core.notifier.MockNotifierProvider", placeholderConfig)
+
+  import Mocks._
+  import MockNotifierProvider._
+
+  "loadAll" should {
+
+    "return some notifier with no configs" in {
+
+      val notifier = NotifierLoader.loadAll(List.empty, mockUserRepository).unsafeRunSync()
+
+      notifier shouldNot be(null)
+      notifier.notify(Notification(3)).unsafeRunSync() shouldBe (())
+    }
+
+    "return a notifier for valid config of one notifier" in {
+      val notifier = NotifierLoader.loadAll(List(goodConfig), mockUserRepository).unsafeRunSync()
+
+      notifier shouldNot be(null)
+
+      val notification = Notification(3)
+
+      reset(mockNotifier)
+
+      when(mockNotifier.notify(notification)).thenReturn(IO.unit)
+
+      notifier.notify(notification).unsafeRunSync()
+
+      verify(mockNotifier).notify(notification)
+    }
+
+    "return a notifier for valid config of multiple notifiers" in {
+      val notifier =
+        NotifierLoader.loadAll(List(goodConfig, goodConfig), mockUserRepository).unsafeRunSync()
+
+      notifier shouldNot be(null)
+
+      val notification = Notification(3)
+
+      reset(mockNotifier)
+
+      when(mockNotifier.notify(notification)).thenReturn(IO.unit)
+
+      notifier.notify(notification).unsafeRunSync()
+
+      verify(mockNotifier, times(2)).notify(notification)
+
+    }
+
+    "Error if a configured provider cannot be found" in {
+      val badProvider =
+        NotifierConfig("vinyldns.core.notifier.NotFoundNotifierProvider", placeholderConfig)
+
+      val load = NotifierLoader.loadAll(List(goodConfig, badProvider), mockUserRepository)
+
+      a[ClassNotFoundException] shouldBe thrownBy(load.unsafeRunSync())
+    }
+
+    "Error if a provider throws exception" in {
+
+      val exceptionProvider =
+        NotifierConfig("vinyldns.core.notifier.FailingProvider", placeholderConfig)
+
+      val load = NotifierLoader.loadAll(List(goodConfig, exceptionProvider), mockUserRepository)
+
+      a[IllegalStateException] shouldBe thrownBy(load.unsafeRunSync())
+    }
+
+  }
+
+}

--- a/modules/core/src/test/scala/vinyldns/core/notifier/NotifierLoaderSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/notifier/NotifierLoaderSpec.scala
@@ -38,13 +38,13 @@ object MockNotifierProvider extends MockitoSugar {
 
 class MockNotifierProvider extends NotifierProvider {
 
-  def load(config: NotifierConfig, userRepo: UserRepository) =
+  def load(config: NotifierConfig, userRepo: UserRepository): IO[Notifier] =
     IO.pure(MockNotifierProvider.mockNotifier)
 }
 
 class FailingProvider extends NotifierProvider {
 
-  def load(config: NotifierConfig, userRepo: UserRepository) =
+  def load(config: NotifierConfig, userRepo: UserRepository): IO[Notifier] =
     IO.raiseError(new IllegalStateException("always failing"))
 
 }


### PR DESCRIPTION
Add the Notifier trait and support for loading Notifiers from config

Changes in this pull request:
- Add Notifier trait
- Add Notification wrapper class
- Add NotifierConfig class
- Add NotifierProvider trait
- Add NotifierLoader object
- Add AllNotifiers wrapper for loaded Notifier instances
