### PR TITLE
change no zones message

### DIFF
--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -58,7 +58,7 @@
                     </div>
                     <div id="zone-list-table" class="panel-body">
                         <p ng-if="!zonesLoaded">Loading zones...</p>
-                        <p ng-if="!hasZones && zonesLoaded">You have not connected to any zones.</p>
+                        <p ng-if="!hasZones && zonesLoaded">No zones found.</p>
                         <p ng-if="hasZones && zonesLoaded && !zones.length">No zones match the search criteria.</p>
 
                         <!-- PAGINATION -->


### PR DESCRIPTION
Fixes #612.

Changes in this pull request:
- change message from "You have not connected to any zones." to "No zones found." in the Zones list table when the user has no zones and the zone load has completed.

![Zones list view with "No zones found." message](https://user-images.githubusercontent.com/4439228/57936419-eb03da00-7891-11e9-89b8-ded2ddc23d56.png)
