### PR TITLE
Wildcard search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ release.version
 .ensime_cache
 package-lock.json
 *trustStore.jks
+.bloop
+.metals

--- a/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
@@ -214,7 +214,7 @@ def test_list_recordsets_with_record_name_filter_all(rs_fixture):
     client = rs_fixture.client
     ok_zone = rs_fixture.test_context
 
-    list_results = client.list_recordsets(ok_zone['id'], record_name_filter="list", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], record_name_filter="*list*", status=200)
     rs_fixture.check_recordsets_page_accuracy(list_results, size=10, offset=0)
 
 
@@ -227,7 +227,7 @@ def test_list_recordsets_with_record_name_filter_and_page_size(rs_fixture):
     ok_zone = rs_fixture.test_context
 
     #page of 4 items
-    list_results = client.list_recordsets(ok_zone['id'], max_items=4, record_name_filter="CNAME", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], max_items=4, record_name_filter="*CNAME*", status=200)
     assert_that(list_results['recordSets'], has_length(4))
 
     list_results_records = list_results['recordSets'];
@@ -235,7 +235,7 @@ def test_list_recordsets_with_record_name_filter_and_page_size(rs_fixture):
         assert_that(list_results_records[i]['name'], contains_string('CNAME'))
 
     #page of 5 items but excess max items
-    list_results = client.list_recordsets(ok_zone['id'], max_items=7, record_name_filter="CNAME", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], max_items=7, record_name_filter="*CNAME*", status=200)
     assert_that(list_results['recordSets'], has_length(5))
 
     list_results_records = list_results['recordSets'];
@@ -252,12 +252,12 @@ def test_list_recordsets_with_record_name_filter_and_chaining_pages_with_nextId(
     ok_zone = rs_fixture.test_context
 
     #page of 2 items
-    list_results = client.list_recordsets(ok_zone['id'], max_items=2, record_name_filter="CNAME", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], max_items=2, record_name_filter="*CNAME*", status=200)
     assert_that(list_results['recordSets'], has_length(2))
     start_key = list_results['nextId']
 
     #page of 2 items
-    list_results = client.list_recordsets(ok_zone['id'], start_from=start_key, max_items=2, record_name_filter="CNAME", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], start_from=start_key, max_items=2, record_name_filter="*CNAME*", status=200)
     assert_that(list_results['recordSets'], has_length(2))
 
     list_results_records = list_results['recordSets'];
@@ -272,7 +272,7 @@ def test_list_recordsets_with_record_name_filter_one(rs_fixture):
     client = rs_fixture.client
     ok_zone = rs_fixture.test_context
 
-    list_results = client.list_recordsets(ok_zone['id'], record_name_filter="8", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], record_name_filter="*8*", status=200)
     rs_fixture.check_recordsets_page_accuracy(list_results, size=1, offset=8)
 
 
@@ -283,7 +283,7 @@ def test_list_recordsets_with_record_name_filter_none(rs_fixture):
     client = rs_fixture.client
     ok_zone = rs_fixture.test_context
 
-    list_results = client.list_recordsets(ok_zone['id'], record_name_filter="Dummy", status=200)
+    list_results = client.list_recordsets(ok_zone['id'], record_name_filter="*Dummy*", status=200)
     rs_fixture.check_recordsets_page_accuracy(list_results, size=0, offset=0)
 
 

--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -199,7 +199,7 @@ def test_list_zones_with_search_first_page(list_zones_context):
     """
     Test that the first page of listing zones returns correctly when a name filter is provided
     """
-    result = list_zones_context.client.list_zones(name_filter='searched', max_items=2, status=200)
+    result = list_zones_context.client.list_zones(name_filter='*searched*', max_items=2, status=200)
     zones = result['zones']
 
     assert_that(zones, has_length(2))
@@ -231,7 +231,7 @@ def test_list_zones_with_search_last_page(list_zones_context):
     """
     Test that the second page of listing zones returns correctly when a name filter is provided
     """
-    result = list_zones_context.client.list_zones(name_filter='searched', start_from="list-zones-test-searched-2.", max_items=2, status=200)
+    result = list_zones_context.client.list_zones(name_filter='*searched*', start_from="list-zones-test-searched-2.", max_items=2, status=200)
     zones = result['zones']
 
     assert_that(zones, has_length(1))

--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -208,7 +208,7 @@ def test_list_zones_with_search_first_page(list_zones_context):
 
     assert_that(result['nextId'], is_('list-zones-test-searched-2.'))
     assert_that(result['maxItems'], is_(2))
-    assert_that(result['nameFilter'], is_('searched'))
+    assert_that(result['nameFilter'], is_('*searched*'))
     assert_that(result, is_not(has_key('startFrom')))
 
 
@@ -239,5 +239,5 @@ def test_list_zones_with_search_last_page(list_zones_context):
 
     assert_that(result, is_not(has_key('nextId')))
     assert_that(result['maxItems'], is_(2))
-    assert_that(result['nameFilter'], is_('searched'))
+    assert_that(result['nameFilter'], is_('*searched*'))
     assert_that(result['startFrom'], is_('list-zones-test-searched-2.'))

--- a/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
@@ -239,6 +239,7 @@ class Aws4Authenticator {
       .
       // and doesn't encode '~' at all
       replaceAllLiterally("%7E", "~")
+      .replaceAllLiterally("*", "%2A") // aws encodes the asterisk specially
 
   private def hexString(bs: Array[Byte]) =
     bs.foldLeft("")((out, b) => f"$out%s${b & 0x0ff}%02x")

--- a/modules/docs/src/main/tut/api/list-recordsets.md
+++ b/modules/docs/src/main/tut/api/list-recordsets.md
@@ -16,7 +16,7 @@ Retrieves a list of RecordSets from the zone
 
 name          | type          | required?   | description |
  ------------ | ------------- | ----------- | :---------- |
-recordNameFilter    | string        | no          | One or more characters contained in the name of the record set to search for.  For example `vinyl`.  This is a contains search only, no wildcards or regular expressions are supported |
+recordNameFilter    | string        | no          | Characters that are part of the record name to search for.  The wildcard character `*` is supported, for example `www*` |
 startFrom     | *any*         | no          | In order to advance through pages of results, the startFrom is set to the `nextId` that is returned on the previous response.  It is up to the client to maintain previous pages if the client wishes to advance forward and backward.   If not specified, will return the first page of results |
 maxItems      | integer       | no          | The number of items to return in the page.  Valid values are 1 to 100. Defaults to 100 if not provided. |
 

--- a/modules/docs/src/main/tut/api/list-recordsets.md
+++ b/modules/docs/src/main/tut/api/list-recordsets.md
@@ -16,7 +16,7 @@ Retrieves a list of RecordSets from the zone
 
 name          | type          | required?   | description |
  ------------ | ------------- | ----------- | :---------- |
-recordNameFilter    | string        | no          | Characters that are part of the record name to search for.  The wildcard character `*` is supported, for example `www*` |
+recordNameFilter    | string        | no          | Characters that are part of the record name to search for.  The wildcard character `*` is supported, for example `www*`.  Omit the wildcard when searching for an exact record name. |
 startFrom     | *any*         | no          | In order to advance through pages of results, the startFrom is set to the `nextId` that is returned on the previous response.  It is up to the client to maintain previous pages if the client wishes to advance forward and backward.   If not specified, will return the first page of results |
 maxItems      | integer       | no          | The number of items to return in the page.  Valid values are 1 to 100. Defaults to 100 if not provided. |
 

--- a/modules/docs/src/main/tut/api/list-zones.md
+++ b/modules/docs/src/main/tut/api/list-zones.md
@@ -16,7 +16,7 @@ Retrieves the list of zones a user has access to.  The zone name is only sorted 
 
 name          | type          | required?   | description |
  ------------ | ------------- | ----------- | :---------- |
-nameFilter    | string        | no          | One or more characters contained in the name of the zone to search for.  For example `www-`.  This is a contains search only, no wildcards or regular expressions are supported |
+nameFilter    | string        | no          | Characters that are part of the zone name to search for.  The wildcard character `*` is supported, for example `www*` |
 startFrom     | *any*         | no          | In order to advance through pages of results, the startFrom is set to the `nextId` that is returned on the previous response.  It is up to the client to maintain previous pages if the client wishes to advance forward and backward.   If not specified, will return the first page of results |
 maxItems      | int           | no          | The number of items to return in the page.  Valid values are 1 - 100. Defaults to 100 if not provided. |
 

--- a/modules/docs/src/main/tut/api/list-zones.md
+++ b/modules/docs/src/main/tut/api/list-zones.md
@@ -16,7 +16,7 @@ Retrieves the list of zones a user has access to.  The zone name is only sorted 
 
 name          | type          | required?   | description |
  ------------ | ------------- | ----------- | :---------- |
-nameFilter    | string        | no          | Characters that are part of the zone name to search for.  The wildcard character `*` is supported, for example `www*` |
+nameFilter    | string        | no          | Characters that are part of the zone name to search for.  The wildcard character `*` is supported, for example `www*`.  Omit the wildcard character when searching for an exact zone name. |
 startFrom     | *any*         | no          | In order to advance through pages of results, the startFrom is set to the `nextId` that is returned on the previous response.  It is up to the client to maintain previous pages if the client wishes to advance forward and backward.   If not specified, will return the first page of results |
 maxItems      | int           | no          | The number of items to return in the page.  Valid values are 1 - 100. Defaults to 100 if not provided. |
 

--- a/modules/docs/src/main/tut/getting-help.md
+++ b/modules/docs/src/main/tut/getting-help.md
@@ -7,7 +7,7 @@ position: 7
 # Getting Help
 
 - Gitter community:
-  <https://gitter.im/vinyldns>
+  <https://gitter.im/vinyldns/vinyldns>
 
 - Contact the VinylDNS Core Team:
   vinyldns-core@googlegroups.com

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -191,7 +191,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
 
           val params = (Some('zoneId -> zoneId) ++
             startFrom.map(n => 'startFrom -> n) ++
-            recordNameFilter.map(f => 'nameFilter -> s"%$f%") ++
+            recordNameFilter.map(f => 'nameFilter -> f.replace('*', '%')) ++
             maxItems.map(m => 'maxItems -> m)).toSeq
 
           val query = "SELECT data FROM recordset WHERE zone_id = {zoneId} " + opts

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -228,7 +228,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           sb.append(withAccessorCheck)
 
           val filters = List(
-            zoneNameFilter.map(flt => s"z.name LIKE '%$flt%'"),
+            zoneNameFilter.map(flt => s"z.name LIKE '${flt.replace('*', '%')}'"),
             startFrom.map(os => s"z.name > '$os'")
           ).flatten
 

--- a/modules/portal/.gitignore
+++ b/modules/portal/.gitignore
@@ -12,3 +12,5 @@ package-lock.json
 release.version
 private
 public/gentelella
+.bloop
+.metals


### PR DESCRIPTION
Support wildcard searches for zones and record sets

* Updated MySqlRecordSetRepository to replace `*` with `%` for the `listRecordSets`
* Updated  MySqlZoneRepository to replace `*` with `%` for `listZones`
* Added integration tests to verify searches
* Updated api documentation to indicate wildcards are supported
* Fixed the `Aws4Authenticator`.  The main issue is how we are calculating the signature server side.  We are `urlDecoding` the query params _first_, and then calculate signature.  However, the way that it works on the client (verified in python and java) is that the query params are **url encoded** before signature calculation.  We may have other issues with query strings in the future.  In otherwords, the client says `recordNameFilter=%2Alist%2A` is signed, whereas on the server we are calculating signature based on `recordNameFilter=*list*`