### PR TITLE
wrap text in the Records table

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -95,28 +95,28 @@
                                 <!--record data name based on record type-->
                                     <td ng-if="change.type=='A'||change.type=='AAAA'">
                                         <ul>
-                                            <li>{{change.record.address}}</li>
+                                            <li class="wrap-long-text">{{change.record.address}}</li>
                                         </ul>
                                     </td>
                                     <td ng-if="change.type=='CNAME'">
                                         <ul>
-                                            <li>{{change.record.cname}}</li>
+                                            <li class="wrap-long-text">{{change.record.cname}}</li>
                                         </ul>
                                     </td>
                                     <td ng-if="change.type=='PTR'">
                                         <ul>
-                                            <li>{{change.record.ptrdname}}</li>
+                                            <li class="wrap-long-text">{{change.record.ptrdname}}</li>
                                         </ul>
                                     </td>
                                     <td ng-if="change.type=='TXT'">
                                         <ul>
-                                            <li>{{change.record.text}}</li>
+                                            <li class="wrap-long-text">{{change.record.text}}</li>
                                         </ul>
                                     </td>
                                     <td ng-if="change.type=='MX'">
                                         <ul>
-                                            <li>Preference: {{change.record.preference}}</li>
-                                            <li>Exchange: {{change.record.exchange}}</li>
+                                            <li class="wrap-long-text">Preference: {{change.record.preference}}</li>
+                                            <li class="wrap-long-text">Exchange: {{change.record.exchange}}</li>
                                         </ul>
                                     </td>
                                 <!--end record data name based on record type-->
@@ -127,7 +127,7 @@
                                     <span ng-if="change.status =='Failed'" class="label label-danger">{{change.status}}</span>
 
                                 </td>
-                                <td>{{change.systemMessage}}</td>
+                                <td class="wrap-long-text">{{change.systemMessage}}</td>
                             </tr>
                             </tbody>
                         </table>

--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -79,7 +79,7 @@
                                 <th>Recordset Name</th>
                                 <th>Zone Name</th>
                                 <th>Record Type</th>
-                                <th>Record Data</th>
+                                <th class="col-md-2">Record Data</th>
                                 <th>TTL</th>
                                 <th>Status</th>
                                 <th class="col-md-2">Additional Info</th>
@@ -88,30 +88,22 @@
                             <tbody>
                             <tr ng-repeat="change in batch.changes|filter:query">
                                 <td ng-bind="change.changeType"></td>
-                                <td>{{change.inputName}}</td>
-                                <td>{{change.recordName}}</td>
-                                <td>{{change.zoneName}}</td>
+                                <td class="wrap-long-text">{{change.inputName}}</td>
+                                <td class="wrap-long-text">{{change.recordName}}</td>
+                                <td class="wrap-long-text">{{change.zoneName}}</td>
                                 <td>{{change.type}}</td>
                                 <!--record data name based on record type-->
-                                    <td ng-if="change.type=='A'||change.type=='AAAA'">
-                                        <ul>
-                                            <li class="wrap-long-text">{{change.record.address}}</li>
-                                        </ul>
+                                    <td ng-if="change.type=='A'||change.type=='AAAA'" class="wrap-long-text">
+                                        {{change.record.address}}
                                     </td>
                                     <td ng-if="change.type=='CNAME'">
-                                        <ul>
-                                            <li class="wrap-long-text">{{change.record.cname}}</li>
-                                        </ul>
+                                        {{change.record.cname}}
                                     </td>
                                     <td ng-if="change.type=='PTR'">
-                                        <ul>
-                                            <li class="wrap-long-text">{{change.record.ptrdname}}</li>
-                                        </ul>
+                                        {{change.record.ptrdname}}
                                     </td>
-                                    <td ng-if="change.type=='TXT'">
-                                        <ul>
-                                            <li class="wrap-long-text">{{change.record.text}}</li>
-                                        </ul>
+                                    <td ng-if="change.type=='TXT'" class="wrap-long-text">
+                                        {{change.record.text}}
                                     </td>
                                     <td ng-if="change.type=='MX'">
                                         <ul>

--- a/modules/portal/app/views/groups/groups.scala.html
+++ b/modules/portal/app/views/groups/groups.scala.html
@@ -58,9 +58,9 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="group in groups.items | orderBy:'+name'">
-                                    <td>{{group.name}}</td>
-                                    <td>{{group.email}}</td>
-                                    <td>{{group.description}}</td>
+                                    <td class="wrap-long-text">{{group.name}}</td>
+                                    <td class="wrap-long-text">{{group.email}}</td>
+                                    <td class="wrap-long-text">{{group.description}}</td>
                                     <td>
                                         <div class="table-form-group">
                                             <a class="btn btn-info btn-rounded" ng-href="/groups/{{group.id}}">

--- a/modules/portal/app/views/zones/zoneTabs/changeHistory.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/changeHistory.scala.html
@@ -27,7 +27,7 @@
             <thead>
                 <tr>
                     <th>Time</th>
-                    <th>Recordset Name</th>
+                    <th class="col-md-5">Recordset Name</th>
                     <th>Recordset Type</th>
                     <th>Change Type</th>
                     <th>User</th>
@@ -38,14 +38,14 @@
             <tbody>
                 <tr ng-repeat="change in recordsetChanges track by $index">
                     <td>{{change.created}}</td>
-                    <td>{{change.recordSet.name}}</td>
+                    <td class="wrap-long-text">{{change.recordSet.name}}</td>
                     <td>{{change.recordSet.type}}</td>
                     <td>{{change.changeType}}</td>
                     <td>{{change.userName}}</td>
                     <td>
                         <span class="label label-{{ getRecordChangeStatusLabel(change.status) }}">{{ change.status }}</span>
                     </td>
-                    <td class="col-md-3">
+                    <td class="col-md-3 wrap-long-text">
                         {{change.systemMessage}}
                         <div ng-if="change.status !='Failed'">
                             <a ng-if="change.changeType =='Create'" ng-click="viewRecordInfo(change.recordSet)" class="force-cursor">View created recordset</a>

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -98,10 +98,10 @@
       <table id="recordDataTable" class="table table-hover table-striped">
             <thead>
                 <tr>
-                    <th>Name</th>
+                    <th class="col-md-4">Name</th>
                     <th>Type</th>
                     <th>TTL</th>
-                    <th>Record Data</th>
+                    <th class="col-md-4">Record Data</th>
                     @if(meta.sharedDisplayEnabled) {
                         <th ng-if="zoneInfo.shared">Owner Group Name</th>
                     }
@@ -115,17 +115,17 @@
                         title="Dotted hosts are invalid! Please delete or update without a '.'">
                             {{record.name}} <span class="fa fa-warning" />
                         </div>
-                        <div ng-if="!record.isDotted">
+                        <div class="wrap-long-text" ng-if="!record.isDotted">
                             {{record.name}}
                         </div>
                     </td>
-                    <td>{{record.type}}</td>
-                    <td>{{record.ttl}}</td>
-                    <td>
+                    <td class="wrap-long-text">{{record.type}}</td>
+                    <td class="wrap-long-text">{{record.ttl}}</td>
+                    <td class="record-data">
                         <span ng-if="record.accessLevel != 'NoAccess'">
                         <span ng-if="record.type == 'A'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.aRecordData track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.aRecordData track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">{{item}}</li>
                                 <span ng-if="record.onlyFour && record.aRecordData.length > 4">
                                     <a href ng-click="record.onlyFour=false">Show more...</a>
@@ -137,7 +137,7 @@
                         </span>
                         <span ng-if="record.type == 'AAAA'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.aaaaRecordData track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.aaaaRecordData track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">{{item}}</li>
                                 <span ng-if="record.onlyFour && record.aaaaRecordData.length > 4">
                                     <a href ng-click="record.onlyFour=false">Show more...</a>
@@ -150,7 +150,7 @@
                         <span ng-if="record.type == 'CNAME'">{{ record.cnameRecordData }}</span>
                         <span ng-if="record.type == 'DS'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.dsItems track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.dsItems track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">
                                     Keytag: {{ item.keytag }} | Algorithm: {{ item.algorithm }} | Digest Type: {{ item.digesttype }} | Digest: {{ item.digest }}
                                 </li>
@@ -164,7 +164,7 @@
                         </span>
                         <span ng-if="record.type == 'MX'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.mxItems track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.mxItems track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">
                                     Preference: {{ item.preference }} | Exchange: {{ item.exchange }}
                                 </li>
@@ -178,7 +178,7 @@
                         </span>
                         <span ng-if="record.type == 'NS'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.nsRecordData track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.nsRecordData track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">{{item}}</li>
                                 <span ng-if="record.onlyFour && record.nsRecordData.length > 4">
                                     <a href ng-click="record.onlyFour=false">Show more...</a>
@@ -190,7 +190,7 @@
                         </span>
                         <span ng-if="record.type == 'PTR'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.ptrRecordData track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.ptrRecordData track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">{{item}}</li>
                                 <span ng-if="record.onlyFour && record.ptrRecordData.length > 4">
                                     <a href ng-click="record.onlyFour=false">Show more...</a>
@@ -203,38 +203,38 @@
                         <span ng-if="record.type == 'SOA'">
                             <table>
                                 <tr>
-                                    <td> Mname: </td>
-                                    <td> {{ record.soaMName }} </td>
+                                    <td class="record-data-label"> Mname: </td>
+                                    <td class="wrap-long-text"> {{ record.soaMName }} </td>
                                 </tr>
                                 <tr>
-                                    <td> Rname: </td>
-                                    <td> {{ record.soaRName }} </td>
+                                    <td class="record-data-label"> Rname: </td>
+                                    <td class="wrap-long-text"> {{ record.soaRName }} </td>
                                 </tr>
                                 <tr>
-                                    <td> Serial: </td>
-                                    <td> {{ record.soaSerial }} </td>
+                                    <td class="record-data-label"> Serial: </td>
+                                    <td class="wrap-long-text"> {{ record.soaSerial }} </td>
                                 </tr>
                                 <tr>
-                                    <td> Refresh: </td>
-                                    <td> {{ record.soaRefresh }} </td>
+                                    <td class="record-data-label"> Refresh: </td>
+                                    <td class="wrap-long-text"> {{ record.soaRefresh }} </td>
                                 </tr>
                                 <tr>
-                                    <td> Retry: </td>
-                                    <td> {{ record.soaRetry }} </td>
+                                    <td class="record-data-label"> Retry: </td>
+                                    <td class="wrap-long-text"> {{ record.soaRetry }} </td>
                                 </tr>
                                 <tr>
-                                    <td> Expire: </td>
-                                    <td> {{ record.soaExpire }} </td>
+                                    <td class="record-data-label"> Expire: </td>
+                                    <td class="wrap-long-text"> {{ record.soaExpire }} </td>
                                 </tr>
                                 <tr>
-                                    <td> Minimum:&emsp; </td>
-                                    <td> {{ record.soaMinimum }} </td>
+                                    <td class="record-data-label"> Minimum:&emsp; </td>
+                                    <td class="wrap-long-text"> {{ record.soaMinimum }} </td>
                                 </tr>
                             </table>
                         </span>
                         <span ng-if="record.type == 'SPF'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.spfRecordData track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.spfRecordData track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">{{item}}</li>
                                 <span ng-if="record.onlyFour && record.spfRecordData.length > 4">
                                     <a href ng-click="record.onlyFour=false">Show more...</a>
@@ -246,7 +246,7 @@
                         </span>
                         <span ng-if="record.type == 'SRV'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.srvItems track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.srvItems track by $index"
                                 ng-if="!record.onlyFour || $index <= 3">
                                     Priority: {{ item.priority }} | Weight: {{ item.weight }} | Port: {{ item.port }}
                                     | Target: {{ item.target }}
@@ -261,7 +261,7 @@
                         </span>
                         <span ng-if="record.type == 'NAPTR'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.naptrItems track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.naptrItems track by $index"
                                 ng-if="!record.onlyFour || $index <= 3">
                                     Order: {{ item.order }} | Preference: {{ item.preference }} | Flags: {{ item.flags }}
                                     | Service: {{ item.service }} | Regexp: {{ item.regexp }} | Replacement: {{ item.replacement }}
@@ -276,7 +276,7 @@
                         </span>
                         <span ng-if="record.type == 'SSHFP'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.sshfpItems track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.sshfpItems track by $index"
                                 ng-if="!record.onlyFour || $index <= 3">
                                     Algorithm: {{ sshfpAlgorithms[item.algorithm-1].name }}
                                     | Type: {{ sshfpTypes[item.type-1].name }}
@@ -292,7 +292,7 @@
                         </span>
                         <span ng-if="record.type == 'TXT'">
                             <ul class="table-cell-list">
-                                <li ng-repeat="item in record.textRecordData track by $index"
+                                <li class="wrap-long-text" ng-repeat="item in record.textRecordData track by $index"
                                     ng-if="!record.onlyFour || $index <= 3">{{item}}</li>
                                 <span ng-if="record.onlyFour && record.textRecordData.length > 4">
                                     <a href ng-click="record.onlyFour=false">Show more...</a>

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -18,7 +18,7 @@
             <thead>
                 <tr>
                     <th>Time</th>
-                    <th>Recordset Name</th>
+                    <th class="col-md-5">Recordset Name</th>
                     <th>Recordset Type</th>
                     <th>Change Type</th>
                     <th>User</th>
@@ -29,14 +29,14 @@
             <tbody>
                 <tr ng-repeat="change in recordsetChangesPreview track by $index">
                     <td>{{change.created}}</td>
-                    <td>{{change.recordSet.name}}</td>
+                    <td class="wrap-long-text">{{change.recordSet.name}}</td>
                     <td>{{change.recordSet.type}}</td>
                     <td>{{change.changeType}}</td>
                     <td>{{change.userName}}</td>
                     <td>
                         <span class="label label-{{ getRecordChangeStatusLabel(change.status) }}">{{ change.status }}</span>
                     </td>
-                    <td class="col-md-3">
+                    <td class="col-md-3 wrap-long-text">
                         {{change.systemMessage}}
                         <div ng-if="change.status !='Failed'">
                             <a ng-if="change.changeType =='Create'" ng-click="viewRecordInfo(change.recordSet)" class="force-cursor">View created recordset</a>

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -111,7 +111,7 @@
             <tbody>
                 <tr ng-repeat="(recordName, record) in records track by $index">
                     <td>
-                        <div ng-if="record.isDotted" class="text-danger" data-toggle="tooltip" data-placement="top"
+                        <div ng-if="record.isDotted" class="text-danger wrap-long-text" data-toggle="tooltip" data-placement="top"
                         title="Dotted hosts are invalid! Please delete or update without a '.'">
                             {{record.name}} <span class="fa fa-warning" />
                         </div>

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -263,7 +263,7 @@
             </thead>
             <tbody>
                 <tr ng-repeat="rule in aclRules track by $index">
-                    <td>
+                    <td class="wrap-long-text">
                         {{rule.displayName}}
                     </td>
 
@@ -280,11 +280,11 @@
                         </ul>
                     </td>
 
-                    <td>
+                    <td class="wrap-long-text">
                         {{rule.recordMask}}
                     </td>
 
-                    <td>
+                    <td class="wrap-long-text">
                         {{rule.description}}
                     </td>
 

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -89,8 +89,8 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="zone in zones">
-                                  <td ng-bind="zone.name"></td>
-                                  <td ng-bind="zone.email"></td>
+                                  <td class="wrap-long-text" ng-bind="zone.name"></td>
+                                  <td class="wrap-long-text" ng-bind="zone.email"></td>
                                   <td>
                                       <a ng-if="canAccessGroup(zone.adminGroupId)" ng-bind="zone.adminGroupName" href="/groups/{{zone.adminGroupId}}"></a>
                                       <span ng-if="!canAccessGroup(zone.adminGroupId)" ng-bind="zone.adminGroupName" style="line-height: 0"></span>

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -401,3 +401,11 @@ input[type="file"] {
     display: flex;
     justify-content: flex-end;
 }
+
+.wrap-long-text {
+    word-break: break-all;
+}
+
+.record-data-label {
+    vertical-align: top;
+}


### PR DESCRIPTION
fixes #477 

Issue:
Really long record data, record names, etc. in the Records table does not wrap and makes the table extend off the page.

Screenshots of current table:
![records table](https://user-images.githubusercontent.com/4439228/58048478-d2592580-7b18-11e9-96c1-78f81564b896.png)

![records table in mobile view](https://user-images.githubusercontent.com/4439228/58048486-d71dd980-7b18-11e9-80ca-4bd5df306fb0.png)


Changes in this pull request:
- in the Records table in the portal added a class that sets the `word-break` to `break-all` so text can break between any characters (not just spaces and hyphens) to wrap onto multiple lines

Screenshots of portal with wrapping added:
![updated records table](https://user-images.githubusercontent.com/4439228/58048548-ef8df400-7b18-11e9-923e-b94db77c1804.png)

![updated mobile view](https://user-images.githubusercontent.com/4439228/58048530-ec930380-7b18-11e9-9557-9efd7b6e8e47.png)


