### PR TITLE
mysql recordset fix paging for duplicate names

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
@@ -209,36 +209,36 @@ def test_list_recordsets_default_size_is_100(rs_fixture):
 
 def test_list_recordsets_duplicate_names(rs_fixture):
     """
-    Test that paging keys work for records with duplicate names, in this SOA and NS
+    Test that paging keys work for records with duplicate names
     """
     client = rs_fixture.client
     ok_zone = rs_fixture.test_context
 
-    apex_ns = False
-    apex_soa = False
+    created = []
 
-    start_key = None
-    offset = 0
-    while offset < 17:
-        list_results = client.list_recordsets(ok_zone['id'], status=200, start_from=start_key, max_items=1)
-        rs_fixture.check_recordsets_page_accuracy(list_results, size=1, offset=offset, nextId=True,
-                                                  startFrom=start_key, maxItems=1)
-        start_key = list_results['nextId']
-        offset = offset + 1
+    try:
+        record_data_a = [{'address': '1.1.1.1'}]
+        record_data_txt = [{'text': 'some=value'}]
 
-        record = list_results['recordSets'][0]
-        if record['name'] == "ok.":
-            if record['type'] == "SOA":
-                apex_soa = True
-            if record['type'] == "NS":
-                apex_ns = True
+        record_json_a = get_recordset_json(ok_zone, '0', 'A', record_data_a, ttl=100)
+        record_json_txt = get_recordset_json(ok_zone, '0', 'TXT', record_data_txt, ttl=100)
 
-    list_results = client.list_recordsets(ok_zone['id'], status=200, max_items=1, start_from=start_key)
-    rs_fixture.check_recordsets_page_accuracy(list_results, size=0, offset=offset, nextId=False,
-                                              maxItems=1, startFrom=start_key)
+        create_response = client.create_recordset(record_json_a, status=202)
+        created.append(client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']['id'])
 
-    assert_that(apex_ns, is_(True))
-    assert_that(apex_soa, is_(True))
+        create_response = client.create_recordset(record_json_txt, status=202)
+        created.append(client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']['id'])
+
+        list_results = client.list_recordsets(ok_zone['id'], status=200, start_from=None, max_items=1)
+        assert_that(list_results['recordSets'][0]['id'], is_(created[0]))
+
+        list_results = client.list_recordsets(ok_zone['id'], status=200, start_from=list_results['nextId'], max_items=1)
+        assert_that(list_results['recordSets'][0]['id'], is_(created[1]))
+
+    finally:
+        for id in created:
+            client.delete_recordset(ok_zone['id'], id, status=202)
+            client.wait_until_recordset_deleted(ok_zone['id'], id)
 
 
 def test_list_recordsets_with_record_name_filter_all(rs_fixture):

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -26,6 +26,8 @@ import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
 import vinyldns.proto.VinylDNSProto
 
+import scala.util.{Failure, Success, Try}
+
 class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
   import MySqlRecordSetRepository._
 
@@ -183,14 +185,19 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     monitor("repo.RecordSet.listRecordSets") {
       IO {
         DB.readOnly { implicit s =>
+          val pagingKey = PagingKey.fromStartFrom(startFrom)
+
           // make sure we sort ascending, so we can do the correct comparison later
-          val opts = (startFrom.as("AND name > {startFrom}") ++
-            recordNameFilter.as("AND name LIKE {nameFilter}") ++
-            Some("ORDER BY name ASC") ++
-            maxItems.as("LIMIT {maxItems}")).toList.mkString(" ")
+          val opts =
+            (pagingKey.as(
+              "AND ((name >= {startFromName} AND type > {startFromType}) OR name > {startFromName})") ++
+              recordNameFilter.as("AND name LIKE {nameFilter}") ++
+              Some("ORDER BY name ASC, type ASC") ++
+              maxItems.as("LIMIT {maxItems}")).toList.mkString(" ")
 
           val params = (Some('zoneId -> zoneId) ++
-            startFrom.map(n => 'startFrom -> n) ++
+            pagingKey.map(pk => 'startFromName -> pk.recordName) ++
+            pagingKey.map(pk => 'startFromType -> pk.recordType) ++
             recordNameFilter.map(f => 'nameFilter -> f.replace('*', '%')) ++
             maxItems.map(m => 'maxItems -> m)).toSeq
 
@@ -205,7 +212,9 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
           // if size of results is less than the number returned, we don't have a next id
           // if maxItems is None, we don't have a next id
           val nextId =
-            maxItems.filter(_ == results.size).flatMap(_ => results.lastOption.map(_.name))
+            maxItems
+              .filter(_ == results.size)
+              .flatMap(_ => results.lastOption.map(PagingKey.toNextId))
 
           ListRecordSetResults(
             recordSets = results,
@@ -356,5 +365,32 @@ object MySqlRecordSetRepository extends ProtobufConversions {
 
     if (absoluteRecordSetName.equals(absoluteZoneName)) absoluteZoneName
     else absoluteRecordSetName + absoluteZoneName
+  }
+
+  case class PagingKey(recordName: String, recordType: Int)
+
+  object PagingKey {
+    val delimiterRegex = "<recordName\\.\\.\\.\\.recordType>"
+    val delimiter = "<recordName....recordType>"
+
+    def fromStartFrom(startFrom: Option[String]): Option[PagingKey] =
+      startFrom.flatMap { sf =>
+        val tokens = sf.split(delimiterRegex)
+        if (tokens.length != 2) None
+        else {
+          val recordName = tokens.head
+          Try(tokens(1).toInt) match {
+            case Success(recordType) => Some(PagingKey(recordName, recordType))
+            case Failure(_) => None
+          }
+        }
+      }
+
+    def toNextId(last: RecordSet): String = {
+      val nextIdName = last.name
+      val nextIdType = MySqlRecordSetRepository.fromRecordType(last.typ)
+
+      s"$nextIdName$delimiter$nextIdType"
+    }
   }
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -370,8 +370,8 @@ object MySqlRecordSetRepository extends ProtobufConversions {
   case class PagingKey(recordName: String, recordType: Int)
 
   object PagingKey {
-    val delimiterRegex = "<\\.\\.\\.\\.>"
-    val delimiter = "<....>"
+    val delimiterRegex = "\\.\\.\\.\\."
+    val delimiter = "...."
 
     def apply(startFrom: Option[String]): Option[PagingKey] =
       for {

--- a/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlRecordSetRepositorySpec.scala
+++ b/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlRecordSetRepositorySpec.scala
@@ -74,30 +74,32 @@ class MySqlRecordSetRepositorySpec extends WordSpec with Matchers {
 
   "PagingKey.fromStartFrom" should {
     "return None if startFrom is None" in {
-      PagingKey.fromStartFrom(None) shouldBe None
+      PagingKey(None) shouldBe None
     }
 
     "return None if startFrom is malformed" in {
       val empty = ""
       val noDelimiter = "nodelim"
       val justDelimiter = s"${PagingKey.delimiter}"
+      val noName = s"${PagingKey.delimiter}1"
       val noType = s"name${PagingKey.delimiter}"
 
-      PagingKey.fromStartFrom(Some(empty)) shouldBe None
-      PagingKey.fromStartFrom(Some(noDelimiter)) shouldBe None
-      PagingKey.fromStartFrom(Some(justDelimiter)) shouldBe None
-      PagingKey.fromStartFrom(Some(noType)) shouldBe None
+      PagingKey(Some(empty)) shouldBe None
+      PagingKey(Some(noDelimiter)) shouldBe None
+      PagingKey(Some(justDelimiter)) shouldBe None
+      PagingKey(Some(noName)) shouldBe None
+      PagingKey(Some(noType)) shouldBe None
     }
 
     "return None if type is not an Int" in {
       val startFrom = s"name${PagingKey.delimiter}notNumber"
-      PagingKey.fromStartFrom(Some(startFrom)) shouldBe None
+      PagingKey(Some(startFrom)) shouldBe None
     }
 
     "return correct PagingKey" in {
       val expected = PagingKey("name", 5)
       val startFrom = s"${expected.recordName}${PagingKey.delimiter}${expected.recordType}"
-      PagingKey.fromStartFrom(Some(startFrom)) shouldBe Some(expected)
+      PagingKey(Some(startFrom)) shouldBe Some(expected)
     }
   }
 

--- a/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlRecordSetRepositorySpec.scala
+++ b/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlRecordSetRepositorySpec.scala
@@ -17,6 +17,7 @@
 package vinyldns.mysql.repository
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.domain.record.RecordType
+import vinyldns.core.TestRecordSetData.aaaa
 
 class MySqlRecordSetRepositorySpec extends WordSpec with Matchers {
   import MySqlRecordSetRepository._
@@ -68,6 +69,45 @@ class MySqlRecordSetRepositorySpec extends WordSpec with Matchers {
       toFQDN(zoneNameWithDot, recordName) shouldBe expected
       toFQDN(zoneName, recordNameWithDot) shouldBe expected
       toFQDN(zoneNameWithDot, recordNameWithDot) shouldBe expected
+    }
+  }
+
+  "PagingKey.fromStartFrom" should {
+    "return None if startFrom is None" in {
+      PagingKey.fromStartFrom(None) shouldBe None
+    }
+
+    "return None if startFrom is malformed" in {
+      val empty = ""
+      val noDelimiter = "nodelim"
+      val justDelimiter = s"${PagingKey.delimiter}"
+      val noType = s"name${PagingKey.delimiter}"
+
+      PagingKey.fromStartFrom(Some(empty)) shouldBe None
+      PagingKey.fromStartFrom(Some(noDelimiter)) shouldBe None
+      PagingKey.fromStartFrom(Some(justDelimiter)) shouldBe None
+      PagingKey.fromStartFrom(Some(noType)) shouldBe None
+    }
+
+    "return None if type is not an Int" in {
+      val startFrom = s"name${PagingKey.delimiter}notNumber"
+      PagingKey.fromStartFrom(Some(startFrom)) shouldBe None
+    }
+
+    "return correct PagingKey" in {
+      val expected = PagingKey("name", 5)
+      val startFrom = s"${expected.recordName}${PagingKey.delimiter}${expected.recordType}"
+      PagingKey.fromStartFrom(Some(startFrom)) shouldBe Some(expected)
+    }
+  }
+
+  "PagingKey.toNextId" should {
+    "return correct NextId" in {
+      val expectedName = "name"
+      val expectedType = MySqlRecordSetRepository.fromRecordType(RecordType.CNAME)
+      val last = aaaa.copy(name = expectedName, typ = RecordType.CNAME)
+
+      PagingKey.toNextId(last) shouldBe s"$expectedName${PagingKey.delimiter}$expectedType"
     }
   }
 }

--- a/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlRecordSetRepositorySpec.scala
+++ b/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlRecordSetRepositorySpec.scala
@@ -81,13 +81,11 @@ class MySqlRecordSetRepositorySpec extends WordSpec with Matchers {
       val empty = ""
       val noDelimiter = "nodelim"
       val justDelimiter = s"${PagingKey.delimiter}"
-      val noName = s"${PagingKey.delimiter}1"
       val noType = s"name${PagingKey.delimiter}"
 
       PagingKey(Some(empty)) shouldBe None
       PagingKey(Some(noDelimiter)) shouldBe None
       PagingKey(Some(justDelimiter)) shouldBe None
-      PagingKey(Some(noName)) shouldBe None
       PagingKey(Some(noType)) shouldBe None
     }
 


### PR DESCRIPTION
Fixes #565 .

* recordset paging is done by name and type
* paging will either match on `(name >= prev.name && type > prev.type) || (name > prev.name)`
* this is to address cases in which a page boundary record shares its name with other records that must still be paged
* in the previous logic, `name > prev.name`, duplicate records that were still not paged would be lost 
* in the new logic, a page will match for records with the previous last items name as long as the record does not have the same type
