### PR TITLE
change Zone shared attribute label to Access

### DIFF
--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -48,7 +48,7 @@
 
                             @if(meta.sharedDisplayEnabled) {
                                 <div class="form-group">
-                                    <label class="col-md-3 control-label">Type</label>
+                                    <label class="col-md-3 control-label">Access</label>
                                     <div class="col-md-9">
                                         <div>
                                             <p class="form-control-static">{{ updateZoneInfo.shared ? "Shared" : "Private" }}</p>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -82,7 +82,7 @@
                                     <th>Admin Group</th>
                                     <th>Status</th>
                                     @if(meta.sharedDisplayEnabled) {
-                                        <th>Type</th>
+                                        <th>Access</th>
                                     }
                                     <th>Actions</th>
                                 </tr>


### PR DESCRIPTION
We said if we ever came up with a better name for the Zone shared attribute in the portal we would change it from Type. Today is that day! Going with "Access". The possible values remain the same as "Shared" or "Private".
