### PR TITLE
Change homepage from Zones to New Batch Change

### DIFF
--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -100,7 +100,7 @@ class FrontendController @Inject()(
   }
 
   def index(): Action[AnyContent] = userAction.async { implicit request =>
-    Future(Ok(views.html.batchChanges.batchChangeNew(request.user.userName)))
+    Future(Ok(views.html.batchChanges.batchChanges(request.user.userName)))
   }
 
   def viewAllGroups(): Action[AnyContent] = userAction.async { implicit request =>

--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -100,7 +100,7 @@ class FrontendController @Inject()(
   }
 
   def index(): Action[AnyContent] = userAction.async { implicit request =>
-    Future(Ok(views.html.zones.zones(request.user.userName)))
+    Future(Ok(views.html.batchChanges.batchChangeNew(request.user.userName)))
   }
 
   def viewAllGroups(): Action[AnyContent] = userAction.async { implicit request =>

--- a/modules/portal/app/views/main.scala.html
+++ b/modules/portal/app/views/main.scala.html
@@ -45,26 +45,26 @@
                         <div id="sidebar-menu" class="main_menu_side hidden-print main_menu">
                             <div class="menu_section">
                                 <ul class="nav side-menu vinyldns-side-menu">
+                                  @if(controller == "BatchChangesController" || controller == "BatchChangeNewController" || controller == "BatchChangeDetailController") {
+                                    <li class="active">
+                                        } else {
+                                    <li>
+                                        }
+                                        <a href="/batchchanges"><i class="fa fa-list-ol"></i>Batch Changes</a>
+                                    </li>
+                                  @if(controller == "GroupsController" || controller == "MembershipController") {
+                                    <li class="active">
+                                        } else {
+                                    <li>
+                                        }
+                                        <a href="/groups"><i class="fa fa-group"></i>Groups</a>
+                                    </li>
                                   @if(controller == "RecordsController" || controller == "ZonesController") {
                                     <li class="active">
                                   } else {
                                     <li>
                                   }
                                     <a href="/zones"><i class="fa fa-table"></i>Zones</a>
-                                  </li>
-                                  @if(controller == "GroupsController" || controller == "MembershipController") {
-                                    <li class="active">
-                                  } else {
-                                    <li>
-                                  }
-                                    <a href="/groups"><i class="fa fa-group"></i>Groups</a>
-                                  </li>
-                                  @if(controller == "BatchChangesController" || controller == "BatchChangeNewController" || controller == "BatchChangeDetailController") {
-                                    <li class="active">
-                                  } else {
-                                    <li>
-                                  }
-                                    <a href="/batchchanges"><i class="fa fa-list-ol"></i>Batch Changes</a>
                                   </li>
                                   @*****************************************
                                    * Custom links from application config *

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -364,13 +364,13 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
         status(result) must equalTo(SEE_OTHER)
         headers(result) must contain("Location" -> "/login")
       }
-      "render the batch changes view page when the user is logged in" in new WithApplication(app) {
+      "render the new batch change view page when the user is logged in" in new WithApplication(app) {
         val result =
           underTest.viewNewBatchChange()(
             FakeRequest(GET, "/batchchanges/new").withSession("username" -> "frodo").withCSRFToken)
         status(result) must beEqualTo(OK)
         contentType(result) must beSome.which(_ == "text/html")
-        contentAsString(result) must contain("Batch Changes | VinylDNS")
+        contentAsString(result) must contain("New Batch Change | VinylDNS")
       }
       "redirect to the no access page when a user is locked out" in new WithApplication(app) {
         val result =

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -93,14 +93,14 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
           status(result) must equalTo(SEE_OTHER)
           headers(result) must contain("Location" -> "/login")
         }
-        "render the new batch change page when the user is logged in" in new WithApplication(app) {
+        "render the batch changes page when the user is logged in" in new WithApplication(app) {
           val result =
             underTest.index()(
               FakeRequest(GET, "/index").withSession("username" -> "frodo").withCSRFToken)
           status(result) must beEqualTo(OK)
           contentType(result) must beSome.which(_ == "text/html")
           contentAsString(result) must contain("Are you sure you want to log out")
-          contentAsString(result) must contain("New Batch Change | VinylDNS")
+          contentAsString(result) must contain("Batch Changes | VinylDNS")
         }
         "redirect to the no access page when a user is locked out" in new WithApplication(app) {
           val result =

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -93,14 +93,14 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
           status(result) must equalTo(SEE_OTHER)
           headers(result) must contain("Location" -> "/login")
         }
-        "render the zone page when the user is logged in" in new WithApplication(app) {
+        "render the new batch change page when the user is logged in" in new WithApplication(app) {
           val result =
             underTest.index()(
               FakeRequest(GET, "/index").withSession("username" -> "frodo").withCSRFToken)
           status(result) must beEqualTo(OK)
           contentType(result) must beSome.which(_ == "text/html")
           contentAsString(result) must contain("Are you sure you want to log out")
-          contentAsString(result) must contain("Zones | VinylDNS")
+          contentAsString(result) must contain("New Batch Change | VinylDNS")
         }
         "redirect to the no access page when a user is locked out" in new WithApplication(app) {
           val result =
@@ -115,7 +115,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
           status(result) must equalTo(SEE_OTHER)
           headers(result) must contain("Location" -> "/login")
         }
-        "render the zone page when the user is logged in" in new WithApplication(app) {
+        "render the new batch change page when the user is logged in" in new WithApplication(app) {
           val result =
             oidcUnderTest.index()(
               FakeRequest(GET, "/index").withSession(VinylDNS.ID_TOKEN -> "test").withCSRFToken)
@@ -123,7 +123,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
           status(result) must beEqualTo(OK)
           contentType(result) must beSome.which(_ == "text/html")
           contentAsString(result) must contain("Are you sure you want to log out")
-          contentAsString(result) must contain("Zones | VinylDNS")
+          contentAsString(result) must contain("New Batch Change | VinylDNS")
         }
       }
     }

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -115,7 +115,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
           status(result) must equalTo(SEE_OTHER)
           headers(result) must contain("Location" -> "/login")
         }
-        "render the new batch change page when the user is logged in" in new WithApplication(app) {
+        "render the batch changes page when the user is logged in" in new WithApplication(app) {
           val result =
             oidcUnderTest.index()(
               FakeRequest(GET, "/index").withSession(VinylDNS.ID_TOKEN -> "test").withCSRFToken)
@@ -123,7 +123,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
           status(result) must beEqualTo(OK)
           contentType(result) must beSome.which(_ == "text/html")
           contentAsString(result) must contain("Are you sure you want to log out")
-          contentAsString(result) must contain("New Batch Change | VinylDNS")
+          contentAsString(result) must contain("Batch Changes | VinylDNS")
         }
       }
     }
@@ -364,13 +364,13 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
         status(result) must equalTo(SEE_OTHER)
         headers(result) must contain("Location" -> "/login")
       }
-      "render the new batch change view page when the user is logged in" in new WithApplication(app) {
+      "render the batch changes view page when the user is logged in" in new WithApplication(app) {
         val result =
           underTest.viewNewBatchChange()(
             FakeRequest(GET, "/batchchanges/new").withSession("username" -> "frodo").withCSRFToken)
         status(result) must beEqualTo(OK)
         contentType(result) must beSome.which(_ == "text/html")
-        contentAsString(result) must contain("New Batch Change | VinylDNS")
+        contentAsString(result) must contain("Batch Changes | VinylDNS")
       }
       "redirect to the no access page when a user is locked out" in new WithApplication(app) {
         val result =


### PR DESCRIPTION
with the addition of shared zones the expectation is majority of portal users will use the new batch change form rather than managing records in individual zones. This PR changes the default home page in the portal to the New Batch Change screen. Also changes the order of the navigation.

![VinylDNS home page screenshot](https://user-images.githubusercontent.com/4439228/58208346-8cd06000-7cb2-11e9-928e-56a2102be209.png)
