### PR TITLE
ensure trailing dot in list zones search

### DIFF
--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -231,7 +231,7 @@ def test_list_zones_with_search_last_page(list_zones_context):
     """
     Test that the second page of listing zones returns correctly when a name filter is provided
     """
-    result = list_zones_context.client.list_zones(name_filter='*searched*', start_from="list-zones-test-searched-2.", max_items=2, status=200)
+    result = list_zones_context.client.list_zones(name_filter='*test-searched-3', start_from="list-zones-test-searched-2.", max_items=2, status=200)
     zones = result['zones']
 
     assert_that(zones, has_length(1))
@@ -239,5 +239,5 @@ def test_list_zones_with_search_last_page(list_zones_context):
 
     assert_that(result, is_not(has_key('nextId')))
     assert_that(result['maxItems'], is_(2))
-    assert_that(result['nameFilter'], is_('*searched*'))
+    assert_that(result['nameFilter'], is_('*test-searched-3'))
     assert_that(result['startFrom'], is_('list-zones-test-searched-2.'))

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -393,7 +393,7 @@ class MySqlZoneRepositoryIntegrationSpec
     "apply the zone filter as a normal user" in {
 
       val testZones = Seq(
-        testZone("system-tes.t", adminGroupId = "foo"),
+        testZone("system-test.", adminGroupId = "foo"),
         testZone("system-temp.", adminGroupId = "foo"),
         testZone("system-nomatch.", adminGroupId = "bar")
       )

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -374,9 +374,9 @@ class MySqlZoneRepositoryIntegrationSpec
     "apply the zone filter as a super user" in {
 
       val testZones = Seq(
-        testZone("system-test"),
-        testZone("system-temp"),
-        testZone("no-match")
+        testZone("system-test."),
+        testZone("system-temp."),
+        testZone("no-match.")
       )
 
       val expectedZones = Seq(testZones(0), testZones(1))
@@ -393,9 +393,9 @@ class MySqlZoneRepositoryIntegrationSpec
     "apply the zone filter as a normal user" in {
 
       val testZones = Seq(
-        testZone("system-test", adminGroupId = "foo"),
-        testZone("system-temp", adminGroupId = "foo"),
-        testZone("system-nomatch", adminGroupId = "bar")
+        testZone("system-tes.t", adminGroupId = "foo"),
+        testZone("system-temp.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar")
       )
 
       val expectedZones = Seq(testZones(0), testZones(1)).sortBy(_.name)
@@ -414,9 +414,9 @@ class MySqlZoneRepositoryIntegrationSpec
     "support starts with wildcard" in {
 
       val testZones = Seq(
-        testZone("system-test", adminGroupId = "foo"),
-        testZone("system-temp", adminGroupId = "foo"),
-        testZone("system-nomatch", adminGroupId = "bar")
+        testZone("system-test.", adminGroupId = "foo"),
+        testZone("system-temp.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar")
       )
 
       val expectedZones = Seq(testZones(0), testZones(1)).sortBy(_.name)
@@ -435,9 +435,9 @@ class MySqlZoneRepositoryIntegrationSpec
     "support ends with wildcard" in {
 
       val testZones = Seq(
-        testZone("system-test", adminGroupId = "foo"),
-        testZone("system-temp", adminGroupId = "foo"),
-        testZone("system-nomatch", adminGroupId = "bar")
+        testZone("system-test.", adminGroupId = "foo"),
+        testZone("system-temp.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar")
       )
 
       val expectedZones = Seq(testZones(0))
@@ -455,9 +455,9 @@ class MySqlZoneRepositoryIntegrationSpec
 
     "support contains wildcard" in {
       val testZones = Seq(
-        testZone("system-jokerswild", adminGroupId = "foo"),
-        testZone("system-wildcard", adminGroupId = "foo"),
-        testZone("system-nomatch", adminGroupId = "bar")
+        testZone("system-jokerswild.", adminGroupId = "foo"),
+        testZone("system-wildcard.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar")
       )
 
       val expectedZones = Seq(testZones(0), testZones(1))

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -27,6 +27,7 @@ import vinyldns.core.domain.zone.{ListZonesResults, Zone, ZoneRepository, ZoneSt
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
 import vinyldns.proto.VinylDNSProto
+import vinyldns.core.domain.DomainHelpers._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -228,7 +229,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           sb.append(withAccessorCheck)
 
           val filters = List(
-            zoneNameFilter.map(flt => s"z.name LIKE '${flt.replace('*', '%')}'"),
+            zoneNameFilter.map(flt => s"z.name LIKE '${ensureTrailingDot(flt.replace('*', '%'))}'"),
             startFrom.map(os => s"z.name > '$os'")
           ).flatten
 


### PR DESCRIPTION
Fixes #652.

Changes in this pull request:
- use the `ensureTrailingDot` DomainHelper method to add a trailing dot to the passed in name_filter if it doesn't have one
- all zones end in a trailing dot so this will have no impact on whether `*` are included for wildcard search or not.
