### PR TITLE
Fail if zone id is not equal on recordset update

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -7,6 +7,8 @@ from vinyldns_python import VinylDNSClient
 from test_data import TestData
 from vinyldns_context import VinylDNSTestContext
 import time
+import json
+from requests.compat import urljoin
 
 
 def test_update_a_with_same_name_as_cname(shared_zone_test_context):
@@ -2365,3 +2367,33 @@ def test_update_ds_bad_ttl(shared_zone_test_context):
         if result_rs:
             client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=(202,404))
             client.wait_until_recordset_deleted(result_rs['zoneId'], result_rs['id'])
+
+def test_update_zoneId_fails(shared_zone_test_context):
+    """
+    Test that a 422 is returned if the zoneId in the body and route do not match
+    """
+
+    client = shared_zone_test_context.ok_vinyldns_client
+    zone = shared_zone_test_context.ok_zone
+
+    created = None
+
+    try:
+        record_json = get_recordset_json(zone, 'test_update_zone_id', 'A', [{'address': '1.1.1.1'}])
+        create_response = client.create_recordset(record_json, status=202)
+        created = client.wait_until_recordset_change_status(create_response, 'Complete')['recordSet']
+
+        update = created
+        update['ttl'] = update['ttl'] + 100
+        update['zoneId'] = shared_zone_test_context.dummy_zone['id']
+
+        url = urljoin(client.index_url, u'/zones/{0}/recordsets/{1}'.format(zone[u'id'], update[u'id']))
+        response, data = client.make_request(url, u'PUT', client.headers, json.dumps(update), not_found_ok=True,
+                                             status=422)
+
+        assert_that(data, is_("Cannot update RecordSet's zoneId attribute"))
+
+    finally:
+        if created:
+            delete_result = client.delete_recordset(zone['id'], created['id'], status=202)
+            client.wait_until_recordset_change_status(delete_result, 'Complete')

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -2368,7 +2368,7 @@ def test_update_ds_bad_ttl(shared_zone_test_context):
             client.delete_recordset(result_rs['zoneId'], result_rs['id'], status=(202,404))
             client.wait_until_recordset_deleted(result_rs['zoneId'], result_rs['id'])
 
-def test_update_zoneId_fails(shared_zone_test_context):
+def test_update_zone_id_fails(shared_zone_test_context):
     """
     Test that a 422 is returned if the zoneId in the body and route do not match
     """

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -83,6 +83,7 @@ class RecordSetService(
     for {
       zone <- getZone(recordSet.zoneId)
       existing <- getRecordSet(recordSet.id, zone)
+      _ <- recordSetIsInZone(existing, zone).toResult
       change <- RecordSetChangeGenerator.forUpdate(existing, recordSet, zone, Some(auth)).toResult
       // because changes happen to the RS in forUpdate itself, converting 1st and validating on that
       rsForValidations = change.recordSet

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -250,4 +250,11 @@ object RecordSetValidations {
         if (authPrincipal.isSuper || authPrincipal.isGroupMember(groupId)) ().asRight
         else InvalidRequest(s"""User not in record owner group with id "$groupId"""").asLeft
     }
+
+  def recordSetIsInZone(recordSet: RecordSet, zone: Zone): Either[Throwable, Unit] =
+    Either.cond(
+      recordSet.zoneId == zone.id,
+      (),
+      InvalidRequest(s"""Cannot update RecordSet's zoneId attribute""")
+    )
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -440,5 +440,16 @@ class RecordSetValidationsSpec
         error shouldBe an[InvalidRequest]
       }
     }
+
+    "recordSetIsInZone" should {
+      "pass if the recordSets's zoneId matches the zone's id" in {
+        recordSetIsInZone(aaaa.copy(zoneId = okZone.id), okZone) should be(right)
+      }
+
+      "fail if the recordSet's zoneId does not match the zone's id" in {
+        val error = leftValue(recordSetIsInZone(aaaa.copy(zoneId = "not-ok-zone"), okZone))
+        error shouldBe an[InvalidRequest]
+      }
+    }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -379,9 +379,7 @@ class RecordSetRoutingSpec
         Right(
           RecordSetChange(
             zone = invalidChangeZone,
-            recordSet = recordSets
-              .get(rsId)
-              .get
+            recordSet = recordSets(rsId)
               .copy(
                 status = RecordSetStatus.Active,
                 created = DateTime.now,

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -50,6 +50,7 @@ class RecordSetRoutingSpec
   private val zoneDeleted = Zone("inactive", "test@test.com", ZoneStatus.Deleted)
   private val notAuthorizedZone = Zone("notAuth", "test@test.com")
   private val syncingZone = Zone("syncing", "test@test.com")
+  private val invalidChangeZone = Zone("invalidChange", "test@test.com")
 
   private val rsAlreadyExists = RecordSet(
     okZone.id,
@@ -142,7 +143,7 @@ class RecordSetRoutingSpec
     List(AData("10.1.1.1")))
 
   private val rsNotAuthorized = RecordSet(
-    okZone.id,
+    notAuthorizedZone.id,
     "changenotauth",
     RecordType.A,
     200,
@@ -374,6 +375,21 @@ class RecordSetRoutingSpec
       case zoneDeleted.id => Left(ZoneInactiveError(zoneId))
       case notAuthorizedZone.id => Left(NotAuthorizedError(zoneId))
       case syncingZone.id => Left(ZoneUnavailableError(zoneId))
+      case invalidChangeZone.id =>
+        Right(
+          RecordSetChange(
+            zone = invalidChangeZone,
+            recordSet = recordSets
+              .get(rsId)
+              .get
+              .copy(
+                status = RecordSetStatus.Active,
+                created = DateTime.now,
+                updated = Some(DateTime.now)),
+            status = RecordSetChangeStatus.Complete,
+            changeType = chgType,
+            userId = authPrincipal.userId
+          ))
       case okZone.id =>
         rsId match {
           case rsError.id => Left(new RuntimeException("fail"))
@@ -740,6 +756,19 @@ class RecordSetRoutingSpec
           "Missing RecordSet.type",
           "Missing RecordSet.ttl"
         )
+      }
+    }
+
+    "return a 422 Unprocessable Entity if the zoneId does not match the one in the route" in {
+      Put(s"/zones/${okZone.id}/recordsets/${rsOk.id}")
+        .withEntity(
+          HttpEntity(
+            ContentTypes.`application/json`,
+            rsJson(rsOk.copy(zoneId = invalidChangeZone.id)))) ~>
+        recordSetRoute(okAuth) ~> check {
+        status shouldBe StatusCodes.UnprocessableEntity
+        val error = responseAs[String]
+        error shouldBe "Cannot update RecordSet's zoneId attribute"
       }
     }
 

--- a/modules/docs/src/main/tut/api/update-recordset.md
+++ b/modules/docs/src/main/tut/api/update-recordset.md
@@ -17,7 +17,7 @@ Updates a RecordSet.  This performs a delete of the old record, and inserts the 
 
 name          | type          | required?   | description |
  ------------ | ------------- | ----------- | :---------- |
-zoneId        | string        | yes         | id of the zone where the recordset belongs |
+zoneId        | string        | yes         | id of the zone where the recordset belongs, this value **must** match the zoneId of the existing recordSet |
 id            | string        | yes         | the id of the recordset being updated |
 name          | string        | yes         | the name of the recordset being updated |
 type          | string        | yes         | the type of recordset |


### PR DESCRIPTION
Fixes #638 

* If the recordSet zoneId and the zoneId in the route do not match return a 422

Can likely close #353 
