### PR TITLE
manual review flag

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -127,7 +127,4 @@ object VinylDNSConfig {
     } else List()
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
-
-  lazy val batchChangeManualReview: Boolean =
-    vinyldnsConfig.as[Option[Boolean]]("batch-change-manual-review").getOrElse(false)
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -127,4 +127,7 @@ object VinylDNSConfig {
     } else List()
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
+
+  lazy val batchChangeManualReviewEnabled: Boolean =
+    vinyldnsConfig.as[Option[Boolean]]("batch-change-manual-review-enabled").getOrElse(false)
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -127,4 +127,7 @@ object VinylDNSConfig {
     } else List()
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
+
+  lazy val batchChangeManualReview: Boolean =
+    vinyldnsConfig.as[Option[Boolean]]("batch-change-manual-review").getOrElse(false)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -16,6 +16,7 @@
 
 package vinyldns.api.domain.batch
 
+import vinyldns.api.VinylDNSConfig
 import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 import vinyldns.core.domain.record.RecordData
 import vinyldns.core.domain.record.RecordType._
@@ -25,6 +26,22 @@ final case class BatchChangeInput(
     changes: List[ChangeInput],
     manualReview: Boolean,
     ownerGroupId: Option[String] = None)
+
+object BatchChangeInput {
+  def fromJson(
+      comments: Option[String],
+      changes: List[ChangeInput],
+      requestedManualReview: Boolean,
+      ownerGroupId: Option[String] = None,
+      manualReviewEnabled: Boolean = VinylDNSConfig.batchChangeManualReviewEnabled)
+    : BatchChangeInput = {
+    val manualReview =
+      if (manualReviewEnabled) requestedManualReview
+      else false
+
+    new BatchChangeInput(comments, changes, manualReview, ownerGroupId)
+  }
+}
 
 sealed trait ChangeInput {
   val inputName: String

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -23,8 +23,8 @@ import vinyldns.core.domain.record.RecordType._
 final case class BatchChangeInput(
     comments: Option[String],
     changes: List[ChangeInput],
-    ownerGroupId: Option[String] = None,
-    manualReview: Boolean = true)
+    manualReview: Boolean,
+    ownerGroupId: Option[String] = None)
 
 sealed trait ChangeInput {
   val inputName: String

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -23,7 +23,8 @@ import vinyldns.core.domain.record.RecordType._
 final case class BatchChangeInput(
     comments: Option[String],
     changes: List[ChangeInput],
-    ownerGroupId: Option[String] = None)
+    ownerGroupId: Option[String] = None,
+    manualReview: Boolean = true)
 
 sealed trait ChangeInput {
   val inputName: String

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -21,6 +21,7 @@ import cats.data.Validated._
 import org.json4s.JsonDSL._
 import org.json4s._
 import cats.implicits._
+import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.DomainValidationError
 import vinyldns.api.domain.batch.ChangeInputType._
 import vinyldns.api.domain.batch._
@@ -52,8 +53,8 @@ trait BatchChangeJsonProtocol extends JsonValidation {
       (
         (js \ "comments").optional[String],
         changeList,
-        (js \ "ownerGroupId").optional[String],
-        (js \ "manualReview").default(true)
+        (js \ "manualReview").default(VinylDNSConfig.batchChangeManualReviewEnabled),
+        (js \ "ownerGroupId").optional[String]
       ).mapN(BatchChangeInput)
     }
   }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -52,7 +52,8 @@ trait BatchChangeJsonProtocol extends JsonValidation {
       (
         (js \ "comments").optional[String],
         changeList,
-        (js \ "ownerGroupId").optional[String]
+        (js \ "ownerGroupId").optional[String],
+        (js \ "manualReview").default(true)
       ).mapN(BatchChangeInput)
     }
   }

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -42,6 +42,9 @@ vinyldns {
   # types of unowned records that users can access in shared zones
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR"]
 
+  # allow the user to set manual review flag for batch changes
+  batch-change-manual-review-enabled = true
+
   # used for testing only
   string-list-test = ["test"]
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -45,4 +45,46 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       input.changes(5).inputName shouldBe "cnamedot.test.com."
     }
   }
+
+  "BatchChangeInput.fromJson" should {
+    "force manual review to false if it is not enabled in config and passed into function as false" in {
+      val inputted = false
+      val config = false
+
+      val actual = BatchChangeInput.fromJson(None, List(), inputted, None, config).manualReview
+      val expected = false
+
+      actual shouldBe expected
+    }
+
+    "force manual review to false if it is not enabled in config and passed into function as true" in {
+      val inputted = true
+      val config = false
+
+      val actual = BatchChangeInput.fromJson(None, List(), inputted, None, config).manualReview
+      val expected = false
+
+      actual shouldBe expected
+    }
+
+    "allow manual review to be false if it is enabled in config and passed into function as false" in {
+      val inputted = false
+      val config = true
+
+      val actual = BatchChangeInput.fromJson(None, List(), inputted, None, config).manualReview
+      val expected = false
+
+      actual shouldBe expected
+    }
+
+    "allow manual review to be true if it is enabled in config and passed into function as true" in {
+      val inputted = true
+      val config = true
+
+      val actual = BatchChangeInput.fromJson(None, List(), inputted, None, config).manualReview
+      val expected = true
+
+      actual shouldBe expected
+    }
+  }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -34,7 +34,8 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
 
       val input = BatchChangeInput(
         None,
-        List(changeA, changeAAAA, changeCname, changeADotted, changeAAAADotted, changeCnameDotted))
+        List(changeA, changeAAAA, changeCname, changeADotted, changeAAAADotted, changeCnameDotted),
+        false)
 
       input.changes(0).inputName shouldBe "apex.test.com."
       input.changes(1).inputName shouldBe "aaaa.test.com."

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -237,7 +237,7 @@ class BatchChangeServiceSpec
 
   "applyBatchChange" should {
     "succeed if all inputs are good" in {
-      val input = BatchChangeInput(None, List(apexAddA, nonApexAddA))
+      val input = BatchChangeInput(None, List(apexAddA, nonApexAddA), false)
 
       val result = rightResultOf(underTest.applyBatchChange(input, auth).value)
 
@@ -245,7 +245,7 @@ class BatchChangeServiceSpec
     }
 
     "fail if conversion cannot process" in {
-      val input = BatchChangeInput(Some("conversionError"), List(apexAddA, nonApexAddA))
+      val input = BatchChangeInput(Some("conversionError"), List(apexAddA, nonApexAddA), false)
       val result = leftResultOf(underTest.applyBatchChange(input, auth).value)
 
       result shouldBe an[BatchConversionError]
@@ -253,7 +253,7 @@ class BatchChangeServiceSpec
 
     "fail with GroupDoesNotExist if owner group ID is provided for a non-existent group" in {
       val ownerGroupId = "non-existent-group-id"
-      val input = BatchChangeInput(None, List(apexAddA), Some(ownerGroupId))
+      val input = BatchChangeInput(None, List(apexAddA), false, Some(ownerGroupId))
       val result = leftResultOf(underTest.applyBatchChange(input, auth).value)
 
       result shouldBe InvalidBatchChangeInput(List(GroupDoesNotExist(ownerGroupId)))
@@ -261,7 +261,7 @@ class BatchChangeServiceSpec
 
     "fail with UserDoesNotBelongToOwnerGroup if normal user does not belong to group specified by owner group ID" in {
       val ownerGroupId = "user-is-not-member"
-      val input = BatchChangeInput(None, List(apexAddA), Some(ownerGroupId))
+      val input = BatchChangeInput(None, List(apexAddA), false, Some(ownerGroupId))
       val result = leftResultOf(underTest.applyBatchChange(input, notAuth).value)
 
       result shouldBe
@@ -270,7 +270,7 @@ class BatchChangeServiceSpec
     }
 
     "succeed if owner group ID is provided and user is a member of the group" in {
-      val input = BatchChangeInput(None, List(apexAddA), Some(okGroup.id))
+      val input = BatchChangeInput(None, List(apexAddA), false, Some(okGroup.id))
       val result = rightResultOf(underTest.applyBatchChange(input, okAuth).value)
 
       result.changes.length shouldBe 1
@@ -278,7 +278,7 @@ class BatchChangeServiceSpec
 
     "succeed if owner group ID is provided and user is a super user" in {
       val ownerGroupId = Some("user-is-not-member")
-      val input = BatchChangeInput(None, List(apexAddA), ownerGroupId)
+      val input = BatchChangeInput(None, List(apexAddA), false, ownerGroupId)
       val result =
         rightResultOf(
           underTest
@@ -698,7 +698,7 @@ class BatchChangeServiceSpec
     "return a BatchChange if all data inputs are valid" in {
       val result = underTest
         .buildResponse(
-          BatchChangeInput(None, List(apexAddA, onlyBaseAddAAAA, cnameAdd)),
+          BatchChangeInput(None, List(apexAddA, onlyBaseAddAAAA, cnameAdd), false),
           List(
             AddChangeForValidation(apexZone, "apex.test.com.", apexAddA).validNel,
             AddChangeForValidation(onlyBaseZone, "have", onlyBaseAddAAAA).validNel,
@@ -756,7 +756,7 @@ class BatchChangeServiceSpec
     "return a BatchChangeErrorList if any data inputs are invalid" in {
       val result = underTest
         .buildResponse(
-          BatchChangeInput(None, List(noZoneAddA, nonApexAddA)),
+          BatchChangeInput(None, List(noZoneAddA, nonApexAddA), false),
           List(
             ZoneDiscoveryError("no.zone.match.").invalidNel,
             AddChangeForValidation(baseZone, "non-apex", nonApexAddA).validNel),

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -89,7 +89,7 @@ class BatchChangeValidationsSpec
     for {
       numChanges <- choose(min, max)
       changes <- listOfN(numChanges, validAChangeGen)
-    } yield batch.BatchChangeInput(None, changes)
+    } yield batch.BatchChangeInput(None, changes, false)
 
   private val createPrivateAddChange = AddChangeForValidation(
     okZone,
@@ -134,7 +134,7 @@ class BatchChangeValidationsSpec
   )
 
   property("validateBatchChangeInputSize: should fail if batch has no changes") {
-    validateBatchChangeInputSize(BatchChangeInput(None, List())) should
+    validateBatchChangeInputSize(BatchChangeInput(None, List(), false)) should
       haveInvalid[DomainValidationError](BatchChangeIsEmpty(maxChanges))
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -263,6 +263,27 @@ class BatchChangeJsonProtocolSpec
         .value shouldBe batchChange
     }
 
+    "successfully serialize manualReview if it is false" in {
+      val input = addBatchChangeInputWithComment ~~ ("manualReview", JBool.False)
+      val result = BatchChangeInputSerializer.fromJson(input).value
+
+      result.manualReview shouldBe false
+    }
+
+    "successfully serialize manualReview if it is true" in {
+      val input = addBatchChangeInputWithComment ~~ ("manualReview", JBool.True)
+      val result = BatchChangeInputSerializer.fromJson(input).value
+
+      result.manualReview shouldBe true
+    }
+
+    "default manualReview to true if it does not exist" in {
+      val input = addBatchChangeInputWithComment
+      val result = BatchChangeInputSerializer.fromJson(input).value
+
+      result.manualReview shouldBe true
+    }
+
     "return an error if the changes are not specified" in {
       val json = "comments" -> "some comments"
       val result = BatchChangeInputSerializer.fromJson(json)

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -241,6 +241,28 @@ class BatchChangeJsonProtocolSpec
         .value shouldBe batchChange
     }
 
+    "make manualReview true if it does not exist" in {
+      val result = BatchChangeInputSerializer.fromJson(addBatchChangeInputWithComment).value
+
+      result.manualReview shouldBe true
+    }
+
+    "successfully serialize manualReview if it is false" in {
+      val input = addBatchChangeInputWithComment.copy(
+        obj = addBatchChangeInputWithComment.obj ::: List(("manualReview", JBool.False)))
+      val result = BatchChangeInputSerializer.fromJson(input).value
+
+      result.manualReview shouldBe false
+    }
+
+    "successfully serialize manualReview if it is true" in {
+      val input = addBatchChangeInputWithComment.copy(
+        obj = addBatchChangeInputWithComment.obj ::: List(("manualReview", JBool.True)))
+      val result = BatchChangeInputSerializer.fromJson(input).value
+
+      result.manualReview shouldBe true
+    }
+
     "successfully serialize valid add and delete change without comment and with owner group ID" in {
       val batchChange = BatchChangeInput(
         None,

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -205,7 +205,8 @@ class BatchChangeJsonProtocolSpec
 
       result shouldBe BatchChangeInput(
         Some("some comment"),
-        List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput))
+        List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput),
+        false)
     }
 
     "successfully serialize valid add change data without comment and owner group ID" in {
@@ -213,7 +214,8 @@ class BatchChangeJsonProtocolSpec
 
       result shouldBe BatchChangeInput(
         None,
-        List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput))
+        List(addAChangeInput, addAAAAChangeInput, addCNAMEChangeInput, addPTRChangeInput),
+        false)
     }
 
     "successfully serialize valid add and delete change data without comment and owner group ID" in {
@@ -221,7 +223,8 @@ class BatchChangeJsonProtocolSpec
 
       result shouldBe BatchChangeInput(
         None,
-        List(deleteAChangeInput, addAAAAChangeInput, addCNAMEChangeInput))
+        List(deleteAChangeInput, addAAAAChangeInput, addCNAMEChangeInput),
+        false)
     }
 
     "successfully serialize valid add and delete change with comment and owner group ID" in {
@@ -233,18 +236,13 @@ class BatchChangeJsonProtocolSpec
           addAAAAChangeInput,
           addCNAMEChangeInput,
           addPTRChangeInput),
+        false,
         Some("owner-group-id")
       )
 
       BatchChangeInputSerializer
         .fromJson(BatchChangeInputSerializer.toJson(batchChange))
         .value shouldBe batchChange
-    }
-
-    "make manualReview true if it does not exist" in {
-      val result = BatchChangeInputSerializer.fromJson(addBatchChangeInputWithComment).value
-
-      result.manualReview shouldBe true
     }
 
     "successfully serialize manualReview if it is false" in {
@@ -270,6 +268,7 @@ class BatchChangeJsonProtocolSpec
           addAAAAChangeInput,
           addCNAMEChangeInput,
           addPTRChangeInput),
+        false,
         Some("owner-group-id")
       )
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -245,20 +245,6 @@ class BatchChangeJsonProtocolSpec
         .value shouldBe batchChange
     }
 
-    "successfully serialize manualReview if it is false" in {
-      val input = addBatchChangeInputWithComment ~~ ("manualReview", JBool.False)
-      val result = BatchChangeInputSerializer.fromJson(input).value
-
-      result.manualReview shouldBe false
-    }
-
-    "successfully serialize manualReview if it is true" in {
-      val input = addBatchChangeInputWithComment ~~ ("manualReview", JBool.True)
-      val result = BatchChangeInputSerializer.fromJson(input).value
-
-      result.manualReview shouldBe true
-    }
-
     "successfully serialize valid add and delete change without comment and with owner group ID" in {
       val batchChange = BatchChangeInput(
         None,

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -248,16 +248,14 @@ class BatchChangeJsonProtocolSpec
     }
 
     "successfully serialize manualReview if it is false" in {
-      val input = addBatchChangeInputWithComment.copy(
-        obj = addBatchChangeInputWithComment.obj ::: List(("manualReview", JBool.False)))
+      val input = addBatchChangeInputWithComment ~~ ("manualReview", JBool.False)
       val result = BatchChangeInputSerializer.fromJson(input).value
 
       result.manualReview shouldBe false
     }
 
     "successfully serialize manualReview if it is true" in {
-      val input = addBatchChangeInputWithComment.copy(
-        obj = addBatchChangeInputWithComment.obj ::: List(("manualReview", JBool.True)))
+      val input = addBatchChangeInputWithComment ~~ ("manualReview", JBool.True)
       val result = BatchChangeInputSerializer.fromJson(input).value
 
       result.manualReview shouldBe true


### PR DESCRIPTION
Batch change input has a manual review flag that defaults to true

In a later pr, a batch change create, if it passes initial input validations and manual review is set to true, will be saved as a pending manual review batch change
