### PR TITLE
[WIP] Adopt Structured Logging

### DIFF
--- a/modules/api/src/main/resources/test/logback.xml
+++ b/modules/api/src/main/resources/test/logback.xml
@@ -1,8 +1,41 @@
 <configuration>
-    <!-- Test configuration, log to console so we can get the docker logs -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d [test] %-5p | \(%logger{4}:%line\) | %msg %n</pattern>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <timeZone>UTC</timeZone>
+                </timestamp>
+                <message/>
+                <globalCustomFields>
+                    <customFields>{"application": "vinyldns-api", "env": "dev"}</customFields>
+                </globalCustomFields>
+                <nestedField>
+                    <fieldName>ecs</fieldName>
+                    <providers>
+                        <globalCustomFields>
+                            <customFields>{"version": "1.0.0"}</customFields>
+                        </globalCustomFields>
+                    </providers>
+                </nestedField>
+                <arguments/>
+                <nestedField>
+                    <fieldName>log</fieldName>
+                    <providers>
+                        <logLevel/>
+                        <loggerName />
+                        <callerData/>
+                    </providers>
+                </nestedField>
+
+                <nestedField>
+                    <fieldName>process</fieldName>
+                    <providers>
+                        <threadName>
+                            <fieldName>thread</fieldName>
+                        </threadName>
+                    </providers>
+                </nestedField>
+            </providers>
         </encoder>
     </appender>
 
@@ -18,7 +51,7 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,8 @@ object Dependencies {
   lazy val awsV = "1.11.423"
   lazy val jaxbV = "2.3.0"
   lazy val ip4sV = "1.1.1"
+  lazy val logbackV = "1.2.3"
+  lazy val logEncoderV = "5.3"
 
   lazy val apiDependencies = Seq(
     "com.typesafe.akka"         %% "akka-http"                      % akkaHttpV,
@@ -64,7 +66,8 @@ object Dependencies {
     "javax.xml.bind"            %  "jaxb-api"                       % jaxbV % "provided",
     "com.sun.xml.bind"          %  "jaxb-core"                      % jaxbV,
     "com.sun.xml.bind"          %  "jaxb-impl"                      % jaxbV,
-    "ch.qos.logback"            %  "logback-classic"                % "1.0.7"
+    "ch.qos.logback"            %  "logback-classic"                % logbackV,
+    "net.logstash.logback"      %  "logstash-logback-encoder"       % logEncoderV
   )
 
   lazy val dynamoDBDependencies = Seq(


### PR DESCRIPTION
This PR is still a WIP.

Changes in this pull request:
- Use [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) library to emit structured JSON logs.
- Configure `modules/api/src/main/resources/test/logback.xml` to use `net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder` to transform logs to JSON documents

With the current change using the library, the JSON formatted logs would like as shown in the sample below (but in a single line - formatted here for easy human readability):
```json
{
  "@timestamp": "2019-05-29T18:11:12.974+00:00",
  "message": "monitor='queue.SQS.receive' millis=1018 fail=0",
  "application": "vinyldns-api",
  "env": "dev",
  "ecs": {
    "version": "1.0.0"
  },
  "log": {
    "level": "INFO",
    "logger_name": "vinyldns.core.route.Monitor",
    "caller_class_name": "vinyldns.core.route.Monitor",
    "caller_method_name": "capture",
    "caller_file_name": "Monitor.scala",
    "caller_line_number": 97
  },
  "process": {
    "thread": "pool-3-thread-26"
  }
}
```

Upcoming changes in this PR:

1. Adopt [Elastic's ECS](https://www.elastic.co/guide/en/ecs/current/index.html) for JSON structured logs
1.1. Document field mappings and if required extend ECS schema for VinylDNS specific fields
1.2. Code and configuration change to emit structured logs in ECS schema. For e.g.: The KV format in the message field in the above sample would be included as fields in JSON document under an appropriate context.
