### PR TITLE
Allow for default TTL on batch

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -63,6 +63,7 @@ object VinylDNSConfig {
       }
       .parSequence
 
+  lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]](s"default-ttl").getOrElse(7200L)
   lazy val restConfig: Config = vinyldnsConfig.getConfig("rest")
   lazy val monitoringConfig: Config = vinyldnsConfig.getConfig("monitoring")
   lazy val messageQueueConfig: IO[MessageQueueConfig] =

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -21,6 +21,7 @@ import cats.data.Validated._
 import org.json4s.JsonDSL._
 import org.json4s._
 import cats.implicits._
+import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.DomainValidationError
 import vinyldns.api.domain.batch.ChangeInputType._
 import vinyldns.api.domain.batch._
@@ -76,7 +77,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
       (
         (js \ "inputName").required[String]("Missing BatchChangeInput.changes.inputName"),
         recordType,
-        (js \ "ttl").required[Long]("Missing BatchChangeInput.changes.ttl"),
+        (js \ "ttl").default[Long](VinylDNSConfig.defaultTtl),
         recordType.andThen(extractRecord(_, js \ "record"))).mapN(AddChangeInput.apply)
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -176,14 +176,14 @@ class BatchChangeJsonProtocolSpec
       result should haveInvalid("Missing BatchChangeInput.changes.type")
     }
 
-    "return an error if the ttl is not specified" in {
+    "default ttl if not specified" in {
       val json = buildAddChangeInputJson(
         inputName = Some("foo."),
         typ = Some(A),
         record = Some(AData("1.1.1.1")))
-      val result = ChangeInputSerializer.fromJson(json)
+      val result = ChangeInputSerializer.fromJson(json).value
 
-      result should haveInvalid("Missing BatchChangeInput.changes.ttl")
+      result shouldBe AddChangeInput("foo.", A, 7200, AData("1.1.1.1"))
     }
 
     "return an error if the record is not specified for add" in {
@@ -273,7 +273,6 @@ class BatchChangeJsonProtocolSpec
 
       result should haveInvalid("Missing BatchChangeInput.changes.inputName")
       result should haveInvalid("Missing BatchChangeInput.changes.type")
-      result should haveInvalid("Missing BatchChangeInput.changes.ttl")
     }
   }
 

--- a/modules/docs/src/main/tut/api/create-batchchange.md
+++ b/modules/docs/src/main/tut/api/create-batchchange.md
@@ -33,7 +33,7 @@ name          | type          | required?   | description |
 changeType    | ChangeInputType | yes       | Type of change input. Must be set to **Add** for *AddChangeInput*. |
 inputName     | string        | yes         | The fully qualified domain name of the record being added. For **PTR**, the input name is a valid IPv4 or IPv6 address. |
 type          | RecordType    | yes         | Type of DNS record. Supported records for batch changes are currently: **A**, **AAAA**, **CNAME**, and **PTR**. |
-ttl           | long          | yes         | The time-to-live in seconds. The minimum and maximum values are 30 and 2147483647, respectively. |
+ttl           | long          | no          | The time-to-live in seconds. The minimum and maximum values are 30 and 2147483647, respectively. If not provided, this field will use a system default of 7200 or whatever is configured by your instance |
 record        | [RecordData](../api/recordset-model/#record-data) | yes         | The data for the record. |
 
 ##### DeleteChangeInput <a id="deletechangeinput-attributes" />


### PR DESCRIPTION
makes this easier on the users. if no ttl is provided, just fall to a system default