### PR TITLE
add high value domain info to docs

### DIFF
--- a/modules/docs/src/main/tut/api/batchchange-errors.md
+++ b/modules/docs/src/main/tut/api/batchchange-errors.md
@@ -90,6 +90,7 @@ Since by-change accumulated errors are collected at different stages, errors at 
 15. [Invalid Record Type In Reverse Zone](#InvalidRecordTypeInReverseZone)
 16. [Missing Owner Group Id](#MissingOwnerGroupId)
 17. [Not a Member of Owner Group](#NotAMemberOfOwnerGroup)
+18. [High Value Domain](#HighValueDomain)
 
 #### 1. Invalid Domain Name <a id="InvalidDomainName"></a>
 
@@ -443,3 +444,17 @@ If there are issues with the JSON provided in a batch change request, errors wil
    ]
 }
 ```
+
+#### 18. High Value Domain <a id="HighValueDomain"></a>
+
+##### Error Message:
+
+```
+Record Name "<record name>" is configured as a High Value Domain, so it cannot be modified.
+```
+
+##### Details:
+
+You are trying to create a record with a name that is not permitted in VinylDNS.
+The list of high value domains is specific to each VinylDNS instance.
+You should reach out to your VinylDNS administrators for more information.

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -603,7 +603,7 @@ akka.http {
 }
 
 # types of unowned records that users can access in shared zones
-shared-approved-types = ["A", "AAAA", "CNAME", "PTR"]
+shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
     
 # FQDNs / IPs that cannot be modified via VinylDNS
 # regex-list: list of regular expressions matching any FQDN that are not allowed to be modified by this VinylDNS instance

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -612,7 +612,6 @@ high-value-domains = {
     regex-list = [
       "high-value-domain.*"
     ip-list = [
-      # using reverse zones in the vinyldns/bind9 docker image for testing
       "192.0.2.252",
       "192.0.2.253",
       "fd69:27cc:fe91:0:0:0:0:ffff",

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -603,7 +603,7 @@ akka.http {
 }
 
 # types of unowned records that users can access in shared zones
-shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
+shared-approved-types = ["A", "AAAA", "CNAME", "PTR"]
     
 # FQDNs / IPs that cannot be modified via VinylDNS
 # regex-list used for all record types except PTR

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -606,12 +606,11 @@ akka.http {
 shared-approved-types = ["A", "AAAA", "CNAME", "PTR"]
     
 # FQDNs / IPs that cannot be modified via VinylDNS
-# regex-list used for all record types except PTR
-# ip-list used exclusively for PTR records
+# regex-list: list of regular expressions matching any FQDN that are not allowed to be modified by this VinylDNS instance
+# ip-list: list of IP addresses that cannot be modified by this VinylDNS instance
 high-value-domains = {
     regex-list = [
-      "high-value-domain.*" # for testing
-    ]
+      "high-value-domain.*"
     ip-list = [
       # using reverse zones in the vinyldns/bind9 docker image for testing
       "192.0.2.252",
@@ -620,5 +619,4 @@ high-value-domains = {
       "fd69:27cc:fe91:0:0:0:ffff:0"
     ]
 }
->>>>>>> add high value domain info to docs
 ```

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -602,6 +602,23 @@ akka.http {
   }
 }
 
-   # types of unowned records that users can access in shared zones
-    shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
+# types of unowned records that users can access in shared zones
+shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
+    
+# FQDNs / IPs that cannot be modified via VinylDNS
+# regex-list used for all record types except PTR
+# ip-list used exclusively for PTR records
+high-value-domains = {
+    regex-list = [
+      "high-value-domain.*" # for testing
+    ]
+    ip-list = [
+      # using reverse zones in the vinyldns/bind9 docker image for testing
+      "192.0.2.252",
+      "192.0.2.253",
+      "fd69:27cc:fe91:0:0:0:0:ffff",
+      "fd69:27cc:fe91:0:0:0:ffff:0"
+    ]
+}
+>>>>>>> add high value domain info to docs
 ```


### PR DESCRIPTION
Fixes #489.

Changes in this pull request:
- add error message information in batch change errors doc
- add example in api config docs
- noticed `shared-approved-types` was incorrectly nested in api config example so fixed that.
