### PR TITLE
make batch change TTL optional in the portal

### DIFF
--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -17,12 +17,17 @@
 package models
 import play.api.Configuration
 
-case class Meta(version: String, sharedDisplayEnabled: Boolean, batchChangeLimit: Int)
+case class Meta(
+    version: String,
+    sharedDisplayEnabled: Boolean,
+    batchChangeLimit: Int,
+    defaultTtl: Long)
 object Meta {
   def apply(config: Configuration): Meta =
     Meta(
       config.getOptional[String]("vinyldns.version").getOrElse("unknown"),
       config.getOptional[Boolean]("shared-display-enabled").getOrElse(false),
-      config.getOptional[Int]("batch-change-limit").getOrElse(1000)
+      config.getOptional[Int]("batch-change-limit").getOrElse(1000),
+      config.getOptional[Long]("default-ttl").getOrElse(7200L)
     )
 }

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -67,11 +67,7 @@
                                             <span class="fa fa-question-circle"></span>
                                         </span>
                                     </th>
-                                    <th class="col-md-1">TTL
-                                        <span data-toggle="tooltip" data-placement="top" title="Optional. Default is {{defaultTtl}}.">
-                                            <span class="fa fa-question-circle"></span>
-                                        </span>
-                                    </th>
+                                    <th class="col-md-1">TTL (optional)</th>
                                     <th>Record Data</th>
                                     <th></th>
                                 </tr>

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -2,7 +2,7 @@
 
 @content = {
 <!-- PAGE CONTENT -->
-<div class="right_col" role="main" ng-init="batchChangeLimit = @meta.batchChangeLimit">
+<div class="right_col" role="main" ng-init="batchChangeLimit = @meta.batchChangeLimit; defaultTtl = @meta.defaultTtl">
 
     <!-- BREADCRUMB -->
     <ul class="breadcrumb">
@@ -67,7 +67,11 @@
                                             <span class="fa fa-question-circle"></span>
                                         </span>
                                     </th>
-                                    <th class="col-md-1">TTL</th>
+                                    <th class="col-md-1">TTL
+                                        <span data-toggle="tooltip" data-placement="top" title="Optional. Default is {{defaultTtl}}.">
+                                            <span class="fa fa-question-circle"></span>
+                                        </span>
+                                    </th>
                                     <th>Record Data</th>
                                     <th></th>
                                 </tr>
@@ -102,9 +106,9 @@
                                     </td>
                                     <!--TTL based on change type-->
                                     <td ng-if="change.changeType=='Add'">
-                                        <input name="ttl_{{$index}}" type="number" ng-model="change.ttl" ng-required="change.changeType=='Add'" required="number" min="30" max="2147483647" class="form-control" ng-disabled="change.changeType=='DeleteRecordSet'">
+                                        <input name="ttl_{{$index}}" type="number" ng-model="change.ttl" min="30" max="2147483647" class="form-control" ng-disabled="change.changeType=='DeleteRecordSet'" placeholder="{{defaultTtl}}">
                                         <p ng-show="createBatchChangeForm.$submitted">
-                                            <span ng-show="createBatchChangeForm.ttl_{{$index}}.$error.required || createBatchChangeForm.ttl_{{$index}}.$error.min || createBatchChangeForm.ttl_{{$index}}.$error.max" class="batch-change-error-help">TTL must be between 30 and 2147483647.</span>
+                                            <span ng-show="createBatchChangeForm.ttl_{{$index}}.$error.number || createBatchChangeForm.ttl_{{$index}}.$error.min || createBatchChangeForm.ttl_{{$index}}.$error.max" class="batch-change-error-help">TTL must be between 30 and 2147483647.</span>
                                         </p>
                                     </td>
                                     <td ng-if="change.changeType=='DeleteRecordSet'">

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -28,13 +28,13 @@
                 });
 
             $scope.batch = {};
-            $scope.newBatch = {comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}]};
+            $scope.newBatch = {comments: "", changes: [{changeType: "Add", type: "A+PTR"}]};
             $scope.alerts = [];
             $scope.batchChangeErrors = false;
             $scope.formStatus = "pendingSubmit";
 
             $scope.addSingleChange = function() {
-                $scope.newBatch.changes.push({changeType: "Add", type: "A+PTR", ttl: 200});
+                $scope.newBatch.changes.push({changeType: "Add", type: "A+PTR"});
                 var changesLength = $scope.newBatch.changes.length;
                 $timeout(function() {document.getElementsByClassName("changeType")[changesLength - 1].focus()});
             };

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -114,7 +114,7 @@ describe('BatchChange', function(){
             it('adds a change to the changes array', function() {
                this.scope.addSingleChange();
 
-               expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}, {changeType: "Add", type: "A+PTR", ttl: 200}]})
+               expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR"}, {changeType: "Add", type: "A+PTR"}]})
             });
         });
 
@@ -212,8 +212,7 @@ describe('BatchChange', function(){
             it('does not import non-CSV format files', function() {
                var newFile = new Blob([], {type: 'any'});
                this.scope.uploadCSV(newFile);
-
-               expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}]});
+               expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR"}]});
             });
         });
 

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -192,7 +192,7 @@ describe('BatchChange', function(){
 
                 setTimeout(function() {
                     expect(batchChange.changes.length).toEqual(1)
-                    expect(batchChange).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}]});
+                    expect(batchChange).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR"}]});
                     done();
                 }, 1000);
             })

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -41,5 +41,13 @@ class MetaSpec extends Specification with Mockito {
       val config = Map("vinyldns.version" -> "foo-bar")
       Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(1000)
     }
+    "get the default-ttl value in config" in {
+      val config = Map("default-ttl" -> 7210)
+      Meta(Configuration.from(config)).defaultTtl must beEqualTo(7210)
+    }
+    "default to 7200 if default-ttl is not found" in {
+      val config = Map("vinyldns.version" -> "foo-bar")
+      Meta(Configuration.from(config)).defaultTtl must beEqualTo(7200)
+    }
   }
 }


### PR DESCRIPTION
builds on #670

Changes in this pull request:
- don't make TTL field required, but still validate minimum and maximum values if there's an input
- add tooltip indicating that the field is optional and what the system default is
- don't include the TTL value by default when adding rows, instead show the default value as placeholder text in the TTL field
