### PR TITLE
change batch change CSV validation

### DIFF
--- a/modules/docs/src/main/tut/portal/batch-changes.md
+++ b/modules/docs/src/main/tut/portal/batch-changes.md
@@ -34,7 +34,7 @@ This does not apply to zone administrators or users with specific ACL access rul
 1. Add a description.
 1. Add record changes in one of two ways:
  - Select the *Add a Change* button to add additional rows for data entry as needed.
- - Select the *Import CSV* button to choose a CSV file of the record changes, then select *Upload* to confirm your submission. Download a sample CSV [here](../static/batch-csv-sample.csv). **Note** The header row is required. The order of the columns is `Change Type, Record Type, Input Name, TTL, Record Data`.
+ - Select the *Import CSV* button to choose and upload a CSV file of the record changes. Download a sample CSV [here](../static/batch-csv-sample.csv). **Note** The header row is required. The order of the columns is `Change Type, Record Type, Input Name, TTL, Record Data`.
 1. Select the submit button. Confirm your submission.
  - If your submission was successful you'll redirect to the batch change summary page where you will see the status of the batch change request overall and of the individual records in the batch change.
  - If there are errors in the batch change you will remain on the form with prompts to correct errors before you attempt to submit again.

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -198,9 +198,8 @@
                                         <span ng-if="csvForm.batchChangeCsv.$pristine || csvForm.batchChangeCsv.$error.filled"><span class="glyphicon glyphicon-import"></span> Import CSV</span>
                                         <span ng-if="csvForm.batchChangeCsv.$dirty && csvForm.batchChangeCsv.$$success.filled"><span class="glyphicon glyphicon-folder-open"></span> Change File</span>
                                     </label>
-                                    <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" filled csv>
+                                    <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" filled>
                                     <button class="btn btn-success" ng-click="uploadCSV(csvForm.batchChangeCsv.$viewValue)" type="button" ng-if="csvForm.batchChangeCsv.$dirty && csvForm.batchChangeCsv.$valid" id="batchChangeCsvUpload"><span class="glyphicon glyphicon-upload"></span> Upload {{csvForm.batchChangeCsv.$viewValue.name}}</button>
-                                    <p ng-show="csvForm.batchChangeCsv.$error.csv && csvForm.batchChangeCsv.$$success.filled" class="batch-change-error-help">{{csvForm.batchChangeCsv.$viewValue.name}} is not a CSV file.</p>
                                     <p><a href="https://www.vinyldns.io/portal/batch-changes#create-a-batch-change" target="_blank" rel="noopener noreferrer">Download sample CSV</a></p>
                                 </ng-form>
                             </div>

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -193,15 +193,11 @@
                             </table>
                             <div class="form-group">
                                 <button type="button" id="addChange" class="btn btn-default" ng-click="addSingleChange()" ng-disabled="newBatch.changes.length >= batchChangeLimit"><span class="glyphicon glyphicon-plus"></span> Add a Change</button>
-                                <ng-form name="csvForm" isolate-form>
-                                    <label class="batch-change-csv-label btn btn-default" for="batchChangeCsv" id="batchChangeCsvImportLabel">
-                                        <span ng-if="csvForm.batchChangeCsv.$pristine || csvForm.batchChangeCsv.$error.filled"><span class="glyphicon glyphicon-import"></span> Import CSV</span>
-                                        <span ng-if="csvForm.batchChangeCsv.$dirty && csvForm.batchChangeCsv.$$success.filled"><span class="glyphicon glyphicon-folder-open"></span> Change File</span>
-                                    </label>
-                                    <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" filled>
-                                    <button class="btn btn-success" ng-click="uploadCSV(csvForm.batchChangeCsv.$viewValue)" type="button" ng-if="csvForm.batchChangeCsv.$dirty && csvForm.batchChangeCsv.$valid" id="batchChangeCsvUpload"><span class="glyphicon glyphicon-upload"></span> Upload {{csvForm.batchChangeCsv.$viewValue.name}}</button>
-                                    <p><a href="https://www.vinyldns.io/portal/batch-changes#create-a-batch-change" target="_blank" rel="noopener noreferrer">Download sample CSV</a></p>
-                                </ng-form>
+                                <label class="batch-change-csv-label btn btn-default" for="batchChangeCsv" id="batchChangeCsvImportLabel">
+                                    <span><span class="glyphicon glyphicon-import"></span> Import CSV</span>
+                                </label>
+                                <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" ng-change="uploadCSV(createBatchChangeForm.batchChangeCsv.$viewValue)" batch-change-file>
+                                <p><a href="https://www.vinyldns.io/portal/batch-changes#create-a-batch-change" target="_blank" rel="noopener noreferrer">Download sample CSV</a></p>
                             </div>
                             <p ng-if="newBatch.changes.length >= batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</p>
                         </div>

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -111,23 +111,26 @@
             }
 
             $scope.uploadCSV = function(file) {
-                if (file.type == "text/csv"){
-                    $scope.newBatch.changes = [];
-                    var reader = new FileReader();
-                    reader.onload = function(e) {
-                        var rows = e.target.result.split("\n");
+                var reader = new FileReader();
+                reader.onload = function(e) {
+                    var rows = e.target.result.split("\n");
+                    console.log(rows[0]);
+                    if (rows[0] == "Change Type,Record Type,Input Name,TTL,Record Data") {
+                        $scope.newBatch.changes = [];
                         for(var i = 1; i < rows.length; i++) {
                             var lengthCheck = rows[i].replace(/,+/g, '').trim().length
                             if (lengthCheck == 0) { continue; }
                             parseRow(rows[i])
                         }
                         $scope.$apply();
+                    } else {
+                        invalidCsvFile();
                     }
-                    reader.readAsText(file);
-                    resetForm();
-                } else {
-                    $scope.alerts.push({type: 'danger', content: 'Import failed. Not a valid CSV file.'});
-                };
+                }
+                console.log(reader.error)
+                reader.readAsText(file);
+                $scope.alerts.push({type: 'danger', content: 'Import failed. Not a valid CSV file.'});
+                resetForm();
 
                 function parseRow(row) {
                     var change = {};
@@ -157,6 +160,11 @@
                         }
                     }
                     $scope.newBatch.changes.push(change);
+                }
+
+                function invalidCsvFile(){
+                    console.log("WHERE AM I??")
+                    $scope.alerts.push({type: 'danger', content: 'Import failed. Not a valid CSV file.'});
                 }
 
                 function resetForm() {

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -18,7 +18,7 @@
     'use strict';
 
     angular.module('batch-change')
-        .controller('BatchChangeNewController', function($scope, $log, $location, $timeout, batchChangeService, utilityService, groupsService){
+        .controller('BatchChangeNewController', function($scope, $log, $location, $timeout, $q, batchChangeService, utilityService, groupsService){
             groupsService.getMyGroups()
                 .then(function (results) {
                     $scope.myGroups = results['data']['groups'];
@@ -111,26 +111,33 @@
             }
 
             $scope.uploadCSV = function(file) {
-                var reader = new FileReader();
-                reader.onload = function(e) {
-                    var rows = e.target.result.split("\n");
-                    console.log(rows[0]);
-                    if (rows[0] == "Change Type,Record Type,Input Name,TTL,Record Data") {
-                        $scope.newBatch.changes = [];
-                        for(var i = 1; i < rows.length; i++) {
-                            var lengthCheck = rows[i].replace(/,+/g, '').trim().length
-                            if (lengthCheck == 0) { continue; }
-                            parseRow(rows[i])
-                        }
-                        $scope.$apply();
-                    } else {
-                        invalidCsvFile();
-                    }
+                parseFile(file).then(function(dataLength){
+                    $scope.alerts.push({type: 'success', content: 'Successfully imported ' + dataLength + ' changes.' });
+                }, function(error) {
+                    $scope.alerts.push({type: 'danger', content: error});
+                });
+
+                function parseFile(file) {
+                  return $q(function(resolve, reject) {
+                      var reader = new FileReader();
+                      reader.onload = function(e) {
+                          var rows = e.target.result.split("\n");
+                          if (rows[0].trim() == "Change Type,Record Type,Input Name,TTL,Record Data") {
+                            $scope.newBatch.changes = [];
+                            for(var i = 1; i < rows.length; i++) {
+                              var lengthCheck = rows[i].replace(/,+/g, '').trim().length
+                              if (lengthCheck == 0) { continue; }
+                              parseRow(rows[i])
+                            }
+                            $scope.$apply()
+                            resolve($scope.newBatch.changes.length);
+                          } else {
+                            reject("Import failed. Not a valid file.");
+                          }
+                      }
+                      reader.readAsText(file);
+                  });
                 }
-                console.log(reader.error)
-                reader.readAsText(file);
-                $scope.alerts.push({type: 'danger', content: 'Import failed. Not a valid CSV file.'});
-                resetForm();
 
                 function parseRow(row) {
                     var change = {};
@@ -160,18 +167,6 @@
                         }
                     }
                     $scope.newBatch.changes.push(change);
-                }
-
-                function invalidCsvFile(){
-                    console.log("WHERE AM I??")
-                    $scope.alerts.push({type: 'danger', content: 'Import failed. Not a valid CSV file.'});
-                }
-
-                function resetForm() {
-                    document.getElementById("batchChangeCsv").value = null;
-                    $scope.csvInput = null;
-                    $scope.csvForm.$setPristine();
-                    $scope.csvForm.$setUntouched();
                 }
             }
         });

--- a/modules/portal/public/lib/batch-change/batch-change.directive.js
+++ b/modules/portal/public/lib/batch-change/batch-change.directive.js
@@ -72,30 +72,18 @@
         };
     });
 
-    app.directive('filled', function() {
+    app.directive('batchChangeFile', function() {
         return {
             require: 'ngModel',
             link: function(scope, elm, attrs, ctrl) {
+                console.log(elm)
                 elm.on('change', function(e){
                     if (e.target.files.length > 0) {
-                        fileType = e.target.files[0].type;
                         ctrl.$setViewValue(e.target.files[0]);
-                        ctrl.$setValidity('filled', true);
                     } else {
                         ctrl.$setViewValue();
-                        ctrl.$setValidity('filled', false);
                     }
                 })
-            }
-        };
-    });
-
-    app.directive('isolateForm', function() {
-        return {
-            restrict: 'A',
-            require: ['form', '^form'],
-            link: function(scope, elm, attrs, forms) {
-                forms[1].$removeControl(forms[0]);
             }
         };
     });

--- a/modules/portal/public/lib/batch-change/batch-change.directive.js
+++ b/modules/portal/public/lib/batch-change/batch-change.directive.js
@@ -72,34 +72,17 @@
         };
     });
 
-    app.directive('csv', function() {
-        return {
-            require: 'ngModel',
-            link: function(scope, elm, attrs, ctrl) {
-                var fileType;
-                ctrl.$validators.csv = function(modelValue, viewValue) {
-                    elm.on('change', function(e){
-                        if (e.target.files.length > 0) {
-                            fileType = e.target.files[0].type;
-                            ctrl.$setViewValue(e.target.files[0]);
-                        } else {
-                            ctrl.$setViewValue();
-                        }
-                    })
-                    return fileType == "text/csv" ? true : false
-                }
-            }
-        };
-    });
-
     app.directive('filled', function() {
         return {
             require: 'ngModel',
             link: function(scope, elm, attrs, ctrl) {
                 elm.on('change', function(e){
                     if (e.target.files.length > 0) {
+                        fileType = e.target.files[0].type;
+                        ctrl.$setViewValue(e.target.files[0]);
                         ctrl.$setValidity('filled', true);
                     } else {
+                        ctrl.$setViewValue();
                         ctrl.$setValidity('filled', false);
                     }
                 })

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -131,8 +131,8 @@ describe('BatchChange', function(){
                 var formInput = $('<ng-form name="createBatchChangeForm">'+
                   '<input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" batch-change-file>' +
                   '</ng-form>');
-                $(document.body).append(form);
-                $compile(form)(this.scope);
+                $(document.body).append(formInput);
+                $compile(formInput)(this.scope);
                 this.scope.$digest();
             }));
 
@@ -184,14 +184,15 @@ describe('BatchChange', function(){
                 }, 1000);
             })
 
-            it('does not include the first line', function(done) {
+            it('fails if the first line is not the header row', function(done) {
                 var fileBlob = new Blob(["Delete,A+PTR,test.example.,,1.1.1.1\nAdd,A+PTR,test.add.,200,1.1.1.1"], { type: 'text/csv' });
                 var batchChange = this.scope.newBatch;
                 this.scope.uploadCSV(fileBlob);
+                var alerts = this.scope.alerts;
 
                 setTimeout(function() {
                     expect(batchChange.changes.length).toEqual(1)
-                    expect(batchChange).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", inputName: "test.add.", ttl: 200, record: {address: "1.1.1.1"}}]});
+                    expect(batchChange).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}]});
                     done();
                 }, 1000);
             })
@@ -209,11 +210,10 @@ describe('BatchChange', function(){
             })
 
             it('does not import non-CSV format files', function() {
-               var newFile = {name: 'a.pdf', type: 'any'}
+               var newFile = new Blob([], {type: 'any'});
                this.scope.uploadCSV(newFile);
 
                expect(this.scope.newBatch).toEqual({comments: "", changes: [{changeType: "Add", type: "A+PTR", ttl: 200}]});
-               expect(this.scope.alerts).toEqual([{ type: 'danger', content: 'Import failed. Not a valid CSV file.'}]);
             });
         });
 

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -128,8 +128,8 @@ describe('BatchChange', function(){
 
         describe('$scope.uploadCSV', function() {
             beforeEach(inject(function($compile) {
-                var form = $('<ng-form name="csvForm" isolate-form>'+
-                  '<input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" filled csv>' +
+                var formInput = $('<ng-form name="createBatchChangeForm">'+
+                  '<input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" batch-change-file>' +
                   '</ng-form>');
                 $(document.body).append(form);
                 $compile(form)(this.scope);
@@ -429,114 +429,6 @@ describe('BatchChange', function(){
             this.scope.$digest();
             expect(this.scope.change.address).toBeUndefined();
             expect(form.address.$valid).toBe(false);
-        });
-    });
-
-    describe('Directive: csv validation', function(){
-        var form, scope, elm;
-        beforeEach(inject(function($compile, $rootScope) {
-            this.rootScope = $rootScope;
-            scope = $rootScope.$new();
-            elm = angular.element(
-                '<form name="form">' +
-                    '<input type="file" ng-model="batchChangeCsv" name="csvInput" csv />' +
-                '</form>'
-            );
-            $compile(elm)(scope);
-            form = scope.form;
-        }));
-
-        it('succeeds when given file is a CSV type', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: [{name: 'CSV', type: 'text/csv'}]}});
-            expect(form.csvInput.$valid).toBe(true);
-        });
-
-        it('fails when given file is not a CSV type', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: [{name: 'plain', type: 'text/plain'}]}});
-            expect(form.csvInput.$valid).toBe(false);
-        });
-
-        it('fails when no file is given', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: []}});
-            expect(form.csvInput.$valid).toBe(false);
-        });
-
-        it('sets the view value to the file', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: [{name: 'CSV', type: 'text/csv'}]}});
-            expect(form.csvInput.$viewValue).toEqual({name: 'CSV', type: 'text/csv'});
-        });
-
-        it('sets the view value to the given file regardless of file type', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: [{name: 'a.pdf', type: 'text/pdf'}]}});
-            expect(form.csvInput.$viewValue).toEqual({name: 'a.pdf', type: 'text/pdf'});
-        });
-
-        it('sets the view value to undefined when no file is given', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: []}});
-            expect(form.csvInput.$viewValue).toEqual(undefined);
-        });
-    });
-
-    describe('Directive: filled validation', function(){
-        var form, scope, elm;
-        beforeEach(inject(function($compile, $rootScope) {
-            this.rootScope = $rootScope;
-            scope = $rootScope.$new();
-            elm = angular.element(
-                '<form name="form">' +
-                    '<input type="file" ng-model="batchChangeCsv" name="csvInput" filled />' +
-                '</form>'
-            );
-            $compile(elm)(scope);
-            form = scope.form;
-        }));
-
-        it('passes when a file is given', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: [{name: 'a.pdf', type: 'any'}]}});
-            expect(form.csvInput.$valid).toBe(true);
-        });
-
-        it('fails when no file is given', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: []}});
-            expect(form.csvInput.$valid).toBe(false);
-        });
-    });
-
-    describe('Directive: form isolation', function(){
-        var form, scope, elm;
-        beforeEach(inject(function($compile, $rootScope) {
-            this.rootScope = $rootScope;
-            scope = $rootScope.$new();
-            elm = angular.element(
-                '<form name="form">' +
-                    '<ng-form name="csvForm" isolate-form>' +
-                        '<input type="file" ng-model="batchChangeCsv" name="csvInput" filled />' +
-                    '</ng-form>' +
-                '</form>'
-            );
-            $compile(elm)(scope);
-            form = scope.form;
-            csvForm = scope.csvForm;
-        }));
-
-        it('does validate the nested form', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: []}});
-            expect(csvForm.$valid).toBe(false);
-        });
-
-        it('does not validate the parent form', function(){
-            scope.$digest();
-            elm.find('input').triggerHandler({type: 'change', target: {files: []}});
-            expect(form.$valid).toBe(true);
         });
     });
 });


### PR DESCRIPTION
I was relying on the checking the file content type to determine if an uploaded file was a CSV. Unfortunately "text/csv" is not the only content type that the file could be, there are many types so the check isn't reliable. 
This stackoverflow illustrates some of the options and issues people have come across https://stackoverflow.com/questions/7076042/what-mime-type-should-i-use-for-csv.

Instead changing it to reading the first line of the file and failing if it's not the header row we're expecting.

Also now there is only an import button and when the file is selected we immediately attempt to parse it. Either indicating the number of changes successfully imported or that the file was invalid.