### PR TITLE
disable multi record batch update

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -451,6 +451,41 @@ def test_create_batch_change_without_comments_succeeds(shared_zone_test_context)
     finally:
         clear_zoneid_rsid_tuple_list(to_delete, client)
 
+
+def test_update_multi_record_record_set_fails(shared_zone_test_context):
+    """
+    Test that a [delete + add] style update of an existing RecordSet with multiple records fails
+    """
+    client = shared_zone_test_context.dummy_vinyldns_client
+    zone = shared_zone_test_context.dummy_zone
+
+    # existing
+    rs_existing = get_recordset_json(zone, "update", "A", [{"address": "2.2.2.2"}, {"address": "3.3.3.3"}])
+
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("update.dummy.", record_type="A", ttl=300, address="1.1.1.1"),
+            get_change_A_AAAA_json("update.dummy.", record_type="A", change_type="DeleteRecordSet")
+        ]
+    }
+
+    to_delete = None
+
+    try:
+        create_rs = client.create_recordset(rs_existing, status=202)
+        to_delete = create_rs['recordSet']
+        client.wait_until_recordset_change_status(create_rs, 'Complete')
+
+        response = client.create_batch_change(batch_change_input, status=400)
+
+        assert_error(response[0], error_messages=['RecordSet with name update and type A cannot be updated in a single Batch Change because it contains multiple DNS records (2). If this is expected, issue a DeleteRecordSet only, and add the record in a new Batch Change.'])
+
+    finally:
+        if to_delete:
+            delete_change = client.delete_recordset(to_delete['zoneId'], to_delete['id'], status=202)
+            client.wait_until_recordset_change_status(delete_change, 'Complete')
+
+
 def test_create_batch_change_with_owner_group_id_succeeds(shared_zone_test_context):
     """
     Test successfully creating a batch change with owner group ID specified

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -128,4 +128,6 @@ object VinylDNSConfig {
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
   lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]](s"default-ttl").getOrElse(7200L)
+  lazy val multiRecordBatchUpdateEnabled: Boolean =
+    vinyldnsConfig.as[Option[Boolean]]("enable-multi-record-batch-update").getOrElse(false)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain
 
 import vinyldns.api.domain.batch.SupportedBatchChangeRecordTypes
-import vinyldns.core.domain.record.RecordType
+import vinyldns.core.domain.record.{RecordSet, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
 
 // $COVERAGE-OFF$
@@ -148,5 +148,13 @@ final case class MissingOwnerGroupId(recordName: String, zoneName: String)
     extends DomainValidationError {
   def message: String =
     s"""Zone "$zoneName" is a shared zone, so owner group ID must be specified for record "$recordName"."""
+}
+
+final case class MultipleRecordsInRecordSet(record: RecordSet) extends DomainValidationError {
+  def message: String =
+    s"""RecordSet with name ${record.name} and type ${record.typ.toString} cannot be updated in a single Batch Change
+       |because it contains multiple DNS records (${record.records.length}). If this is expected, issue a
+       |DeleteRecordSet only, and add the record in a new Batch Change.""".stripMargin
+      .replaceAll("\n", " ")
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -205,7 +205,8 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
             ownerGroupProvidedIfNeeded(
               change,
               existingRecordSets.get(change.zone.id, change.recordName, change.inputChange.typ),
-              batchOwnerGroupId)
+              batchOwnerGroupId) |+|
+            isNotMultiRecordUpdate(rs)
         case None => RecordDoesNotExist(change.inputChange.inputName).invalidNel
       }
 
@@ -415,4 +416,9 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
           MissingOwnerGroupId(change.recordName, change.zone.name).invalidNel
       }
     }
+
+  def isNotMultiRecordUpdate(recordBeingUpdated: RecordSet): SingleValidation[Unit] =
+    if (recordBeingUpdated.records.length > 1 && !VinylDNSConfig.multiRecordBatchUpdateEnabled)
+      MultipleRecordsInRecordSet(recordBeingUpdated).invalidNel
+    else ().validNel
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1493,4 +1493,18 @@ class BatchChangeValidationsSpec
 
     result(0) shouldBe valid
   }
+
+  property("validateChangesWithContext: fail for an update to a multi record RecordSet") {
+    val existing = sharedZoneRecord.copy(
+      name = updateSharedAddChange.recordName,
+      records = List(AAAAData("1::1"), AAAAData("2::2")))
+
+    val result = validateChangesWithContext(
+      List(updateSharedAddChange.validNel, updateSharedDeleteChange.validNel),
+      ExistingRecordSets(List(existing)),
+      sharedAuth,
+      Some(okGroup.id))
+
+    result(0) should haveInvalid[DomainValidationError](MultipleRecordsInRecordSet(existing))
+  }
 }


### PR DESCRIPTION
There can be multiple records in a RecordSet. Adds a check to block updates of these records via the batch change interface. Can be disabled via config