### PR TITLE
Config disabling of multirecord batch updates

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -79,10 +79,8 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
         "comments": "this is optional",
         "changes": [
             get_change_A_AAAA_json("parent.com.", address="4.5.6.7"),
-            get_change_A_AAAA_json("parent.com", address="4.5.6.7"),
             get_change_A_AAAA_json("ok.", record_type="AAAA", address="fd69:27cc:fe91::60"),
             get_change_A_AAAA_json("relative.parent.com.", address="1.1.1.1"),
-            get_change_A_AAAA_json("relative.parent.com", address="2.2.2.2"),
             get_change_CNAME_json("cname.parent.com", cname="nice.parent.com"),
             get_change_CNAME_json("2cname.parent.com", cname="nice.parent.com"),
             get_change_CNAME_json("4.2.0.192.in-addr.arpa.", cname="4.4/30.2.0.192.in-addr.arpa."),
@@ -94,7 +92,6 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
             get_change_TXT_json("txt-unique-characters.ok.", text='a\\\\`=` =\\"Cat\\"\nattr=val'),
             get_change_TXT_json("txt.2.0.192.in-addr.arpa."),
             get_change_MX_json("mx.ok.", preference=0),
-            get_change_MX_json("mx.ok.", preference=65535),
             get_change_MX_json("ok.", preference=1000, exchange="bar.foo.")
         ]
     }
@@ -115,39 +112,33 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
 
         assert_change_success_response_values(result['changes'], zone=parent_zone, index=0, record_name="parent.com.",
                                               input_name="parent.com.", record_data="4.5.6.7")
-        assert_change_success_response_values(result['changes'], zone=parent_zone, index=1, record_name="parent.com.",
-                                              input_name="parent.com.", record_data="4.5.6.7")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=2, record_name="ok.",
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, record_name="ok.",
                                               input_name="ok.", record_data="fd69:27cc:fe91::60", record_type="AAAA")
-        assert_change_success_response_values(result['changes'], zone=parent_zone, index=3, record_name="relative",
+        assert_change_success_response_values(result['changes'], zone=parent_zone, index=2, record_name="relative",
                                               input_name="relative.parent.com.", record_data="1.1.1.1")
-        assert_change_success_response_values(result['changes'], zone=parent_zone, index=4, record_name="relative",
-                                              input_name="relative.parent.com.", record_data="2.2.2.2"),
-        assert_change_success_response_values(result['changes'], zone=parent_zone, index=5, record_name="cname",
+        assert_change_success_response_values(result['changes'], zone=parent_zone, index=3, record_name="cname",
                                               input_name="cname.parent.com.", record_data="nice.parent.com.", record_type="CNAME")
-        assert_change_success_response_values(result['changes'], zone=parent_zone, index=6, record_name="2cname",
+        assert_change_success_response_values(result['changes'], zone=parent_zone, index=4, record_name="2cname",
                                               input_name="2cname.parent.com.", record_data="nice.parent.com.", record_type="CNAME")
-        assert_change_success_response_values(result['changes'], zone=classless_base_zone, index=7, record_name="4",
+        assert_change_success_response_values(result['changes'], zone=classless_base_zone, index=5, record_name="4",
                                               input_name="4.2.0.192.in-addr.arpa.", record_data="4.4/30.2.0.192.in-addr.arpa.", record_type="CNAME")
-        assert_change_success_response_values(result['changes'], zone=classless_delegation_zone, index=8, record_name="193",
+        assert_change_success_response_values(result['changes'], zone=classless_delegation_zone, index=6, record_name="193",
                                               input_name="192.0.2.193", record_data="www.vinyldns.", record_type="PTR")
-        assert_change_success_response_values(result['changes'], zone=classless_base_zone, index=9, record_name="44",
+        assert_change_success_response_values(result['changes'], zone=classless_base_zone, index=7, record_name="44",
                                               input_name="192.0.2.44", record_data="test.com.", record_type="PTR")
-        assert_change_success_response_values(result['changes'], zone=ip6_reverse_zone, index=10, record_name="0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
+        assert_change_success_response_values(result['changes'], zone=ip6_reverse_zone, index=8, record_name="0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
                                               input_name="fd69:27cc:fe91::60", record_data="www.vinyldns.", record_type="PTR")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, record_name="txt",
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=9, record_name="txt",
                                               input_name="txt.ok.", record_data="test", record_type="TXT")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=12, record_name="ok.",
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=10, record_name="ok.",
                                               input_name="ok.", record_data="test", record_type="TXT")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, record_name="txt-unique-characters",
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, record_name="txt-unique-characters",
                                               input_name="txt-unique-characters.ok.", record_data='a\\\\`=` =\\"Cat\\"\nattr=val', record_type="TXT")
-        assert_change_success_response_values(result['changes'], zone=classless_base_zone, index=14, record_name="txt",
+        assert_change_success_response_values(result['changes'], zone=classless_base_zone, index=12, record_name="txt",
                                               input_name="txt.2.0.192.in-addr.arpa.", record_data="test", record_type="TXT")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=15, record_name="mx",
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, record_name="mx",
                                               input_name="mx.ok.", record_data={'preference': 0, 'exchange': 'foo.bar.'}, record_type="MX")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=16, record_name="mx",
-                                              input_name="mx.ok.", record_data={'preference': 65535, 'exchange': 'foo.bar.'}, record_type="MX")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=17, record_name="ok.",
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=14, record_name="ok.",
                                               input_name="ok.", record_data={'preference': 1000, 'exchange': 'bar.foo.'}, record_type="MX")
 
         completed_status = [change['status'] == 'Complete' for change in completed_batch['changes']]
@@ -162,10 +153,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                     'records': [{'address': '4.5.6.7'}]}
         verify_recordset(rs1, expected1)
 
-        rs2 = client.get_recordset(record_set_list[1][0], record_set_list[1][1])['recordSet']
-        assert_that(rs2, is_(rs1)) # duplicate entry, should get same thing
-
-        rs3 = client.get_recordset(record_set_list[2][0], record_set_list[2][1])['recordSet']
+        rs3 = client.get_recordset(record_set_list[1][0], record_set_list[1][1])['recordSet']
         expected3 = {'name': 'ok.',
                      'zoneId': ok_zone['id'],
                      'type': 'AAAA',
@@ -173,15 +161,15 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'address': 'fd69:27cc:fe91::60'}]}
         verify_recordset(rs3, expected3)
 
-        rs4 = client.get_recordset(record_set_list[3][0], record_set_list[3][1])['recordSet']
+        rs4 = client.get_recordset(record_set_list[2][0], record_set_list[2][1])['recordSet']
         expected4 = {'name': 'relative',
                      'zoneId': parent_zone['id'],
                      'type': 'A',
                      'ttl': 200,
-                     'records': [{'address': '1.1.1.1'}, {'address': '2.2.2.2'}]}
+                     'records': [{'address': '1.1.1.1'}]}
         verify_recordset(rs4, expected4)
 
-        rs5 = client.get_recordset(record_set_list[5][0], record_set_list[5][1])['recordSet']
+        rs5 = client.get_recordset(record_set_list[3][0], record_set_list[3][1])['recordSet']
         expected5 = {'name': 'cname',
                      'zoneId': parent_zone['id'],
                      'type': 'CNAME',
@@ -189,7 +177,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'cname': 'nice.parent.com.'}]}
         verify_recordset(rs5, expected5)
 
-        rs6 = client.get_recordset(record_set_list[6][0], record_set_list[6][1])['recordSet']
+        rs6 = client.get_recordset(record_set_list[4][0], record_set_list[4][1])['recordSet']
         expected6 = {'name': '2cname',
                      'zoneId': parent_zone['id'],
                      'type': 'CNAME',
@@ -197,7 +185,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'cname': 'nice.parent.com.'}]}
         verify_recordset(rs6, expected6)
 
-        rs7 = client.get_recordset(record_set_list[7][0], record_set_list[7][1])['recordSet']
+        rs7 = client.get_recordset(record_set_list[5][0], record_set_list[5][1])['recordSet']
         expected7 = {'name': '4',
                      'zoneId': classless_base_zone['id'],
                      'type': 'CNAME',
@@ -205,7 +193,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'cname': '4.4/30.2.0.192.in-addr.arpa.'}]}
         verify_recordset(rs7, expected7)
 
-        rs8 = client.get_recordset(record_set_list[8][0], record_set_list[8][1])['recordSet']
+        rs8 = client.get_recordset(record_set_list[6][0], record_set_list[6][1])['recordSet']
         expected8 = {'name': '193',
                      'zoneId': classless_delegation_zone['id'],
                      'type': 'PTR',
@@ -213,7 +201,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'ptrdname': 'www.vinyldns.'}]}
         verify_recordset(rs8, expected8)
 
-        rs9 = client.get_recordset(record_set_list[9][0], record_set_list[9][1])['recordSet']
+        rs9 = client.get_recordset(record_set_list[7][0], record_set_list[7][1])['recordSet']
         expected9 = {'name': '44',
                      'zoneId': classless_base_zone['id'],
                      'type': 'PTR',
@@ -221,7 +209,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'ptrdname': 'test.com.'}]}
         verify_recordset(rs9, expected9)
 
-        rs10 = client.get_recordset(record_set_list[10][0], record_set_list[10][1])['recordSet']
+        rs10 = client.get_recordset(record_set_list[8][0], record_set_list[8][1])['recordSet']
         expected10 = {'name': '0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0',
                      'zoneId': ip6_reverse_zone['id'],
                      'type': 'PTR',
@@ -229,7 +217,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                      'records': [{'ptrdname': 'www.vinyldns.'}]}
         verify_recordset(rs10, expected10)
 
-        rs11 = client.get_recordset(record_set_list[11][0], record_set_list[11][1])['recordSet']
+        rs11 = client.get_recordset(record_set_list[9][0], record_set_list[9][1])['recordSet']
         expected11 = {'name': 'txt',
                       'zoneId': ok_zone['id'],
                       'type': 'TXT',
@@ -237,7 +225,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                       'records': [{'text': 'test'}]}
         verify_recordset(rs11, expected11)
 
-        rs12 = client.get_recordset(record_set_list[12][0], record_set_list[12][1])['recordSet']
+        rs12 = client.get_recordset(record_set_list[10][0], record_set_list[10][1])['recordSet']
         expected12 = {'name': 'ok.',
                       'zoneId': ok_zone['id'],
                       'type': 'TXT',
@@ -245,7 +233,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                       'records': [{'text': 'test'}]}
         verify_recordset(rs12, expected12)
 
-        rs13 = client.get_recordset(record_set_list[13][0], record_set_list[13][1])['recordSet']
+        rs13 = client.get_recordset(record_set_list[11][0], record_set_list[11][1])['recordSet']
         expected13 = {'name': 'txt-unique-characters',
                       'zoneId': ok_zone['id'],
                       'type': 'TXT',
@@ -253,7 +241,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                       'records': [{'text': 'a\\\\`=` =\\"Cat\\"\nattr=val'}]}
         verify_recordset(rs13, expected13)
 
-        rs14 = client.get_recordset(record_set_list[14][0], record_set_list[14][1])['recordSet']
+        rs14 = client.get_recordset(record_set_list[12][0], record_set_list[12][1])['recordSet']
         expected14 = {'name': 'txt',
                       'zoneId': classless_base_zone['id'],
                       'type': 'TXT',
@@ -261,15 +249,15 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
                       'records': [{'text': 'test'}]}
         verify_recordset(rs14, expected14)
 
-        rs15 = client.get_recordset(record_set_list[15][0], record_set_list[15][1])['recordSet']
+        rs15 = client.get_recordset(record_set_list[13][0], record_set_list[13][1])['recordSet']
         expected15 = {'name': 'mx',
                       'zoneId': ok_zone['id'],
                       'type': 'MX',
                       'ttl': 200,
-                      'records': [{'preference': 0, 'exchange': 'foo.bar.'}, {'preference': 65535, 'exchange': 'foo.bar.'}]}
+                      'records': [{'preference': 0, 'exchange': 'foo.bar.'}]}
         verify_recordset(rs15, expected15)
 
-        rs16 = client.get_recordset(record_set_list[17][0], record_set_list[17][1])['recordSet']
+        rs16 = client.get_recordset(record_set_list[14][0], record_set_list[14][1])['recordSet']
         expected16 = {'name': 'ok.',
                       'zoneId': ok_zone['id'],
                       'type': 'MX',

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2920,7 +2920,7 @@ def test_create_batch_duplicates_add_check(shared_zone_test_context):
     response = client.create_batch_change(batch_change_input, status=400)
     def err(name, type):
         return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-               'There are duplicate changes with name {} and type {} in this batch.'.format(name, type)
+               'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name, type)
 
     assert_error(response[0], error_messages=[err("multi.ok.", "A")])
     assert_error(response[1], error_messages=[err("multi.ok.", "A")])
@@ -2978,7 +2978,7 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
                    'Batch Change because it contains multiple DNS records (2).'
         def new_err(name, type):
             return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-               'There are duplicate changes with name {} and type {} in this batch.'.format(name, type)
+               'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name, type)
 
         assert_error(response[0], error_messages=[existing_err("multi.ok.", "A")])
         assert_error(response[1], error_messages=[existing_err("multi.ok.", "A"), new_err("multi.ok.", "A")])

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1110,8 +1110,6 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
         "changes": [
             # valid changes
             get_change_A_AAAA_json("good-record.parent.com.", address="1.2.3.4"),
-            get_change_A_AAAA_json("summed-record.parent.com.", address="1.2.3.4"),
-            get_change_A_AAAA_json("summed-record.parent.com.", address="5.6.7.8"),
 
             # input validation failures
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, address="1.2.3.4"),
@@ -1141,34 +1139,32 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
 
         # successful changes
         assert_successful_change_in_error_response(response[0], input_name="good-record.parent.com.", record_data="1.2.3.4")
-        assert_successful_change_in_error_response(response[1], input_name="summed-record.parent.com.", record_data="1.2.3.4")
-        assert_successful_change_in_error_response(response[2], input_name="summed-record.parent.com.", record_data="5.6.7.8")
 
         # ttl, domain name, reverse zone input validations
-        assert_failed_change_in_error_response(response[3], input_name="bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[1], input_name="bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_data="1.2.3.4",
                                             error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                             'Invalid domain name: "bad-ttl-and-invalid-name$.parent.com.", '
                                                             'valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[4], input_name="reverse-zone.10.10.in-addr.arpa.", record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[2], input_name="reverse-zone.10.10.in-addr.arpa.", record_data="1.2.3.4",
                                             error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse-zone.10.10.in-addr.arpa.\" and type \"A\" is not allowed in a reverse zone."])
 
         # zone discovery failures
-        assert_failed_change_in_error_response(response[5], input_name="no.subzone.parent.com.", record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_data="1.2.3.4",
                                             error_messages=['Zone Discovery Failed: zone for "no.subzone.parent.com." does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS.'])
-        assert_failed_change_in_error_response(response[6], input_name="no.zone.at.all.", record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_data="1.2.3.4",
                                             error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS.'])
 
         # context validations: duplicate name failure is always on the cname
-        assert_failed_change_in_error_response(response[7], input_name="cname-duplicate.parent.com.", record_type="CNAME", record_data="test.com.",
+        assert_failed_change_in_error_response(response[5], input_name="cname-duplicate.parent.com.", record_type="CNAME", record_data="test.com.",
                                                error_messages=["Record Name \"cname-duplicate.parent.com.\" Not Unique In Batch Change: cannot have multiple \"CNAME\" records with the same name."])
-        assert_successful_change_in_error_response(response[8], input_name="cname-duplicate.parent.com.", record_data="1.2.3.4")
+        assert_successful_change_in_error_response(response[6], input_name="cname-duplicate.parent.com.", record_data="1.2.3.4")
 
         # context validations: conflicting recordsets, unauthorized error
-        assert_failed_change_in_error_response(response[9], input_name="existing-a.parent.com.", record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[7], input_name="existing-a.parent.com.", record_data="1.2.3.4",
                                             error_messages=["Record \"existing-a.parent.com.\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
-        assert_failed_change_in_error_response(response[10], input_name="existing-cname.parent.com.", record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[8], input_name="existing-cname.parent.com.", record_data="1.2.3.4",
                                             error_messages=["CNAME Conflict: CNAME record names must be unique. Existing record with name \"existing-cname.parent.com.\" and type \"CNAME\" conflicts with this record."])
-        assert_failed_change_in_error_response(response[11], input_name="user-add-unauthorized.dummy.", record_data="1.2.3.4",
+        assert_failed_change_in_error_response(response[9], input_name="user-add-unauthorized.dummy.", record_data="1.2.3.4",
                                             error_messages=["User \"ok\" is not authorized."])
 
     finally:
@@ -1288,8 +1284,6 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
         "changes": [
             # valid changes
             get_change_A_AAAA_json("good-record.parent.com.", record_type="AAAA", address="1::1"),
-            get_change_A_AAAA_json("summed-record.parent.com.", record_type="AAAA", address="1::1"),
-            get_change_A_AAAA_json("summed-record.parent.com.", record_type="AAAA", address="1::2"),
 
             # input validation failures
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_type="AAAA", address="1::1"),
@@ -1319,32 +1313,30 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
 
         # successful changes
         assert_successful_change_in_error_response(response[0], input_name="good-record.parent.com.", record_type="AAAA", record_data="1::1")
-        assert_successful_change_in_error_response(response[1], input_name="summed-record.parent.com.", record_type="AAAA", record_data="1::1")
-        assert_successful_change_in_error_response(response[2], input_name="summed-record.parent.com.", record_type="AAAA", record_data="1::2")
 
         # ttl, domain name, reverse zone input validations
-        assert_failed_change_in_error_response(response[3], input_name="bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_type="AAAA", record_data="1::1",
+        assert_failed_change_in_error_response(response[1], input_name="bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_type="AAAA", record_data="1::1",
                                             error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                             'Invalid domain name: "bad-ttl-and-invalid-name$.parent.com.", '
                                                             'valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[4], input_name="reverse-zone.1.2.3.ip6.arpa.", record_type="AAAA", record_data="1::1",
+        assert_failed_change_in_error_response(response[2], input_name="reverse-zone.1.2.3.ip6.arpa.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse-zone.1.2.3.ip6.arpa.\" and type \"AAAA\" is not allowed in a reverse zone."])
 
         # zone discovery failures
-        assert_failed_change_in_error_response(response[5], input_name="no.subzone.parent.com.", record_type="AAAA", record_data="1::1",
+        assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Zone Discovery Failed: zone for \"no.subzone.parent.com.\" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS."])
-        assert_failed_change_in_error_response(response[6], input_name="no.zone.at.all.", record_type="AAAA", record_data="1::1",
+        assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Zone Discovery Failed: zone for \"no.zone.at.all.\" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS."])
 
         # context validations: duplicate name failure (always on the cname), conflicting recordsets, unauthorized error
-        assert_failed_change_in_error_response(response[7], input_name="cname-duplicate.parent.com.", record_type="CNAME", record_data="test.com.",
+        assert_failed_change_in_error_response(response[5], input_name="cname-duplicate.parent.com.", record_type="CNAME", record_data="test.com.",
                                                error_messages=["Record Name \"cname-duplicate.parent.com.\" Not Unique In Batch Change: cannot have multiple \"CNAME\" records with the same name."])
-        assert_successful_change_in_error_response(response[8], input_name="cname-duplicate.parent.com.", record_type="AAAA", record_data="1::1")
-        assert_failed_change_in_error_response(response[9], input_name="existing-aaaa.parent.com.", record_type="AAAA", record_data="1::1",
+        assert_successful_change_in_error_response(response[6], input_name="cname-duplicate.parent.com.", record_type="AAAA", record_data="1::1")
+        assert_failed_change_in_error_response(response[7], input_name="existing-aaaa.parent.com.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Record \"existing-aaaa.parent.com.\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
-        assert_failed_change_in_error_response(response[10], input_name="existing-cname.parent.com.", record_type="AAAA", record_data="1::1",
+        assert_failed_change_in_error_response(response[8], input_name="existing-cname.parent.com.", record_type="AAAA", record_data="1::1",
                                             error_messages=["CNAME Conflict: CNAME record names must be unique. Existing record with name \"existing-cname.parent.com.\" and type \"CNAME\" conflicts with this record."])
-        assert_failed_change_in_error_response(response[11], input_name="user-add-unauthorized.dummy.", record_type="AAAA", record_data="1::1",
+        assert_failed_change_in_error_response(response[9], input_name="user-add-unauthorized.dummy.", record_type="AAAA", record_data="1::1",
                                             error_messages=["User \"ok\" is not authorized."])
 
     finally:
@@ -1738,8 +1730,6 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
             # valid change
             get_change_PTR_json("192.0.2.44", ptrdname="base.vinyldns"),
             get_change_PTR_json("192.0.2.198", ptrdname="delegated.vinyldns"),
-            get_change_PTR_json("192.0.2.197"),
-            get_change_PTR_json("192.0.2.197", ptrdname="ptrdata."),
 
             # input validation failures
             get_change_PTR_json("invalidip.111."),
@@ -1776,37 +1766,32 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[0], input_name="192.0.2.44", record_type="PTR", record_data="base.vinyldns.")
         assert_successful_change_in_error_response(response[1], input_name="192.0.2.198", record_type="PTR", record_data="delegated.vinyldns.")
 
-
-        # duplicate names succeed for ptr
-        assert_successful_change_in_error_response(response[2], input_name="192.0.2.197", record_type="PTR", record_data="test.com.")
-        assert_successful_change_in_error_response(response[3], input_name="192.0.2.197", record_type="PTR", record_data="ptrdata.")
-
         # input validation failures: invalid ip, ttl, data
-        assert_failed_change_in_error_response(response[4], input_name="invalidip.111.", record_type="PTR", record_data="test.com.",
+        assert_failed_change_in_error_response(response[2], input_name="invalidip.111.", record_type="PTR", record_data="test.com.",
                                                error_messages=['Invalid IP address: "invalidip.111.".'])
-        assert_failed_change_in_error_response(response[5], input_name="4.5.6.7", ttl=29, record_type="PTR", record_data="-1.2.3.4.",
+        assert_failed_change_in_error_response(response[3], input_name="4.5.6.7", ttl=29, record_type="PTR", record_data="-1.2.3.4.",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                                'Invalid domain name: "-1.2.3.4.", '
                                                                'valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
 
         # delegated and non-delegated PTR duplicate name checks
-        assert_successful_change_in_error_response(response[6], input_name="192.0.2.196", record_type="PTR", record_data="test.com.")
-        assert_successful_change_in_error_response(response[7], input_name="196.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.")
-        assert_failed_change_in_error_response(response[8], input_name="196.192/30.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.",
+        assert_successful_change_in_error_response(response[4], input_name="192.0.2.196", record_type="PTR", record_data="test.com.")
+        assert_successful_change_in_error_response(response[5], input_name="196.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.")
+        assert_failed_change_in_error_response(response[6], input_name="196.192/30.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.",
                                                error_messages=['Record Name "196.192/30.2.0.192.in-addr.arpa." Not Unique In Batch Change: cannot have multiple "CNAME" records with the same name.'])
-        assert_successful_change_in_error_response(response[9], input_name="192.0.2.55", record_type="PTR", record_data="test.com.")
-        assert_failed_change_in_error_response(response[10], input_name="55.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.",
+        assert_successful_change_in_error_response(response[7], input_name="192.0.2.55", record_type="PTR", record_data="test.com.")
+        assert_failed_change_in_error_response(response[8], input_name="55.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.",
                                                error_messages=['Record Name "55.2.0.192.in-addr.arpa." Not Unique In Batch Change: cannot have multiple "CNAME" records with the same name.'])
-        assert_successful_change_in_error_response(response[11], input_name="55.192/30.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.")
+        assert_successful_change_in_error_response(response[9], input_name="55.192/30.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="test.com.")
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[12], input_name="192.0.1.192", record_type="PTR", record_data="test.com.",
+        assert_failed_change_in_error_response(response[10], input_name="192.0.1.192", record_type="PTR", record_data="test.com.",
                                                error_messages=['Zone Discovery Failed: zone for "192.0.1.192" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS.'])
 
         # context validations: existing cname recordset
-        assert_failed_change_in_error_response(response[13], input_name="192.0.2.193", record_type="PTR", record_data="existing-ptr.",
+        assert_failed_change_in_error_response(response[11], input_name="192.0.2.193", record_type="PTR", record_data="existing-ptr.",
                                                error_messages=['Record "192.0.2.193" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add.'])
-        assert_failed_change_in_error_response(response[14], input_name="192.0.2.199", record_type="PTR", record_data="existing-cname.",
+        assert_failed_change_in_error_response(response[12], input_name="192.0.2.199", record_type="PTR", record_data="existing-cname.",
                                                error_messages=['CNAME Conflict: CNAME record names must be unique. Existing record with name "192.0.2.199" and type "CNAME" conflicts with this record.'])
 
     finally:
@@ -1853,7 +1838,6 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
     rs_replace_cname = get_recordset_json(base_zone, "21", "CNAME", [{"cname": "replace.cname."}], 200)
     rs_replace_ptr = get_recordset_json(base_zone, "17", "PTR", [{"ptrdname": "replace.ptr."}], 200)
     rs_update_ipv4_fail = get_recordset_json(base_zone, "9", "PTR", [{"ptrdname": "failed-update.ptr."}], 200)
-    rs_update_ipv4_double_update = get_recordset_json(shared_zone_test_context.classless_base_zone, "50", "PTR", [{"ptrdname": "ptrdname.data."}])
 
     batch_change_input = {
         "comments": "this is optional",
@@ -1881,13 +1865,10 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_PTR_json("192.0.2.199", change_type="DeleteRecordSet"),
             get_change_PTR_json("192.0.2.200", ttl=300, ptrdname="has-updated.ptr."),
             get_change_PTR_json("192.0.2.200", change_type="DeleteRecordSet"),
-            get_change_PTR_json("192.0.2.50", change_type="DeleteRecordSet"),
-            get_change_PTR_json("192.0.2.50"),
-            get_change_PTR_json("192.0.2.50", ttl=350)
         ]
     }
 
-    to_create = [rs_delete_ipv4, rs_update_ipv4, rs_replace_cname, rs_replace_ptr, rs_update_ipv4_fail, rs_update_ipv4_double_update]
+    to_create = [rs_delete_ipv4, rs_update_ipv4, rs_replace_cname, rs_replace_ptr, rs_update_ipv4_fail]
     to_delete = []
 
     try:
@@ -1907,11 +1888,6 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[4], input_name="192.0.2.21", record_type="PTR", record_data="replace-cname.ptr.")
         assert_successful_change_in_error_response(response[5], input_name="17.2.0.192.in-addr.arpa.", record_type="CNAME", record_data="replace-ptr.cname.")
         assert_successful_change_in_error_response(response[6], input_name="192.0.2.17", record_type="PTR", record_data=None, change_type="DeleteRecordSet")
-
-        #successful changes: record input_name does not have to be unique
-        assert_successful_change_in_error_response(response[14], input_name="192.0.2.50", record_type="PTR", change_type="DeleteRecordSet")
-        assert_successful_change_in_error_response(response[15], input_name="192.0.2.50", record_type="PTR", record_data="test.com.")
-        assert_successful_change_in_error_response(response[16], input_name="192.0.2.50", record_type="PTR", record_data="test.com.", ttl=350)
 
         # input validations failures: invalid IP, ttl, and record data
         assert_failed_change_in_error_response(response[7], input_name="1.1.1", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
@@ -1951,8 +1927,6 @@ def test_ipv6_ptr_recordtype_add_checks(shared_zone_test_context):
         "changes": [
             # valid change
             get_change_PTR_json("fd69:27cc:fe91::1234"),
-            get_change_PTR_json("fd69:27cc:fe91::abc", ptrdname="duplicate.record1."),
-            get_change_PTR_json("fd69:27cc:fe91::abc", ptrdname="duplicate.record2."),
 
             # input validation failures
             get_change_PTR_json("fd69:27cc:fe91::abe", ttl=29),
@@ -1979,24 +1953,20 @@ def test_ipv6_ptr_recordtype_add_checks(shared_zone_test_context):
         # successful changes
         assert_successful_change_in_error_response(response[0], input_name="fd69:27cc:fe91::1234", record_type="PTR", record_data="test.com.")
 
-        # successful changes: input_name does not have to be unique
-        assert_successful_change_in_error_response(response[1], input_name="fd69:27cc:fe91::abc", record_type="PTR", record_data="duplicate.record1.")
-        assert_successful_change_in_error_response(response[2], input_name="fd69:27cc:fe91::abc", record_type="PTR", record_data="duplicate.record2.")
-
         # independent validations: bad TTL, malformed host name/IP address, duplicate record
-        assert_failed_change_in_error_response(response[3], input_name="fd69:27cc:fe91::abe", ttl=29, record_type="PTR", record_data="test.com.",
+        assert_failed_change_in_error_response(response[1], input_name="fd69:27cc:fe91::abe", ttl=29, record_type="PTR", record_data="test.com.",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.'])
-        assert_failed_change_in_error_response(response[4], input_name="fd69:27cc:fe91::bae", record_type="PTR", record_data="$malformed.hostname.",
+        assert_failed_change_in_error_response(response[2], input_name="fd69:27cc:fe91::bae", record_type="PTR", record_data="$malformed.hostname.",
                                                error_messages=['Invalid domain name: "$malformed.hostname.", valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[5], input_name="fd69:27cc:fe91de::ab", record_type="PTR", record_data="malformed.ip.address.",
+        assert_failed_change_in_error_response(response[3], input_name="fd69:27cc:fe91de::ab", record_type="PTR", record_data="malformed.ip.address.",
                                                error_messages=['Invalid IP address: "fd69:27cc:fe91de::ab".'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[6], input_name="fedc:ba98:7654::abc", record_type="PTR", record_data="zone.discovery.error.",
+        assert_failed_change_in_error_response(response[4], input_name="fedc:ba98:7654::abc", record_type="PTR", record_data="zone.discovery.error.",
                                                error_messages=["Zone Discovery Failed: zone for \"fedc:ba98:7654::abc\" does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS."])
 
         # context validations: existing record sets pre-request
-        assert_failed_change_in_error_response(response[7], input_name="fd69:27cc:fe91::aaaa", record_type="PTR", record_data="existing.ptr.",
+        assert_failed_change_in_error_response(response[5], input_name="fd69:27cc:fe91::aaaa", record_type="PTR", record_data="existing.ptr.",
                                                    error_messages=["Record \"fd69:27cc:fe91::aaaa\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
 
     finally:
@@ -2013,7 +1983,6 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
     rs_delete_ipv6 = get_recordset_json(ip6_reverse_zone, "a.a.a.a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR", [{"ptrdname": "delete.ptr."}], 200)
     rs_update_ipv6 = get_recordset_json(ip6_reverse_zone, "2.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR", [{"ptrdname": "update.ptr."}], 200)
     rs_update_ipv6_fail = get_recordset_json(ip6_reverse_zone, "8.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR", [{"ptrdname": "failed-update.ptr."}], 200)
-    rs_doubly_updated = get_recordset_json(shared_zone_test_context.ip6_reverse_zone, "2.2.1.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "PTR", [{"ptrdname": "test.com."}], 100)
 
     batch_change_input = {
         "comments": "this is optional",
@@ -2034,15 +2003,11 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             # context validation failures
             get_change_PTR_json("fd69:27cc:fe91::60", change_type="DeleteRecordSet"),
             get_change_PTR_json("fd69:27cc:fe91::65", ttl=300, ptrdname="has-updated.ptr."),
-            get_change_PTR_json("fd69:27cc:fe91::65", change_type="DeleteRecordSet"),
-            get_change_PTR_json("fd69:27cc:fe91::1122", change_type="DeleteRecordSet"),
-            get_change_PTR_json("fd69:27cc:fe91::1122"),
-            get_change_PTR_json("fd69:27cc:fe91::1122", ttl=350)
-
+            get_change_PTR_json("fd69:27cc:fe91::65", change_type="DeleteRecordSet")
         ]
     }
 
-    to_create = [rs_delete_ipv6, rs_update_ipv6, rs_update_ipv6_fail, rs_doubly_updated]
+    to_create = [rs_delete_ipv6, rs_update_ipv6, rs_update_ipv6_fail]
     to_delete = []
 
     try:
@@ -2056,10 +2021,6 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[0], input_name="fd69:27cc:fe91::aaaa", record_type="PTR", record_data=None, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[1], ttl=300, input_name="fd69:27cc:fe91::62", record_type="PTR", record_data="has-updated.ptr.")
         assert_successful_change_in_error_response(response[2], input_name="fd69:27cc:fe91::62", record_type="PTR", record_data=None, change_type="DeleteRecordSet")
-
-        # successful changes: input_name does not have to be unique
-        assert_successful_change_in_error_response(response[11], input_name="fd69:27cc:fe91::1122", record_type="PTR", record_data="test.com.")
-        assert_successful_change_in_error_response(response[12], input_name="fd69:27cc:fe91::1122", record_type="PTR", record_data="test.com.", ttl=350)
 
         # input validations failures: invalid IP, ttl, and record data
         assert_failed_change_in_error_response(response[3], input_name="fd69:27cc:fe91de::ab", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
@@ -2082,7 +2043,6 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
                                                    error_messages=["Record \"fd69:27cc:fe91::65\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="fd69:27cc:fe91::65", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"fd69:27cc:fe91::65\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[10], input_name="fd69:27cc:fe91::1122", record_type="PTR", change_type="DeleteRecordSet")
 
 
     finally:
@@ -2102,8 +2062,6 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
         "changes": [
             # valid change
             get_change_TXT_json("good-record.ok."),
-            get_change_TXT_json("summed.ok."),
-            get_change_TXT_json("summed.ok.", text="test2"),
             get_change_TXT_json("some.dotted.txt.ok.", text="dotted"),
             get_change_TXT_json("ok.", text="apex"),
 
@@ -2133,31 +2091,29 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
 
         # successful changes
         assert_successful_change_in_error_response(response[0], input_name="good-record.ok.", record_type="TXT", record_data="test")
-        assert_successful_change_in_error_response(response[1], input_name="summed.ok.", record_type="TXT", record_data="test")
-        assert_successful_change_in_error_response(response[2], input_name="summed.ok.", record_type="TXT", record_data="test2")
-        assert_successful_change_in_error_response(response[3], input_name="some.dotted.txt.ok.", record_type="TXT", record_data="dotted")
-        assert_successful_change_in_error_response(response[4], input_name="ok.", record_type="TXT", record_data="apex")
+        assert_successful_change_in_error_response(response[1], input_name="some.dotted.txt.ok.", record_type="TXT", record_data="dotted")
+        assert_successful_change_in_error_response(response[2], input_name="ok.", record_type="TXT", record_data="apex")
 
         # ttl, domain name, record data
-        assert_failed_change_in_error_response(response[5], input_name="bad-ttl-and-invalid-name$.ok.", ttl=29, record_type="TXT", record_data="test",
+        assert_failed_change_in_error_response(response[3], input_name="bad-ttl-and-invalid-name$.ok.", ttl=29, record_type="TXT", record_data="test",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                                'Invalid domain name: "bad-ttl-and-invalid-name$.ok.", '
                                                                'valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
 
         # zone discovery failures
-        assert_failed_change_in_error_response(response[6], input_name="no.zone.at.all.", record_type="TXT", record_data="test",
+        assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_type="TXT", record_data="test",
                                                error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be created in VinylDNS.'])
 
         # context validations: cname duplicate
-        assert_failed_change_in_error_response(response[7], input_name="cname-duplicate.ok.", record_type="CNAME", record_data="test.com.",
+        assert_failed_change_in_error_response(response[5], input_name="cname-duplicate.ok.", record_type="CNAME", record_data="test.com.",
                                                error_messages=["Record Name \"cname-duplicate.ok.\" Not Unique In Batch Change: cannot have multiple \"CNAME\" records with the same name."])
 
         # context validations: conflicting recordsets, unauthorized error
-        assert_failed_change_in_error_response(response[9], input_name="existing-txt.ok.", record_type="TXT", record_data="test",
+        assert_failed_change_in_error_response(response[7], input_name="existing-txt.ok.", record_type="TXT", record_data="test",
                                                error_messages=["Record \"existing-txt.ok.\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
-        assert_failed_change_in_error_response(response[10], input_name="existing-cname.ok.", record_type="TXT", record_data="test",
+        assert_failed_change_in_error_response(response[8], input_name="existing-cname.ok.", record_type="TXT", record_data="test",
                                                error_messages=["CNAME Conflict: CNAME record names must be unique. Existing record with name \"existing-cname.ok.\" and type \"CNAME\" conflicts with this record."])
-        assert_failed_change_in_error_response(response[11], input_name="user-add-unauthorized.dummy.", record_type="TXT", record_data="test",
+        assert_failed_change_in_error_response(response[9], input_name="user-add-unauthorized.dummy.", record_type="TXT", record_data="test",
                                                error_messages=["User \"ok\" is not authorized."])
 
     finally:

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -451,6 +451,41 @@ def test_create_batch_change_without_comments_succeeds(shared_zone_test_context)
     finally:
         clear_zoneid_rsid_tuple_list(to_delete, client)
 
+
+def test_update_multi_record_record_set_fails(shared_zone_test_context):
+    """
+    Test that a [delete + add] style update of an existing RecordSet with multiple records fails
+    """
+    client = shared_zone_test_context.dummy_vinyldns_client
+    zone = shared_zone_test_context.dummy_zone
+
+    # existing
+    rs_existing = get_recordset_json(zone, "update", "A", [{"address": "2.2.2.2"}, {"address": "3.3.3.3"}])
+
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("update.dummy.", record_type="A", ttl=300, address="1.1.1.1"),
+            get_change_A_AAAA_json("update.dummy.", record_type="A", change_type="DeleteRecordSet")
+        ]
+    }
+
+    to_delete = None
+
+    try:
+        create_rs = client.create_recordset(rs_existing, status=202)
+        to_delete = create_rs['recordSet']
+        client.wait_until_recordset_change_status(create_rs, 'Complete')
+
+        response = client.create_batch_change(batch_change_input, status=400)
+
+        assert_error(response[0], error_messages=['RecordSet with name update and type A cannot be updated in a single Batch Change because it contains multiple DNS records (2). If this is expected, issue a DeleteRecordSet only, and add the record in a new Batch Change.'])
+
+    finally:
+        if to_delete:
+            delete_change = client.delete_recordset(to_delete['zoneId'], to_delete['id'], status=202)
+            client.wait_until_recordset_change_status(delete_change, 'Complete')
+
+
 def test_create_batch_change_with_owner_group_id_succeeds(shared_zone_test_context):
     """
     Test successfully creating a batch change with owner group ID specified

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -106,7 +106,10 @@ object Boot extends App {
         .start
     } yield {
       val zoneValidations = new ZoneValidations(syncDelay)
-      val batchChangeValidations = new BatchChangeValidations(batchChangeLimit, AccessValidations)
+      val batchChangeValidations = new BatchChangeValidations(
+        batchChangeLimit,
+        AccessValidations,
+        VinylDNSConfig.multiRecordBatchUpdateEnabled)
       val membershipService = MembershipService(repositories)
       val connectionValidator =
         new ZoneConnectionValidator(connections)

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -128,4 +128,6 @@ object VinylDNSConfig {
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
   lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]](s"default-ttl").getOrElse(7200L)
+  lazy val multiRecordBatchUpdateEnabled: Boolean =
+    vinyldnsConfig.as[Option[Boolean]]("enable-multi-record-batch-update").getOrElse(false)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -151,7 +151,8 @@ final case class MissingOwnerGroupId(recordName: String, zoneName: String)
     s"""Zone "$zoneName" is a shared zone, so owner group ID must be specified for record "$recordName"."""
 }
 
-final case class ExistingMultiRecordError(fqdn: String, record: RecordSet) extends DomainValidationError {
+final case class ExistingMultiRecordError(fqdn: String, record: RecordSet)
+    extends DomainValidationError {
   def message: String =
     s"""RecordSet with name $fqdn and type ${record.typ.toString} cannot be updated in a single Batch Change
        |because it contains multiple DNS records (${record.records.length}).""".stripMargin

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -162,8 +162,8 @@ final case class ExistingMultiRecordError(fqdn: String, record: RecordSet)
 final case class NewMultiRecordError(change: AddChangeForValidation) extends DomainValidationError {
   def message: String =
     s"""Multi-record recordsets are not enabled for this instance of VinylDNS.
-       |There are duplicate changes with name ${change.inputChange.inputName} and type ${change.inputChange.typ}
-       |in this batch.""".stripMargin
+       |Cannot create a new record set with multiple records for inputName ${change.inputChange.inputName} and
+       |type ${change.inputChange.typ}.""".stripMargin
       .replaceAll("\n", " ")
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain
 
 import vinyldns.api.domain.batch.SupportedBatchChangeRecordTypes
-import vinyldns.core.domain.record.RecordType
+import vinyldns.core.domain.record.{RecordSet, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
 
 // $COVERAGE-OFF$
@@ -148,5 +148,13 @@ final case class MissingOwnerGroupId(recordName: String, zoneName: String)
     extends DomainValidationError {
   def message: String =
     s"""Zone "$zoneName" is a shared zone, so owner group ID must be specified for record "$recordName"."""
+}
+
+final case class MultipleRecordsInRecordSet(record: RecordSet) extends DomainValidationError {
+  def message: String =
+    s"""RecordSet with name ${record.name} and type ${record.typ.toString} cannot be updated in a single Batch Change
+       |because it contains multiple DNS records (${record.records.length}). If this is expected, issue a
+       |DeleteRecordSet only, and add the record in a new Batch Change.""".stripMargin
+      .replaceAll("\n", " ")
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -205,7 +205,8 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
             ownerGroupProvidedIfNeeded(
               change,
               existingRecordSets.get(change.zone.id, change.recordName, change.inputChange.typ),
-              batchOwnerGroupId)
+              batchOwnerGroupId) |+|
+            isNotMultiRecordUpdate(rs)
         case None => RecordDoesNotExist(change.inputChange.inputName).invalidNel
       }
 
@@ -415,4 +416,9 @@ class BatchChangeValidations(changeLimit: Int, accessValidation: AccessValidatio
           MissingOwnerGroupId(change.recordName, change.zone.name).invalidNel
       }
     }
+
+  def isNotMultiRecordUpdate(recordBeingUpdated: RecordSet): SingleValidation[Unit] =
+    if (recordBeingUpdated.records.length > 1 && !VinylDNSConfig.multiRecordBatchUpdateEnabled)
+      MultipleRecordsInRecordSet(recordBeingUpdated).invalidNel
+    else ().validNel
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -184,15 +184,16 @@ class BatchChangeValidations(
 
   def newRecordSetIsNotMulti(
       change: AddChangeForValidation,
-      changeGroups: ChangeForValidationMap): SingleValidation[Unit] =
-    if (!multiRecordEnabled && changeGroups
-        .getList(change.recordKey)
-        .collect {
-          case add: AddChangeForValidation => add
-        }
-        .length > 1)
+      changeGroups: ChangeForValidationMap): SingleValidation[Unit] = {
+    lazy val matchingAddRecords = changeGroups
+      .getList(change.recordKey)
+      .collect {
+        case add: AddChangeForValidation => add
+      }
+    if (!multiRecordEnabled && matchingAddRecords.length > 1)
       NewMultiRecordError(change).invalidNel
     else ().validNel
+  }
 
   def validateDeleteWithContext(
       change: DeleteChangeForValidation,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -287,7 +287,7 @@ class BatchChangeServiceSpec
     "succeed with excluded TTL" in {
       val noTtl = AddChangeInput("no-ttl-add.test.com", RecordType.A, None, AData("1.1.1.1"))
       val withTtl =
-        AddChangeInput("with-ttl-add.test.com", RecordType.A, Some(900), AData("1.1.1.1"))
+        AddChangeInput("with-ttl-add-2.test.com", RecordType.A, Some(900), AData("1.1.1.1"))
       val noTtlDel = DeleteChangeInput("non-apex.test.com.", RecordType.TXT)
       val noTtlUpdate =
         AddChangeInput("non-apex.test.com.", RecordType.TXT, None, TXTData("hello"))

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1505,23 +1505,32 @@ class BatchChangeValidationsSpec
         records = List(AAAAData("1::1"), AAAAData("2::2"))),
       sharedZoneRecord.copy(
         name = deleteSharedChange.recordName,
-        records = List(AAAAData("1::1"), AAAAData("2::2")))
+        records = List(AAAAData("1::1"), AAAAData("2::2"))),
+      rsOk.copy(name = updatePrivateAddChange.recordName),
+      rsOk.copy(name = deletePrivateChange.recordName)
     )
 
     val result = underTest.validateChangesWithContext(
       List(
         updateSharedAddChange.validNel,
         updateSharedDeleteChange.validNel,
-        deleteSharedChange.validNel
+        deleteSharedChange.validNel,
+        updatePrivateAddChange.validNel,
+        updatePrivateDeleteChange.validNel,
+        deletePrivateChange.validNel
       ),
       ExistingRecordSets(existing),
-      sharedAuth,
+      okAuth,
       Some(okGroup.id)
     )
 
     result(0) shouldBe valid
     result(1) shouldBe valid
     result(2) shouldBe valid
+    // non duplicate
+    result(3) shouldBe valid
+    result(4) shouldBe valid
+    result(5) shouldBe valid
   }
 
   property(
@@ -1532,17 +1541,22 @@ class BatchChangeValidationsSpec
         records = List(AAAAData("1::1"), AAAAData("2::2"))),
       sharedZoneRecord.copy(
         name = deleteSharedChange.recordName,
-        records = List(AAAAData("1::1"), AAAAData("2::2")))
+        records = List(AAAAData("1::1"), AAAAData("2::2"))),
+      rsOk.copy(name = updatePrivateAddChange.recordName),
+      rsOk.copy(name = deletePrivateChange.recordName)
     )
 
     val result = underTestMultiDisabled.validateChangesWithContext(
       List(
         updateSharedAddChange.validNel,
         updateSharedDeleteChange.validNel,
-        deleteSharedChange.validNel
+        deleteSharedChange.validNel,
+        updatePrivateAddChange.validNel,
+        updatePrivateDeleteChange.validNel,
+        deletePrivateChange.validNel
       ),
       ExistingRecordSets(existing),
-      sharedAuth,
+      okAuth,
       Some(okGroup.id)
     )
 
@@ -1552,14 +1566,15 @@ class BatchChangeValidationsSpec
       ExistingMultiRecordError(updateSharedDeleteChange.inputChange.inputName, existing(0)))
     result(2) should haveInvalid[DomainValidationError](
       ExistingMultiRecordError(deleteSharedChange.inputChange.inputName, existing(1)))
+    // non duplicate
+    result(3) shouldBe valid
+    result(4) shouldBe valid
+    result(5) shouldBe valid
   }
 
   property("validateChangesWithContext: succeed on add/update to a multi record if multi enabled") {
     val existing = List(
-      sharedZoneRecord.copy(
-        name = updateSharedAddChange.recordName,
-        records = List(AAAAData("1::1"))
-      )
+      sharedZoneRecord.copy(name = updateSharedAddChange.recordName)
     )
 
     val update1 = updateSharedAddChange.copy(
@@ -1582,10 +1597,11 @@ class BatchChangeValidationsSpec
         update1.validNel,
         update2.validNel,
         add1.validNel,
-        add2.validNel
+        add2.validNel,
+        updatePrivateAddChange.validNel
       ),
       ExistingRecordSets(existing),
-      sharedAuth,
+      okAuth,
       Some(okGroup.id)
     )
 
@@ -1594,6 +1610,8 @@ class BatchChangeValidationsSpec
     result(2) shouldBe valid
     result(3) shouldBe valid
     result(4) shouldBe valid
+    // non duplicate
+    result(5) shouldBe valid
   }
 
   property("validateChangesWithContext: fail on add/update to a multi record if multi disabled") {
@@ -1624,10 +1642,11 @@ class BatchChangeValidationsSpec
         update1.validNel,
         update2.validNel,
         add1.validNel,
-        add2.validNel
+        add2.validNel,
+        updatePrivateAddChange.validNel
       ),
       ExistingRecordSets(existing),
-      sharedAuth,
+      okAuth,
       Some(okGroup.id)
     )
 
@@ -1636,5 +1655,7 @@ class BatchChangeValidationsSpec
     result(2) should haveInvalid[DomainValidationError](NewMultiRecordError(update2))
     result(3) should haveInvalid[DomainValidationError](NewMultiRecordError(add1))
     result(4) should haveInvalid[DomainValidationError](NewMultiRecordError(add2))
+    // non duplicate
+    result(5) shouldBe valid
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1493,4 +1493,18 @@ class BatchChangeValidationsSpec
 
     result(0) shouldBe valid
   }
+
+  property("validateChangesWithContext: fail for an update to a multi record RecordSet") {
+    val existing = sharedZoneRecord.copy(
+      name = updateSharedAddChange.recordName,
+      records = List(AAAAData("1::1"), AAAAData("2::2")))
+
+    val result = validateChangesWithContext(
+      List(updateSharedAddChange.validNel, updateSharedDeleteChange.validNel),
+      ExistingRecordSets(List(existing)),
+      sharedAuth,
+      Some(okGroup.id))
+
+    result(0) should haveInvalid[DomainValidationError](MultipleRecordsInRecordSet(existing))
+  }
 }


### PR DESCRIPTION
in batch:
- disallow updates in batch that will update/delete an existing recordset with multiple recorddata fields
- disallow updates in batch that will create new recordsets with multiple recorddata fields

all of ^ config driven