### PR TITLE
validate batch change review rejection

### DIFF
--- a/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
@@ -2,28 +2,15 @@ from hamcrest import *
 from utils import *
 
 @pytest.mark.manual_batch_review
-def test_reject_batch_change_without_comments_succeeds(shared_zone_test_context):
+def test_reject_batch_change_with_invalid_batch_change_id_fails(shared_zone_test_context):
     """
-    Test rejecting a batch change without comments succeeds
-    """
-
-    client = shared_zone_test_context.ok_vinyldns_client
-
-    #TODO Update to actual pending batch change
-    client.reject_batch_change("some-id", status=200)
-
-@pytest.mark.manual_batch_review
-def test_reject_batch_change_with_comments_succeeds(shared_zone_test_context):
-    """
-    Test rejecting a batch change with comments succeeds
+    Test rejecting a batch change with invalid batch change ID
     """
 
     client = shared_zone_test_context.ok_vinyldns_client
-    reject_batch_change_input = {
-        "reviewComment": "some-comments"
-    }
-    #TODO Update to actual pending batch change
-    client.reject_batch_change("some-id", reject_batch_change_input, status=200)
+
+    error = client.reject_batch_change("some-id", status=404)
+    assert_that(error, is_("Batch change with id some-id cannot be found"))
 
 @pytest.mark.manual_batch_review
 def test_reject_batch_change_with_comments_exceeding_max_length_fails(shared_zone_test_context):
@@ -35,14 +22,13 @@ def test_reject_batch_change_with_comments_exceeding_max_length_fails(shared_zon
     reject_batch_change_input = {
         "reviewComment": "a"*1025
     }
-    #TODO Update to actual pending batch change
     errors = client.reject_batch_change("some-id", reject_batch_change_input, status=400)['errors']
     assert_that(errors, contains_inanyorder("Comment length must not exceed 1024 characters."))
 
-@skip_manual_review
-def test_reject_batch_change_fails_with_forbidden_error(shared_zone_test_context):
+@pytest.mark.manual_batch_review
+def test_reject_batch_change_fails_with_forbidden_error_for_non_system_admins(shared_zone_test_context):
     """
-    Test successfully creating a batch change without owner group ID specified
+    Test rejecting a batch change if the reviewer is not a super user or support user
     """
     client = shared_zone_test_context.ok_vinyldns_client
     batch_change_input = {

--- a/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
@@ -38,3 +38,25 @@ def test_reject_batch_change_with_comments_exceeding_max_length_fails(shared_zon
     #TODO Update to actual pending batch change
     errors = client.reject_batch_change("some-id", reject_batch_change_input, status=400)['errors']
     assert_that(errors, contains_inanyorder("Comment length must not exceed 1024 characters."))
+
+@skip_manual_review
+def test_reject_batch_change_fails_with_forbidden_error(shared_zone_test_context):
+    """
+    Test successfully creating a batch change without owner group ID specified
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("no-owner-group-id.ok.", address="4.3.2.1")
+        ]
+    }
+    to_delete = []
+
+    try:
+        result = client.create_batch_change(batch_change_input, status=202)
+        completed_batch = client.wait_until_batch_change_completed(result)
+        to_delete = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
+        error = client.reject_batch_change(completed_batch['id'], status=403)
+        assert_that(error, is_("User does not have access to item " + completed_batch['id']))
+    finally:
+        clear_zoneid_rsid_tuple_list(to_delete, client)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -26,9 +26,6 @@ sealed trait BatchChangeErrorResponse
 final case class InvalidBatchChangeInput(errors: List[DomainValidationError])
     extends BatchChangeErrorResponse
 
-final case class InvalidBatchChangeReview(errors: List[BatchChangeErrorResponse])
-    extends BatchChangeErrorResponse
-
 // This separates error by change requested
 final case class InvalidBatchChangeResponses(
     changeRequests: List[ChangeInput],

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -26,6 +26,9 @@ sealed trait BatchChangeErrorResponse
 final case class InvalidBatchChangeInput(errors: List[DomainValidationError])
     extends BatchChangeErrorResponse
 
+final case class InvalidBatchChangeReview(errors: List[BatchChangeErrorResponse])
+    extends BatchChangeErrorResponse
+
 // This separates error by change requested
 final case class InvalidBatchChangeResponses(
     changeRequests: List[ChangeInput],
@@ -44,3 +47,8 @@ final case class BatchConversionError(change: SingleChange) extends BatchChangeE
        |and type "${change.typ}"""".stripMargin
 }
 final case class UnknownConversionError(message: String) extends BatchChangeErrorResponse
+
+final case class BatchChangeNotPendingApproval(id: String) extends BatchChangeErrorResponse {
+  def message: String =
+    s"""Batch change $id is not pending approval, so it cannot be rejected."""
+}

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeInterfaces.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeInterfaces.scala
@@ -27,6 +27,7 @@ object BatchChangeInterfaces {
   type SingleValidation[A] = ValidatedNel[DomainValidationError, A]
   type ValidatedBatch[A] = List[ValidatedNel[DomainValidationError, A]]
   type BatchResult[A] = EitherT[IO, BatchChangeErrorResponse, A]
+  type BatchApproval[A] = ValidatedNel[BatchChangeErrorResponse, A]
 
   implicit class IOBatchResultImprovements[A](theIo: IO[A]) {
     def toBatchResult: BatchResult[A] = EitherT.liftF(theIo)
@@ -70,6 +71,11 @@ object BatchChangeInterfaces {
 
   implicit class SingleValidationImprovements[A](validation: SingleValidation[A]) {
     def asUnit: SingleValidation[Unit] =
+      validation.map(_ => ())
+  }
+
+  implicit class BatchApprovalImprovements[A](validation: BatchApproval[A]) {
+    def asUnit: BatchApproval[Unit] =
       validation.map(_ => ())
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeInterfaces.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeInterfaces.scala
@@ -27,7 +27,6 @@ object BatchChangeInterfaces {
   type SingleValidation[A] = ValidatedNel[DomainValidationError, A]
   type ValidatedBatch[A] = List[ValidatedNel[DomainValidationError, A]]
   type BatchResult[A] = EitherT[IO, BatchChangeErrorResponse, A]
-  type BatchApproval[A] = ValidatedNel[BatchChangeErrorResponse, A]
 
   implicit class IOBatchResultImprovements[A](theIo: IO[A]) {
     def toBatchResult: BatchResult[A] = EitherT.liftF(theIo)
@@ -71,11 +70,6 @@ object BatchChangeInterfaces {
 
   implicit class SingleValidationImprovements[A](validation: SingleValidation[A]) {
     def asUnit: SingleValidation[Unit] =
-      validation.map(_ => ())
-  }
-
-  implicit class BatchApprovalImprovements[A](validation: BatchApproval[A]) {
-    def asUnit: BatchApproval[Unit] =
       validation.map(_ => ())
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -88,7 +88,7 @@ class BatchChangeService(
   def rejectBatchChange(
       batchChangeId: String,
       authPrincipal: AuthPrincipal,
-      rejectionComment: Option[RejectBatchChangeInput]): BatchResult[BatchChange] =
+      rejectBatchChangeInput: Option[RejectBatchChangeInput]): BatchResult[BatchChange] =
     for {
       batchChange <- getExistingBatchChange(batchChangeId)
       _ <- validateBatchChangeRejection(batchChange, authPrincipal).toBatchResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -91,7 +91,7 @@ class BatchChangeService(
       rejectionComment: Option[RejectBatchChangeInput]): BatchResult[BatchChange] =
     for {
       batchChange <- getExistingBatchChange(batchChangeId)
-      _ <- validateRejectedBatchChange(batchChange, authPrincipal)
+      _ <- validateRejectedBatchChange(batchChange, authPrincipal).toBatchResult
     } yield batchChange
 
   def getBatchChange(id: String, auth: AuthPrincipal): BatchResult[BatchChangeInfo] =

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -85,6 +85,15 @@ class BatchChangeService(
         batchChangeInput.ownerGroupId)
     } yield conversionResult.batchChange
 
+  def rejectBatchChange(
+      batchChangeId: String,
+      authPrincipal: AuthPrincipal,
+      rejectionComment: Option[RejectBatchChangeInput]): BatchResult[BatchChange] =
+    for {
+      batchChange <- getExistingBatchChange(batchChangeId)
+      _ <- validateRejectedBatchChange(batchChange, authPrincipal)
+    } yield batchChange
+
   def getBatchChange(id: String, auth: AuthPrincipal): BatchResult[BatchChangeInfo] =
     for {
       batchChange <- getExistingBatchChange(id)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -91,7 +91,7 @@ class BatchChangeService(
       rejectionComment: Option[RejectBatchChangeInput]): BatchResult[BatchChange] =
     for {
       batchChange <- getExistingBatchChange(batchChangeId)
-      _ <- validateRejectedBatchChange(batchChange, authPrincipal).toBatchResult
+      _ <- validateBatchChangeRejection(batchChange, authPrincipal).toBatchResult
     } yield batchChange
 
   def getBatchChange(id: String, auth: AuthPrincipal): BatchResult[BatchChangeInfo] =

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -36,6 +36,6 @@ trait BatchChangeServiceAlgebra {
   def rejectBatchChange(
       batchChangeId: String,
       authPrincipal: AuthPrincipal,
-      rejectionComment: Option[RejectBatchChangeInput]): BatchResult[BatchChange]
+      rejectBatchChangeInput: Option[RejectBatchChangeInput]): BatchResult[BatchChange]
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -32,5 +32,10 @@ trait BatchChangeServiceAlgebra {
       auth: AuthPrincipal,
       startFrom: Option[Int],
       maxItems: Int): BatchResult[BatchChangeSummaryList]
+
+  def rejectBatchChange(
+      batchChangeId: String,
+      authPrincipal: AuthPrincipal,
+      rejectionComment: Option[RejectBatchChangeInput]): BatchResult[BatchChange]
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -48,7 +48,7 @@ trait BatchChangeValidationsAlgebra {
       batchChange: BatchChange,
       auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit]
 
-  def validateRejectedBatchChange(
+  def validateBatchChangeRejection(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit]
 }
@@ -98,7 +98,7 @@ class BatchChangeValidations(
         else NotAMemberOfOwnerGroup(groupId, authPrincipal.signedInUser.userName).invalidNel
     }
 
-  def validateRejectedBatchChange(
+  def validateBatchChangeRejection(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
     validateAuthorizedReviewer(authPrincipal, batchChange) |+| validateBatchChangePendingApproval(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -114,7 +114,7 @@ class BatchChangeValidations(
   def validateAuthorizedReviewer(
       auth: AuthPrincipal,
       batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
-    if (auth.canReadAll) {
+    if (auth.isSystemAdmin) {
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft
@@ -441,7 +441,7 @@ class BatchChangeValidations(
   def canGetBatchChange(
       batchChange: BatchChange,
       auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    if (auth.canReadAll || auth.userId == batchChange.userId) {
+    if (auth.isSystemAdmin || auth.userId == batchChange.userId) {
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -137,7 +137,7 @@ class MembershipService(
       maxItems: Int,
       authPrincipal: AuthPrincipal): Result[ListMyGroupsResponse] = {
     val groupsCall =
-      if (authPrincipal.canReadAll) {
+      if (authPrincipal.isSystemAdmin) {
         groupRepo.getAllGroups()
       } else {
         groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -40,6 +40,6 @@ object MembershipValidations {
 
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.isGroupMember(groupId) || authPrincipal.canReadAll
+      authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -100,8 +100,8 @@ trait BatchChangeRoute extends Directives {
       case Left(cnf: BatchChangeNotFound) => complete(StatusCodes.NotFound, cnf.message)
       case Left(una: UserNotAuthorizedError) => complete(StatusCodes.Forbidden, una.message)
       case Left(uct: BatchConversionError) => complete(StatusCodes.BadRequest, uct)
-      case Left(bcnpa: BatchChangeNotPendingApproval) => complete(StatusCodes.BadRequest, bcnpa)
-      case Left(ibcr: InvalidBatchChangeReview) => complete(StatusCodes.BadRequest, ibcr)
+      case Left(bcnpa: BatchChangeNotPendingApproval) =>
+        complete(StatusCodes.BadRequest, bcnpa.message)
       case Left(uce: UnknownConversionError) => complete(StatusCodes.InternalServerError, uce)
     }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -334,7 +334,7 @@ class BatchChangeServiceSpec
       val result =
         leftResultOf(underTest.rejectBatchChange(batchChange.id, supportUserAuth, None).value)
 
-      result shouldBe InvalidBatchChangeReview(List(BatchChangeNotPendingApproval(batchChange.id)))
+      result shouldBe BatchChangeNotPendingApproval(batchChange.id)
     }
 
     "fail if the batchChange reviewer is not authorized" in {
@@ -351,7 +351,7 @@ class BatchChangeServiceSpec
       val result =
         leftResultOf(underTest.rejectBatchChange(batchChange.id, auth, None).value)
 
-      result shouldBe InvalidBatchChangeReview(List(UserNotAuthorizedError(batchChange.id)))
+      result shouldBe UserNotAuthorizedError(batchChange.id)
     }
 
     "fail if the batchChange reviewer is not authorized and the batchChange is not Pending Approval" in {
@@ -368,8 +368,7 @@ class BatchChangeServiceSpec
       val result =
         leftResultOf(underTest.rejectBatchChange(batchChange.id, auth, None).value)
 
-      result shouldBe InvalidBatchChangeReview(
-        List(BatchChangeNotPendingApproval(batchChange.id), UserNotAuthorizedError(batchChange.id)))
+      result shouldBe UserNotAuthorizedError(batchChange.id)
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -272,25 +272,25 @@ class BatchChangeValidationsSpec
   }
 
   property(
-    "validateRejectedBatchChange: should succeed if batch change is pending approval and reviewer" +
+    "validateBatchChangeRejection: should succeed if batch change is pending approval and reviewer" +
       "is authorized") {
-    validateRejectedBatchChange(validPendingBatchChange, supportUserAuth).value should be(right)
+    validateBatchChangeRejection(validPendingBatchChange, supportUserAuth).value should be(right)
   }
 
-  property("validateRejectedBatchChange: should fail if batch change is not pending approval") {
-    validateRejectedBatchChange(invalidPendingBatchChange, supportUserAuth).value shouldBe
+  property("validateBatchChangeRejection: should fail if batch change is not pending approval") {
+    validateBatchChangeRejection(invalidPendingBatchChange, supportUserAuth).value shouldBe
       Left(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
   }
 
-  property("validateRejectedBatchChange: should fail if reviewer is not authorized") {
-    validateRejectedBatchChange(validPendingBatchChange, okAuth).value shouldBe
+  property("validateBatchChangeRejection: should fail if reviewer is not authorized") {
+    validateBatchChangeRejection(validPendingBatchChange, okAuth).value shouldBe
       Left(UserNotAuthorizedError(validPendingBatchChange.id))
   }
 
   property(
-    "validateRejectedBatchChange: should fail if batch change is not pending approval and reviewer is not" +
+    "validateBatchChangeRejection: should fail if batch change is not pending approval and reviewer is not" +
       "authorized") {
-    validateRejectedBatchChange(invalidPendingBatchChange, okAuth).value shouldBe
+    validateBatchChangeRejection(invalidPendingBatchChange, okAuth).value shouldBe
       Left(UserNotAuthorizedError(invalidPendingBatchChange.id))
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -250,56 +250,48 @@ class BatchChangeValidationsSpec
   }
 
   property("validateBatchChangePendingApproval: should succeed if batch change is PendingApproval") {
-    validateBatchChangePendingApproval(validPendingBatchChange) should beValid(())
+    validateBatchChangePendingApproval(validPendingBatchChange) should be(right)
   }
 
   property("validateBatchChangePendingApproval: should fail if batch change is not PendingApproval") {
-    validateBatchChangePendingApproval(invalidPendingBatchChange) should
-      haveInvalid[BatchChangeErrorResponse](
-        BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
+    validateBatchChangePendingApproval(invalidPendingBatchChange) shouldBe
+      Left(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
   }
 
   property("validateAuthorizedReviewer: should succeed if the reviewer is a super user") {
-    validateAuthorizedReviewer(superUserAuth, validPendingBatchChange) should beValid(())
+    validateAuthorizedReviewer(superUserAuth, validPendingBatchChange) should be(right)
   }
 
   property("validateAuthorizedReviewer: should succeed if the reviewer is a support user") {
-    validateAuthorizedReviewer(supportUserAuth, validPendingBatchChange) should beValid(())
+    validateAuthorizedReviewer(supportUserAuth, validPendingBatchChange) should be(right)
   }
 
   property("validateAuthorizedReviewer: should fail if the reviewer is not a super or support user") {
-    validateAuthorizedReviewer(okAuth, validPendingBatchChange) should
-      haveInvalid[BatchChangeErrorResponse](UserNotAuthorizedError(validPendingBatchChange.id))
+    validateAuthorizedReviewer(okAuth, validPendingBatchChange) shouldBe
+      Left(UserNotAuthorizedError(validPendingBatchChange.id))
   }
 
   property(
     "validateRejectedBatchChange: should succeed if batch change is pending approval and reviewer" +
       "is authorized") {
-    validateRejectedBatchChange(validPendingBatchChange, supportUserAuth).value
-      .unsafeRunSync() should be(right)
+    validateRejectedBatchChange(validPendingBatchChange, supportUserAuth).value should be(right)
   }
 
   property("validateRejectedBatchChange: should fail if batch change is not pending approval") {
-    validateRejectedBatchChange(invalidPendingBatchChange, supportUserAuth).value
-      .unsafeRunSync() shouldBe
-      Left(
-        InvalidBatchChangeReview(List(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))))
+    validateRejectedBatchChange(invalidPendingBatchChange, supportUserAuth).value shouldBe
+      Left(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
   }
 
   property("validateRejectedBatchChange: should fail if reviewer is not authorized") {
-    validateRejectedBatchChange(validPendingBatchChange, okAuth).value.unsafeRunSync() shouldBe
-      Left(InvalidBatchChangeReview(List(UserNotAuthorizedError(validPendingBatchChange.id))))
+    validateRejectedBatchChange(validPendingBatchChange, okAuth).value shouldBe
+      Left(UserNotAuthorizedError(validPendingBatchChange.id))
   }
 
   property(
     "validateRejectedBatchChange: should fail if batch change is not pending approval and reviewer is not" +
       "authorized") {
-    validateRejectedBatchChange(invalidPendingBatchChange, okAuth).value.unsafeRunSync() shouldBe
-      Left(
-        InvalidBatchChangeReview(
-          List(
-            BatchChangeNotPendingApproval(invalidPendingBatchChange.id),
-            UserNotAuthorizedError(invalidPendingBatchChange.id))))
+    validateRejectedBatchChange(invalidPendingBatchChange, okAuth).value shouldBe
+      Left(UserNotAuthorizedError(invalidPendingBatchChange.id))
   }
 
   property("validateInputChanges: should fail with mix of success and failure inputs") {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -18,6 +18,7 @@ package vinyldns.api.domain.batch
 
 import cats.implicits._
 import cats.scalatest.{EitherMatchers, ValidatedMatchers}
+import org.joda.time.DateTime
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{EitherValues, Matchers, PropSpec}
@@ -27,6 +28,7 @@ import vinyldns.core.TestZoneData._
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.batch.{BatchChange, BatchChangeApprovalStatus}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone, ZoneStatus}
 
@@ -58,6 +60,7 @@ class BatchChangeValidationsSpec
     status = ZoneStatus.Active,
     connection = testConnection,
     adminGroupId = okGroup.id)
+
   private val validIp4ReverseZone = Zone(
     "2.0.192.in-addr.arpa",
     "test@test.com",
@@ -137,6 +140,22 @@ class BatchChangeValidationsSpec
     "shared-delete",
     DeleteChangeInput("shared-delete", RecordType.AAAA)
   )
+
+  private val validPendingBatchChange = BatchChange(
+    okUser.id,
+    okUser.userName,
+    None,
+    DateTime.now,
+    List(),
+    approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+
+  private val invalidPendingBatchChange = BatchChange(
+    okUser.id,
+    okUser.userName,
+    None,
+    DateTime.now,
+    List(),
+    approvalStatus = BatchChangeApprovalStatus.AutoApproved)
 
   property("validateBatchChangeInputSize: should fail if batch has no changes") {
     validateBatchChangeInputSize(BatchChangeInput(None, List())) should
@@ -228,6 +247,59 @@ class BatchChangeValidationsSpec
           InvalidBatchChangeInput(
             List(BatchChangeIsEmpty(maxChanges), GroupDoesNotExist(dummyGroup.id))))
     }
+  }
+
+  property("validateBatchChangePendingApproval: should succeed if batch change is PendingApproval") {
+    validateBatchChangePendingApproval(validPendingBatchChange) should beValid(())
+  }
+
+  property("validateBatchChangePendingApproval: should fail if batch change is not PendingApproval") {
+    validateBatchChangePendingApproval(invalidPendingBatchChange) should
+      haveInvalid[BatchChangeErrorResponse](
+        BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
+  }
+
+  property("validateAuthorizedReviewer: should succeed if the reviewer is a super user") {
+    validateAuthorizedReviewer(superUserAuth, validPendingBatchChange) should beValid(())
+  }
+
+  property("validateAuthorizedReviewer: should succeed if the reviewer is a support user") {
+    validateAuthorizedReviewer(supportUserAuth, validPendingBatchChange) should beValid(())
+  }
+
+  property("validateAuthorizedReviewer: should fail if the reviewer is not a super or support user") {
+    validateAuthorizedReviewer(okAuth, validPendingBatchChange) should
+      haveInvalid[BatchChangeErrorResponse](UserNotAuthorizedError(validPendingBatchChange.id))
+  }
+
+  property(
+    "validateRejectedBatchChange: should succeed if batch change is pending approval and reviewer" +
+      "is authorized") {
+    validateRejectedBatchChange(validPendingBatchChange, supportUserAuth).value
+      .unsafeRunSync() should be(right)
+  }
+
+  property("validateRejectedBatchChange: should fail if batch change is not pending approval") {
+    validateRejectedBatchChange(invalidPendingBatchChange, supportUserAuth).value
+      .unsafeRunSync() shouldBe
+      Left(
+        InvalidBatchChangeReview(List(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))))
+  }
+
+  property("validateRejectedBatchChange: should fail if reviewer is not authorized") {
+    validateRejectedBatchChange(validPendingBatchChange, okAuth).value.unsafeRunSync() shouldBe
+      Left(InvalidBatchChangeReview(List(UserNotAuthorizedError(validPendingBatchChange.id))))
+  }
+
+  property(
+    "validateRejectedBatchChange: should fail if batch change is not pending approval and reviewer is not" +
+      "authorized") {
+    validateRejectedBatchChange(invalidPendingBatchChange, okAuth).value.unsafeRunSync() shouldBe
+      Left(
+        InvalidBatchChangeReview(
+          List(
+            BatchChangeNotPendingApproval(invalidPendingBatchChange.id),
+            UserNotAuthorizedError(invalidPendingBatchChange.id))))
   }
 
   property("validateInputChanges: should fail with mix of success and failure inputs") {

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -22,6 +22,7 @@ import vinyldns.core.domain.batch._
 import scala.collection.concurrent
 import cats.effect._
 import cats.implicits._
+import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 
 class InMemoryBatchChangeRepository extends BatchChangeRepository {
 
@@ -34,7 +35,11 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
       createdTimestamp: DateTime,
       changes: List[String],
       ownerGroupId: Option[String],
-      id: String)
+      id: String,
+      approvalStatus: BatchChangeApprovalStatus,
+      reviewerId: Option[String],
+      reviewComment: Option[String],
+      reviewTimestamp: Option[DateTime])
   object StoredBatchChange {
     def apply(batchChange: BatchChange): StoredBatchChange =
       new StoredBatchChange(
@@ -44,7 +49,11 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
         batchChange.createdTimestamp,
         batchChange.changes.map(_.id),
         batchChange.ownerGroupId,
-        batchChange.id
+        batchChange.id,
+        batchChange.approvalStatus,
+        batchChange.reviewerId,
+        batchChange.reviewComment,
+        batchChange.reviewTimestamp
       )
   }
 
@@ -75,10 +84,10 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
           sc.createdTimestamp,
           singleChangesFromRepo,
           sc.ownerGroupId,
-          BatchChangeApprovalStatus.AutoApproved,
-          None,
-          None,
-          None,
+          sc.approvalStatus,
+          sc.reviewerId,
+          sc.reviewComment,
+          sc.reviewTimestamp,
           sc.id
         )
       }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -248,7 +248,7 @@ class BatchChangeRoutingSpec
         authPrincipal: AuthPrincipal,
         rejectionComment: Option[RejectBatchChangeInput])
       : EitherT[IO, BatchChangeErrorResponse, BatchChange] =
-      (batchChangeId, authPrincipal.canReadAll) match {
+      (batchChangeId, authPrincipal.isSystemAdmin) match {
         case ("pendingBatchId", true) => EitherT(IO.pure(genericValidResponse.asRight))
         case ("pendingBatchId", false) =>
           EitherT(IO.pure(UserNotAuthorizedError("notAuthedID").asLeft))

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -242,6 +242,18 @@ class BatchChangeRoutingSpec
           case (_) => EitherT.rightT(BatchChangeSummaryList(List()))
         } else
         EitherT.rightT(BatchChangeSummaryList(List()))
+
+    def rejectBatchChange(
+        batchChangeId: String,
+        authPrincipal: AuthPrincipal,
+        rejectionComment: Option[RejectBatchChangeInput])
+      : EitherT[IO, BatchChangeErrorResponse, BatchChange] =
+      (batchChangeId, authPrincipal.canReadAll) match {
+        case ("pendingBatchId", true) => EitherT(IO.pure(genericValidResponse.asRight))
+        case ("pendingBatchId", false) =>
+          EitherT(IO.pure(UserNotAuthorizedError("notAuthedID").asLeft))
+        case (_, _) => EitherT(IO.pure(BatchChangeNotPendingApproval("batchId").asLeft))
+      }
   }
 
   "POST batch change" should {
@@ -432,26 +444,33 @@ class BatchChangeRoutingSpec
   }
 
   "POST reject batch change" should {
-    "return OK if comments are provided" in {
-      Post("/zones/batchrecordchanges/existingID/reject").withEntity(
-        HttpEntity(
-          ContentTypes.`application/json`,
-          compact(render("reviewComment" -> "some comments")))) ~>
-        batchChangeRoute(okAuth) ~> check {
+    "return OK if review comment is provided, batch change is PendingApproval, and reviewer is authorized" in {
+      Post("/zones/batchrecordchanges/pendingBatchId/reject").withEntity(HttpEntity(
+        ContentTypes.`application/json`,
+        compact(render("comments" -> "some comments")))) ~>
+        batchChangeRoute(supportUserAuth) ~> check {
         status shouldBe OK
       }
     }
 
-    "return OK if comments are not provided" in {
-      Post("/zones/batchrecordchanges/existingID/reject").withEntity(
+    "return OK if comments are not provided, batch change is PendingApproval, and reviewer is authorized" in {
+      Post("/zones/batchrecordchanges/pendingBatchId/reject").withEntity(
+        HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
+        batchChangeRoute(supportUserAuth) ~> check {
+        status shouldBe OK
+      }
+    }
+
+    "return Forbidden if user is not a super or support admin" in {
+      Post("/zones/batchrecordchanges/pendingBatchId/reject").withEntity(
         HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
         batchChangeRoute(okAuth) ~> check {
-        status shouldBe OK
+        status shouldBe Forbidden
       }
     }
 
     "return BadRequest if comments exceed 1024 characters" in {
-      Post("/zones/batchrecordchanges/existingID/reject").withEntity(HttpEntity(
+      Post("/zones/batchrecordchanges/pendingBatchId/reject").withEntity(HttpEntity(
         ContentTypes.`application/json`,
         compact(render("reviewComment" -> "a" * 1025)))) ~> Route.seal(batchChangeRoute(okAuth)) ~> check {
         status shouldBe BadRequest
@@ -461,8 +480,16 @@ class BatchChangeRoutingSpec
     }
 
     "return OK no request entity is provided" in {
-      Post("/zones/batchrecordchanges/existingID/reject") ~> batchChangeRoute(okAuth) ~> check {
+      Post("/zones/batchrecordchanges/pendingBatchId/reject") ~> batchChangeRoute(supportUserAuth) ~> check {
         status shouldBe OK
+      }
+    }
+
+    "return BadRequest if batch change is not pending approval" in {
+      Post("/zones/batchrecordchanges/batchId/reject").withEntity(
+        HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
+        batchChangeRoute(supportUserAuth) ~> check {
+        status shouldBe BadRequest
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -23,7 +23,7 @@ case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
   def isSuper: Boolean =
     signedInUser.isSuper
 
-  def canReadAll: Boolean =
+  def isSystemAdmin: Boolean =
     signedInUser.isSuper || signedInUser.isSupport
 
   def isGroupAdmin(group: Group): Boolean =


### PR DESCRIPTION
Rebased off #665 

Changes in this pull request:
- Adds validations to the reject batch change endpoint to check if a batch change is PendingReview and if the reviewer is a super user or support user