### PR TITLE
Reverse zone discovery bug

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
@@ -47,8 +47,9 @@ object ReverseZoneHelpers {
     }
   }
 
-  // NOTE: this function assumes record/zone interface as the record name is strictly the base string within
-  // zone context
+  // NOTE: this function assumes record/zone interface. Unless prior checks have been made, it should not
+  // be used to check if an FQDN is within a reverse zone unless we know the rest of the zone matches the higher
+  // octets
   def ptrIsInClasslessDelegatedZone(zone: Zone, recordName: String): Either[Throwable, Unit] =
     if (zone.isIPv4) {
       handleIpv4RecordValidation(zone: Zone, recordName)

--- a/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
@@ -34,6 +34,7 @@ object ReverseZoneHelpers {
       Try(CIDR.valueOf(mask).contains(ipAddr)).getOrElse(false)
     }
 
+  // NOTE: this will not work for zones with less than 3 octets
   def ipIsInIpv4ReverseZone(zone: Zone, ipv4: String): Boolean = {
     val base = getIPv4NonDelegatedZoneName(ipv4)
 
@@ -46,6 +47,8 @@ object ReverseZoneHelpers {
     }
   }
 
+  // NOTE: this function assumes record/zone interface as the record name is strictly the base string within
+  // zone context
   def ptrIsInClasslessDelegatedZone(zone: Zone, recordName: String): Either[Throwable, Unit] =
     if (zone.isIPv4) {
       handleIpv4RecordValidation(zone: Zone, recordName)
@@ -102,7 +105,7 @@ object ReverseZoneHelpers {
   private def ipv4ReverseSplitByOctets(string: String): List[String] =
     string.split('.').filter(!_.isEmpty).reverse.toList
 
-  def getZoneAsCIDRString(zone: Zone): Either[Throwable, String] = {
+  private def getZoneAsCIDRString(zone: Zone): Either[Throwable, String] = {
     val zoneName = zone.name.split("in-addr.arpa.")(0)
     val zoneOctets = ipv4ReverseSplitByOctets(zoneName)
     val zoneString = zoneOctets.mkString(".")

--- a/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
@@ -96,7 +96,7 @@ object ReverseZoneHelpers {
   private def ipv4ReverseSplitByOctets(string: String): List[String] =
     string.split('.').filter(!_.isEmpty).reverse.toList
 
-  private def getZoneAsCIDRString(zone: Zone): Either[Throwable, String] = {
+  def getZoneAsCIDRString(zone: Zone): Either[Throwable, String] = {
     val zoneName = zone.name.split("in-addr.arpa.")(0)
     val zoneOctets = ipv4ReverseSplitByOctets(zoneName)
     val zoneString = zoneOctets.mkString(".")

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -22,7 +22,6 @@ import cats.implicits._
 import org.joda.time.DateTime
 import org.slf4j.{Logger, LoggerFactory}
 import vinyldns.api.domain.DomainValidations._
-import vinyldns.api.domain.ReverseZoneHelpers.ptrIsInZone
 import vinyldns.api.domain.batch.BatchChangeInterfaces._
 import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain.dns.DnsConversions._
@@ -269,8 +268,7 @@ class BatchChangeService(
       change: ChangeInput,
       zoneMap: ExistingZones): SingleValidation[ChangeForValidation] = {
     val recordName = change.inputName.split('.').takeRight(1).mkString
-    val validZones =
-      zoneMap.getipv4PTRMatches(change.inputName).filter(ptrIsInZone(_, recordName, PTR).isRight)
+    val validZones = zoneMap.getipv4PTRMatches(change.inputName)
 
     val zone = {
       if (validZones.size > 1) validZones.find(zn => zn.name.contains("/"))

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -17,7 +17,6 @@
 package vinyldns.api.domain.batch
 
 import com.aaronbedra.orchard.CIDR
-import com.comcast.ip4s.Cidr
 import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.ReverseZoneHelpers
 import vinyldns.api.domain.dns.DnsConversions.{getIPv4NonDelegatedZoneName, getIPv6FullReverseName}
@@ -50,8 +49,8 @@ object BatchTransformations {
           lazy val cidrMatch = ReverseZoneHelpers.getZoneAsCIDRString(zn).toOption
 
           foundZoneName == baseZoneName ||
-            (foundZoneName.endsWith(s".$baseZoneName")
-              && cidrMatch.exists(CIDR.valueOf(_).contains(ipv4)))
+          (foundZoneName.endsWith(s".$baseZoneName")
+          && cidrMatch.exists(CIDR.valueOf(_).contains(ipv4)))
         }
       }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -16,10 +16,9 @@
 
 package vinyldns.api.domain.batch
 
-import com.aaronbedra.orchard.CIDR
 import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.ReverseZoneHelpers
-import vinyldns.api.domain.dns.DnsConversions.{getIPv4NonDelegatedZoneName, getIPv6FullReverseName}
+import vinyldns.api.domain.dns.DnsConversions.getIPv6FullReverseName
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.{RecordSet, RecordSetChange}
 import vinyldns.core.domain.record.RecordType._
@@ -43,16 +42,9 @@ object BatchTransformations {
     def getByName(name: String): Option[Zone] = zoneMap.get(name)
 
     def getipv4PTRMatches(ipv4: String): List[Zone] =
-      getIPv4NonDelegatedZoneName(ipv4).toList.flatMap { baseZoneName =>
-        zones.filter { zn =>
-          val foundZoneName = zn.name
-          lazy val cidrMatch = ReverseZoneHelpers.getZoneAsCIDRString(zn).toOption
-
-          foundZoneName == baseZoneName ||
-          (foundZoneName.endsWith(s".$baseZoneName")
-          && cidrMatch.exists(CIDR.valueOf(_).contains(ipv4)))
-        }
-      }
+      zones.filter { zn =>
+        ReverseZoneHelpers.ipIsInIpv4ReverseZone(zn, ipv4)
+      }.toList
 
     def getipv6PTRMatches(ipv6: String): List[Zone] = {
       val fullReverseZone = getIPv6FullReverseName(ipv6)

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -206,7 +206,7 @@ object RecordSetValidations {
 
   def ptrValidations(newRecordSet: RecordSet, zone: Zone): Either[Throwable, Unit] =
     // TODO we don't check for PTR as dotted...not sure why
-    ReverseZoneHelpers.ptrIsInZone(zone, newRecordSet.name, newRecordSet.typ).map(_ => ())
+    ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zone, newRecordSet.name).map(_ => ())
 
   private def isNotOrigin(recordSet: RecordSet, zone: Zone, err: String): Either[Throwable, Unit] =
     ensuring(InvalidRequest(err))(

--- a/modules/api/src/test/scala/vinyldns/api/domain/ReverseZoneHelpersSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/ReverseZoneHelpersSpec.scala
@@ -240,7 +240,7 @@ class ReverseZoneHelpersSpec
         }
       }
     }
-    "ptrIsInZone" should {
+    "ptrIsInClasslessDelegatedZone" should {
       "return InvalidRequest if a PTR is being added to a non-ipv4/ipv6 zone" in {
         eventually {
           val error =
@@ -304,6 +304,28 @@ class ReverseZoneHelpersSpec
             leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zoneIp6, badPtr.name))
           error shouldBe a[InvalidRequest]
         }
+      }
+    }
+    "ipIsInIpv4ReverseZone" should {
+      "return true for the base zone" in {
+        val zone = Zone("1.2.3.in-addr.arpa.", "email")
+        ReverseZoneHelpers.ipIsInIpv4ReverseZone(zone, "3.2.1.10") shouldBe true
+      }
+      "return false for a zone ending in the base zone" in {
+        val zone = Zone("21.2.3.in-addr.arpa.", "email")
+        ReverseZoneHelpers.ipIsInIpv4ReverseZone(zone, "3.2.1.10") shouldBe false
+      }
+      "return true for a valid delegated zone" in {
+        val zone = Zone("0/30.1.2.3.in-addr.arpa.", "email")
+        ReverseZoneHelpers.ipIsInIpv4ReverseZone(zone, "3.2.1.1") shouldBe true
+      }
+      "return false for a delegated zone that does not contain the fqdn" in {
+        val zone = Zone("0/30.1.2.3.in-addr.arpa.", "email")
+        ReverseZoneHelpers.ipIsInIpv4ReverseZone(zone, "3.2.1.10") shouldBe false
+      }
+      "return false for a zone similar to the fqdn" in {
+        val zone = Zone("1.2.3.in-addr.arpa.", "email")
+        ReverseZoneHelpers.ipIsInIpv4ReverseZone(zone, "3.2.21.10") shouldBe false
       }
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/ReverseZoneHelpersSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/ReverseZoneHelpersSpec.scala
@@ -243,19 +243,21 @@ class ReverseZoneHelpersSpec
     "ptrIsInZone" should {
       "return InvalidRequest if a PTR is being added to a non-ipv4/ipv6 zone" in {
         eventually {
-          val error = leftValue(ReverseZoneHelpers.ptrIsInZone(zoneActive, ptrIp6.name, ptrIp6.typ))
+          val error =
+            leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zoneActive, ptrIp6.name))
           error shouldBe a[InvalidRequest]
         }
       }
       "when testing IPv4" should {
         "return ok if the ptr is for an IP4 reverse zone (octet boundry)" in {
-          ReverseZoneHelpers.ptrIsInZone(zoneIp4, ptrIp4.name, ptrIp4.typ) shouldBe right
+          ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zoneIp4, ptrIp4.name) shouldBe right
         }
 
         "return InvalidRequest if ptr is not valid for an IP4 reverse zone (octet boundry)" in {
           val badPtr = ptrIp4.copy(name = "1.2.3")
 
-          val error = leftValue(ReverseZoneHelpers.ptrIsInZone(zoneIp4, badPtr.name, badPtr.typ))
+          val error =
+            leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zoneIp4, badPtr.name))
           error shouldBe a[InvalidRequest]
         }
         "return ok if the ptr is within CIDR for the zone (classless)" in {
@@ -263,14 +265,14 @@ class ReverseZoneHelpersSpec
           val record =
             RecordSet("id", "44", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)
 
-          ReverseZoneHelpers.ptrIsInZone(zone, record.name, record.typ) shouldBe right
+          ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zone, record.name) shouldBe right
         }
         "return InvalidRequest if the ptr is outside of the CIDR range for the zone (classless)" in {
           val zone = Zone("32/27.1.10.10.in-addr.arpa.", "email")
           val record =
             RecordSet("id", "90", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)
 
-          val error = leftValue(ReverseZoneHelpers.ptrIsInZone(zone, record.name, record.typ))
+          val error = leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zone, record.name))
           error shouldBe a[InvalidRequest]
         }
         "return InvalidRequest if the ptr created is illegal (classless)" in {
@@ -278,7 +280,7 @@ class ReverseZoneHelpersSpec
           val record =
             RecordSet("id", "44.44", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)
 
-          val error = leftValue(ReverseZoneHelpers.ptrIsInZone(zone, record.name, record.typ))
+          val error = leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zone, record.name))
           error shouldBe a[InvalidRequest]
         }
         "return InvalidRequest if the ptr is outside of the CIDR range for the zone (classless - 2 octet)" in {
@@ -286,19 +288,20 @@ class ReverseZoneHelpersSpec
           val record =
             RecordSet("id", "90.90", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)
 
-          val error = leftValue(ReverseZoneHelpers.ptrIsInZone(zone, record.name, record.typ))
+          val error = leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zone, record.name))
           error shouldBe a[InvalidRequest]
         }
       }
 
       "when testing IPv6" should {
         "return ok if the ptr is for an IP6 reverse zone" in {
-          ReverseZoneHelpers.ptrIsInZone(zoneIp6, ptrIp6.name, ptrIp6.typ) shouldBe right
+          ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zoneIp6, ptrIp6.name) shouldBe right
         }
         "return invalid request if ptr is not valid for an IP6 reverse zone" in {
           val badPtr = ptrIp6.copy(name = "1.2.3")
 
-          val error = leftValue(ReverseZoneHelpers.ptrIsInZone(zoneIp6, badPtr.name, badPtr.typ))
+          val error =
+            leftValue(ReverseZoneHelpers.ptrIsInClasslessDelegatedZone(zoneIp6, badPtr.name))
           error shouldBe a[InvalidRequest]
         }
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchTransformationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchTransformationsSpec.scala
@@ -24,6 +24,7 @@ class BatchTransformationsSpec extends WordSpec with Matchers {
 
   "ExistingZones" should {
     val ip4base1 = Zone("1.2.3.in-addr.arpa.", "test")
+    val ip4nonMatch = Zone("21.2.3.in-addr.arpa.", "test")
     val ip4del1 = Zone("0/30.1.2.3.in-addr.arpa.", "test")
     val ip4base2 = Zone("10.2.3.in-addr.arpa.", "test")
     val ip4del2 = Zone("0/30.10.2.3.in-addr.arpa.", "test")
@@ -37,6 +38,7 @@ class BatchTransformationsSpec extends WordSpec with Matchers {
     val existingZones = ExistingZones(
       Set(
         ip4base1,
+        ip4nonMatch,
         ip4del1,
         ip4base2,
         ip4del2,
@@ -48,10 +50,13 @@ class BatchTransformationsSpec extends WordSpec with Matchers {
         ipv6nonMatch3))
 
     "getipv4PTRMatches" should {
-      "return all possible matches" in {
-        existingZones.getipv4PTRMatches("3.2.1.55") should contain theSameElementsAs List(
+      "return all possible matches including proper delegations" in {
+        existingZones.getipv4PTRMatches("3.2.1.2") should contain theSameElementsAs List(
           ip4base1,
           ip4del1)
+      }
+      "return all possible matches excluding similar delegations" in {
+        existingZones.getipv4PTRMatches("3.2.1.55") should contain theSameElementsAs List(ip4base1)
       }
       "return empty if there are no matches" in {
         existingZones.getipv4PTRMatches("55.55.55.55") shouldBe List()


### PR DESCRIPTION
bug fix.

in short, zone discovery for ipv4 relies on `endswith` to address delegated zone challenges. As a result, if you are looking for the zone for `1.2.3.0`, that will be transformed into a base of `3.2.1.in-addr.arpa.`, and we get all ending with that (so `3.2.1.in-addr.arpa.` and `0/30.3.2.1.in-addr.arpa.` (good), AND`13.2.1.in-addr.arpa.` (bad!))

this fixes that problem 