### PR TITLE
make delimiter better

### DIFF
--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -370,8 +370,8 @@ object MySqlRecordSetRepository extends ProtobufConversions {
   case class PagingKey(recordName: String, recordType: Int)
 
   object PagingKey {
-    val delimiterRegex = "\\.\\.\\.\\."
-    val delimiter = "...."
+    val delimiterRegex = "<\\.\\.\\.\\.>"
+    val delimiter = "<....>"
 
     def apply(startFrom: Option[String]): Option[PagingKey] =
       for {


### PR DESCRIPTION
the original delimiter `....` has a bug on the edge case of an apex record since that will end in a dot, so the second half of the startFrom key that gets parsed would be `.<number>` which would turn into a number parsing error and be treated as no nextId 
<img width="787" alt="Screen Shot 2019-06-10 at 3 15 07 PM" src="https://user-images.githubusercontent.com/9893183/59221755-01057180-8b96-11e9-9035-b28cb92eeb03.png">
<img width="786" alt="Screen Shot 2019-06-10 at 3 15 13 PM" src="https://user-images.githubusercontent.com/9893183/59221759-02cf3500-8b96-11e9-8cb0-786cfb8649b0.png">
