### PR TITLE
sync-banned zones list

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -105,7 +105,7 @@ object Boot extends App {
         )
         .start
     } yield {
-      val zoneValidations = new ZoneValidations(syncDelay)
+      val zoneValidations = new ZoneValidations(syncDelay, VinylDNSConfig.syncBannedZones)
       val batchChangeValidations = new BatchChangeValidations(
         batchChangeLimit,
         AccessValidations,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -108,6 +108,7 @@ class ZoneService(
   def syncZone(zoneId: String, auth: AuthPrincipal): Result[ZoneCommandResult] =
     for {
       zone <- getZoneOrFail(zoneId)
+      _ <- isNotSyncBanned(zone.name).toResult
       _ <- canChangeZone(auth, zone.name, zone.adminGroupId).toResult
       _ <- outsideSyncDelay(zone).toResult
       syncZoneChange <- ZoneChangeGenerator.forSync(zone, auth).toResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -23,10 +23,11 @@ import vinyldns.api.Interfaces.ensuring
 import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone.{ACLRule, Zone, ZoneACL}
+import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 
 import scala.util.{Failure, Success, Try}
 
-class ZoneValidations(syncDelayMillis: Int) {
+class ZoneValidations(syncDelayMillis: Int, syncBannedZones: List[String] = List()) {
 
   def outsideSyncDelay(zone: Zone): Either[Throwable, Unit] =
     zone.latestSync match {
@@ -85,4 +86,9 @@ class ZoneValidations(syncDelayMillis: Int) {
       NotAuthorizedError(
         s"Not authorized to update zone shared status from $currentShared to $updateShared."))(
       currentShared == updateShared || user.isSuper || user.isSupport)
+
+  def isNotSyncBanned(zoneName: String): Either[Throwable, Unit] =
+    ensuring(InvalidRequest(s"Syncs in zone $zoneName are disabled"))(
+      !syncBannedZones.contains(ensureTrailingDot(zoneName.toLowerCase))
+    )
 }

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -39,6 +39,8 @@ vinyldns {
     ]
   }
 
+  sync-banned-zones = ["can.not.sync.", "TO.lOwEr"]
+
   # types of unowned records that users can access in shared zones
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSConfigSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSConfigSpec.scala
@@ -94,5 +94,8 @@ class VinylDNSConfigSpec extends WordSpec with Matchers {
       backends.head.zoneConnection.decrypted(Crypto.instance) shouldBe zc
       backends.head.transferConnection.decrypted(Crypto.instance) shouldBe tc
     }
+    "load the sync blacklist as lowercase, trailing dot" in {
+      VinylDNSConfig.syncBannedZones shouldBe List("can.not.sync.", "to.lower.")
+    }
   }
 }


### PR DESCRIPTION

allows you to configure a list of zones that we will disallow syncs in. At the moment, this does not stop the sync that occurs on initial connection