### PR TITLE
update 'Zone already exists' verbiage

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -221,7 +221,7 @@ class ZoneService(
         case Some(existingZone) if existingZone.status != ZoneStatus.Deleted =>
           ZoneAlreadyExistsError(
             s"Zone with name $zoneName already exists. " +
-              s"Please contact ${existingZone.email} for access to the zone.").asLeft
+              s"Please contact ${existingZone.email} to request access to the zone.").asLeft
         case _ => ().asRight
       }
       .toResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -219,7 +219,9 @@ class ZoneService(
       .getZoneByName(zoneName)
       .map {
         case Some(existingZone) if existingZone.status != ZoneStatus.Deleted =>
-          ZoneAlreadyExistsError(s"Zone with name $zoneName already exists").asLeft
+          ZoneAlreadyExistsError(
+            s"Zone with name $zoneName already exists. " +
+              s"Please contact ${existingZone.email} for access to the zone.").asLeft
         case _ => ().asRight
       }
       .toResult


### PR DESCRIPTION
Fixes #79.

Changes in this pull request:
- add "Please contact <zone email> for access to the zone." to error message when a user tries to connect to a zone that already exists in VinylDNS.

 I don't think we've used zone email for anything to this point, it's there so we should use it. If it's not as useful as the admin group name and admin group email we could change to that in the future, but this seems like it meets the objective of putting contact information in the message in the least complex manner.
