### PR TITLE
update docs and links for batch change csv import

### DIFF
--- a/modules/docs/src/main/resources/microsite/static/batch-csv-sample.csv
+++ b/modules/docs/src/main/resources/microsite/static/batch-csv-sample.csv
@@ -1,9 +1,9 @@
 Change Type,Record Type,Input Name,TTL,Record Data
-Add,A+PTR,test.example.,200,1.1.1.1
-Add,A,test1.example.,200,1.2.3.4
+Add,A+PTR,test.example.,7200,1.1.1.1
+Add,A,test1.example.,7200,1.2.3.4
 Add,AAAA+PTR,test2.example.,200,fd69:27cc:fe91::60
-Add,AAAA,test3.example.com.,200,fd69:27cc:fe91::60
-Add,CNAME,test4.example.com.,200,test0.example.com.
+Add,AAAA,test3.example.com.,,fd69:27cc:fe91::60
+Add,CNAME,test4.example.com.,,test0.example.com.
 Add,PTR,192.0.2.193,200,test.example.com.
 DeleteRecordSet,A+PTR,test5.example.com.,,1.1.1.1
 DeleteRecordSet,A,test6.exmaple.com.,,

--- a/modules/docs/src/main/tut/portal/batch-changes.md
+++ b/modules/docs/src/main/tut/portal/batch-changes.md
@@ -34,7 +34,7 @@ This does not apply to zone administrators or users with specific ACL access rul
 1. Add a description.
 1. Add record changes in one of two ways:
  - Select the *Add a Change* button to add additional rows for data entry as needed.
- - Select the *Import CSV* button to choose and upload a CSV file of the record changes. Download a sample CSV [here](../static/batch-csv-sample.csv). **Note** The header row is required. The order of the columns is `Change Type, Record Type, Input Name, TTL, Record Data`.
+ - Select the *Import CSV* button to choose and upload a CSV file of the record changes. See [Batch Change CSV Import](#batch-change-csv-import) for more information.
 1. Select the submit button. Confirm your submission.
  - If your submission was successful you'll redirect to the batch change summary page where you will see the status of the batch change request overall and of the individual records in the batch change.
  - If there are errors in the batch change you will remain on the form with prompts to correct errors before you attempt to submit again.
@@ -42,6 +42,11 @@ This does not apply to zone administrators or users with specific ACL access rul
 [![Batch change main page screenshot](../img/portal/batch-change-main-annotated.png){: .screenshot}](../img/portal/batch-change-main-annotated.png)
 [![New batch change form screenshot](../img/portal/batch-change-new-annotated.png){: .screenshot}](../img/portal/batch-change-new-annotated.png)
 [![Submitted batch change screenshot](../img/portal/batch-change-summary.png){: .screenshot}](../img/portal/batch-change-summary.png)
+
+#### Batch Change CSV Import
+[Download a sample CSV here](../static/batch-csv-sample.csv)
+* The header row is required. The order of the columns is `Change Type, Record Type, Input Name, TTL, Record Data`.
+* The TTL field is optional for each record, but the column is still required. If TTL is empty VinylDNS will use the existing TTL value for record updates or the default TTL value for new records.
 
 ### Review a Batch Change
 You can review your submitted batch change requests by selecting the linked Batch ID or View button for the batch change on the main page of the Batch Change section in the portal.

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -197,7 +197,7 @@
                                     <span><span class="glyphicon glyphicon-import"></span> Import CSV</span>
                                 </label>
                                 <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" ng-change="uploadCSV(createBatchChangeForm.batchChangeCsv.$viewValue)" batch-change-file>
-                                <p><a href="https://www.vinyldns.io/portal/batch-changes#create-a-batch-change" target="_blank" rel="noopener noreferrer">Download sample CSV</a></p>
+                                <p><a href="https://www.vinyldns.io/portal/batch-changes#batch-change-csv-import" target="_blank" rel="noopener noreferrer">See documentation for sample CSV</a></p>
                             </div>
                             <p ng-if="newBatch.changes.length >= batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per batch change.</p>
                         </div>


### PR DESCRIPTION
![Batch Change CSV documentation](https://user-images.githubusercontent.com/4439228/59520411-e1bd5b80-8e97-11e9-8ef0-e21bc4108c7d.png)

Changes in this pull request:
- move the Batch Change CSV information to it's own section in the docs
  - add info about the optional TTL field
- change the link text in the portal to "See documentation for sample CSV" and link to the Batch Change CSV section
