### PR TITLE
Large zone updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,12 @@ cache:
   bundler: true
   npm: true
   directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt
-    - $HOME/.m2
+  - $HOME/.sbt/1.0
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/cache
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2/cache
+  - $HOME/.coursier
   timeout: 900
 
 before_install:
@@ -31,11 +34,13 @@ install:
   - gem install sass jekyll:3.2.1
 
 before_cache:
-  # Cleanup the cached directories to avoid unnecessary cache updates (https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html)
-  - sudo chown -R travis:travis $HOME/.sbt
-  - sudo chown -R travis:travis $HOME/.ivy2/cache
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
-  - find $HOME/.sbt        -name "*.lock"               -print -delete
+# Cleanup the cached directories to avoid unnecessary cache updates (https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html)
+- du -h -d 1 $HOME/.ivy2/
+- du -h -d 2 $HOME/.sbt/
+- du -h -d 4 $HOME/.coursier/
+- find $HOME/.sbt -name "*.lock" -type f -delete
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+- find $HOME/.coursier/cache -name "*.lock" -type f -delete
 
 jobs:
   include:

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -106,4 +106,11 @@ vinyldns {
   }
 
   batch-change-limit = 1000
+
+  metrics {
+    memory {
+      log-enabled = false
+      log-seconds = 30
+    }
+  }
 }

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -32,6 +32,7 @@ import vinyldns.api.domain.batch.{BatchChangeConverter, BatchChangeService, Batc
 import vinyldns.api.domain.membership._
 import vinyldns.api.domain.record.RecordSetService
 import vinyldns.api.domain.zone._
+import vinyldns.api.metrics.APIMetrics
 import vinyldns.api.repository.{ApiDataAccessor, ApiDataAccessorProvider, TestDataLoader}
 import vinyldns.api.route.VinylDNSService
 import vinyldns.core.VinylDNSMetrics
@@ -89,6 +90,8 @@ object Boot extends App {
       healthCheckTimeout <- VinylDNSConfig.healthCheckTimeout
       notifierConfigs <- VinylDNSConfig.notifierConfigs
       notifiers <- NotifierLoader.loadAll(notifierConfigs, repositories.userRepository)
+      metricsSettings <- APIMetrics.loadSettings(VinylDNSConfig.config)
+      _ <- APIMetrics.initialize(metricsSettings)
       _ <- CommandHandler
         .run(
           messageQueue,

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -90,7 +90,7 @@ object Boot extends App {
       healthCheckTimeout <- VinylDNSConfig.healthCheckTimeout
       notifierConfigs <- VinylDNSConfig.notifierConfigs
       notifiers <- NotifierLoader.loadAll(notifierConfigs, repositories.userRepository)
-      metricsSettings <- APIMetrics.loadSettings(VinylDNSConfig.config)
+      metricsSettings <- APIMetrics.loadSettings(VinylDNSConfig.vinyldnsConfig.getConfig("metrics"))
       _ <- APIMetrics.initialize(metricsSettings)
       _ <- CommandHandler
         .run(

--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -117,7 +117,7 @@ object CommandHandler {
         case sync: ZoneChange
             if sync.changeType == ZoneChangeType.Sync || sync.changeType == ZoneChangeType.Create =>
           logger.info(s"Updating visibility timeout for zone change; changeId=${sync.id}")
-          mq.changeMessageTimeout(message, 1200.seconds)
+          mq.changeMessageTimeout(message, 1.hour)
 
         case _ =>
           // do not change visibility for all other change types

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -75,7 +75,8 @@ class ZoneConnectionValidator(connections: ConfiguredDnsConnections)
   import ZoneConnectionValidator._
   import ZoneRecordValidations._
 
-  val opTimeout: FiniteDuration = 6.seconds
+  // Takes a long time to load large zones
+  val opTimeout: FiniteDuration = 60.seconds
 
   val (healthCheckAddress, healthCheckPort) =
     DnsConnection.parseHostAndPort(connections.defaultZoneConnection.primaryServer)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
@@ -85,7 +85,7 @@ case class DnsZoneViewLoader(
           recordSets <- IO(rawDnsRecords.map(toRecordSet(_, dnsZoneName, zone.id)))
           _ <- IO(
             DnsZoneViewLoader.logger.info(
-              s"dns.loadDnsView rawRsCount=${zoneXfr.size} rsCount=${recordSets.size}"))
+              s"dns.loadDnsView zoneName=${zone.name}; rawRsCount=${zoneXfr.size}; rsCount=${recordSets.size}"))
         } yield ZoneView(zone, recordSets)
     }
 }
@@ -107,7 +107,7 @@ case class VinylDNSZoneViewLoader(zone: Zone, recordSetRepository: RecordSetRepo
             recordNameFilter = None)
           .map { result =>
             VinylDNSZoneViewLoader.logger.info(
-              s"vinyldns.loadZoneView rsCount=${result.recordSets.size}")
+              s"vinyldns.loadZoneView zoneName=${zone.name}; rsCount=${result.recordSets.size}")
             ZoneView(zone, result.recordSets)
           }
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
@@ -17,6 +17,7 @@
 package vinyldns.api.domain.zone
 
 import cats.effect._
+import org.slf4j.LoggerFactory
 import org.xbill.DNS
 import org.xbill.DNS.{TSIG, ZoneTransferIn}
 import vinyldns.api.VinylDNSConfig
@@ -34,6 +35,8 @@ trait ZoneViewLoader {
 }
 
 object DnsZoneViewLoader extends DnsConversions {
+
+  val logger = LoggerFactory.getLogger("DnsZoneViewLoader")
 
   def dnsZoneTransfer(zone: Zone): ZoneTransferIn = {
     val conn =
@@ -80,10 +83,16 @@ case class DnsZoneViewLoader(
           else IO.pure(Unit)
           dnsZoneName <- IO(zoneDnsName(zone.name))
           recordSets <- IO(rawDnsRecords.map(toRecordSet(_, dnsZoneName, zone.id)))
+          _ <- IO(
+            DnsZoneViewLoader.logger.info(
+              s"dns.loadDnsView rawRsCount=${zoneXfr.size} rsCount=${recordSets.size}"))
         } yield ZoneView(zone, recordSets)
     }
 }
 
+object VinylDNSZoneViewLoader {
+  val logger = LoggerFactory.getLogger("VinylDNSZoneViewLoader")
+}
 case class VinylDNSZoneViewLoader(zone: Zone, recordSetRepository: RecordSetRepository)
     extends ZoneViewLoader
     with Monitored {
@@ -96,6 +105,10 @@ case class VinylDNSZoneViewLoader(zone: Zone, recordSetRepository: RecordSetRepo
             startFrom = None,
             maxItems = None,
             recordNameFilter = None)
-          .map(result => ZoneView(zone, result.recordSets))
+          .map { result =>
+            VinylDNSZoneViewLoader.logger.info(
+              s"vinyldns.loadZoneView rsCount=${result.recordSets.size}")
+            ZoneView(zone, result.recordSets)
+          }
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/metrics/APIMetrics.scala
+++ b/modules/api/src/main/scala/vinyldns/api/metrics/APIMetrics.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.metrics
+import java.util.concurrent.TimeUnit
+
+import cats.effect.IO
+import com.codahale.metrics.{Metric, MetricFilter, ScheduledReporter, Slf4jReporter}
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+import pureconfig.module.catseffect.loadConfigF
+import vinyldns.core.VinylDNSMetrics
+
+final case class MemoryMetricsSettings(logEnabled: Boolean, logSeconds: Int)
+final case class APIMetricsSettings(memory: MemoryMetricsSettings)
+
+object APIMetrics {
+
+  // Output all memory metrics to the log, do not start unless configured
+  private val logReporter = Slf4jReporter
+    .forRegistry(VinylDNSMetrics.metricsRegistry)
+    .filter(new MetricFilter {
+      def matches(name: String, metric: Metric): Boolean =
+        metric == VinylDNSMetrics.memoryUsageGaugeSet
+    })
+    .outputTo(LoggerFactory.getLogger("MemStats"))
+    .convertRatesTo(TimeUnit.SECONDS)
+    .convertDurationsTo(TimeUnit.MILLISECONDS)
+    .build()
+
+  def initialize(
+      settings: APIMetricsSettings,
+      reporter: ScheduledReporter = logReporter): IO[Unit] = IO {
+    if (settings.memory.logEnabled) {
+      reporter.start(settings.memory.logSeconds, TimeUnit.SECONDS)
+    }
+  }
+
+  def loadSettings(config: Config): IO[APIMetricsSettings] =
+    loadConfigF[IO, APIMetricsSettings](config)
+}

--- a/modules/api/src/main/scala/vinyldns/api/metrics/APIMetrics.scala
+++ b/modules/api/src/main/scala/vinyldns/api/metrics/APIMetrics.scala
@@ -18,6 +18,7 @@ package vinyldns.api.metrics
 import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
+import com.codahale.metrics.Slf4jReporter.LoggingLevel
 import com.codahale.metrics.{Metric, MetricFilter, ScheduledReporter, Slf4jReporter}
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
@@ -33,9 +34,11 @@ object APIMetrics {
   private val logReporter = Slf4jReporter
     .forRegistry(VinylDNSMetrics.metricsRegistry)
     .filter(new MetricFilter {
-      def matches(name: String, metric: Metric): Boolean =
-        metric == VinylDNSMetrics.memoryUsageGaugeSet
+      def matches(name: String, metric: Metric): Boolean = {
+        name.startsWith("memory")
+      }
     })
+    .withLoggingLevel(LoggingLevel.INFO)
     .outputTo(LoggerFactory.getLogger("MemStats"))
     .convertRatesTo(TimeUnit.SECONDS)
     .convertDurationsTo(TimeUnit.MILLISECONDS)

--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -112,7 +112,7 @@ class CommandHandlerSpec
         .drain
         .unsafeRunSync()
 
-      verify(mq).changeMessageTimeout(msg, 1200.seconds)
+      verify(mq).changeMessageTimeout(msg, 1.hour)
     }
     "update the timeout for zone creates" in {
       doReturn(IO.unit).when(mq).changeMessageTimeout(any[CommandMessage], any[FiniteDuration])
@@ -125,7 +125,7 @@ class CommandHandlerSpec
         .drain
         .unsafeRunSync()
 
-      verify(mq).changeMessageTimeout(msg, 1200.seconds)
+      verify(mq).changeMessageTimeout(msg, 1.hour)
     }
     "not update the timeout for zone deletes" in {
       val del = zoneCreate.copy(changeType = ZoneChangeType.Delete)

--- a/modules/api/src/test/scala/vinyldns/api/metrics/APIMetricsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/metrics/APIMetricsSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.metrics
+import java.util.concurrent.TimeUnit
+
+import cats.scalatest.EitherMatchers
+import com.codahale.metrics.ScheduledReporter
+import com.typesafe.config.ConfigFactory
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import vinyldns.api.VinylDNSConfig
+
+class APIMetricsSpec extends WordSpec with Matchers with MockitoSugar with EitherMatchers {
+
+  "APIMetricsSettings" should {
+    "succeed with valid config" in {
+      val config = ConfigFactory.parseString(
+        """
+          |{
+          |  memory {
+          |    log-enabled = true
+          |    log-seconds = 5
+          |  }
+          |}
+        """.stripMargin
+      )
+      APIMetrics.loadSettings(config).attempt.unsafeRunSync() shouldBe Right(
+        APIMetricsSettings(MemoryMetricsSettings(logEnabled = true, logSeconds = 5)))
+    }
+    "fail with invalid config" in {
+      val config = ConfigFactory.parseString(
+        """
+          |{
+          |  memory {
+          |    log-blah-enabled = true
+          |    log-seconds = 5
+          |  }
+          |}
+        """.stripMargin
+      )
+      APIMetrics.loadSettings(config).attempt.unsafeRunSync() shouldBe left
+    }
+    "default to log memory off" in {
+      APIMetrics
+        .loadSettings(VinylDNSConfig.vinyldnsConfig.getConfig("metrics"))
+        .unsafeRunSync()
+        .memory
+        .logEnabled shouldBe false
+    }
+  }
+
+  "APIMetrics" should {
+    "start the log reporter if enabled" in {
+      val reporter = mock[ScheduledReporter]
+      APIMetrics
+        .initialize(
+          APIMetricsSettings(MemoryMetricsSettings(logEnabled = true, logSeconds = 5)),
+          reporter)
+        .unsafeRunSync()
+      verify(reporter).start(5, TimeUnit.SECONDS)
+    }
+    "not start the log reporter if not enabled" in {
+      val reporter = mock[ScheduledReporter]
+      APIMetrics
+        .initialize(
+          APIMetricsSettings(MemoryMetricsSettings(logEnabled = false, logSeconds = 5)),
+          reporter)
+        .unsafeRunSync()
+      verifyZeroInteractions(reporter)
+    }
+  }
+}

--- a/modules/core/src/main/scala/vinyldns/core/Instrumented.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Instrumented.scala
@@ -25,7 +25,6 @@ object VinylDNSMetrics {
   val metricsRegistry: MetricRegistry = new MetricRegistry
 
   // Collect memory stats, always exposed via JMX
-  val memoryUsageGaugeSet: MemoryUsageGaugeSet = new MemoryUsageGaugeSet()
   metricsRegistry.register("memory", new MemoryUsageGaugeSet())
 
   // Output all VinylDNS metrics as jmx under the "vinyldns.core" domain as milliseconds

--- a/modules/core/src/main/scala/vinyldns/core/Instrumented.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Instrumented.scala
@@ -16,20 +16,17 @@
 
 package vinyldns.core
 
-import java.util.concurrent.TimeUnit
-
 import com.codahale.metrics._
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet
 import nl.grons.metrics.scala.InstrumentedBuilder
-import org.slf4j.LoggerFactory
 
 object VinylDNSMetrics {
 
   val metricsRegistry: MetricRegistry = new MetricRegistry
-  val memoryRegistry: MetricRegistry = new MetricRegistry
 
-  // Collect memory stats
-  memoryRegistry.register("memory", new MemoryUsageGaugeSet())
+  // Collect memory stats, always exposed via JMX
+  val memoryUsageGaugeSet: MemoryUsageGaugeSet = new MemoryUsageGaugeSet()
+  metricsRegistry.register("memory", new MemoryUsageGaugeSet())
 
   // Output all VinylDNS metrics as jmx under the "vinyldns.core" domain as milliseconds
   JmxReporter
@@ -37,15 +34,6 @@ object VinylDNSMetrics {
     .inDomain("vinyldns.core")
     .build()
     .start()
-
-  // Output all memory metrics to the log
-  Slf4jReporter
-    .forRegistry(memoryRegistry)
-    .outputTo(LoggerFactory.getLogger("VinylDNSJVM"))
-    .convertRatesTo(TimeUnit.SECONDS)
-    .convertDurationsTo(TimeUnit.MILLISECONDS)
-    .build()
-    .start(10, TimeUnit.SECONDS)
 }
 
 /**

--- a/modules/core/src/main/scala/vinyldns/core/Instrumented.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Instrumented.scala
@@ -16,12 +16,20 @@
 
 package vinyldns.core
 
-import com.codahale.metrics.{JmxReporter, MetricRegistry}
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics._
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet
 import nl.grons.metrics.scala.InstrumentedBuilder
+import org.slf4j.LoggerFactory
 
 object VinylDNSMetrics {
 
   val metricsRegistry: MetricRegistry = new MetricRegistry
+  val memoryRegistry: MetricRegistry = new MetricRegistry
+
+  // Collect memory stats
+  memoryRegistry.register("memory", new MemoryUsageGaugeSet())
 
   // Output all VinylDNS metrics as jmx under the "vinyldns.core" domain as milliseconds
   JmxReporter
@@ -29,6 +37,15 @@ object VinylDNSMetrics {
     .inDomain("vinyldns.core")
     .build()
     .start()
+
+  // Output all memory metrics to the log
+  Slf4jReporter
+    .forRegistry(memoryRegistry)
+    .outputTo(LoggerFactory.getLogger("VinylDNSJVM"))
+    .convertRatesTo(TimeUnit.SECONDS)
+    .convertDurationsTo(TimeUnit.MILLISECONDS)
+    .build()
+    .start(10, TimeUnit.SECONDS)
 }
 
 /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,8 @@ object Dependencies {
     "javax.xml.bind"            %  "jaxb-api"                       % jaxbV % "provided",
     "com.sun.xml.bind"          %  "jaxb-core"                      % jaxbV,
     "com.sun.xml.bind"          %  "jaxb-impl"                      % jaxbV,
-    "ch.qos.logback"            %  "logback-classic"                % "1.0.7"
+    "ch.qos.logback"            %  "logback-classic"                % "1.0.7",
+    "io.dropwizard.metrics"     %  "metrics-jvm"                    % "3.2.2"
   )
 
   lazy val dynamoDBDependencies = Seq(


### PR DESCRIPTION
Adding updates to handle large zones (> 500,000).

1. `APIMetrics` allows configuration driven metrics collection.  Metrics we need here are for large zones, so we have a flag to enable logging of memory usage.  If `log-enabled=true` in the settings, start up a logging reporter that will memory usage to the log file every `log-seconds` seconds.
1. `CommandHandler` - increase the visibility timeout to 1 hour.  In testing with a large zone of 600,000 records, the initial zone sync process took 36 minutes.  Going to 1 hour should give us the ability to handle zones a little larger than 600,000 DNS records
1. `ZoneConnectionValidator` - increasing the timeout to 60 seconds from 6 seconds, as doing a zone transfer of large zones can take 10-20 seconds
1. `DNSZoneViewLoader` - adding logging around how many raw records are loaded so we can marry raw counts to memory usage
1. `core.Instrumented` - I put the `MemoryGaugeSet` into the `core` project as I thought it would be useful for the portal as well as the API.
