### PR TITLE
update zone shared status in the portal

### DIFF
--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -51,7 +51,14 @@
                                     <label class="col-md-3 control-label">Access</label>
                                     <div class="col-md-9">
                                         <div>
-                                            <p class="form-control-static">{{ updateZoneInfo.shared ? "Shared" : "Private" }}</p>
+                                            <select class="form-control" ng-model="updateZoneInfo.shared">
+                                                <option ng-value="true" ng-model="updateZoneInfo.shared"
+                                                        ng-selected="updateZoneInfo.shared == true">
+                                                    Shared</option>
+                                                <option ng-value="false" ng-model="updateZoneInfo.shared"
+                                                        ng-selected="updateZoneInfo.shared == false">
+                                                    Private</option>
+                                            </select>
                                         </div>
                                     </div>
                                 </div>
@@ -213,7 +220,7 @@
                             ng-click="clickUpdateZone()">
                         Update Zone
                     </button>
-                    <button id="zone-delete-{{zone.name}}" class="btn btn-danger btn-rounded mb-control"
+                    <button ng-if="currentManageZoneState == manageZoneState.UPDATE" id="zone-delete-{{zone.name}}" class="btn btn-danger btn-rounded mb-control"
                             ng-click="confirmDeleteZone();">
                         Abandon Zone
                     </button>

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -173,7 +173,7 @@ angular.module('controller.manageZones', [])
         zone = zonesService.normalizeZoneDates(zone);
         zone = zonesService.setConnectionKeys(zone);
         zone = zonesService.checkBackendId(zone);
-        zone.shared = (String(zone.shared).toLowerCase() == 'true');
+        zone = zonesService.checkSharedStatus(zone);
         $scope.currentManageZoneState = $scope.manageZoneState.UPDATE;
         $scope.updateZone(zone, 'Zone Update');
     };

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -173,6 +173,7 @@ angular.module('controller.manageZones', [])
         zone = zonesService.normalizeZoneDates(zone);
         zone = zonesService.setConnectionKeys(zone);
         zone = zonesService.checkBackendId(zone);
+        zone.shared = (String(zone.shared).toLowerCase() == 'true');
         $scope.currentManageZoneState = $scope.manageZoneState.UPDATE;
         $scope.updateZone(zone, 'Zone Update');
     };

--- a/modules/portal/public/lib/controllers/controller.manageZones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.spec.js
@@ -71,6 +71,7 @@ describe('Controller: ManageZonesController', function () {
             .and.stub();
         var checkBackendId = spyOn(this.zonesService, 'checkBackendId')
                     .and.stub();
+        var checkSharedStatus = spyOn(this.zonesService, 'checkSharedStatus').and.stub();
         var updateZone = spyOn(this.scope, 'updateZone')
             .and.stub();
 

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -108,6 +108,11 @@ angular.module('service.zones', [])
             return zone;
         };
 
+        this.checkSharedStatus = function(zone) {
+            zone.shared = (String(zone.shared).toLowerCase() == 'true');
+            return zone;
+        }
+
         this.toApiIso = function(date) {
             /* when we parse the DateTimes from the api it gets turned into javascript readable format
              * instead of just staying the way it is, so for now converting it back to ISO format on the fly,


### PR DESCRIPTION
Fixes #698.

Changes in this pull request:
- change Access value in Manage Zone to be a drop down menu with Private and Shared. Default value is the zone's current shared value. false = Private, true = Shared.
- hide Abandon Zone button when confirming zone update. We already hide the Update Zone button at this point, just forgot to hide Abandon Zone as well in an earlier PR.

<img width="1310" alt="zone access drop down" src="https://user-images.githubusercontent.com/4439228/59792005-41a17100-92a1-11e9-86a6-7f22055d1939.png">

<img width="1308" alt="not displaying abandon zone button when confirming a zone update" src="https://user-images.githubusercontent.com/4439228/59792011-449c6180-92a1-11e9-9809-cd4e94d62264.png">
