### PR TITLE
allow super and support users to list all batch changes

### DIFF
--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -581,7 +581,7 @@ class VinylDNSClient(object):
         _, data = self.make_request(url, u'POST', self.headers, json.dumps(reject_batch_change_input), **kwargs)
         return data
 
-    def list_batch_change_summaries(self, start_from=None, max_items=None, **kwargs):
+    def list_batch_change_summaries(self, start_from=None, max_items=None, list_all=False, **kwargs):
         """
         Gets list of user's batch change summaries
         :return: the content of the response
@@ -591,6 +591,8 @@ class VinylDNSClient(object):
             args.append(u'startFrom={0}'.format(start_from))
         if max_items is not None:
             args.append(u'maxItems={0}'.format(max_items))
+        if list_all:
+            args.append(u'listAll={0}'.format(list_all))
 
         url = urljoin(self.index_url, u'/zones/batchrecordchanges') + u'?' + u'&'.join(args)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -31,7 +31,8 @@ trait BatchChangeServiceAlgebra {
   def listBatchChangeSummaries(
       auth: AuthPrincipal,
       startFrom: Option[Int],
-      maxItems: Int): BatchResult[BatchChangeSummaryList]
+      maxItems: Int,
+      listAll: Boolean): BatchResult[BatchChangeSummaryList]
 
   def rejectBatchChange(
       batchChangeId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -50,16 +50,20 @@ trait BatchChangeRoute extends Directives {
         }
       } ~
       (get & path("zones" / "batchrecordchanges") & monitor("Endpoint.listBatchChangeSummaries")) {
-        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(MAX_ITEMS_LIMIT)) {
-          (startFrom: Option[Int], maxItems: Int) =>
+        parameters(
+          "startFrom".as[Int].?,
+          "maxItems".as[Int].?(MAX_ITEMS_LIMIT),
+          "listAll".as[Boolean].?(false)) {
+          (startFrom: Option[Int], maxItems: Int, listAll: Boolean) =>
             {
               handleRejections(invalidQueryHandler) {
                 validate(
                   0 < maxItems && maxItems <= MAX_ITEMS_LIMIT,
                   s"maxItems was $maxItems, maxItems must be between 1 and $MAX_ITEMS_LIMIT, inclusive.") {
                   execute(batchChangeService
-                    .listBatchChangeSummaries(authPrincipal, startFrom, maxItems)) { summaries =>
-                    complete(StatusCodes.OK, summaries)
+                    .listBatchChangeSummaries(authPrincipal, startFrom, maxItems, listAll)) {
+                    summaries =>
+                      complete(StatusCodes.OK, summaries)
                   }
                 }
               }

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -113,9 +113,7 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
       userId: Option[String],
       startFrom: Option[Int] = None,
       maxItems: Int = 100): IO[BatchChangeSummaryList] = {
-    val userBatchChanges =
-      if (userId.isDefined) batches.values.toList.filter(_.userId == userId.get)
-      else batches.values.toList
+    val userBatchChanges = batches.values.toList.filter(b => userId.forall(_ == b.userId))
     val batchChangeSummaries = for {
       sc <- userBatchChanges
       ids = sc.changes

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -109,11 +109,13 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     IO.pure(changes)
   }
 
-  def getBatchChangeSummariesByUserId(
-      userId: String,
+  def getBatchChangeSummaries(
+      userId: Option[String],
       startFrom: Option[Int] = None,
       maxItems: Int = 100): IO[BatchChangeSummaryList] = {
-    val userBatchChanges = batches.values.toList.filter(_.userId == userId)
+    val userBatchChanges =
+      if (userId.isDefined) batches.values.toList.filter(_.userId == userId.get)
+      else batches.values.toList
     val batchChangeSummaries = for {
       sc <- userBatchChanges
       ids = sc.changes

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -26,8 +26,8 @@ trait BatchChangeRepository extends Repository {
 
   def getBatchChange(batchChangeId: String): IO[Option[BatchChange]]
 
-  def getBatchChangeSummariesByUserId(
-      userId: String,
+  def getBatchChangeSummaries(
+      userId: Option[String],
       startFrom: Option[Int] = None,
       maxItems: Int = 100): IO[BatchChangeSummaryList]
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -65,4 +65,5 @@ case class BatchChangeSummaryList(
     batchChanges: List[BatchChangeSummary],
     startFrom: Option[Int] = None,
     nextId: Option[Int] = None,
-    maxItems: Int = 100)
+    maxItems: Int = 100,
+    listAll: Boolean = false)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -77,8 +77,8 @@ class MySqlBatchChangeRepository
          |    ON sc.batch_change_id = bc.id
         """.stripMargin
 
-  private final val GET_BATCH_CHANGE_SUMMARY =
-    sql"""
+  private final val GET_BATCH_CHANGE_SUMMARY_BASE =
+    """
          |       SELECT bc.id, bc.user_id, bc.user_name, bc.created_time, bc.comments, bc.owner_group_id,
          |              bc.approval_status, bc.reviewer_id, bc.review_comment, bc.review_timestamp,
          |              SUM( case sc.status when 'Failed' then 1 else 0 end ) AS fail_count,
@@ -87,7 +87,10 @@ class MySqlBatchChangeRepository
          |         FROM single_change sc
          |         JOIN batch_change bc
          |           ON sc.batch_change_id = bc.id
-         |        WHERE bc.user_id LIKE {userId}
+        """.stripMargin
+
+  private final val GET_BATCH_CHANGE_SUMMARY_END =
+    """
          |        GROUP BY bc.id
          |        ORDER BY bc.created_time DESC
          |        LIMIT {maxItems}
@@ -223,29 +226,33 @@ class MySqlBatchChangeRepository
       IO {
         DB.readOnly { implicit s =>
           val startValue = startFrom.getOrElse(0)
-          // maxItems gets a plus one to know if the table is exhausted so we can conditionally give a nextId
-          val queryResult = GET_BATCH_CHANGE_SUMMARY
-            .bindByName(
-              'userId -> userId.getOrElse("%"),
-              'startFrom -> startValue,
-              'maxItems -> (maxItems + 1))
-            .map { res =>
-              val pending = res.int("pending_count")
-              val failed = res.int("fail_count")
-              val complete = res.int("complete_count")
-              BatchChangeSummary(
-                res.string("user_id"),
-                res.string("user_name"),
-                Option(res.string("comments")),
-                new org.joda.time.DateTime(res.timestamp("created_time")),
-                pending + failed + complete,
-                BatchChangeStatus.fromSingleStatuses(pending > 0, failed > 0, complete > 0),
-                Option(res.string("owner_group_id")),
-                res.string("id"),
-              )
-            }
-            .list()
-            .apply()
+
+          val sb = new StringBuilder
+          sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
+          userId.foreach(uid => sb.append(s"WHERE bc.user_id = '$uid' "))
+          sb.append(GET_BATCH_CHANGE_SUMMARY_END)
+          val query = sb.toString()
+
+          val queryResult =
+            SQL(query)
+              .bindByName('startFrom -> startValue, 'maxItems -> (maxItems + 1))
+              .map { res =>
+                val pending = res.int("pending_count")
+                val failed = res.int("fail_count")
+                val complete = res.int("complete_count")
+                BatchChangeSummary(
+                  res.string("user_id"),
+                  res.string("user_name"),
+                  Option(res.string("comments")),
+                  new org.joda.time.DateTime(res.timestamp("created_time")),
+                  pending + failed + complete,
+                  BatchChangeStatus.fromSingleStatuses(pending > 0, failed > 0, complete > 0),
+                  Option(res.string("owner_group_id")),
+                  res.string("id"),
+                )
+              }
+              .list()
+              .apply()
           val maxQueries = queryResult.take(maxItems)
           val nextId = if (queryResult.size <= maxItems) None else Some(startValue + maxItems)
           BatchChangeSummaryList(maxQueries, startFrom, nextId, maxItems)


### PR DESCRIPTION
This is in support of implementing the batch change review process (#659).

Currently the `listBatchChange` is restricted to only showing the batch changes of the user making the request. We want to allow super and support users the ability to view all batch changes, regardless of user. 

Changes in this pull request:
- Add `listAll` Boolean parameter to the `listBatchChange` endpoint, default is false.
- If `'listAll` is set to true and the user is a super user or support user all batch changes in the system are returned (bearing in mind the current maxItems parameter, etc)
- if `listAll` is set to true but the user is not a super user or support user then only their batch changes will be returned.
