### PR TITLE
remove SPF record type from portal menus

### DIFF
--- a/modules/docs/src/main/tut/portal/manage-records.md
+++ b/modules/docs/src/main/tut/portal/manage-records.md
@@ -10,7 +10,7 @@ There are currently two ways to manage records in the VinylDNS portal. This cove
 Only zone administrators and users with ACL rules can manage records this way.
 
 #### Supported record types
-A, AAAA, CNAME, DS, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, and TXT
+A, AAAA, CNAME, DS, MX, NAPTR, NS, PTR, SRV, SSHFP, and TXT
 
 ---
 

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -69,7 +69,7 @@ angular.module('controller.manageZones', [])
             readOnly: false
         }
     };
-    $scope.aclRecordTypes = ['A', 'AAAA', 'CNAME', 'DS', 'MX', 'NS', 'PTR', 'SPF', 'SRV', 'NAPTR', 'SSHFP', 'TXT'];
+    $scope.aclRecordTypes = ['A', 'AAAA', 'CNAME', 'DS', 'MX', 'NS', 'PTR', 'SRV', 'NAPTR', 'SSHFP', 'TXT'];
 
     /**
      * Zone modal control functions

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -24,7 +24,7 @@ angular.module('controller.records', [])
     $scope.query = "";
     $scope.alerts = [];
 
-    $scope.recordTypes = ['A', 'AAAA', 'CNAME', 'DS', 'MX', 'NS', 'PTR', 'SPF', 'SRV', 'NAPTR', 'SSHFP', 'TXT'];
+    $scope.recordTypes = ['A', 'AAAA', 'CNAME', 'DS', 'MX', 'NS', 'PTR', 'SRV', 'NAPTR', 'SSHFP', 'TXT'];
     $scope.sshfpAlgorithms = [{name: '(1) RSA', number: 1}, {name: '(2) DSA', number: 2}, {name: '(3) ECDSA', number: 3},
         {name: '(4) Ed25519', number: 4}];
     $scope.sshfpTypes = [{name: '(1) SHA-1', number: 1}, {name: '(2) SHA-256', number: 2}];


### PR DESCRIPTION
The way we implemented SPF was not correct. Eventually, SPF will have to be implemented properly as a sub-type TXT record. For now remove support for creating new SPF records in the portal by removing the option from the record type menus in the portal. 

Leaving other references to SPF in the portal codebase for now so it doesn't interfere with any existing SPF records and in the event we repurpose that code when SPF is implemented properly.
