### PR TITLE
Allow updating and deleting dotted host records in batch change

### DIFF
--- a/docker/bind9/zones/ok.hosts
+++ b/docker/bind9/zones/ok.hosts
@@ -12,4 +12,3 @@ test             IN  A   3.3.3.3
 test             IN  A   4.4.4.4
 @                IN  A   5.5.5.5
 already-exists   IN  A   6.6.6.6
-dotted.record    IN  A   1.1.1.1

--- a/docker/bind9/zones/ok.hosts
+++ b/docker/bind9/zones/ok.hosts
@@ -12,3 +12,4 @@ test             IN  A   3.3.3.3
 test             IN  A   4.4.4.4
 @                IN  A   5.5.5.5
 already-exists   IN  A   6.6.6.6
+dotted.record    IN  A   1.1.1.1

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1115,10 +1115,8 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, address="1.2.3.4"),
             get_change_A_AAAA_json("reverse-zone.10.10.in-addr.arpa.", address="1.2.3.4"),
 
-            # dotted host failure
-            get_change_A_AAAA_json("no.subzone.parent.com.", address="1.2.3.4"),
-
             # zone discovery failures
+            get_change_A_AAAA_json("no.subzone.parent.com.", address="1.2.3.4"),
             get_change_A_AAAA_json("no.zone.at.all.", address="1.2.3.4"),
 
             # context validation failures
@@ -1150,11 +1148,9 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[2], input_name="reverse-zone.10.10.in-addr.arpa.", record_data="1.2.3.4",
                                             error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse-zone.10.10.in-addr.arpa.\" and type \"A\" is not allowed in a reverse zone."])
 
-        # dotted host failure
-        assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_data="1.2.3.4",
-                                            error_messages=['Cannot create dotted host "no.subzone" with record type A in the zone parent.com.'])
-
         # zone discovery failure
+        assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_data="1.2.3.4",
+                                            error_messages=['Zone Discovery Failed: zone for "no.subzone.parent.com." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_data="1.2.3.4",
                                             error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 
@@ -1293,10 +1289,8 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_type="AAAA", address="1::1"),
             get_change_A_AAAA_json("reverse-zone.1.2.3.ip6.arpa.", record_type="AAAA", address="1::1"),
 
-            # dotted host failure
+            # zone discovery failures
             get_change_A_AAAA_json("no.subzone.parent.com.", record_type="AAAA", address="1::1"),
-
-            # zone discovery failure
             get_change_A_AAAA_json("no.zone.at.all.", record_type="AAAA", address="1::1"),
 
             # context validation failures
@@ -1328,11 +1322,9 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[2], input_name="reverse-zone.1.2.3.ip6.arpa.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse-zone.1.2.3.ip6.arpa.\" and type \"AAAA\" is not allowed in a reverse zone."])
 
-        # dotted host failure
+        # zone discovery failures
         assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_type="AAAA", record_data="1::1",
-                                            error_messages=['Cannot create dotted host "no.subzone" with record type AAAA in the zone parent.com.'])
-
-        # zone discovery failure
+                                            error_messages=['Zone Discovery Failed: zone for \"no.subzone.parent.com.\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Zone Discovery Failed: zone for \"no.zone.at.all.\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."])
 
@@ -2276,11 +2268,9 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[3], input_name="mx.2.0.192.in-addr.arpa.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
                                        error_messages=['Invalid Record Type In Reverse Zone: record with name "mx.2.0.192.in-addr.arpa." and type "MX" is not allowed in a reverse zone.'])
 
-        # dotted host failure
+        # zone discovery failures
         assert_failed_change_in_error_response(response[4], input_name="no.subzone.ok.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
-                                               error_messages=['Cannot create dotted host "no.subzone" with record type MX in the zone ok.'])
-
-        # zone discovery failure
+                                               error_messages=['Zone Discovery Failed: zone for "no.subzone.ok." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
         assert_failed_change_in_error_response(response[5], input_name="no.zone.at.all.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1481,7 +1481,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
             get_change_CNAME_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, cname="also$bad.name"),
 
             # zone discovery failure
-            get_change_CNAME_json("no.subzone.parent.com."),
+            get_change_CNAME_json("no.zone.com."),
 
             # cant be apex
             get_change_CNAME_json("parent.com."),
@@ -1527,8 +1527,8 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
                                                                'valid domain names must be letters, numbers, and hyphens, '
                                                                'joined by dots, and terminated with a dot.'])
         # zone discovery failure
-        assert_failed_change_in_error_response(response[7], input_name="no.subzone.parent.com.", record_type="CNAME", record_data="test.com.",
-                                               error_messages=["Zone Discovery Failed: zone for \"no.subzone.parent.com.\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."])
+        assert_failed_change_in_error_response(response[7], input_name="no.zone.com.", record_type="CNAME", record_data="test.com.",
+                                               error_messages=["Zone Discovery Failed: zone for \"no.zone.com.\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."])
 
         # CNAME cant be apex
         assert_failed_change_in_error_response(response[8], input_name="parent.com.", record_type="CNAME", record_data="test.com.",

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1115,8 +1115,10 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, address="1.2.3.4"),
             get_change_A_AAAA_json("reverse-zone.10.10.in-addr.arpa.", address="1.2.3.4"),
 
-            # zone discovery failures
+            # dotted host failure
             get_change_A_AAAA_json("no.subzone.parent.com.", address="1.2.3.4"),
+
+            # zone discovery failures
             get_change_A_AAAA_json("no.zone.at.all.", address="1.2.3.4"),
 
             # context validation failures
@@ -1148,9 +1150,11 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[2], input_name="reverse-zone.10.10.in-addr.arpa.", record_data="1.2.3.4",
                                             error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse-zone.10.10.in-addr.arpa.\" and type \"A\" is not allowed in a reverse zone."])
 
-        # zone discovery failures
+        # dotted host failure
         assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_data="1.2.3.4",
-                                            error_messages=['Zone Discovery Failed: zone for "no.subzone.parent.com." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
+                                            error_messages=['Record with name no.subzone is a dotted host which is illegal in the zone: parent.com.'])
+
+        # zone discovery failure
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_data="1.2.3.4",
                                             error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 
@@ -1250,7 +1254,7 @@ def test_a_recordtype_update_delete_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[8], input_name="another.reverse.zone.in-addr.arpa.", change_type="DeleteRecordSet",
                                                error_messages=['Invalid Record Type In Reverse Zone: record with name "another.reverse.zone.in-addr.arpa." and type "A" is not allowed in a reverse zone.'])
 
-        # zone discovery failures
+        # zone discovery failure
         assert_failed_change_in_error_response(response[9], input_name="zone.discovery.error.", change_type="DeleteRecordSet",
                                                error_messages=['Zone Discovery Failed: zone for "zone.discovery.error." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 
@@ -1289,8 +1293,10 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$.parent.com.", ttl=29, record_type="AAAA", address="1::1"),
             get_change_A_AAAA_json("reverse-zone.1.2.3.ip6.arpa.", record_type="AAAA", address="1::1"),
 
-            # zone discovery failures
+            # dotted host failure
             get_change_A_AAAA_json("no.subzone.parent.com.", record_type="AAAA", address="1::1"),
+
+            # zone discovery failure
             get_change_A_AAAA_json("no.zone.at.all.", record_type="AAAA", address="1::1"),
 
             # context validation failures
@@ -1322,9 +1328,11 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[2], input_name="reverse-zone.1.2.3.ip6.arpa.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse-zone.1.2.3.ip6.arpa.\" and type \"AAAA\" is not allowed in a reverse zone."])
 
-        # zone discovery failures
+        # dotted host failure
         assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_type="AAAA", record_data="1::1",
-                                            error_messages=["Zone Discovery Failed: zone for \"no.subzone.parent.com.\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."])
+                                            error_messages=["Record with name no.subzone is a dotted host which is illegal in the zone: parent.com."])
+
+        # zone discovery failure
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_type="AAAA", record_data="1::1",
                                             error_messages=["Zone Discovery Failed: zone for \"no.zone.at.all.\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."])
 
@@ -1371,7 +1379,7 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$-update.ok.", record_type="AAAA", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json("bad-ttl-and-invalid-name$-update.ok.", ttl=29, record_type="AAAA", address="1:2:3:4:5:6:7:8"),
 
-            # zone discovery failures
+            # zone discovery failure
             get_change_A_AAAA_json("no.zone.at.all.", record_type="AAAA", change_type="DeleteRecordSet"),
 
             # context validation failures
@@ -1641,7 +1649,7 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                                'Invalid domain name: "$another.invalid.host.name.", valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.',
                                                                'Invalid domain name: "$another.invalid.cname.", valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
 
-        # zone discovery failures
+        # zone discovery failure
         assert_failed_change_in_error_response(response[9], input_name="zone.discovery.error.", record_type="CNAME", change_type="DeleteRecordSet",
                                                error_messages=['Zone Discovery Failed: zone for "zone.discovery.error." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 
@@ -2100,7 +2108,7 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
                                                                'Invalid domain name: "bad-ttl-and-invalid-name$.ok.", '
                                                                'valid domain names must be letters, numbers, and hyphens, joined by dots, and terminated with a dot.'])
 
-        # zone discovery failures
+        # zone discovery failure
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_type="TXT", record_data="test",
                                                error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 
@@ -2146,7 +2154,7 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_TXT_json("invalid-name$.ok.", change_type="DeleteRecordSet"),
             get_change_TXT_json("delete.ok.", ttl=29, text="bad-ttl"),
 
-            # zone discovery failures
+            # zone discovery failure
             get_change_TXT_json("no.zone.at.all.", change_type="DeleteRecordSet"),
 
             # context validation failures
@@ -2268,9 +2276,11 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[3], input_name="mx.2.0.192.in-addr.arpa.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
                                        error_messages=['Invalid Record Type In Reverse Zone: record with name "mx.2.0.192.in-addr.arpa." and type "MX" is not allowed in a reverse zone.'])
 
-        # zone discovery failures
+        # dotted host failure
         assert_failed_change_in_error_response(response[4], input_name="no.subzone.ok.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
-                                               error_messages=['Zone Discovery Failed: zone for "no.subzone.ok." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
+                                               error_messages=['Record with name no.subzone is a dotted host which is illegal in the zone: ok.'])
+
+        # zone discovery failure
         assert_failed_change_in_error_response(response[5], input_name="no.zone.at.all.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=['Zone Discovery Failed: zone for "no.zone.at.all." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1152,7 +1152,7 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
 
         # dotted host failure
         assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_data="1.2.3.4",
-                                            error_messages=['Record with name no.subzone is a dotted host which is illegal in the zone: parent.com.'])
+                                            error_messages=['Cannot create dotted host "no.subzone" with record type A in the zone parent.com.'])
 
         # zone discovery failure
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_data="1.2.3.4",
@@ -1330,7 +1330,7 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
 
         # dotted host failure
         assert_failed_change_in_error_response(response[3], input_name="no.subzone.parent.com.", record_type="AAAA", record_data="1::1",
-                                            error_messages=["Record with name no.subzone is a dotted host which is illegal in the zone: parent.com."])
+                                            error_messages=['Cannot create dotted host "no.subzone" with record type AAAA in the zone parent.com.'])
 
         # zone discovery failure
         assert_failed_change_in_error_response(response[4], input_name="no.zone.at.all.", record_type="AAAA", record_data="1::1",
@@ -1866,7 +1866,7 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_PTR_json("192.0.2.", change_type="DeleteRecordSet"),
             get_change_PTR_json("192.0.2.", ttl=29, ptrdname="failed-update$.ptr"),
 
-            # zone discovery failures
+            # zone discovery failure
             get_change_PTR_json("192.0.1.25", change_type="DeleteRecordSet"),
 
             # context validation failures
@@ -2278,7 +2278,7 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
 
         # dotted host failure
         assert_failed_change_in_error_response(response[4], input_name="no.subzone.ok.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
-                                               error_messages=['Record with name no.subzone is a dotted host which is illegal in the zone: ok.'])
+                                               error_messages=['Cannot create dotted host "no.subzone" with record type MX in the zone ok.'])
 
         # zone discovery failure
         assert_failed_change_in_error_response(response[5], input_name="no.zone.at.all.", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -166,13 +166,4 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
        |type ${change.inputChange.typ}.""".stripMargin
       .replaceAll("\n", " ")
 }
-
-final case class CreateDottedHostError(
-    recordSetName: String,
-    zoneName: String,
-    recordType: RecordType)
-    extends DomainValidationError {
-  def message: String =
-    s"""Cannot create dotted host "$recordSetName" with record type $recordType in the zone $zoneName"""
-}
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -167,4 +167,9 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
       .replaceAll("\n", " ")
 }
 
+final case class CreateDottedHostError(recordSetName: String, zoneName: String)
+    extends DomainValidationError {
+  def message: String =
+    s"Record with name $recordSetName is a dotted host which is illegal in the zone: $zoneName"
+}
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -167,9 +167,12 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
       .replaceAll("\n", " ")
 }
 
-final case class CreateDottedHostError(recordSetName: String, zoneName: String)
+final case class CreateDottedHostError(
+    recordSetName: String,
+    zoneName: String,
+    recordType: RecordType)
     extends DomainValidationError {
   def message: String =
-    s"Record with name $recordSetName is a dotted host which is illegal in the zone: $zoneName"
+    s"""Cannot create dotted host "$recordSetName" with record type $recordType in the zone $zoneName"""
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -136,7 +136,7 @@ class BatchChangeService(
 
     nonPtr
       .map {
-        case record if List(A, AAAA, MX, TXT).contains(record.typ) =>
+        case record if List(A, AAAA, MX, PTR, TXT).contains(record.typ) =>
           getAllPossibleZones(record.inputName).toSet
         case otherForward => getZonesForNonDottedTypes(otherForward)
       }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -136,7 +136,8 @@ class BatchChangeService(
 
     nonPtr
       .map {
-        case txt if txt.typ == TXT => getAllPossibleZones(txt.inputName).toSet
+        case record if List(A, AAAA, MX, TXT).contains(record.typ) =>
+          getAllPossibleZones(record.inputName).toSet
         case otherForward => getZonesForNonDottedTypes(otherForward)
       }
       .toSet
@@ -231,7 +232,7 @@ class BatchChangeService(
       zoneMap: ExistingZones): ValidatedBatch[ChangeForValidation] =
     changes.mapValid { change =>
       change.typ match {
-        case A | AAAA | MX => standardZoneDiscovery(change, zoneMap)
+        case A | AAAA | MX => dottedZoneDiscovery(change, zoneMap)
         case TXT => dottedZoneDiscovery(change, zoneMap)
         case CNAME => cnameZoneDiscovery(change, zoneMap)
         case PTR if validateIpv4Address(change.inputName).isValid =>

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -232,8 +232,7 @@ class BatchChangeService(
       zoneMap: ExistingZones): ValidatedBatch[ChangeForValidation] =
     changes.mapValid { change =>
       change.typ match {
-        case A | AAAA | MX => standardZoneDiscovery(change, zoneMap)
-        case TXT => standardZoneDiscovery(change, zoneMap)
+        case A | AAAA | MX | TXT => standardZoneDiscovery(change, zoneMap)
         case CNAME => cnameZoneDiscovery(change, zoneMap)
         case PTR if validateIpv4Address(change.inputName).isValid =>
           ptrIpv4ZoneDiscovery(change, zoneMap)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -232,11 +232,13 @@ class BatchChangeValidations(
   }
 
   def newRecordSetIsNotDotted(change: AddChangeForValidation): SingleValidation[Unit] =
-    if (change.inputChange.typ != RecordType.TXT &&
-      (change.recordName == change.zone.name || !change.recordName.contains(".")))
-      ().validNel
-    else
-      CreateDottedHostError(change.recordName, change.zone.name).invalidNel
+    change.inputChange.typ match {
+      case TXT | PTR => ().validNel
+      case A | AAAA | CNAME | MX
+          if change.recordName == change.zone.name || !change.recordName.contains(".") =>
+        ().validNel
+      case _ => CreateDottedHostError(change.recordName, change.zone.name).invalidNel
+    }
 
   def validateDeleteWithContext(
       change: DeleteChangeForValidation,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -232,15 +232,10 @@ class BatchChangeValidations(
   }
 
   def newRecordSetIsNotDotted(change: AddChangeForValidation): SingleValidation[Unit] =
-    change.inputChange.typ match {
-      case A | AAAA | MX
-          if change.recordName == change.zone.name || !change.recordName.contains(".") =>
-        ().validNel
-      case CNAME if !change.recordName.contains(".") =>
-        ().validNel
-      case _ =>
-        ZoneDiscoveryError(change.inputChange.inputName).invalidNel
-    }
+    if (change.recordName != change.zone.name && change.recordName.contains("."))
+      ZoneDiscoveryError(change.inputChange.inputName).invalidNel
+    else
+      ().validNel
 
   def validateDeleteWithContext(
       change: DeleteChangeForValidation,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -231,6 +231,13 @@ class BatchChangeValidations(
     else ().validNel
   }
 
+  def newRecordSetIsNotDotted(change: AddChangeForValidation): SingleValidation[Unit] =
+    if (change.inputChange.typ != RecordType.TXT &&
+      (change.recordName == change.zone.name || !change.recordName.contains(".")))
+      ().validNel
+    else
+      CreateDottedHostError(change.recordName, change.zone.name).invalidNel
+
   def validateDeleteWithContext(
       change: DeleteChangeForValidation,
       existingRecords: ExistingRecordSets,
@@ -305,7 +312,8 @@ class BatchChangeValidations(
           change.inputChange.inputName,
           existingRecords,
           changeGroups) |+|
-          newRecordSetIsNotMulti(change, changeGroups)
+          newRecordSetIsNotMulti(change, changeGroups) |+|
+          newRecordSetIsNotDotted(change)
       case CNAME =>
         cnameHasUniqueNameInExistingRecords(
           change.zone.id,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -233,7 +233,6 @@ class BatchChangeValidations(
 
   def newRecordSetIsNotDotted(change: AddChangeForValidation): SingleValidation[Unit] =
     change.inputChange.typ match {
-      case TXT | PTR => ().validNel
       case A | AAAA | CNAME | MX
           if change.recordName == change.zone.name || !change.recordName.contains(".") =>
         ().validNel
@@ -308,7 +307,7 @@ class BatchChangeValidations(
       auth: AuthPrincipal,
       ownerGroupId: Option[String]): SingleValidation[ChangeForValidation] = {
     val typedValidations = change.inputChange.typ match {
-      case A | AAAA | MX | PTR =>
+      case A | AAAA | MX =>
         noCnameWithRecordNameInExistingRecords(
           change.zone.id,
           change.recordName,
@@ -325,7 +324,7 @@ class BatchChangeValidations(
           existingRecords,
           changeGroups) |+|
           cnameHasUniqueNameInBatch(change, changeGroups)
-      case TXT =>
+      case TXT | PTR =>
         noCnameWithRecordNameInExistingRecords(
           change.zone.id,
           change.recordName,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -237,7 +237,7 @@ class BatchChangeValidations(
           if change.recordName == change.zone.name || !change.recordName.contains(".") =>
         ().validNel
       case _ =>
-        CreateDottedHostError(change.recordName, change.zone.name, change.inputChange.typ).invalidNel
+        ZoneDiscoveryError(change.inputChange.inputName).invalidNel
     }
 
   def validateDeleteWithContext(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -237,7 +237,8 @@ class BatchChangeValidations(
       case A | AAAA | CNAME | MX
           if change.recordName == change.zone.name || !change.recordName.contains(".") =>
         ().validNel
-      case _ => CreateDottedHostError(change.recordName, change.zone.name).invalidNel
+      case _ =>
+        CreateDottedHostError(change.recordName, change.zone.name, change.inputChange.typ).invalidNel
     }
 
   def validateDeleteWithContext(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -764,26 +764,21 @@ class BatchChangeValidationsSpec
       CnameIsNotUniqueError(addCname.inputChange.inputName, existingA.typ))
   }
 
-  // Is this test valid??
   property("""validateChangesWithContext: should succeed for CNAME record
-      |if there's a duplicate PTR ipv6 record that is being deleted""".stripMargin) {
+      |if there's a duplicate PTR ipv4 record that is being deleted""".stripMargin) {
     val addCname = AddChangeForValidation(
-      validZone,
-      "0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
-      AddChangeInput(
-        "0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.",
-        RecordType.CNAME,
-        ttl,
-        CNAMEData("cname"))
+      validIp4ReverseZone,
+      "30",
+      AddChangeInput("30.2.0.192.in-addr.arpa.", RecordType.CNAME, ttl, CNAMEData("cname"))
     )
     val deletePtr = DeleteChangeForValidation(
-      validZone,
-      "0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
-      DeleteChangeInput("0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", RecordType.PTR))
-    val existingRecordPTR = ptrIp6.copy(zoneId = addCname.zone.id, name = addCname.recordName)
+      validIp4ReverseZone,
+      "30",
+      DeleteChangeInput("192.0.2.30", RecordType.PTR))
+    val ptr4 = ptrIp4.copy(zoneId = validIp4ReverseZone.id)
     val result = validateChangesWithContext(
       List(addCname.validNel, deletePtr.validNel),
-      ExistingRecordSets(List(existingRecordPTR)),
+      ExistingRecordSets(List(ptr4)),
       okAuth,
       None)
 


### PR DESCRIPTION
VinylDNS doesn't allow the creation of dotted hosts, but legacy zones that are imported into Vinyl may have dotted hosts. We want to give users the ability to update or delete those existing dotted hosts. 

Changes in this pull request:
- affects batch change only.
- This only includes the following record types: A, AAAA, CNAME, MX (TXT was already allowed)
- Does not allowed creating new dotted hosts through batch change for any record type besides TXT
