### PR TITLE
allow updates for dotted host records in update recordset

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -602,8 +602,8 @@ def test_create_dotted_a_record_not_apex_fails(shared_zone_test_context):
     }
 
     error = client.create_recordset(dotted_host_a_record, status=422)
-    assert_that(error, is_("Record with name " + dotted_host_a_record['name'] + " is a dotted host which "
-                              "is illegal in this zone " + zone['name']))
+    assert_that(error, is_("Record with name " + dotted_host_a_record['name'] + " and type A is a dotted host which "
+                              "is not allowed in zone " + zone['name']))
 
 def test_create_dotted_a_record_apex_succeeds(shared_zone_test_context):
     """
@@ -2189,4 +2189,4 @@ def test_create_dotted_ds_fails(shared_zone_test_context):
     record_data = [{'keytag': 60485, 'algorithm': 5, 'digesttype': 1, 'digest': '2BB183AF5F22588179A53B0A98631FAD1A292118'}]
     record_json = get_recordset_json(zone, 'dotted.ds', 'DS', record_data, ttl=100)
     error = client.create_recordset(record_json, status=422)
-    assert_that(error, is_("Record with name dotted.ds is a dotted host which is illegal in this zone example.com."))
+    assert_that(error, is_("Record with name dotted.ds and type DS is a dotted host which is not allowed in zone example.com."))

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -1762,8 +1762,8 @@ def test_update_dotted_a_record_not_apex_fails(shared_zone_test_context):
 
     try:
         error = client.update_recordset(create_rs, status=422)
-        assert_that(error, is_("Record with name " + create_rs['name'] + " is a dotted host which is illegal "
-                                "in this zone " + zone['name']))
+        assert_that(error, is_("Record with name " + create_rs['name'] + " and type A is a dotted host which is "
+                                "not allowed in zone " + zone['name']))
 
     finally:
         delete_result = client.delete_recordset(zone['id'], create_rs['id'], status=202)

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -75,7 +75,7 @@ class RecordSetService(
       ownerGroup <- getGroupIfProvided(rsForValidations.ownerGroupId)
       _ <- canUseOwnerGroup(rsForValidations.ownerGroupId, ownerGroup, auth).toResult
       _ <- noCnameWithNewName(rsForValidations, existingRecordsWithName, zone).toResult
-      _ <- typeSpecificAddValidations(rsForValidations, existingRecordsWithName, zone).toResult
+      _ <- typeSpecificValidations(rsForValidations, existingRecordsWithName, zone).toResult
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
 
@@ -99,7 +99,7 @@ class RecordSetService(
         .toResult[List[RecordSet]]
       _ <- isUniqueUpdate(rsForValidations, existingRecordsWithName, zone).toResult
       _ <- noCnameWithNewName(rsForValidations, existingRecordsWithName, zone).toResult
-      _ <- typeSpecificEditValidations(rsForValidations, existing, existingRecordsWithName, zone).toResult
+      _ <- typeSpecificValidations(rsForValidations, existingRecordsWithName, zone, Some(existing)).toResult
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -95,7 +95,7 @@ object RecordSetValidations {
       existingRecordSet: Option[RecordSet] = None): Either[Throwable, Unit] =
     newRecordSet.typ match {
       case CNAME => cnameValidations(newRecordSet, existingRecordsWithName, zone)
-      case NS => nsValidations(newRecordSet, zone)
+      case NS => nsValidations(newRecordSet, zone, existingRecordSet)
       case SOA => soaValidations(newRecordSet, zone)
       case PTR => ptrValidations(newRecordSet, zone)
       case SRV | TXT | NAPTR => ().asRight // SRV, TXT and NAPTR do not go through dotted host check

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -282,7 +282,7 @@ class RecordSetServiceSpec
         underTest.updateRecordSet(aaaa.copy(zoneId = zoneNotAuthorized.id), okAuth).value)
       result shouldBe a[NotAuthorizedError]
     }
-    "fail if the record is dotted" in {
+    "fail if the new record name is dotted" in {
       val oldRecord = aaaa.copy(zoneId = okZone.id, status = RecordSetStatus.Active)
       val newRecord = oldRecord.copy(name = "new.name")
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -337,22 +337,22 @@ class RecordSetValidationsSpec
       }
     }
 
-    "CnameValidations" should {
+    "CnameAddValidations" should {
       val invalidCnameApexRs: RecordSet = cname.copy(name = "@")
       "return a RecordSetAlreadyExistsError if a record with the same name exists and creating a cname" in {
-        val error = leftValue(cnameValidations(cname, List(aaaa), okZone))
+        val error = leftValue(cnameAddValidations(cname, List(aaaa), okZone))
         error shouldBe a[RecordSetAlreadyExists]
       }
       "return ok if name is not '@'" in {
-        cnameValidations(cname, List(), okZone) should be(right)
+        cnameAddValidations(cname, List(), okZone) should be(right)
       }
       "return an InvalidRequest if a cname record set name is '@'" in {
-        val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone))
+        val error = leftValue(cnameAddValidations(invalidCnameApexRs, List(), okZone))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is same as zone" in {
         val invalid = invalidCnameApexRs.copy(name = okZone.name)
-        val error = leftValue(cnameValidations(invalid, List(), okZone))
+        val error = leftValue(cnameAddValidations(invalid, List(), okZone))
         error shouldBe an[InvalidRequest]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -355,6 +355,34 @@ class RecordSetValidationsSpec
         val error = leftValue(cnameAddValidations(invalid, List(), okZone))
         error shouldBe an[InvalidRequest]
       }
+      "return an InvalidRequest if a cname record set name is dotted" in {
+        val error = leftValue(cnameAddValidations(cname.copy(name = "dot.ted"), List(), okZone))
+        error shouldBe an[InvalidRequest]
+      }
+    }
+
+    "CnameEditValidations" should {
+      val invalidCnameApexRs: RecordSet = cname.copy(name = "@")
+      "return a RecordSetAlreadyExistsError if a record with the same name exists as updated cname" in {
+        val error = leftValue(cnameEditValidations(cname, List(aaaa), okZone, cname.name))
+        error shouldBe a[RecordSetAlreadyExists]
+      }
+      "return ok if new name does not contain dot" in {
+        cnameEditValidations(cname, List(), okZone, "dot.ted") should be(right)
+      }
+      "return ok if dotted host name doesn't change" in {
+        val updatedRecord = cname.copy(name = "dot.ted", ttl = 500)
+        cnameEditValidations(updatedRecord, List(), okZone, "dot.ted") should be(right)
+      }
+      "return an InvalidRequest if a cname record set name is '@'" in {
+        val error = leftValue(cnameEditValidations(invalidCnameApexRs, List(), okZone, "old-name"))
+        error shouldBe an[InvalidRequest]
+      }
+      "return an InvalidRequest if a cname record set name is same as zone" in {
+        val invalid = invalidCnameApexRs.copy(name = okZone.name)
+        val error = leftValue(cnameEditValidations(invalid, List(), okZone, okZone.name))
+        error shouldBe an[InvalidRequest]
+      }
     }
 
     "isNotHighValueDomain" should {

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -167,24 +167,38 @@ class RecordSetValidationsSpec
 
         isNotDotted(test, okZone) should be(right)
       }
+
+      "return success for a new record that has the same name as the existing record" in {
+        val newRecord = aaaa.copy(name = "dot.ted")
+        val existingRecord = newRecord.copy(ttl = 330)
+
+        isNotDotted(newRecord, okZone, Some(existingRecord)) should be(right)
+      }
+
+      "return failure for a new record that is a dotted record name" in {
+        val existingRecord = aaaa.copy(ttl = 330)
+        val newRecord = existingRecord.copy(name = "dot.ted")
+
+        leftValue(isNotDotted(newRecord, okZone, Some(existingRecord))) shouldBe an[InvalidRequest]
+      }
     }
 
-    "typeSpecificAddValidations" should {
+    "typeSpecificValidations" should {
       "Run dotted hosts checks" should {
         val dottedARecord = rsOk.copy(name = "this.is.a.failure.")
         "return a failure for any record with dotted hosts in forward zones" in {
           leftValue(
-            typeSpecificAddValidations(dottedARecord, List(), okZone)
+            typeSpecificValidations(dottedARecord, List(), okZone)
           ) shouldBe an[InvalidRequest]
         }
         "return a failure for any record with dotted hosts in forward zones (CNAME)" in {
           leftValue(
-            typeSpecificAddValidations(dottedARecord.copy(typ = CNAME), List(), okZone)
+            typeSpecificValidations(dottedARecord.copy(typ = CNAME), List(), okZone)
           ) shouldBe an[InvalidRequest]
         }
         "return a failure for any record with dotted hosts in forward zones (NS)" in {
           leftValue(
-            typeSpecificAddValidations(dottedARecord.copy(typ = NS), List(), okZone)
+            typeSpecificValidations(dottedARecord.copy(typ = NS), List(), okZone)
           ) shouldBe an[InvalidRequest]
         }
       }
@@ -193,35 +207,35 @@ class RecordSetValidationsSpec
           val test = srv.copy(name = "_sip._tcp.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
         "return success for an SRV record following convention without FQDN" in {
           val test = srv.copy(name = "_sip._tcp")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
         "return success for an SRV record following convention with a record name" in {
           val test = srv.copy(name = "_sip._tcp.foo.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
         "return success on a wildcard SRV that follows convention" in {
           val test = srv.copy(name = "*._tcp.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
         "return success on a wildcard in second position SRV that follows convention" in {
           val test = srv.copy(name = "_sip._*.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
       }
       "Skip dotted checks on NAPTR" should {
@@ -229,21 +243,21 @@ class RecordSetValidationsSpec
           val test = naptr.copy(name = "sub.naptr.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
         "return success for an NAPTR record without FQDN" in {
           val test = naptr.copy(name = "sub.naptr")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
         "return success on a wildcard NAPTR" in {
           val test = naptr.copy(name = "*.sub.naptr.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
       }
@@ -252,7 +266,7 @@ class RecordSetValidationsSpec
           val test = ptrIp4.copy(name = "10.1.2.")
           val zone = zoneIp4.copy(name = "198.in-addr.arpa.")
 
-          typeSpecificAddValidations(test, List(), zone) should be(right)
+          typeSpecificValidations(test, List(), zone) should be(right)
         }
 
       }
@@ -268,7 +282,7 @@ class RecordSetValidationsSpec
             None,
             List(SOAData("something", "other", 1, 2, 3, 5, 6)))
 
-          typeSpecificAddValidations(test, List(), zoneIp4) should be(right)
+          typeSpecificValidations(test, List(), zoneIp4) should be(right)
         }
       }
     }
@@ -337,50 +351,44 @@ class RecordSetValidationsSpec
       }
     }
 
-    "CnameAddValidations" should {
+    "CnameValidations" should {
       val invalidCnameApexRs: RecordSet = cname.copy(name = "@")
       "return a RecordSetAlreadyExistsError if a record with the same name exists and creating a cname" in {
-        val error = leftValue(cnameAddValidations(cname, List(aaaa), okZone))
+        val error = leftValue(cnameValidations(cname, List(aaaa), okZone))
         error shouldBe a[RecordSetAlreadyExists]
       }
       "return ok if name is not '@'" in {
-        cnameAddValidations(cname, List(), okZone) should be(right)
+        cnameValidations(cname, List(), okZone) should be(right)
       }
       "return an InvalidRequest if a cname record set name is '@'" in {
-        val error = leftValue(cnameAddValidations(invalidCnameApexRs, List(), okZone))
+        val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is same as zone" in {
         val invalid = invalidCnameApexRs.copy(name = okZone.name)
-        val error = leftValue(cnameAddValidations(invalid, List(), okZone))
+        val error = leftValue(cnameValidations(invalid, List(), okZone))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is dotted" in {
-        val error = leftValue(cnameAddValidations(cname.copy(name = "dot.ted"), List(), okZone))
+        val error = leftValue(cnameValidations(cname.copy(name = "dot.ted"), List(), okZone))
         error shouldBe an[InvalidRequest]
       }
-    }
-
-    "CnameEditValidations" should {
-      val invalidCnameApexRs: RecordSet = cname.copy(name = "@")
-      "return a RecordSetAlreadyExistsError if a record with the same name exists as updated cname" in {
-        val error = leftValue(cnameEditValidations(cname, List(aaaa), okZone, cname.name))
-        error shouldBe a[RecordSetAlreadyExists]
-      }
-      "return ok if new name does not contain dot" in {
-        cnameEditValidations(cname, List(), okZone, "dot.ted") should be(right)
+      "return ok if new recordset name does not contain dot" in {
+        cnameValidations(cname, List(), okZone, Some(cname.copy(name = "not-dotted"))) should be(
+          right)
       }
       "return ok if dotted host name doesn't change" in {
-        val updatedRecord = cname.copy(name = "dot.ted", ttl = 500)
-        cnameEditValidations(updatedRecord, List(), okZone, "dot.ted") should be(right)
+        val newRecord = cname.copy(name = "dot.ted", ttl = 500)
+        cnameValidations(newRecord, List(), okZone, Some(newRecord.copy(ttl = 300))) should be(
+          right)
       }
-      "return an InvalidRequest if a cname record set name is '@'" in {
-        val error = leftValue(cnameEditValidations(invalidCnameApexRs, List(), okZone, "old-name"))
+      "return an InvalidRequest if a cname record set name is updated to '@'" in {
+        val error = leftValue(cnameValidations(cname.copy(name = "@"), List(), okZone, Some(cname)))
         error shouldBe an[InvalidRequest]
       }
-      "return an InvalidRequest if a cname record set name is same as zone" in {
-        val invalid = invalidCnameApexRs.copy(name = okZone.name)
-        val error = leftValue(cnameEditValidations(invalid, List(), okZone, okZone.name))
+      "return an InvalidRequest if updated cname record set name is same as zone" in {
+        val error =
+          leftValue(cnameValidations(cname.copy(name = okZone.name), List(), okZone, Some(cname)))
         error shouldBe an[InvalidRequest]
       }
     }


### PR DESCRIPTION
in the same vein as #702 we want to allow users to update existing recordsets with dotted hosts.

This pertains to the update recordset route.

Changes in this pull request:
- users can modify dotted host records with the following exceptions:
  - users cannot create new dotted hosts (except TXT record types)
  - users cannot change the name of a dotted host to another dotted host (except TXT record types)
