### PR TITLE
WIP: starter code for manual approval flow

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -128,8 +128,8 @@ object Boot extends App {
           loaderResponse.healthChecks)
       val batchChangeConverter =
         new BatchChangeConverter(repositories.batchChangeRepository, messageQueue)
-      val batchChangeService =
-        BatchChangeService(repositories, batchChangeValidations, batchChangeConverter)
+      val batchChangeService = BatchChangeService(repositories, batchChangeValidations, batchChangeConverter,
+          VinylDNSConfig.manualBatchReviewEnabled)
       val collectorRegistry = CollectorRegistry.defaultRegistry
       val vinyldnsService = new VinylDNSService(
         membershipService,

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -107,7 +107,7 @@ final case class InvalidBatchRecordType(param: String) extends DomainValidationE
       s"${SupportedBatchChangeRecordTypes.get}."
 }
 
-final case class ZoneDiscoveryError(name: String) extends SoftBatchError {
+final case class ZoneDiscoveryError(name: String) extends DomainValidationError {
   def message: String =
     s"""Zone Discovery Failed: zone for "$name" does not exist in VinylDNS. """ +
       "If zone exists, then it must be connected to in VinylDNS."

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -24,6 +24,13 @@ import vinyldns.core.domain.record.RecordType.RecordType
 // $COVERAGE-OFF$
 sealed trait DomainValidationError {
   def message: String
+
+  val isSoftFailure: Boolean = false
+}
+
+sealed trait SoftBatchError extends DomainValidationError {
+  override val isSoftFailure: Boolean = true
+  // TODO envisioning error codes, display options in here
 }
 
 // The request itself is invalid in this case, so we fail fast
@@ -100,7 +107,7 @@ final case class InvalidBatchRecordType(param: String) extends DomainValidationE
       s"${SupportedBatchChangeRecordTypes.get}."
 }
 
-final case class ZoneDiscoveryError(name: String) extends DomainValidationError {
+final case class ZoneDiscoveryError(name: String) extends SoftBatchError {
   def message: String =
     s"""Zone Discovery Failed: zone for "$name" does not exist in VinylDNS. """ +
       "If zone exists, then it must be connected to in VinylDNS."

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -16,7 +16,10 @@
 
 package vinyldns.api.domain.batch
 
+import vinyldns.api.VinylDNSConfig
+import vinyldns.api.domain.SoftBatchError
 import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
+import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordData
 import vinyldns.core.domain.record.RecordType._
 
@@ -28,6 +31,7 @@ final case class BatchChangeInput(
 sealed trait ChangeInput {
   val inputName: String
   val typ: RecordType
+  def asNewStoredChange(errors: List[SoftBatchError]): SingleChange
 }
 
 final case class AddChangeInput(
@@ -35,9 +39,38 @@ final case class AddChangeInput(
     typ: RecordType,
     ttl: Option[Long],
     record: RecordData)
-    extends ChangeInput
+    extends ChangeInput {
 
-final case class DeleteChangeInput(inputName: String, typ: RecordType) extends ChangeInput
+  def asNewStoredChange(errors: List[SoftBatchError]): SingleChange = {
+    val knownTtl = ttl.getOrElse(VinylDNSConfig.defaultTtl)
+    SingleAddChange(
+      None,
+      None,
+      None,
+      inputName,
+      typ,
+      knownTtl,
+      record,
+      SingleChangeStatus.UnValidated,
+      None,
+      None,
+      None)
+  }
+}
+
+final case class DeleteChangeInput(inputName: String, typ: RecordType) extends ChangeInput {
+  def asNewStoredChange(errors: List[SoftBatchError]): SingleChange =
+    SingleDeleteChange(
+      None,
+      None,
+      None,
+      inputName,
+      typ,
+      SingleChangeStatus.UnValidated,
+      None,
+      None,
+      None)
+}
 
 object AddChangeInput {
   def apply(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -51,7 +51,7 @@ final case class AddChangeInput(
       typ,
       knownTtl,
       record,
-      SingleChangeStatus.UnValidated,
+      SingleChangeStatus.NeedsReview,
       None,
       None,
       None)
@@ -66,7 +66,7 @@ final case class DeleteChangeInput(inputName: String, typ: RecordType) extends C
       None,
       inputName,
       typ,
-      SingleChangeStatus.UnValidated,
+      SingleChangeStatus.NeedsReview,
       None,
       None,
       None)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -81,12 +81,12 @@ class BatchChangeService(
         auth,
         batchChangeInput.ownerGroupId)
       changeForConversion <- buildResponse(batchChangeInput, validatedSingleChanges, auth).toBatchResult
-      conversionResult <- batchChangeConverter.sendBatchForProcessing(
+      serviceCompleteBatch <- convertOrSave(
         changeForConversion,
         zoneMap,
         recordSets,
         batchChangeInput.ownerGroupId)
-    } yield conversionResult.batchChange
+    } yield serviceCompleteBatch
 
   def rejectBatchChange(
       batchChangeId: String,

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -39,8 +39,9 @@ case class BatchChange(
     val hasPending = singleStatuses.contains(SingleChangeStatus.Pending)
     val hasFailed = singleStatuses.contains(SingleChangeStatus.Failed)
     val hasComplete = singleStatuses.contains(SingleChangeStatus.Complete)
+    val hasNeedsReview = singleStatuses.contains(SingleChangeStatus.NeedsReview)
 
-    BatchChangeStatus.fromSingleStatuses(hasPending, hasFailed, hasComplete)
+    BatchChangeStatus.fromSingleStatuses(hasPending, hasFailed, hasComplete, hasNeedsReview)
   }
 }
 
@@ -57,11 +58,13 @@ object BatchChangeStatus extends Enumeration {
   def fromSingleStatuses(
       hasPending: Boolean,
       hasFailed: Boolean,
-      hasComplete: Boolean): BatchChangeStatus =
-    (hasPending, hasFailed, hasComplete) match {
-      case (true, _, _) => BatchChangeStatus.Pending
-      case (_, true, true) => BatchChangeStatus.PartialFailure
-      case (_, true, false) => BatchChangeStatus.Failed
+      hasComplete: Boolean,
+      hasNeedsReview: Boolean): BatchChangeStatus =
+    (hasPending, hasFailed, hasComplete, hasNeedsReview) match {
+      case (true, _, _, _) => BatchChangeStatus.Pending
+      case (_, _, _, true) => BatchChangeStatus.Pending
+      case (_, true, true, _) => BatchChangeStatus.PartialFailure
+      case (_, true, false, _) => BatchChangeStatus.Failed
       case _ => BatchChangeStatus.Complete
     }
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
@@ -105,11 +105,11 @@ final case class SingleDeleteChange(
  - Pending has not yet been processed
  - Complete has been processed - must have recordChangeId
  - Failed had some error (see systemMessage) - may have recordChangeId, not required
- - UnValidated means there was a validation error and it needs manual review
+ - NeedsReview means there was a validation error and it needs manual review
  */
 object SingleChangeStatus extends Enumeration {
   type SingleChangeStatus = Value
-  val Pending, Complete, Failed, UnValidated = Value
+  val Pending, Complete, Failed, NeedsReview = Value
 }
 
 case class RecordKey(zoneId: String, recordName: String, recordType: RecordType)

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
@@ -105,10 +105,11 @@ final case class SingleDeleteChange(
  - Pending has not yet been processed
  - Complete has been processed - must have recordChangeId
  - Failed had some error (see systemMessage) - may have recordChangeId, not required
+ - UnValidated means there was a validation error and it needs manual review
  */
 object SingleChangeStatus extends Enumeration {
   type SingleChangeStatus = Value
-  val Pending, Complete, Failed = Value
+  val Pending, Complete, Failed, UnValidated = Value
 }
 
 case class RecordKey(zoneId: String, recordName: String, recordType: RecordType)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -83,7 +83,8 @@ class MySqlBatchChangeRepository
          |              bc.approval_status, bc.reviewer_id, bc.review_comment, bc.review_timestamp,
          |              SUM( case sc.status when 'Failed' then 1 else 0 end ) AS fail_count,
          |              SUM( case sc.status when 'Pending' then 1 else 0 end ) AS pending_count,
-         |              SUM( case sc.status when 'Complete' then 1 else 0 end )  AS complete_count
+         |              SUM( case sc.status when 'Complete' then 1 else 0 end ) AS complete_count
+         |              SUM( case sc.status when 'NeedsReview' then 1 else 0 end ) AS needs_review_count
          |         FROM single_change sc
          |         JOIN batch_change bc
          |           ON sc.batch_change_id = bc.id
@@ -230,15 +231,16 @@ class MySqlBatchChangeRepository
               val pending = res.int("pending_count")
               val failed = res.int("fail_count")
               val complete = res.int("complete_count")
+              val needsReview = res.int("needs_review_count")
               BatchChangeSummary(
                 userId,
                 res.string("user_name"),
                 Option(res.string("comments")),
                 new org.joda.time.DateTime(res.timestamp("created_time")),
                 pending + failed + complete,
-                BatchChangeStatus.fromSingleStatuses(pending > 0, failed > 0, complete > 0),
+                BatchChangeStatus.fromSingleStatuses(pending > 0, failed > 0, complete > 0, needsReview > 0),
                 Option(res.string("owner_group_id")),
-                res.string("id"),
+                res.string("id")
               )
             }
             .list()


### PR DESCRIPTION
no tests yet, expect failures

the general idea is to split out soft failures, and if all errors are in that bucket, save the batch change.
have not yet actually assigned any errors as soft or decided what to save for those on the single change (use a list of error codes? save something in system message? something else?). These will all be followup