### PR TITLE
adjust zone listAll func tests

### DIFF
--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -255,8 +255,17 @@ def test_list_zones_list_all_success(list_zones_context):
     result = list_zones_context.client.list_zones(list_all=True, status=200)
     retrieved = result['zones']
 
-    assert_that(retrieved, has_length(17))
-    assert_that(retrieved, has_item(has_entry('name', 'list-zones-test-searched-1.')))
-    assert_that(retrieved, has_item(has_entry('adminGroupName', 'list-zones-group')))
-    assert_that(retrieved, has_item(has_entry('backendId', 'func-test-backend')))
+    assert_that(result['listAll'], is_(True))
+    assert_that(len(retrieved), greater_than(5))
+
+
+def test_list_zones_list_all_success_with_name_filter(list_zones_context):
+    """
+    Test that we can retrieve a list of all zones with a name filter
+    """
+    result = list_zones_context.client.list_zones(name_filter='shared', list_all=True, status=200)
+    retrieved = result['zones']
+
+    assert_that(result['listAll'], is_(True))
+    assert_that(retrieved, has_item(has_entry('name', 'shared.')))
     assert_that(retrieved, has_item(has_entry('accessLevel', 'NoAccess')))


### PR DESCRIPTION
Changes in this pull request:
- zones can vary in different environments so can't assume the count of zones when passing the listAll parameter
- verify listAll results in more zones than the test client has access to without listAll
- apply a name filter with the name of a test zone the user doesn't have access to and assert that it is in the results and the accessLevel is "NoAccess"
