### PR TITLE
add no translate meta tag

### DIFF
--- a/modules/portal/app/views/login.scala.html
+++ b/modules/portal/app/views/login.scala.html
@@ -5,6 +5,7 @@
     <head>
             <!-- META SECTION -->
         <title>Please sign in using your Corporate Credentials</title>
+        <meta name="google" content="notranslate" />
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/modules/portal/app/views/main.scala.html
+++ b/modules/portal/app/views/main.scala.html
@@ -9,6 +9,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="google" content="notranslate" />
         <meta id="csrf" content="@CSRF.getToken.value" />
         <link rel="icon" href="/public/images/favicon.ico" type="image/x-icon" />
             <!-- END META SECTION -->

--- a/modules/portal/app/views/setOidcSession.scala.html
+++ b/modules/portal/app/views/setOidcSession.scala.html
@@ -4,6 +4,7 @@
 <head>
     <!-- META SECTION -->
     <title>Login</title>
+    <meta name="google" content="notranslate" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/modules/portal/app/views/systemMessage.scala.html
+++ b/modules/portal/app/views/systemMessage.scala.html
@@ -4,6 +4,7 @@
 <head>
     <!-- META SECTION -->
     <title>No Access to VinylDNS</title>
+    <meta name="google" content="notranslate" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Some users have reported seeing a prompt in Google Chrome to translate pages in Vinyl and appears to be detecting the page is in French. Specifically it's trying to translate the "Zones" menu label to "areas". I checked and all of our html tags already include `lang="en"` as recommended. But I've also read that Google may disregard that and have issues with language detection when there aren't a lot of words on the page. Depending on the amount of data a user has access to in Vinyl it seems the language detection might be off.

<img width="1441" alt="screenshot of translated VinylDNS portal page" src="https://user-images.githubusercontent.com/4439228/60125722-65116380-975a-11e9-83d1-22067beaa65c.png">

Changes in this pull request:
- Google recommends using this meta tag `<meta name="google" content="notranslate" />` to stop translation. Found here: https://support.google.com/webmasters/answer/79812?hl=en and in case the content on that page changes in the future, this is what it says:

meta tag         | description |
 ------------ | :---------- |
`<meta name="google" content="notranslate" />` | When we recognize that the contents of a page are not in the language that the user is likely to want to read, we often provide a link to a translation in the search results. In general, this gives you the chance to provide your unique and compelling content to a much larger group of users. However, there may be situations where this is not desired. This meta tag tells Google that you don't want us to provide a translation for this page. |
