### PR TITLE
update latest tag on release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -454,10 +454,9 @@ lazy val setDockerReleaseSettings = ReleaseStep(action = oldState => {
   val extracted = Project.extract(oldState)
   val v = extracted.get(Keys.version)
   val snap = v.endsWith("SNAPSHOT")
-  if (!snap) {
-    extracted
-      .appendWithSession(Seq(dockerUpdateLatest := true), oldState)
-  } else oldState
+  if (snap) extracted
+      .appendWithSession(Seq(dockerUpdateLatest in ThisScope := true), oldState)
+  else oldState
 })
 
 lazy val initReleaseStage = Seq[ReleaseStep](

--- a/build.sbt
+++ b/build.sbt
@@ -456,7 +456,7 @@ lazy val setDockerReleaseSettings = ReleaseStep(action = oldState => {
   val snap = v.endsWith("SNAPSHOT")
   if (!snap) {
     extracted
-      .appendWithSession(Seq(dockerUpdateLatest in api := true, dockerUpdateLatest in portal := true), oldState)
+      .appendWithSession(Seq(dockerUpdateLatest := true), oldState)
   } else oldState
 })
 

--- a/build.sbt
+++ b/build.sbt
@@ -455,14 +455,14 @@ lazy val setDockerReleaseSettings = ReleaseStep(action = oldState => {
   val v = extracted.get(Keys.version)
   val snap = v.endsWith("SNAPSHOT")
   if (snap) extracted
-      .appendWithSession(Seq(dockerUpdateLatest in ThisScope := true), oldState)
+      .appendWithSession(Seq(dockerUpdateLatest in api := true, dockerUpdateLatest in portal := true), oldState)
   else oldState
 })
 
 lazy val initReleaseStage = Seq[ReleaseStep](
-  releaseStepCommand(";project root"), // use version.sbt file from root
   inquireVersions, // have a developer confirm versions
   setReleaseVersion,
+  releaseStepCommandAndRemaining(";project api;compile;project portal;compile;project root"),
   setDockerReleaseSettings,
   setSonatypeReleaseSettings
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "5.0.0")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.3.7")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.23")
 
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
 


### PR DESCRIPTION
Fixes #655 .

`dockerUpdateLatest in api := true` does not scale to sub projects, the solution I found was to run `set every dockerUpdateLatest := true` 
