### PR TITLE
change listAll query parameter to ignoreAccess

### DIFF
--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -132,7 +132,7 @@ def test_list_zones_list_all_default_false(list_zones_context):
     Test that the default list all value for a list zones request is false
     """
     result = list_zones_context.client.list_zones(status=200)
-    assert_that(result['listAll'], is_(False))
+    assert_that(result['ignoreAccess'], is_(False))
 
 def test_list_zones_invalid_max_items_fails(list_zones_context):
     """
@@ -255,7 +255,7 @@ def test_list_zones_list_all_success(list_zones_context):
     result = list_zones_context.client.list_zones(list_all=True, status=200)
     retrieved = result['zones']
 
-    assert_that(result['listAll'], is_(True))
+    assert_that(result['ignoreAccess'], is_(True))
     assert_that(len(retrieved), greater_than(5))
 
 
@@ -266,6 +266,6 @@ def test_list_zones_list_all_success_with_name_filter(list_zones_context):
     result = list_zones_context.client.list_zones(name_filter='shared', list_all=True, status=200)
     retrieved = result['zones']
 
-    assert_that(result['listAll'], is_(True))
+    assert_that(result['ignoreAccess'], is_(True))
     assert_that(retrieved, has_item(has_entry('name', 'shared.')))
     assert_that(retrieved, has_item(has_entry('accessLevel', 'NoAccess')))

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -462,7 +462,7 @@ class VinylDNSClient(object):
             query.append(u'maxItems=' + str(max_items))
 
         if list_all:
-            query.append(u'listAll=' + str(list_all))
+            query.append(u'ignoreAccess=' + str(list_all))
 
         if query:
             url = url + u'?' + u'&'.join(query)
@@ -595,7 +595,7 @@ class VinylDNSClient(object):
         if max_items is not None:
             args.append(u'maxItems={0}'.format(max_items))
         if list_all:
-            args.append(u'listAll={0}'.format(list_all))
+            args.append(u'ignoreAccess={0}'.format(list_all))
 
         url = urljoin(self.index_url, u'/zones/batchrecordchanges') + u'?' + u'&'.join(args)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -348,8 +348,8 @@ class BatchChangeService(
       auth: AuthPrincipal,
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
-      listAll: Boolean = false): BatchResult[BatchChangeSummaryList] = {
-    val userId = if (listAll && auth.isSystemAdmin) None else Some(auth.userId)
+      ignoreAccess: Boolean = false): BatchResult[BatchChangeSummaryList] = {
+    val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
     for {
       listResults <- batchChangeRepo
         .getBatchChangeSummaries(userId, startFrom, maxItems)
@@ -361,7 +361,7 @@ class BatchChangeService(
         rsOwnerGroups)
       listWithGroupNames = listResults.copy(
         batchChanges = summariesWithGroupNames,
-        listAll = listAll)
+        ignoreAccess = ignoreAccess)
     } yield listWithGroupNames
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -32,7 +32,7 @@ trait BatchChangeServiceAlgebra {
       auth: AuthPrincipal,
       startFrom: Option[Int],
       maxItems: Int,
-      listAll: Boolean): BatchResult[BatchChangeSummaryList]
+      ignoreAccess: Boolean): BatchResult[BatchChangeSummaryList]
 
   def rejectBatchChange(
       batchChangeId: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -212,7 +212,7 @@ case class ListZonesResponse(
     startFrom: Option[String] = None,
     nextId: Option[String] = None,
     maxItems: Int = 100,
-    listAll: Boolean = false)
+    ignoreAccess: Boolean = false)
 
 // Errors
 case class InvalidRequest(msg: String) extends Throwable(msg)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -137,14 +137,14 @@ class ZoneService(
       nameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      listAll: Boolean = false): Result[ListZonesResponse] = {
+      ignoreAccess: Boolean = false): Result[ListZonesResponse] = {
     for {
       listZonesResult <- zoneRepository.listZones(
         authPrincipal,
         nameFilter,
         startFrom,
         maxItems,
-        listAll)
+        ignoreAccess)
       zones = listZonesResult.zones
       groupIds = zones.map(_.adminGroupId).toSet
       groups <- groupRepository.getGroups(groupIds)
@@ -156,7 +156,7 @@ class ZoneService(
         listZonesResult.startFrom,
         listZonesResult.nextId,
         listZonesResult.maxItems,
-        listZonesResult.listAll)
+        listZonesResult.ignoreAccess)
   }.toResult
 
   def zoneSummaryInfoMapping(

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -41,7 +41,7 @@ trait ZoneServiceAlgebra {
       nameFilter: Option[String],
       startFrom: Option[String],
       maxItems: Int,
-      listAll: Boolean): Result[ListZonesResponse]
+      ignoreAccess: Boolean): Result[ListZonesResponse]
 
   def listZoneChanges(
       zoneId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -53,15 +53,15 @@ trait BatchChangeRoute extends Directives {
         parameters(
           "startFrom".as[Int].?,
           "maxItems".as[Int].?(MAX_ITEMS_LIMIT),
-          "listAll".as[Boolean].?(false)) {
-          (startFrom: Option[Int], maxItems: Int, listAll: Boolean) =>
+          "ignoreAccess".as[Boolean].?(false)) {
+          (startFrom: Option[Int], maxItems: Int, ignoreAccess: Boolean) =>
             {
               handleRejections(invalidQueryHandler) {
                 validate(
                   0 < maxItems && maxItems <= MAX_ITEMS_LIMIT,
                   s"maxItems was $maxItems, maxItems must be between 1 and $MAX_ITEMS_LIMIT, inclusive.") {
                   execute(batchChangeService
-                    .listBatchChangeSummaries(authPrincipal, startFrom, maxItems, listAll)) {
+                    .listBatchChangeSummaries(authPrincipal, startFrom, maxItems, ignoreAccess)) {
                     summaries =>
                       complete(StatusCodes.OK, summaries)
                   }

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -54,20 +54,21 @@ trait ZoneRoute extends Directives {
           "nameFilter".?,
           "startFrom".as[String].?,
           "maxItems".as[Int].?(DEFAULT_MAX_ITEMS),
-          "listAll".as[Boolean].?(false)) {
+          "ignoreAccess".as[Boolean].?(false)) {
           (
               nameFilter: Option[String],
               startFrom: Option[String],
               maxItems: Int,
-              listAll: Boolean) =>
+              ignoreAccess: Boolean) =>
             {
               handleRejections(invalidQueryHandler) {
                 validate(
                   0 < maxItems && maxItems <= MAX_ITEMS_LIMIT,
                   s"maxItems was $maxItems, maxItems must be between 0 and $MAX_ITEMS_LIMIT") {
                   execute(zoneService
-                    .listZones(authPrincipal, nameFilter, startFrom, maxItems, listAll)) { result =>
-                    complete(StatusCodes.OK, result)
+                    .listZones(authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess)) {
+                    result =>
+                      complete(StatusCodes.OK, result)
                   }
                 }
               }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -901,7 +901,7 @@ class BatchChangeServiceSpec
       result.maxItems shouldBe 100
       result.nextId shouldBe None
       result.startFrom shouldBe None
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
 
       result.batchChanges.length shouldBe 1
       result.batchChanges(0).createdTimestamp shouldBe batchChange.createdTimestamp
@@ -932,7 +932,7 @@ class BatchChangeServiceSpec
       result.maxItems shouldBe 100
       result.nextId shouldBe None
       result.startFrom shouldBe None
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
 
       result.batchChanges.length shouldBe 2
       result.batchChanges(0).createdTimestamp shouldBe batchChangeTwo.createdTimestamp
@@ -964,7 +964,7 @@ class BatchChangeServiceSpec
       result.maxItems shouldBe 1
       result.nextId shouldBe Some(1)
       result.startFrom shouldBe None
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
 
       result.batchChanges.length shouldBe 1
       result.batchChanges(0).createdTimestamp shouldBe batchChangeTwo.createdTimestamp
@@ -996,7 +996,7 @@ class BatchChangeServiceSpec
       result.maxItems shouldBe 100
       result.nextId shouldBe None
       result.startFrom shouldBe Some(1)
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
 
       result.batchChanges.length shouldBe 1
       result.batchChanges(0).createdTimestamp shouldBe batchChangeOne.createdTimestamp
@@ -1029,7 +1029,7 @@ class BatchChangeServiceSpec
       result(0).createdTimestamp shouldBe batchChangeUserOne.createdTimestamp
     }
 
-    "only return summaries associated with user who called even if listAll is true if user is not super" in {
+    "only return summaries associated with user who called even if ignoreAccess is true if user is not super" in {
       val batchChangeUserOne =
         BatchChange(
           auth.userId,
@@ -1050,7 +1050,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeUserTwo)
 
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(auth, listAll = true).value).batchChanges
+        rightResultOf(underTest.listBatchChangeSummaries(auth, ignoreAccess = true).value).batchChanges
 
       result.length shouldBe 1
       result(0).createdTimestamp shouldBe batchChangeUserOne.createdTimestamp
@@ -1077,12 +1077,12 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeUserTwo)
 
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(superUserAuth, listAll = true).value)
+        rightResultOf(underTest.listBatchChangeSummaries(superUserAuth, ignoreAccess = true).value)
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
       result.startFrom shouldBe None
-      result.listAll shouldBe true
+      result.ignoreAccess shouldBe true
 
       result.batchChanges.length shouldBe 2
       result.batchChanges(0).createdTimestamp shouldBe batchChangeUserTwo.createdTimestamp

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -503,7 +503,7 @@ class ZoneServiceSpec
       result.startFrom shouldBe None
       result.nameFilter shouldBe None
       result.nextId shouldBe None
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
     }
 
     "return the appropriate zones" in {
@@ -520,11 +520,11 @@ class ZoneServiceSpec
       result.startFrom shouldBe None
       result.nameFilter shouldBe None
       result.nextId shouldBe None
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
     }
 
     "return all zones" in {
-      doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone), listAll = true)))
+      doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone), ignoreAccess = true)))
         .when(mockZoneRepo)
         .listZones(abcAuth, None, None, 100, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
@@ -532,13 +532,13 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
 
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, listAll = true).value)
+        rightResultOf(underTest.listZones(abcAuth, ignoreAccess = true).value)
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
       result.nameFilter shouldBe None
       result.nextId shouldBe None
-      result.listAll shouldBe true
+      result.ignoreAccess shouldBe true
     }
 
     "return Unknown group name if zone admin group cannot be found" in {
@@ -564,7 +564,7 @@ class ZoneServiceSpec
             List(abcZone, xyzZone),
             maxItems = 2,
             nextId = Some("zone2."),
-            listAll = false)))
+            ignoreAccess = false)))
         .when(mockZoneRepo)
         .listZones(abcAuth, None, None, 2, false)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
@@ -588,7 +588,7 @@ class ZoneServiceSpec
             zonesFilter = Some("foo"),
             maxItems = 2,
             nextId = Some("zone2."),
-            listAll = false)))
+            ignoreAccess = false)))
         .when(mockZoneRepo)
         .listZones(abcAuth, Some("foo"), None, 2, false)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
@@ -610,7 +610,7 @@ class ZoneServiceSpec
             List(abcZone, xyzZone),
             startFrom = Some("zone4."),
             maxItems = 2,
-            listAll = false)))
+            ignoreAccess = false)))
         .when(mockZoneRepo)
         .listZones(abcAuth, None, Some("zone4."), 2, false)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
@@ -631,7 +631,7 @@ class ZoneServiceSpec
             startFrom = Some("zone4."),
             maxItems = 2,
             nextId = Some("zone6."),
-            listAll = false)))
+            ignoreAccess = false)))
         .when(mockZoneRepo)
         .listZones(abcAuth, None, Some("zone4."), 2, false)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -68,7 +68,7 @@ trait EmptyZoneRepo extends ZoneRepository {
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      listAll: Boolean = false): IO[ListZonesResults] = IO.pure(ListZonesResults())
+      ignoreAccess: Boolean = false): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]] = IO.pure(List())
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -229,9 +229,10 @@ class BatchChangeRoutingSpec
         auth: AuthPrincipal,
         startFrom: Option[Int],
         maxItems: Int,
-        listAll: Boolean = false): EitherT[IO, BatchChangeErrorResponse, BatchChangeSummaryList] =
+        ignoreAccess: Boolean = false)
+      : EitherT[IO, BatchChangeErrorResponse, BatchChangeSummaryList] =
       if (auth.userId == okAuth.userId)
-        (auth, startFrom, maxItems, listAll) match {
+        (auth, startFrom, maxItems, ignoreAccess) match {
           case (_, None, 100, false) =>
             EitherT.rightT(
               BatchChangeSummaryList(
@@ -273,7 +274,7 @@ class BatchChangeRoutingSpec
 
           case (_) => EitherT.rightT(BatchChangeSummaryList(List()))
         } else if (auth.userId == superUserAuth.userId)
-        (auth, startFrom, maxItems, listAll) match {
+        (auth, startFrom, maxItems, ignoreAccess) match {
           case (_, None, 100, true) =>
             EitherT.rightT(
               BatchChangeSummaryList(
@@ -284,7 +285,7 @@ class BatchChangeRoutingSpec
                   batchChangeSummaryInfo4),
                 startFrom = None,
                 nextId = None,
-                listAll = true
+                ignoreAccess = true
               )
             )
           case (_) => EitherT.rightT(BatchChangeSummaryList(List()))
@@ -504,8 +505,8 @@ class BatchChangeRoutingSpec
       }
     }
 
-    "return all batch changes if listAll is true" in {
-      Get("/zones/batchrecordchanges?listAll=true") ~> batchChangeRoute(superUserAuth) ~> check {
+    "return all batch changes if ignoreAccess is true" in {
+      Get("/zones/batchrecordchanges?ignoreAccess=true") ~> batchChangeRoute(superUserAuth) ~> check {
         status shouldBe OK
 
         val resp = responseAs[BatchChangeSummaryList]

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -225,9 +225,9 @@ class ZoneRoutingSpec
         nameFilter: Option[String],
         startFrom: Option[String],
         maxItems: Int,
-        listAll: Boolean = false): Result[ListZonesResponse] = {
+        ignoreAccess: Boolean = false): Result[ListZonesResponse] = {
 
-      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, listAll) match {
+      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess) match {
         case (_, None, Some("zone3."), 3, false) =>
           Right(
             ListZonesResponse(
@@ -236,7 +236,7 @@ class ZoneRoutingSpec
               startFrom = Some("zone3."),
               nextId = Some("zone6."),
               maxItems = 3,
-              listAll = false
+              ignoreAccess = false
             )
           )
         case (_, None, Some("zone4."), 4, false) =>
@@ -247,7 +247,7 @@ class ZoneRoutingSpec
               startFrom = Some("zone4."),
               nextId = None,
               maxItems = 4,
-              listAll = false)
+              ignoreAccess = false)
           )
 
         case (_, None, None, 3, false) =>
@@ -258,7 +258,7 @@ class ZoneRoutingSpec
               startFrom = None,
               nextId = Some("zone3."),
               maxItems = 3,
-              listAll = false)
+              ignoreAccess = false)
           )
 
         case (_, None, None, 5, true) =>
@@ -274,7 +274,7 @@ class ZoneRoutingSpec
               startFrom = None,
               nextId = None,
               maxItems = 5,
-              listAll = true
+              ignoreAccess = true
             )
           )
 
@@ -286,7 +286,8 @@ class ZoneRoutingSpec
               startFrom = Some("zone4."),
               nextId = None,
               maxItems = 4,
-              listAll = false)
+              ignoreAccess = false
+            )
           )
 
         case (_, None, None, _, _) =>
@@ -296,7 +297,7 @@ class ZoneRoutingSpec
               nameFilter = None,
               startFrom = None,
               nextId = None,
-              listAll = false)
+              ignoreAccess = false)
           )
 
         case _ => Left(InvalidRequest("shouldnt get here"))
@@ -857,7 +858,7 @@ class ZoneRoutingSpec
         resp.nextId shouldBe None
         resp.maxItems shouldBe 4
         resp.startFrom shouldBe Some("zone4.")
-        resp.listAll shouldBe false
+        resp.ignoreAccess shouldBe false
       }
     }
 
@@ -870,7 +871,7 @@ class ZoneRoutingSpec
         resp.nextId shouldBe Some("zone3.")
         resp.maxItems shouldBe 3
         resp.startFrom shouldBe None
-        resp.listAll shouldBe false
+        resp.ignoreAccess shouldBe false
       }
     }
 
@@ -884,12 +885,12 @@ class ZoneRoutingSpec
         resp.maxItems shouldBe 4
         resp.startFrom shouldBe Some("zone4.")
         resp.nameFilter shouldBe Some("foo")
-        resp.listAll shouldBe false
+        resp.ignoreAccess shouldBe false
       }
     }
 
     "return all zones when list all is true" in {
-      Get(s"/zones?maxItems=5&listAll=true") ~> zoneRoute(okAuth) ~> check {
+      Get(s"/zones?maxItems=5&ignoreAccess=true") ~> zoneRoute(okAuth) ~> check {
         val resp = responseAs[ListZonesResponse]
         val zones = resp.zones
         (zones.map(_.id) should contain)
@@ -898,7 +899,7 @@ class ZoneRoutingSpec
         resp.maxItems shouldBe 5
         resp.startFrom shouldBe None
         resp.nameFilter shouldBe None
-        resp.listAll shouldBe true
+        resp.ignoreAccess shouldBe true
       }
     }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -66,4 +66,4 @@ case class BatchChangeSummaryList(
     startFrom: Option[Int] = None,
     nextId: Option[Int] = None,
     maxItems: Int = 100,
-    listAll: Boolean = false)
+    ignoreAccess: Boolean = false)

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
@@ -21,5 +21,5 @@ case class ListZonesResults(
     nextId: Option[String] = None,
     startFrom: Option[String] = None,
     maxItems: Int = 100,
-    listAll: Boolean = false,
+    ignoreAccess: Boolean = false,
     zonesFilter: Option[String] = None)

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -38,7 +38,7 @@ trait ZoneRepository extends Repository {
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      listAll: Boolean = false): IO[ListZonesResults]
+      ignoreAccess: Boolean = false): IO[ListZonesResults]
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -229,10 +229,10 @@ class MySqlZoneRepositoryIntegrationSpec
       )
 
       f.unsafeRunSync()
-      repo.listZones(okUserAuth, listAll=true).unsafeRunSync().zones should contain theSameElementsAs testZones
+      repo.listZones(okUserAuth, ignoreAccess=true).unsafeRunSync().zones should contain theSameElementsAs testZones
 
       // dummy user only have all of the zones returned
-      repo.listZones(dummyAuth, listAll=true).unsafeRunSync().zones should contain theSameElementsAs testZones
+      repo.listZones(dummyAuth, ignoreAccess=true).unsafeRunSync().zones should contain theSameElementsAs testZones
     }
 
     "get zones that are accessible by everyone" in {

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -74,13 +74,13 @@ describe('Controller: ZonesController', function () {
         var expectedMaxItems = 100;
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
-        var expectedListAll = false;
+        var expectedignoreAccess = false;
 
         this.scope.nextPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedListAll]);
+          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
     });
 
     it('prevPageMyZones should call getZones with the correct parameters', function () {
@@ -91,19 +91,19 @@ describe('Controller: ZonesController', function () {
         var expectedMaxItems = 100;
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
-        var expectedListAll = false;
+        var expectedignoreAccess = false;
 
         this.scope.prevPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedListAll]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
 
         this.scope.nextPageMyZones();
         this.scope.prevPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(3);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedListAll]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
     });
 });

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -19,7 +19,7 @@
 angular.module('service.zones', [])
     .service('zonesService', function ($http, groupsService, $log, utilityService) {
 
-        this.getZones = function (limit, startFrom, query, listAll) {
+        this.getZones = function (limit, startFrom, query, ignoreAccess) {
             if (query == "") {
                 query = null;
             }
@@ -27,7 +27,7 @@ angular.module('service.zones', [])
                 "maxItems": limit,
                 "startFrom": startFrom,
                 "nameFilter": query,
-                "listAll": listAll
+                "ignoreAccess": ignoreAccess
             };
             var url = groupsService.urlBuilder("/api/zones", params);
             return $http.get(url);

--- a/modules/portal/public/lib/services/zones/service.zones.spec.js
+++ b/modules/portal/public/lib/services/zones/service.zones.spec.js
@@ -27,7 +27,7 @@ describe('Service: zoneService', function () {
     }));
 
     it('http backend gets called properly when getting zones', function () {
-        this.$httpBackend.expectGET('/api/zones?maxItems=100&startFrom=start&nameFilter=someQuery&listAll=false').respond('zone returned');
+        this.$httpBackend.expectGET('/api/zones?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=false').respond('zone returned');
         this.zonesService.getZones('100', 'start', 'someQuery', false)
             .then(function(response) {
                 expect(response.data).toBe('zone returned');


### PR DESCRIPTION
Follow up to #689  and #700

Changes in this pull request:
- change "listAll" query parameter to "ignoreAccess" so it's more clear that the response will be zones or batch changes that are in the system regardless of the requesting user's access, _not_ a reflection of the quantity of results that are returned.
