### PR TITLE
Add approvalStatus query param to list batch changes

### DIFF
--- a/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
@@ -145,6 +145,15 @@ def test_list_batch_change_summaries_with_next_id(list_fixture):
     list_fixture.check_batch_change_summaries_page_accuracy(next_page_result, size=1, start_from=batch_change_summaries_result['nextId'])
 
 
+def test_list_batch_change_summaries_with_pending_status(list_fixture):
+    """
+    Test listing a limited number of user's batch change summaries with maxItems parameter
+    """
+    client = list_fixture.client
+    batch_change_summaries_result = client.list_batch_change_summaries(status=200, approval_status="PendingApproval")
+
+    list_fixture.check_batch_change_summaries_page_accuracy(batch_change_summaries_result, size=0, approval_status="PendingApproval")
+
 def test_list_batch_change_summaries_with_list_batch_change_summaries_with_no_changes_passes():
     """
     Test successfully getting an empty list of summaries when user has no batch changes
@@ -252,7 +261,7 @@ def test_list_batch_change_summaries_with_deleted_record_owner_group_passes(shar
             client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
-def test_list_batch_change_summaries_with_list_all_true_only_shows_requesting_users_records(shared_zone_test_context):
+def test_list_batch_change_summaries_with_ignore_access_true_only_shows_requesting_users_records(shared_zone_test_context):
     """
     Test that getting a batch change summary with list all set to true only returns the requesting user's batch changes
     if they are not a super user
@@ -287,7 +296,7 @@ def test_list_batch_change_summaries_with_list_all_true_only_shows_requesting_us
         record_set_list = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
         record_to_delete = set(record_set_list)
 
-        batch_change_summaries_result = client.list_batch_change_summaries(list_all=True, status=200)["batchChanges"]
+        batch_change_summaries_result = client.list_batch_change_summaries(ignore_access=True, status=200)["batchChanges"]
 
         under_test = [item for item in batch_change_summaries_result if item['id'] == completed_batch['id']]
         assert_that(under_test, has_length(1))
@@ -299,7 +308,7 @@ def test_list_batch_change_summaries_with_list_all_true_only_shows_requesting_us
         ok_record_set_list = [(change['zoneId'], change['recordSetId']) for change in ok_completed_batch['changes']]
         ok_record_to_delete = set(ok_record_set_list)
 
-        ok_batch_change_summaries_result = ok_client.list_batch_change_summaries(list_all=True, status=200)["batchChanges"]
+        ok_batch_change_summaries_result = ok_client.list_batch_change_summaries(ignore_access=True, status=200)["batchChanges"]
 
         ok_under_test = [item for item in ok_batch_change_summaries_result if (item['id'] == ok_completed_batch['id'] or item['id'] == completed_batch['id']) ]
         assert_that(ok_under_test, has_length(1))
@@ -311,3 +320,4 @@ def test_list_batch_change_summaries_with_list_all_true_only_shows_requesting_us
         for result_rs in ok_record_to_delete:
             delete_result = client.delete_recordset(result_rs[0], result_rs[1], status=202)
             client.wait_until_recordset_change_status(delete_result, 'Complete')
+

--- a/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
@@ -63,7 +63,8 @@ class ListBatchChangeSummariesFixture():
             shared_zone_test_context.ok_vinyldns_client.wait_until_recordset_change_status(delete_result, 'Complete')
         clear_ok_acl_rules(shared_zone_test_context)
 
-    def check_batch_change_summaries_page_accuracy(self, summaries_page, size, next_id=False, start_from=False, max_items=100):
+    def check_batch_change_summaries_page_accuracy(self, summaries_page, size, next_id=False, start_from=False,
+                                                   max_items=100, approval_status=False):
         # validate fields
         if next_id:
             assert_that(summaries_page, has_key('nextId'))
@@ -73,6 +74,10 @@ class ListBatchChangeSummariesFixture():
             assert_that(summaries_page['startFrom'], is_(start_from))
         else:
             assert_that(summaries_page, is_not(has_key('startFrom')))
+        if approval_status:
+            assert_that(summaries_page, has_key('approvalStatus'))
+        else:
+            assert_that(summaries_page, is_not(has_key('approvalStatus')))
         assert_that(summaries_page['maxItems'], is_(max_items))
 
 

--- a/modules/api/functional_test/live_tests/zones/list_zones_test.py
+++ b/modules/api/functional_test/live_tests/zones/list_zones_test.py
@@ -127,9 +127,9 @@ def test_list_zones_max_items_100(list_zones_context):
     result = list_zones_context.client.list_zones(status=200)
     assert_that(result['maxItems'], is_(100))
 
-def test_list_zones_list_all_default_false(list_zones_context):
+def test_list_zones_ignore_access_default_false(list_zones_context):
     """
-    Test that the default list all value for a list zones request is false
+    Test that the default ignore access value for a list zones request is false
     """
     result = list_zones_context.client.list_zones(status=200)
     assert_that(result['ignoreAccess'], is_(False))
@@ -248,22 +248,22 @@ def test_list_zones_with_search_last_page(list_zones_context):
     assert_that(result['nameFilter'], is_('*test-searched-3'))
     assert_that(result['startFrom'], is_('list-zones-test-searched-2.'))
 
-def test_list_zones_list_all_success(list_zones_context):
+def test_list_zones_ignore_access_success(list_zones_context):
     """
-    Test that we can retrieve a list of all zones
+    Test that we can retrieve a list of zones regardless of zone access
     """
-    result = list_zones_context.client.list_zones(list_all=True, status=200)
+    result = list_zones_context.client.list_zones(ignore_access=True, status=200)
     retrieved = result['zones']
 
     assert_that(result['ignoreAccess'], is_(True))
     assert_that(len(retrieved), greater_than(5))
 
 
-def test_list_zones_list_all_success_with_name_filter(list_zones_context):
+def test_list_zones_ignore_access_success_with_name_filter(list_zones_context):
     """
     Test that we can retrieve a list of all zones with a name filter
     """
-    result = list_zones_context.client.list_zones(name_filter='shared', list_all=True, status=200)
+    result = list_zones_context.client.list_zones(name_filter='shared', ignore_access=True, status=200)
     retrieved = result['zones']
 
     assert_that(result['ignoreAccess'], is_(True))

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -444,7 +444,7 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, u'GET', self.headers, not_found_ok=True, **kwargs)
         return data
 
-    def list_zones(self, name_filter=None, start_from=None, max_items=None, list_all=False, **kwargs):
+    def list_zones(self, name_filter=None, start_from=None, max_items=None, ignore_access=False, **kwargs):
         """
         Gets a list of zones that currently exist
         :return: a list of zones
@@ -461,8 +461,8 @@ class VinylDNSClient(object):
         if max_items:
             query.append(u'maxItems=' + str(max_items))
 
-        if list_all:
-            query.append(u'ignoreAccess=' + str(list_all))
+        if ignore_access:
+            query.append(u'ignoreAccess=' + str(ignore_access))
 
         if query:
             url = url + u'?' + u'&'.join(query)
@@ -595,7 +595,7 @@ class VinylDNSClient(object):
         _, data = self.make_request(url, u'POST', self.headers, json.dumps(approve_batch_change_input), **kwargs)
         return data
 
-    def list_batch_change_summaries(self, start_from=None, max_items=None, list_all=False, **kwargs):
+    def list_batch_change_summaries(self, start_from=None, max_items=None, ignore_access=False, approval_status=None, **kwargs):
         """
         Gets list of user's batch change summaries
         :return: the content of the response
@@ -605,8 +605,10 @@ class VinylDNSClient(object):
             args.append(u'startFrom={0}'.format(start_from))
         if max_items is not None:
             args.append(u'maxItems={0}'.format(max_items))
-        if list_all:
-            args.append(u'ignoreAccess={0}'.format(list_all))
+        if ignore_access:
+            args.append(u'ignoreAccess={0}'.format(ignore_access))
+        if approval_status:
+            args.append(u'approvalStatus={0}'.format(approval_status))
 
         url = urljoin(self.index_url, u'/zones/batchrecordchanges') + u'?' + u'&'.join(args)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -29,6 +29,7 @@ import vinyldns.api.domain.dns.DnsConversions._
 import vinyldns.api.domain.{RecordAlreadyExists, ZoneDiscoveryError}
 import vinyldns.api.repository.ApiDataAccessor
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.batch.BatchChangeApprovalStatus._
 import vinyldns.core.domain.membership.{Group, GroupRepository}
@@ -416,11 +417,13 @@ class BatchChangeService(
       auth: AuthPrincipal,
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
-      ignoreAccess: Boolean = false): BatchResult[BatchChangeSummaryList] = {
+      ignoreAccess: Boolean = false,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None)
+    : BatchResult[BatchChangeSummaryList] = {
     val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
     for {
       listResults <- batchChangeRepo
-        .getBatchChangeSummaries(userId, startFrom, maxItems)
+        .getBatchChangeSummaries(userId, startFrom, maxItems, approvalStatus)
         .toBatchResult
       rsOwnerGroupIds = listResults.batchChanges.flatMap(_.ownerGroupId).toSet
       rsOwnerGroups <- groupRepository.getGroups(rsOwnerGroupIds).toBatchResult
@@ -429,7 +432,8 @@ class BatchChangeService(
         rsOwnerGroups)
       listWithGroupNames = listResults.copy(
         batchChanges = summariesWithGroupNames,
-        ignoreAccess = ignoreAccess)
+        ignoreAccess = ignoreAccess,
+        approvalStatus = approvalStatus)
     } yield listWithGroupNames
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -18,6 +18,7 @@ package vinyldns.api.domain.batch
 
 import vinyldns.api.domain.batch.BatchChangeInterfaces.BatchResult
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.domain.batch.{BatchChange, BatchChangeInfo, BatchChangeSummaryList}
 
 // $COVERAGE-OFF$
@@ -32,7 +33,8 @@ trait BatchChangeServiceAlgebra {
       auth: AuthPrincipal,
       startFrom: Option[Int],
       maxItems: Int,
-      ignoreAccess: Boolean): BatchResult[BatchChangeSummaryList]
+      ignoreAccess: Boolean,
+      approvalStatus: Option[BatchChangeApprovalStatus]): BatchResult[BatchChangeSummaryList]
 
   def rejectBatchChange(
       batchChangeId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -33,6 +33,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
   val batchChangeSerializers = Seq(
     JsonEnumV(ChangeInputType),
     JsonEnumV(SingleChangeStatus),
+    JsonEnumV(BatchChangeApprovalStatus),
     BatchChangeInputSerializer,
     ChangeInputSerializer,
     AddChangeInputSerializer,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -63,7 +63,8 @@ trait BatchChangeRoute extends Directives {
               ignoreAccess: Boolean,
               approvalStatus: Option[String]) =>
             {
-              val convertApprovalStatus = BatchChangeApprovalStatus.fromString(approvalStatus)
+              val convertApprovalStatus = BatchChangeApprovalStatus.find(approvalStatus.mkString)
+
               handleRejections(invalidQueryHandler) {
                 validate(
                   0 < maxItems && maxItems <= MAX_ITEMS_LIMIT,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -33,7 +33,6 @@ trait BatchChangeRoute extends Directives {
 
   final private val MAX_ITEMS_LIMIT: Int = 100
 
-  case class BatchChangeApproval(approvalType: String) {}
   val batchChangeRoute: AuthPrincipal => server.Route = { authPrincipal: AuthPrincipal =>
     val standardBatchChangeRoutes = (post & path("zones" / "batchrecordchanges")) {
       monitor("Endpoint.postBatchChange") {
@@ -63,7 +62,7 @@ trait BatchChangeRoute extends Directives {
               ignoreAccess: Boolean,
               approvalStatus: Option[String]) =>
             {
-              val convertApprovalStatus = BatchChangeApprovalStatus.find(approvalStatus.mkString)
+              val convertApprovalStatus = approvalStatus.flatMap(BatchChangeApprovalStatus.find)
 
               handleRejections(invalidQueryHandler) {
                 validate(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1169,7 +1169,7 @@ class BatchChangeServiceSpec
       result.maxItems shouldBe 100
       result.nextId shouldBe None
       result.startFrom shouldBe None
-      result.listAll shouldBe false
+      result.ignoreAccess shouldBe false
       result.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
 
       result.batchChanges.length shouldBe 1

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1139,6 +1139,43 @@ class BatchChangeServiceSpec
       result.batchChanges(0).createdTimestamp shouldBe batchChangeTwo.createdTimestamp
     }
 
+    "return list of batchChangeSummaries filtered by approvalStatus if some exist" in {
+      val batchChangeOne =
+        BatchChange(
+          auth.userId,
+          auth.signedInUser.userName,
+          None,
+          DateTime.now,
+          List(),
+          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+      batchChangeRepo.save(batchChangeOne)
+
+      val batchChangeTwo = BatchChange(
+        auth.userId,
+        auth.signedInUser.userName,
+        None,
+        new DateTime(DateTime.now.getMillis + 1000),
+        List(),
+        approvalStatus = BatchChangeApprovalStatus.AutoApproved)
+      batchChangeRepo.save(batchChangeTwo)
+
+      val result = rightResultOf(
+        underTest
+          .listBatchChangeSummaries(
+            auth,
+            approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval))
+          .value)
+
+      result.maxItems shouldBe 100
+      result.nextId shouldBe None
+      result.startFrom shouldBe None
+      result.listAll shouldBe false
+      result.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
+
+      result.batchChanges.length shouldBe 1
+      result.batchChanges(0).createdTimestamp shouldBe batchChangeOne.createdTimestamp
+    }
+
     "return an offset list of batchChangeSummaries if some exist" in {
       val batchChangeOne =
         BatchChange(

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -551,7 +551,7 @@ class BatchChangeRoutingSpec
     }
 
     "return user's Pending batch changes if approval status is `PendingApproval`" in {
-      Get("/zones/batchrecordchanges?approvalStatus=pending") ~>
+      Get("/zones/batchrecordchanges?approvalStatus=pendingapproval") ~>
         batchChangeRoute(okAuth) ~> check {
         status shouldBe OK
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -34,6 +34,7 @@ import vinyldns.core.domain.record._
 import cats.effect._
 import vinyldns.api.domain.BatchChangeIsEmpty
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.domain.batch._
 
 class BatchChangeRoutingSpec
@@ -59,7 +60,9 @@ class BatchChangeRoutingSpec
     def createBatchChangeResponse(
         comments: Option[String] = None,
         ownerGroupId: Option[String] = None,
-        auth: AuthPrincipal = okAuth): BatchChange =
+        auth: AuthPrincipal = okAuth,
+        approvalStatus: BatchChangeApprovalStatus = BatchChangeApprovalStatus.AutoApproved)
+      : BatchChange =
       BatchChange(
         auth.userId,
         auth.signedInUser.userName,
@@ -92,7 +95,7 @@ class BatchChangeRoutingSpec
             "singleDeleteChangeId")
         ),
         ownerGroupId,
-        BatchChangeApprovalStatus.AutoApproved,
+        approvalStatus,
         None,
         None,
         None,
@@ -139,10 +142,16 @@ class BatchChangeRoutingSpec
       compact(render(("comments" -> comments) ~~ changeList))
 
     val batchChangeSummaryInfo1 = BatchChangeSummary(createBatchChangeResponse(Some("first")))
-    val batchChangeSummaryInfo2 = BatchChangeSummary(createBatchChangeResponse(Some("second")))
+    val batchChangeSummaryInfo2 = BatchChangeSummary(
+      createBatchChangeResponse(
+        Some("second"),
+        approvalStatus = BatchChangeApprovalStatus.PendingApproval))
     val batchChangeSummaryInfo3 = BatchChangeSummary(createBatchChangeResponse(Some("third")))
     val batchChangeSummaryInfo4 = BatchChangeSummary(
-      createBatchChangeResponse(Some("fourth"), auth = dummyAuth))
+      createBatchChangeResponse(
+        Some("fourth"),
+        auth = dummyAuth,
+        approvalStatus = BatchChangeApprovalStatus.PendingApproval))
 
     val validResponseWithComments: BatchChange = createBatchChangeResponse(
       Some("validChangeWithComments"))
@@ -229,11 +238,12 @@ class BatchChangeRoutingSpec
         auth: AuthPrincipal,
         startFrom: Option[Int],
         maxItems: Int,
-        ignoreAccess: Boolean = false)
+        ignoreAccess: Boolean = false,
+        approvalStatus: Option[BatchChangeApprovalStatus] = None)
       : EitherT[IO, BatchChangeErrorResponse, BatchChangeSummaryList] =
       if (auth.userId == okAuth.userId)
-        (auth, startFrom, maxItems, ignoreAccess) match {
-          case (_, None, 100, false) =>
+        (auth, startFrom, maxItems, ignoreAccess, approvalStatus) match {
+          case (_, None, 100, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges =
@@ -243,7 +253,7 @@ class BatchChangeRoutingSpec
               )
             )
 
-          case (_, None, 1, false) =>
+          case (_, None, 1, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo1),
@@ -253,7 +263,7 @@ class BatchChangeRoutingSpec
               )
             )
 
-          case (_, Some(1), 100, false) =>
+          case (_, Some(1), 100, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -262,7 +272,7 @@ class BatchChangeRoutingSpec
               )
             )
 
-          case (_, Some(1), 1, false) =>
+          case (_, Some(1), 1, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -272,10 +282,20 @@ class BatchChangeRoutingSpec
               )
             )
 
+          case (_, None, 100, _, Some(BatchChangeApprovalStatus.PendingApproval)) =>
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(batchChangeSummaryInfo2),
+                startFrom = None,
+                nextId = None,
+                approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+              )
+            )
+
           case (_) => EitherT.rightT(BatchChangeSummaryList(List()))
         } else if (auth.userId == superUserAuth.userId)
-        (auth, startFrom, maxItems, ignoreAccess) match {
-          case (_, None, 100, true) =>
+        (auth, startFrom, maxItems, ignoreAccess, approvalStatus) match {
+          case (_, None, 100, true, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(
@@ -288,6 +308,38 @@ class BatchChangeRoutingSpec
                 ignoreAccess = true
               )
             )
+
+          case (_, None, 100, true, Some(BatchChangeApprovalStatus.PendingApproval)) => {
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(batchChangeSummaryInfo2, batchChangeSummaryInfo4),
+                startFrom = None,
+                nextId = None,
+                ignoreAccess = true,
+                approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+              )
+            )
+          }
+
+          case (_, None, 100, false, None) =>
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(),
+                startFrom = None,
+                nextId = None
+              )
+            )
+
+          case (_, None, 100, false, Some(BatchChangeApprovalStatus.PendingApproval)) =>
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(),
+                startFrom = None,
+                nextId = None,
+                approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+              )
+            )
+
           case (_) => EitherT.rightT(BatchChangeSummaryList(List()))
         } else
         EitherT.rightT(BatchChangeSummaryList(List()))
@@ -498,6 +550,21 @@ class BatchChangeRoutingSpec
       }
     }
 
+    "return user's Pending batch changes if approval status is `PendingApproval`" in {
+      Get("/zones/batchrecordchanges?approvalStatus=pending") ~>
+        batchChangeRoute(okAuth) ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeSummaryList]
+
+        resp.batchChanges.length shouldBe 1
+        resp.maxItems shouldBe 100
+        resp.startFrom shouldBe None
+        resp.nextId shouldBe None
+        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
+      }
+    }
+
     "return an error if maxItems is out of range" in {
       Get("/zones/batchrecordchanges?startFrom=1&maxItems=101") ~> batchChangeRoute(okAuth) ~> check {
         status shouldBe BadRequest
@@ -517,7 +584,7 @@ class BatchChangeRoutingSpec
       }
     }
 
-    "return all batch changes if ignoreAccess is true" in {
+    "return all batch changes if ignoreAccess is true and requester is a super user" in {
       Get("/zones/batchrecordchanges?ignoreAccess=true") ~> batchChangeRoute(superUserAuth) ~> check {
         status shouldBe OK
 
@@ -527,6 +594,23 @@ class BatchChangeRoutingSpec
         resp.maxItems shouldBe 100
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
+      }
+    }
+
+    "return all Pending batch changes if ignoreAccess is true, approval status is `PendingApproval`," +
+      " and requester is a super user" in {
+      Get("/zones/batchrecordchanges?ignoreAccess=true&approvalStatus=PendingApproval") ~>
+        batchChangeRoute(superUserAuth) ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeSummaryList]
+
+        resp.batchChanges.length shouldBe 2
+        resp.maxItems shouldBe 100
+        resp.startFrom shouldBe None
+        resp.nextId shouldBe None
+        resp.ignoreAccess shouldBe true
+        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -76,7 +76,8 @@ object BatchChangeApprovalStatus extends Enumeration {
   type BatchChangeApprovalStatus = Value
   val AutoApproved, PendingApproval, ManuallyApproved, ManuallyRejected = Value
 
-  private val valueMap = BatchChangeApprovalStatus.values.map(v => v.toString.toLowerCase -> v).toMap
+  private val valueMap =
+    BatchChangeApprovalStatus.values.map(v => v.toString.toLowerCase -> v).toMap
 
   def find(status: String): Option[BatchChangeApprovalStatus] =
     valueMap.get(status.toLowerCase)

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -76,18 +76,10 @@ object BatchChangeApprovalStatus extends Enumeration {
   type BatchChangeApprovalStatus = Value
   val AutoApproved, PendingApproval, ManuallyApproved, ManuallyRejected = Value
 
-  def fromString(status: Option[String]): Option[BatchChangeApprovalStatus] =
-    status match {
-      case Some(p) if p.toLowerCase().contains("pending") =>
-        Some(BatchChangeApprovalStatus.PendingApproval)
-      case Some(aa) if aa.toLowerCase.contains("autoapproved") =>
-        Some(BatchChangeApprovalStatus.AutoApproved)
-      case Some(ma) if ma.toLowerCase.contains("manuallyapproved") =>
-        Some(BatchChangeApprovalStatus.ManuallyApproved)
-      case Some(r) if r.toLowerCase.contains("rejected") =>
-        Some(BatchChangeApprovalStatus.ManuallyRejected)
-      case _ => None
-    }
+  private val valueMap = BatchChangeApprovalStatus.values.map(v => v.toString.toLowerCase -> v).toMap
+
+  def find(status: String): Option[BatchChangeApprovalStatus] =
+    valueMap.get(status.toLowerCase)
 }
 
 case class BatchChangeInfo(

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -75,6 +75,19 @@ object BatchChangeStatus extends Enumeration {
 object BatchChangeApprovalStatus extends Enumeration {
   type BatchChangeApprovalStatus = Value
   val AutoApproved, PendingApproval, ManuallyApproved, ManuallyRejected = Value
+
+  def fromString(status: Option[String]): Option[BatchChangeApprovalStatus] =
+    status match {
+      case Some(p) if p.toLowerCase().contains("pending") =>
+        Some(BatchChangeApprovalStatus.PendingApproval)
+      case Some(aa) if aa.toLowerCase.contains("autoapproved") =>
+        Some(BatchChangeApprovalStatus.AutoApproved)
+      case Some(ma) if ma.toLowerCase.contains("manuallyapproved") =>
+        Some(BatchChangeApprovalStatus.ManuallyApproved)
+      case Some(r) if r.toLowerCase.contains("rejected") =>
+        Some(BatchChangeApprovalStatus.ManuallyRejected)
+      case _ => None
+    }
 }
 
 case class BatchChangeInfo(

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -31,7 +31,7 @@ trait BatchChangeRepository extends Repository {
       userId: Option[String],
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
-      approvalStatus: Option[BatchChangeApprovalStatus]): IO[BatchChangeSummaryList]
+      approvalStatus: Option[BatchChangeApprovalStatus] = None): IO[BatchChangeSummaryList]
 
   // updateSingleChanges updates status, recordSetId, recordChangeId and systemMessage (in data).
   def updateSingleChanges(singleChanges: List[SingleChange]): IO[Option[BatchChange]]

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -17,6 +17,7 @@
 package vinyldns.core.domain.batch
 
 import cats.effect.IO
+import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.repository.Repository
 
 // $COVERAGE-OFF$
@@ -29,7 +30,8 @@ trait BatchChangeRepository extends Repository {
   def getBatchChangeSummaries(
       userId: Option[String],
       startFrom: Option[Int] = None,
-      maxItems: Int = 100): IO[BatchChangeSummaryList]
+      maxItems: Int = 100,
+      approvalStatus: Option[BatchChangeApprovalStatus]): IO[BatchChangeSummaryList]
 
   // updateSingleChanges updates status, recordSetId, recordChangeId and systemMessage (in data).
   def updateSingleChanges(singleChanges: List[SingleChange]): IO[Option[BatchChange]]

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -19,6 +19,7 @@ package vinyldns.core.domain.batch
 import java.util.UUID
 
 import org.joda.time.DateTime
+import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.domain.batch.BatchChangeStatus.BatchChangeStatus
 
 case class BatchChangeSummary(
@@ -66,4 +67,5 @@ case class BatchChangeSummaryList(
     startFrom: Option[Int] = None,
     nextId: Option[Int] = None,
     maxItems: Int = 100,
-    ignoreAccess: Boolean = false)
+    ignoreAccess: Boolean = false,
+    approvalStatus: Option[BatchChangeApprovalStatus] = None)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -229,15 +229,12 @@ class MySqlBatchChangeRepository
           val startValue = startFrom.getOrElse(0)
           val sb = new StringBuilder
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
-          (userId, approvalStatus) match {
-            case (Some(uid), Some(status)) =>
-              sb.append(
-                s"WHERE bc.user_id = '$uid' AND bc.approval_status = '${fromApprovalStatus(status)}'")
-            case (Some(uid), None) => sb.append(s"WHERE bc.user_id = '$uid'")
-            case (None, Some(status)) =>
-              sb.append(s"WHERE bc.approval_status = '${fromApprovalStatus(status)}'")
-            case _ => ()
-          }
+
+          val uid = userId.map(u => s"bc.user_id = '$u'")
+          val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
+          val opts = uid ++ as
+
+          sb.append("WHERE").append(opts.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -234,7 +234,7 @@ class MySqlBatchChangeRepository
           val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
           val opts = uid ++ as
 
-          sb.append("WHERE").append(opts.mkString(" AND "))
+          sb.append("WHERE ").append(opts.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -263,7 +263,7 @@ class MySqlBatchChangeRepository
               .apply()
           val maxQueries = queryResult.take(maxItems)
           val nextId = if (queryResult.size <= maxItems) None else Some(startValue + maxItems)
-          val ignoreAccess = userId.isDefined
+          val ignoreAccess = userId.isEmpty
           BatchChangeSummaryList(
             maxQueries,
             startFrom,

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -234,7 +234,7 @@ class MySqlBatchChangeRepository
           val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
           val opts = uid ++ as
 
-          sb.append("WHERE ").append(opts.mkString(" AND "))
+          if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()


### PR DESCRIPTION
In support of #659 

Changes in this pull request:
- add `approvalStatus` query parameter on the list batch changes route to filter returned batch changes by their approval status. Parameter is available for any users.
- In conjunction with the `ignoreAccess` parameter this will allow super users to retrieve all batch changes in the system that are in a pending approval state.