### PR TITLE
Apex cname error message

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1524,7 +1524,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
 
         # CNAME cant be apex
         assert_failed_change_in_error_response(response[8], input_name="parent.com.", record_type="CNAME", record_data="test.com.",
-                                               error_messages=["CNAME at the zone apex is not allowed."])
+                                               error_messages=["CNAME cannot be the same name as zone parent.com."])
 
         # context validations: duplicates in batch
         assert_successful_change_in_error_response(response[9], input_name="192.0.2.15", record_type="PTR", record_data="test.com.")

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1524,7 +1524,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
 
         # CNAME cant be apex
         assert_failed_change_in_error_response(response[8], input_name="parent.com.", record_type="CNAME", record_data="test.com.",
-                                               error_messages=["Record \"parent.com.\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                               error_messages=["CNAME at the zone apex is not allowed."])
 
         # context validations: duplicates in batch
         assert_successful_change_in_error_response(response[9], input_name="192.0.2.15", record_type="PTR", record_data="test.com.")

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1524,7 +1524,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
 
         # CNAME cant be apex
         assert_failed_change_in_error_response(response[8], input_name="parent.com.", record_type="CNAME", record_data="test.com.",
-                                               error_messages=["CNAME cannot be the same name as zone parent.com."])
+                                               error_messages=["CNAME cannot be the same name as zone \"parent.com.\"."])
 
         # context validations: duplicates in batch
         assert_successful_change_in_error_response(response[9], input_name="192.0.2.15", record_type="PTR", record_data="test.com.")

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -167,7 +167,7 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
       .replaceAll("\n", " ")
 }
 
-final case class CnameAtZoneApexError() extends DomainValidationError {
-  def message: String = "CNAME at the zone apex is not allowed."
+final case class CnameAtZoneApexError(zoneName: String) extends DomainValidationError {
+  def message: String = s"CNAME cannot be the same name as zone $zoneName"
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -168,6 +168,6 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
 }
 
 final case class CnameAtZoneApexError(zoneName: String) extends DomainValidationError {
-  def message: String = s"CNAME cannot be the same name as zone \"$zoneName\"."
+  def message: String = s"""CNAME cannot be the same name as zone "$zoneName"."""
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -168,6 +168,6 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
 }
 
 final case class CnameAtZoneApexError(zoneName: String) extends DomainValidationError {
-  def message: String = s"CNAME cannot be the same name as zone $zoneName"
+  def message: String = s"CNAME cannot be the same name as zone \"$zoneName\"."
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidationErrors.scala
@@ -166,4 +166,8 @@ final case class NewMultiRecordError(change: AddChangeForValidation) extends Dom
        |type ${change.inputChange.typ}.""".stripMargin
       .replaceAll("\n", " ")
 }
+
+final case class CnameAtZoneApexError() extends DomainValidationError {
+  def message: String = "CNAME at the zone apex is not allowed."
+}
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -236,7 +236,7 @@ class BatchChangeService(
 
     zone match {
       case Some(zn) if (zn.name == change.inputName && change.typ == CNAME) =>
-        CnameAtZoneApexError().invalidNel
+        CnameAtZoneApexError(zn.name).invalidNel
       case Some(zn) =>
         ChangeForValidation(zn, relativize(change.inputName, zn.name), change).validNel
       case None => ZoneDiscoveryError(change.inputName).invalidNel

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -26,7 +26,7 @@ import vinyldns.api.domain.DomainValidations._
 import vinyldns.api.domain.batch.BatchChangeInterfaces._
 import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain.dns.DnsConversions._
-import vinyldns.api.domain.{RecordAlreadyExists, ZoneDiscoveryError}
+import vinyldns.api.domain.{CnameAtZoneApexError, ZoneDiscoveryError}
 import vinyldns.api.repository.ApiDataAccessor
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.batch._
@@ -236,7 +236,7 @@ class BatchChangeService(
 
     zone match {
       case Some(zn) if (zn.name == change.inputName && change.typ == CNAME) =>
-        RecordAlreadyExists(change.inputName).invalidNel
+        CnameAtZoneApexError().invalidNel
       case Some(zn) =>
         ChangeForValidation(zn, relativize(change.inputName, zn.name), change).validNel
       case None => ZoneDiscoveryError(change.inputName).invalidNel

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -819,7 +819,7 @@ class BatchChangeServiceSpec
       val result =
         underTest.zoneDiscovery(List(cnameApexAdd.validNel), ExistingZones(Set(apexZone)))
 
-      result.head should haveInvalid[DomainValidationError](CnameAtZoneApexError())
+      result.head should haveInvalid[DomainValidationError](CnameAtZoneApexError(apexZone.name))
     }
 
     "return an error if no base zone is found for CNAME records" in {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -819,7 +819,7 @@ class BatchChangeServiceSpec
       val result =
         underTest.zoneDiscovery(List(cnameApexAdd.validNel), ExistingZones(Set(apexZone)))
 
-      result.head should haveInvalid[DomainValidationError](RecordAlreadyExists("apex.test.com."))
+      result.head should haveInvalid[DomainValidationError](CnameAtZoneApexError())
     }
 
     "return an error if no base zone is found for CNAME records" in {

--- a/modules/docs/src/main/tut/api/batchchange-errors.md
+++ b/modules/docs/src/main/tut/api/batchchange-errors.md
@@ -93,7 +93,7 @@ Since by-change accumulated errors are collected at different stages, errors at 
 18. [High Value Domain](#HighValueDomain)
 19. [RecordSet has Multiple Records](#ExistingMultiRecordError)
 20. [Cannot Create a RecordSet with Multiple Records](#NewMultiRecordError)
-
+21. [CNAME at the Zone Apex Is Not Allowed]("CnameApexError")
 
 #### 1. Invalid Domain Name <a id="InvalidDomainName"></a>
 
@@ -414,6 +414,18 @@ This error means that you have multiple Add entries with the same name and type 
 
 Note that this error is configuration-driven and will only appear if your instance of VinylDNS does not support multi-record batch updates.
 
+
+#### 21. CNAME at the Zone Apex is not Allowed <a id="CnameApexError"></a>
+
+##### Error Message:
+
+```
+CNAME at the zone apex is not allowed
+```
+
+##### Details:
+
+CNAME records cannot be `@` or the same name as the zone.
 
 
 ### FULL-REQUEST ERRORS <a id="full-request-errors" />

--- a/modules/docs/src/main/tut/api/batchchange-errors.md
+++ b/modules/docs/src/main/tut/api/batchchange-errors.md
@@ -420,7 +420,7 @@ Note that this error is configuration-driven and will only appear if your instan
 ##### Error Message:
 
 ```
-CNAME cannot be the same name as zone <zone_name>
+CNAME cannot be the same name as zone "<zone_name>".
 ```
 
 ##### Details:

--- a/modules/docs/src/main/tut/api/batchchange-errors.md
+++ b/modules/docs/src/main/tut/api/batchchange-errors.md
@@ -93,7 +93,7 @@ Since by-change accumulated errors are collected at different stages, errors at 
 18. [High Value Domain](#HighValueDomain)
 19. [RecordSet has Multiple Records](#ExistingMultiRecordError)
 20. [Cannot Create a RecordSet with Multiple Records](#NewMultiRecordError)
-21. [CNAME at the Zone Apex Is Not Allowed]("CnameApexError")
+21. [CNAME Cannot be the Same Name as Zone Name]("CnameApexError")
 
 #### 1. Invalid Domain Name <a id="InvalidDomainName"></a>
 
@@ -420,7 +420,7 @@ Note that this error is configuration-driven and will only appear if your instan
 ##### Error Message:
 
 ```
-CNAME at the zone apex is not allowed
+CNAME cannot be the same name as zone <zone_name>
 ```
 
 ##### Details:


### PR DESCRIPTION
branched off of #702 

Changes in this pull request:
- create CnameAtApexError message and use it instead of RecordAlreadyExists error message when a CNAME record creation is attempted at a zone apex. 
