### PR TITLE
set default ownerGroup on batch change if user has only one group

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -43,11 +43,7 @@
                                             <span class="fa fa-question-circle"></span>
                                         </span>
                                     </label>
-                                    <select class="form-control" id="recordOwnerGroup" ng-model="newBatch.ownerGroupId">
-                                        <option></option>
-                                        <option ng-repeat="group in myGroups | orderBy: 'name'" value="{{ group.id }}"
-                                                ng-selected="updateZoneInfo.adminGroupName == group.name">
-                                            {{group.name}}</option>
+                                    <select class="form-control" id="recordOwnerGroup" ng-model="newBatch.ownerGroupId" ng-options="group.id as group.name for group in myGroups | orderBy: 'name'">
                                     </select>
                                     <p class="help-block"><a href="/groups">Or you can create a new group from the Groups page.</a></p>
                                 </div>

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -22,6 +22,9 @@
             groupsService.getMyGroups()
                 .then(function (results) {
                     $scope.myGroups = results['data']['groups'];
+                    if ($scope.myGroups.length == 1) {
+                        $scope.newBatch.ownerGroupId = $scope.myGroups[0]['id']
+                    }
                 })
                 .catch(function (error) {
                     handleError(error, 'groupsService::getMyGroups-failure');


### PR DESCRIPTION
This is for the portal. If a user is only part of one group make that group the default selection in the new batch change form. Should help cut down on confusion over selecting an owner group when it's needed for record changes in shared zones.
