### PR TITLE
Fixing task scheduler running too often

### DIFF
--- a/modules/core/src/main/scala/vinyldns/core/task/TaskRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/task/TaskRepository.scala
@@ -23,7 +23,10 @@ import scala.concurrent.duration.FiniteDuration
 
 trait TaskRepository extends Repository {
 
-  def claimTask(name: String, taskTimeout: FiniteDuration): IO[Boolean]
+  def claimTask(
+      name: String,
+      taskTimeout: FiniteDuration,
+      pollingInterval: FiniteDuration): IO[Boolean]
 
   def releaseTask(name: String): IO[Unit]
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlTaskRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlTaskRepositoryIntegrationSpec.scala
@@ -62,35 +62,58 @@ class MySqlTaskRepositoryIntegrationSpec extends WordSpec with BeforeAndAfterAll
 
   "claimTask" should {
     "return true if non-in-flight task exists task is new" in {
+      // in_flight = 0; updated = NULL
       val f = for {
         _ <- repo.saveTask(TASK_NAME)
-        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.hour)
+        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.hour, 1.hour)
       } yield unclaimedTaskExists
 
       f.unsafeRunSync() shouldBe true
     }
     "return true if non-in-flight task exists and expiration time has elapsed" in {
+      // in_flight = 0; updated > {taskTimeout}
       val f = for {
         _ <- repo.saveTask(TASK_NAME)
         _ <- ageTaskBySeconds(100) // Age the task by 100 seconds
-        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.second)
+        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 5.seconds, 3.seconds)
       } yield unclaimedTaskExists
 
       f.unsafeRunSync() shouldBe true
     }
-    "return false if in-flight task exists and expiration time has not elapsed" in {
+    "return true if non-in-flight task exists and polling interval has elapsed" in {
+      // in_flight = 0; updated > {pollingInterval}; updated < {taskTimeout}
       val f = for {
         _ <- repo.saveTask(TASK_NAME)
-        _ <- repo.claimTask(TASK_NAME, 1.hour)
-        _ <- ageTaskBySeconds(5) // Age the task by only 5 seconds
-        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.hour)
+        _ <- ageTaskBySeconds(100) // Age the task by 100 seconds
+        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 200.seconds, 3.seconds)
+      } yield unclaimedTaskExists
+
+      f.unsafeRunSync() shouldBe true
+    }
+    "return false if non-in-flight task exists and polling interval has not elapsed" in {
+      // in_flight = 0; updated < {pollingInterval}; updated < {taskTimeout}
+      val f = for {
+        _ <- repo.saveTask(TASK_NAME)
+        _ <- ageTaskBySeconds(100) // Age the task by 100 seconds
+        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 200.seconds, 200.seconds)
+      } yield unclaimedTaskExists
+
+      f.unsafeRunSync() shouldBe false
+    }
+    "return false if in-flight task exists and expiration time has not elapsed" in {
+      // in_flight = 1; updated < {pollingInterval}; updated < {taskTimeout}
+      val f = for {
+        _ <- repo.saveTask(TASK_NAME)
+        _ <- repo.claimTask(TASK_NAME, 1.hour, 30.seconds)
+        _ <- ageTaskBySeconds(5) // Age the task by only 5 seconds, polling interval is 30 seconds
+        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.hour, 30.seconds)
       } yield unclaimedTaskExists
 
       f.unsafeRunSync() shouldBe false
     }
     "return false if task does not exist" in {
       val f = for {
-        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.hour)
+        unclaimedTaskExists <- repo.claimTask(TASK_NAME, 1.hour, 1.hour)
       } yield unclaimedTaskExists
 
       f.unsafeRunSync() shouldBe false
@@ -101,7 +124,7 @@ class MySqlTaskRepositoryIntegrationSpec extends WordSpec with BeforeAndAfterAll
     "unset in-flight flag for task and update time" in {
       val f = for {
         _ <- repo.saveTask(TASK_NAME)
-        _ <- repo.claimTask(TASK_NAME, 1.hour)
+        _ <- repo.claimTask(TASK_NAME, 1.hour, 30.seconds)
         _ <- ageTaskBySeconds(2)
         oldTaskInfo <- getTaskInfo(TASK_NAME)
         _ <- repo.releaseTask(TASK_NAME)
@@ -140,7 +163,7 @@ class MySqlTaskRepositoryIntegrationSpec extends WordSpec with BeforeAndAfterAll
       // the result should be that the task is still claimed / in_flight
       val f = for {
         _ <- repo.saveTask("repeat")
-        _ <- repo.claimTask("repeat", 5.seconds)
+        _ <- repo.claimTask("repeat", 30.seconds, 10.seconds)
         firstTaskInfo <- getTaskInfo("repeat")
         _ <- repo.saveTask("repeat")
         secondTaskInfo <- getTaskInfo("repeat")

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlTaskRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlTaskRepository.scala
@@ -39,8 +39,8 @@ class MySqlTaskRepository extends TaskRepository {
     sql"""
       |UPDATE task
       |   SET in_flight = 1, updated = NOW()
-      | WHERE (in_flight = 0 OR updated < DATE_SUB(NOW(),INTERVAL {timeoutSeconds} SECOND))
-      |   AND (updated IS NULL OR updated < DATE_SUB(NOW(),INTERVAL {pollingInterval} SECOND))
+      | WHERE (in_flight = 0 AND (updated IS NULL OR updated < DATE_SUB(NOW(),INTERVAL {pollingInterval} SECOND)))
+      |   OR (updated < DATE_SUB(NOW(),INTERVAL {timeoutSeconds} SECOND))
       |   AND name = {taskName};
       """.stripMargin
 


### PR DESCRIPTION
* `TaskRepository.claimTask` - modified to take a polling interval in addition to the task timeout
* `MySqlTaskRepository` - this is where the bug lies.  Before we were claiming the task if it WAS NOT in_flight and if the task had not expired.  This meant that every node if it started at a different time would run the task.  Changed the SQL so that we check if the task is NOT in_flight that it also hasn't been executed within the last pollingInterval.  *double check this guy*
* `TaskScheduler` - small fix to auto execute the task on task scheduler start up.  This is useful for tasks with long polling intervals.