### PR TITLE
add backend ID info to docs

### DIFF
--- a/modules/docs/src/main/tut/api/zone-model.md
+++ b/modules/docs/src/main/tut/api/zone-model.md
@@ -31,7 +31,7 @@ account       | string      | **DEPRECATED** The account that created the zone |
 email         | string      | The distribution email for the zone |
 backendId     | string      | Optional. Recommended over `connection` and `transferConnection`. The configuration ID of the DNS backend server for the zone. If not provided, default keys will be used unless connection and transfer connection are provided. |
 connection    | ZoneConnection | Optional. The connection used to issue DDNS updates to the backend zone.  If not provided, default keys will be used unless backendId is provided.  See the [Zone Connection Attributes](#zone-conn-attr) for more information |
-transferConnection | ZoneConnection | Optional. The connection that is used to sync the zone with the DNS backend.  This can be different than the update connection.  If not provided, default keys will be used |
+transferConnection | ZoneConnection | Optional. The connection that is used to sync the zone with the DNS backend.  This can be different than the update connection.  If not provided, default keys will be used unless backendId is provided. |
 shared        | boolean     | An indicator that the zone is shared with anyone. At this time only VinylDNS administrators can set this to true.|
 acl           | ZoneACL     | The access control rules governing the zone.  See the [Zone ACL Rule Attributes](#zone-acl-rule-attr) for more information
 id            | string      | The unique identifier for this zone
@@ -231,6 +231,14 @@ The **IPv6** ACL Rule
 Will give Read permissions to PTR Record Sets 1000:1000:1000:1000:0000:0000:0000:0000 to 1000:1000:1000:1000:FFFF:FFFF:FFFF:FFFF, as 64 bits is half of an IPv6 address.
 
 #### ZONE CONNECTION ATTRIBUTES <a id="zone-conn-attr"></a>
+In order for VinylDNS to make updates in DNS, it needs key information for every zone. There are 3 ways to specify that key information; ask your VinylDNS admin which is appropriate for your zone based on the configuration of the service:
+
+1. Leave connection, transfer connection, and backendId blank: In this case, the default VinylDNS keys will be used
+2. Specify a backendID on the zone: if multiple backends are configured for your instance of VinylDNS, you can specify a backendID on the zone and the keys associated with that backend will be used.
+3. Specify ZoneConnection and TransferConnection on the zone itself: See below for details
+
+Note that if both a backendID and specific connection keys are included on a zone, the specific connection keys will be used.
+
 Zone Connection specifies the connection information to the backend DNS server.
 
 field        | type        | description |

--- a/modules/docs/src/main/tut/api/zone-model.md
+++ b/modules/docs/src/main/tut/api/zone-model.md
@@ -190,7 +190,7 @@ ACL rules can be applied to specific record types and can include record masks t
 apply to. These record masks apply to record names, but because PTR record names are part their reverse zone ip, the use of regular
 expressions for record masks are not supported.
 <br><br>
-Instead PTR record masks must be CIDR rules, which will denote a range of ip addresses that the rule will apply to.
+Instead PTR record masks must be CIDR rules, which will denote a range of IP addresses that the rule will apply to.
 While more information and useful CIDR rule utility tools can be found online, CIDR rules describe how many bits of an ip address' binary representation
 must be the same for a match.
 

--- a/modules/docs/src/main/tut/api/zone-model.md
+++ b/modules/docs/src/main/tut/api/zone-model.md
@@ -235,7 +235,7 @@ Zone Connection specifies the connection information to the backend DNS server.
 
 field        | type        | description |
 ------------ | :---------- | :---------- |
-primaryServer | string      | The ip address or host that is connected to.  This can take a port as well `127.0.0.1:5300`.  If no port is specified, 53 will be assumed. |
+primaryServer | string      | The IP address or host that is connected to.  This can take a port as well `127.0.0.1:5300`.  If no port is specified, 53 will be assumed. |
 keyName       | string      | The name of the DNS key that has access to the DNS server and zone.  **Note:** For the transfer connection, the key must be given *allow-transfer* access to the zone.  For the primary connection, the key must be given *allow-update* access to the zone. |
 name          | string      | A user identifier for the connection.
 key           | string      | The TSIG secret key used to sign requests when communicating with the primary server.  **Note:** After creating the zone, the key value itself is hashed and obfuscated, so it will be unusable from a client perspective. |

--- a/modules/docs/src/main/tut/api/zone-model.md
+++ b/modules/docs/src/main/tut/api/zone-model.md
@@ -29,8 +29,8 @@ adminGroupId  | string      | The id of the administrators group for the zone |
 created       | date-time   | The time when the zone was first created |
 account       | string      | **DEPRECATED** The account that created the zone |
 email         | string      | The distribution email for the zone |
-backendId     | string      | Optional. Recommended over `connection` and `transferConnection`. The configuration ID of the DNS backend server for the zone |
-connection    | ZoneConnection | Optional. The connection used to issue DDNS updates to the backend zone.  If not provided, default keys will be used.  See the [Zone Connection Attributes](#zone-conn-attr) for more information |
+backendId     | string      | Optional. Recommended over `connection` and `transferConnection`. The configuration ID of the DNS backend server for the zone. If not provided, default keys will be used unless connection and transfer connection are provided. |
+connection    | ZoneConnection | Optional. The connection used to issue DDNS updates to the backend zone.  If not provided, default keys will be used unless backendId is provided.  See the [Zone Connection Attributes](#zone-conn-attr) for more information |
 transferConnection | ZoneConnection | Optional. The connection that is used to sync the zone with the DNS backend.  This can be different than the update connection.  If not provided, default keys will be used |
 shared        | boolean     | An indicator that the zone is shared with anyone. At this time only VinylDNS administrators can set this to true.|
 acl           | ZoneACL     | The access control rules governing the zone.  See the [Zone ACL Rule Attributes](#zone-acl-rule-attr) for more information

--- a/modules/docs/src/main/tut/api/zone-model.md
+++ b/modules/docs/src/main/tut/api/zone-model.md
@@ -29,8 +29,9 @@ adminGroupId  | string      | The id of the administrators group for the zone |
 created       | date-time   | The time when the zone was first created |
 account       | string      | **DEPRECATED** The account that created the zone |
 email         | string      | The distribution email for the zone |
-connection    | ZoneConnection | The connection used to issue DDNS updates to the backend zone.  If not provided, default keys will be used.  See the [Zone Connection Attributes](#zone-conn-attr) for more information |
-transferConnection | ZoneConnection | The connection that is used to sync the zone with the DNS backend.  This can be different than the update connection.  If not provided, default keys will be used |
+backendId     | string      | Optional. Recommended over `connection` and `transferConnection`. The configuration ID of the DNS backend server for the zone |
+connection    | ZoneConnection | Optional. The connection used to issue DDNS updates to the backend zone.  If not provided, default keys will be used.  See the [Zone Connection Attributes](#zone-conn-attr) for more information |
+transferConnection | ZoneConnection | Optional. The connection that is used to sync the zone with the DNS backend.  This can be different than the update connection.  If not provided, default keys will be used |
 shared        | boolean     | An indicator that the zone is shared with anyone. At this time only VinylDNS administrators can set this to true.|
 acl           | ZoneACL     | The access control rules governing the zone.  See the [Zone ACL Rule Attributes](#zone-acl-rule-attr) for more information
 id            | string      | The unique identifier for this zone
@@ -88,28 +89,8 @@ accessLevel   | string      | Access level of the user requesting the zone. Curr
   },
   "id": "9cbdd3ac-9752-4d56-9ca0-6a1a14fc5562",
   "latestSync": "2016-12-16T15:27:26Z",
+  "backendId":"func-test-backend",
   "accessLevel": "Delete"
-}
-```
-
-#### ZONE CONNECTION ATTRIBUTES <a id="zone-conn-attr"></a>
-Zone Connection specifies the connection information to the backend DNS server.
-
-field        | type        | description |
------------- | :---------- | :---------- |
-primaryServer | string      | The ip address or host that is connected to.  This can take a port as well `127.0.0.1:5300`.  If no port is specified, 53 will be assumed. |
-keyName       | string      | The name of the DNS key that has access to the DNS server and zone.  **Note:** For the transfer connection, the key must be given *allow-transfer* access to the zone.  For the primary connection, the key must be given *allow-update* access to the zone. |
-name          | string      | A user identifier for the connection.
-key           | string      | The TSIG secret key used to sign requests when communicating with the primary server.  **Note:** After creating the zone, the key value itself is hashed and obfuscated, so it will be unusable from a client perspective. |
-
-#### ZONE CONNECTION EXAMPLE <a id="zone-conn-example"></a>
-
-```
-{
-  "primaryServer": "127.0.0.1:5301",
-  "keyName": "vinyl.",
-  "name": "ok.",
-  "key": "OBF:1:W1FXgpOjjrQAABAARrZmyLjFSOuFYTAw81mhvNEmNAc4RnYzPjJQMEjVQWWLRohu7gRAVw=="
 }
 ```
 
@@ -248,6 +229,27 @@ The **IPv6** ACL Rule
 ```
 
 Will give Read permissions to PTR Record Sets 1000:1000:1000:1000:0000:0000:0000:0000 to 1000:1000:1000:1000:FFFF:FFFF:FFFF:FFFF, as 64 bits is half of an IPv6 address.
+
+#### ZONE CONNECTION ATTRIBUTES <a id="zone-conn-attr"></a>
+Zone Connection specifies the connection information to the backend DNS server.
+
+field        | type        | description |
+------------ | :---------- | :---------- |
+primaryServer | string      | The ip address or host that is connected to.  This can take a port as well `127.0.0.1:5300`.  If no port is specified, 53 will be assumed. |
+keyName       | string      | The name of the DNS key that has access to the DNS server and zone.  **Note:** For the transfer connection, the key must be given *allow-transfer* access to the zone.  For the primary connection, the key must be given *allow-update* access to the zone. |
+name          | string      | A user identifier for the connection.
+key           | string      | The TSIG secret key used to sign requests when communicating with the primary server.  **Note:** After creating the zone, the key value itself is hashed and obfuscated, so it will be unusable from a client perspective. |
+
+#### ZONE CONNECTION EXAMPLE <a id="zone-conn-example"></a>
+
+```
+{
+  "primaryServer": "127.0.0.1:5301",
+  "keyName": "vinyl.",
+  "name": "ok.",
+  "key": "OBF:1:W1FXgpOjjrQAABAARrZmyLjFSOuFYTAw81mhvNEmNAc4RnYzPjJQMEjVQWWLRohu7gRAVw=="
+}
+```
 
 ### SHARED ZONES <a id="shared-zones"></a>
 

--- a/modules/docs/src/main/tut/api/zone-model.md
+++ b/modules/docs/src/main/tut/api/zone-model.md
@@ -233,11 +233,11 @@ Will give Read permissions to PTR Record Sets 1000:1000:1000:1000:0000:0000:0000
 #### ZONE CONNECTION ATTRIBUTES <a id="zone-conn-attr"></a>
 In order for VinylDNS to make updates in DNS, it needs key information for every zone. There are 3 ways to specify that key information; ask your VinylDNS admin which is appropriate for your zone based on the configuration of the service:
 
-1. Leave connection, transfer connection, and backendId blank: In this case, the default VinylDNS keys will be used
-2. Specify a backendID on the zone: if multiple backends are configured for your instance of VinylDNS, you can specify a backendID on the zone and the keys associated with that backend will be used.
-3. Specify ZoneConnection and TransferConnection on the zone itself: See below for details
+1. Leave connection, transfer connection, and backend ID blank: In this case, the default VinylDNS keys will be used
+2. Specify a backend ID on the zone: if multiple backends are configured for your instance of VinylDNS, you can specify a backend ID on the zone and the keys associated with that backend will be used.
+3. Specify zone connection and transfer connection on the zone itself: see below for details
 
-Note that if both a backendID and specific connection keys are included on a zone, the specific connection keys will be used.
+Note that if both a backend ID and specific connection keys are included on a zone, the specific connection keys will be used.
 
 Zone Connection specifies the connection information to the backend DNS server.
 

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -329,15 +329,16 @@ vinyldns {
 ```
 
 ## Default Zone Connections
-VinylDNS allows you to specify zone connection information _for each zone_.
+VinylDNS has three ways of indicating zone connections:
+
+1. Global default connection applies to all zones unless overridden by one of the following connections. This configuration is required.
+2. Backends allows you to specify zone connection information for an individual zone by choosing a pre-configured zone connection. This configuration is optional.
+3. Zone level override allows you to specify zone update and transfer connection information _for each zone_. More information is in the [Zone Model](../api/zone-model).
 
 VinylDNS has **2** connections for each zone:
 
 1. The DDNS connection - used for making DDNS updates to the zone
 1. The Transfer connection - used for making AXFR requests for zone syncing with the DNS backend
-
-VinylDNS supports the ability to provide _default_ connections, so keys do not need to be generated for _every_ zone.  This assumes a
-"default" DNS backend.
 
 VinylDNS also ties in testing network connectivity to the default zone connection's primary server into its API health checks. A value
 for the health check connection timeout in milliseconds can be specified using `health-check-timeout`; a default value of 10000 will
@@ -372,6 +373,25 @@ vinyldns {
     primaryServer = "vinyldns-bind9"
   }
 }
+
+# Zone Connection Data, ID can be specified in a zone to override the global default configuration
+backends = [
+    {
+      id = "test-backend-id"
+      zone-connection {
+        name = "vinyldns."
+        key-name = "vinyldns."
+        key = "nzisn+4G2ldMn0q1CV3vsg=="
+        primary-server = "127.0.0.1:19001"
+      }
+      transfer-connection {
+        name = "vinyldns."
+        key-name = "vinyldns."
+        key = "nzisn+4G2ldMn0q1CV3vsg=="
+        primary-server = "127.0.0.1:19001"
+      }
+    }
+]
 ```
 
 ## Additional Configuration Settings

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -635,7 +635,7 @@ high-value-domains = {
 # Zone Connection Data
 backends = [
     {
-      id = "func-test-backend"
+      id = "test-backend-id"
       zone-connection {
         name = "vinyldns."
         key-name = "vinyldns."

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -631,4 +631,23 @@ high-value-domains = {
       "fd69:27cc:fe91:0:0:0:ffff:0"
     ]
 }
+
+# Zone Connection Data
+backends = [
+    {
+      id = "func-test-backend"
+      zone-connection {
+        name = "vinyldns."
+        key-name = "vinyldns."
+        key = "nzisn+4G2ldMn0q1CV3vsg=="
+        primary-server = "127.0.0.1:19001"
+      }
+      transfer-connection {
+        name = "vinyldns."
+        key-name = "vinyldns."
+        key = "nzisn+4G2ldMn0q1CV3vsg=="
+        primary-server = "127.0.0.1:19001"
+      }
+    }
+]
 ```


### PR DESCRIPTION
Fixes #623.

Changes in this pull request:
- add zone backend ID info to the zone model docs
- add zone backend ID info to the configuration example
