### PR TITLE
Task Scheduler Fix

### DIFF
--- a/modules/portal/app/tasks/UserSyncTask.scala
+++ b/modules/portal/app/tasks/UserSyncTask.scala
@@ -28,7 +28,8 @@ class UserSyncTask(
     userAccountAccessor: UserAccountAccessor,
     authenticator: Authenticator,
     val runEvery: FiniteDuration = 24.hours,
-    val timeout: FiniteDuration = 24.hours)
+    val timeout: FiniteDuration = 24.hours,
+    val checkInterval: FiniteDuration = 1.minute)
     extends Task {
   val name: String = "user_sync"
   private val logger: Logger = LoggerFactory.getLogger("UserSyncTask")


### PR DESCRIPTION
The last fix improved the scheduling of tasks, but there is the possibility of a scheduled run to be missed.

We saw this running the user sync in dev every 1 hour:

1. Node 1 runs the task at 6:13:20, the task completes and the task completion time is updated to 6:13:50
2. Node 2 (on a different timer) attempts to run at 7:10:00 and notices it has only be 56:10 since the last run (less than one hour) and does not run it.
3. Node 1 attempts to run the task at 7:13:20, which is only 59:30 since the last run and does not run it.

The result is the "7 o'clock" execution time is skipped, as the task goes back to sleep for a full hour.

There are two problems:

1. We use `awakeEvery` instead of `fixedDelay`.  `awakeEvery` will try its best to wake up every hour, regardless of how long the tasks takes to run.  This results in the situation where Node 1 "skipped" the 7 o'clock run.
2. The `runEvery` is the polling time.  In reality, the polling time should be much shorter.  Even if we fix number 1 above, it is possible around the second boundary that we miss a scheduled run.  Added a `checkInterval` which is "how often to I check the task store to see if the task should run".  By setting this to small number, we can be certain that even if we fall around the second boundary that we will still run.

With the changes, the behavior that we noticed would follow:

1. Node 1 runs the task at 6:13:20, the task completes at 6:13:50
2. Node 2 and Node 1 are both using the check interval, on a much shorter interval of 1.minute.  Node 1 will check at 7:13:50, and Node 2 will check at 7:14:00.
3. If Node 2 queries the table at 7:13:49, it may miss the run.  However, Node 1 using the check interval of every minute will pick it up at 7:14:00.
4. If Node 1 _dies_, Node 2 will still pick it up at 7:14:00


