### PR TITLE
add errors to record owner group field

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -36,7 +36,7 @@
                                 <input type="text" class="form-control" ng-model="newBatch.comments">
                             </div>
                             @if(meta.sharedDisplayEnabled) {
-                            <div class="form-group row">
+                            <div class="form-group row" ng-class="{ownerGroupError: ownerGroupError}">
                                 <div class="col-md-6">
                                     <label class="h5" for="recordOwnerGroup">Record Owner Group
                                         <span data-toggle="tooltip" data-placement="top" title="Record Owner Group is required if any records in the batch change are in shared zones and not already owned.">
@@ -45,6 +45,7 @@
                                     </label>
                                     <select class="form-control" id="recordOwnerGroup" ng-model="newBatch.ownerGroupId" ng-options="group.id as group.name for group in myGroups | orderBy: 'name'">
                                     </select>
+                                    <p ng-if="ownerGroupError"><strong>Record Owner Group is required for records in shared zones.</strong></p>
                                     <p class="help-block"><a href="/groups">Or you can create a new group from the Groups page.</a></p>
                                 </div>
                             </div>

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -372,7 +372,7 @@ label.switch {
    display: none;
 }
 
-.changeError {
+.changeError, .ownerGroupError {
     background: rgba(255, 0, 0, 0.32);
 }
 

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -34,6 +34,7 @@
             $scope.newBatch = {comments: "", changes: [{changeType: "Add", type: "A+PTR"}]};
             $scope.alerts = [];
             $scope.batchChangeErrors = false;
+            $scope.ownerGroupError = false;
             $scope.formStatus = "pendingSubmit";
 
             $scope.addSingleChange = function() {
@@ -93,6 +94,9 @@
                         } else {
                             $scope.newBatch.changes = error.data;
                             $scope.batchChangeErrors = true;
+                            $scope.ownerGroupError = error.data.filter(d => d.errors)
+                                .flatMap(d => d.errors)
+                                .find(e => e.includes('owner group ID must be specified for record')) ? true : false;
                             $scope.formStatus = "pendingSubmit";
                             $scope.alerts.push({type: 'danger', content: 'Errors found. Please correct and submit again.'});
                         }

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -94,9 +94,8 @@
                         } else {
                             $scope.newBatch.changes = error.data;
                             $scope.batchChangeErrors = true;
-                            $scope.ownerGroupError = error.data.filter(d => d.errors)
-                                .flatMap(d => d.errors)
-                                .find(e => e.includes('owner group ID must be specified for record')) ? true : false;
+                            $scope.ownerGroupError = error.data.flatMap(d => d.errors)
+                                .some(e => e.includes('owner group ID must be specified for record'));
                             $scope.formStatus = "pendingSubmit";
                             $scope.alerts.push({type: 'danger', content: 'Errors found. Please correct and submit again.'});
                         }


### PR DESCRIPTION
With the implementation of shared zones some batch change requests require a record owner group. Users see the error message when relevant on the single line, but they still seem to be confused about how to resolve it, they aren't recognizing it's referring to the Record Owner Group field.

### Current portal view with error messages:
![Screen Shot 2019-07-11 at 2 57 07 PM](https://user-images.githubusercontent.com/4439228/61077340-2cc18480-a3ec-11e9-8da1-bffd715a4b3d.png)

Some enhancements I want to try are highlighting the record owner group field if any of the changes error because there is no owner group and adding more messaging that the field is required.

### Updated portal view error messages:
![Screen Shot 2019-07-11 at 1 48 00 PM](https://user-images.githubusercontent.com/4439228/61077133-c2a8df80-a3eb-11e9-88e5-5e510da8b246.png)
