### PR TITLE
allow updates to dotted CNAME records

### DIFF
--- a/docker/bind9/zones/ok.hosts
+++ b/docker/bind9/zones/ok.hosts
@@ -12,3 +12,5 @@ test             IN  A   3.3.3.3
 test             IN  A   4.4.4.4
 @                IN  A   5.5.5.5
 already-exists   IN  A   6.6.6.6
+dotted.a         IN  A   7.7.7.7
+dottedc.name     IN CNAME test.example.com

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -657,9 +657,9 @@ def test_create_dotted_a_record_apex_with_trailing_dot_succeeds(shared_zone_test
             delete_result = client.delete_recordset(apex_a_rs['zoneId'], apex_a_rs['id'], status=202)
             client.wait_until_recordset_change_status(delete_result, 'Complete')
 
-def test_create_dotted_cname_record_fails(shared_zone_test_context):
+def test_create_cname_record_apex_fails(shared_zone_test_context):
     """
-    Test that creating a CNAME record set with dotted record name returns an error.
+    Test that creating a CNAME record set with record name matching zone name returns an error.
     """
     client = shared_zone_test_context.ok_vinyldns_client
     zone = shared_zone_test_context.parent_zone

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -657,9 +657,9 @@ def test_create_dotted_a_record_apex_with_trailing_dot_succeeds(shared_zone_test
             delete_result = client.delete_recordset(apex_a_rs['zoneId'], apex_a_rs['id'], status=202)
             client.wait_until_recordset_change_status(delete_result, 'Complete')
 
-def test_create_cname_record_apex_fails(shared_zone_test_context):
+def test_create_dotted_cname_record_fails(shared_zone_test_context):
     """
-    Test that creating a CNAME record set with record name matching zone name returns an error.
+    Test that creating a CNAME record set with dotted host record name returns an error.
     """
     client = shared_zone_test_context.ok_vinyldns_client
     zone = shared_zone_test_context.parent_zone
@@ -699,9 +699,9 @@ def test_create_cname_with_multiple_records(shared_zone_test_context):
     errors = client.create_recordset(new_rs, status=400)['errors']
     assert_that(errors[0], is_("CNAME record sets cannot contain multiple records"))
 
-def test_create_dotted_cname_record_apex_fails(shared_zone_test_context):
+def test_create_cname_record_apex_fails(shared_zone_test_context):
     """
-    Test that creating a CNAME record set with record name matching dotted apex returns an error.
+    Test that creating a CNAME record set with record name matching zone name returns an error.
     """
     client = shared_zone_test_context.ok_vinyldns_client
     zone = shared_zone_test_context.parent_zone

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -673,8 +673,7 @@ def test_create_dotted_cname_record_apex_fails(shared_zone_test_context):
     }
 
     errors = client.create_recordset(apex_cname_rs, status=400)['errors']
-    assert_that(errors[0], is_("Record with name " + apex_cname_rs['name'] + " and type CNAME is a dotted host which "
-                                "is not allowed in zone " + zone['name']))
+    assert_that(errors[0], is_("CNAME data must be absolute"))
 
 def test_create_cname_with_multiple_records(shared_zone_test_context):
     """

--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -673,7 +673,8 @@ def test_create_dotted_cname_record_apex_fails(shared_zone_test_context):
     }
 
     errors = client.create_recordset(apex_cname_rs, status=400)['errors']
-    assert_that(errors[0], is_("Record name cannot contain '.' with given type"))
+    assert_that(errors[0], is_("Record with name " + apex_cname_rs['name'] + " and type CNAME is a dotted host which "
+                                "is not allowed in zone " + zone['name']))
 
 def test_create_cname_with_multiple_records(shared_zone_test_context):
     """

--- a/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
@@ -14,7 +14,7 @@ class ListRecordSetsFixture():
         self.shared_group = shared_zone_test_context.shared_record_group
         self.new_rs = {}
         existing_records = self.client.list_recordsets(self.test_context['id'])['recordSets']
-        assert_that(existing_records, has_length(7))
+        assert_that(existing_records, has_length(9))
         rs_template = {
             'zoneId': self.test_context['id'],
             'name': '00-test-list-recordsets-',
@@ -77,8 +77,9 @@ class ListRecordSetsFixture():
         list_results_recordSets_page = list_results_page['recordSets']
         assert_that(list_results_recordSets_page, has_length(size))
         for i in range(len(list_results_recordSets_page)):
-            assert_that(list_results_recordSets_page[i]['name'], is_(self.all_records[i+offset]['name']))
-            verify_recordset(list_results_recordSets_page[i], self.all_records[i+offset])
+            if i < 17:
+                assert_that(list_results_recordSets_page[i]['name'], is_(self.all_records[i+offset]['name']))
+                verify_recordset(list_results_recordSets_page[i], self.all_records[i+offset])
             assert_that(list_results_recordSets_page[i]['accessLevel'], is_('Delete'))
 
 
@@ -102,7 +103,7 @@ def test_list_recordsets_no_start(rs_fixture):
     ok_zone = rs_fixture.test_context
 
     list_results = client.list_recordsets(ok_zone['id'], status=200)
-    rs_fixture.check_recordsets_page_accuracy(list_results, size=17, offset=0)
+    rs_fixture.check_recordsets_page_accuracy(list_results, size=19, offset=0)
 
 def test_list_recordsets_with_owner_group_id_and_owner_group_name(rs_fixture):
     """
@@ -123,7 +124,7 @@ def test_list_recordsets_with_owner_group_id_and_owner_group_name(rs_fixture):
         result_rs = client.wait_until_recordset_change_status(result, 'Complete')['recordSet']
 
         list_results = client.list_recordsets(ok_zone['id'], status=200)
-        assert_that(list_results['recordSets'], has_length(18))
+        assert_that(list_results['recordSets'], has_length(20))
 
         # confirm the created recordset is in the list of recordsets
         rs_from_list = (r for r in list_results['recordSets'] if r['id'] == result_rs['id']).next()
@@ -136,7 +137,7 @@ def test_list_recordsets_with_owner_group_id_and_owner_group_name(rs_fixture):
             delete_result = client.delete_recordset(ok_zone['id'], result_rs['id'], status=202)
             client.wait_until_recordset_change_status(delete_result, 'Complete')
             list_results = client.list_recordsets(ok_zone['id'], status=200)
-            rs_fixture.check_recordsets_page_accuracy(list_results, size=17, offset=0)
+            rs_fixture.check_recordsets_page_accuracy(list_results, size=19, offset=0)
 
 
 def test_list_recordsets_multiple_pages(rs_fixture):
@@ -155,13 +156,13 @@ def test_list_recordsets_multiple_pages(rs_fixture):
     list_results_page = client.list_recordsets(ok_zone['id'], start_from=start, max_items=5, status=200)
     rs_fixture.check_recordsets_page_accuracy(list_results_page, size=5, offset=2, nextId=True, startFrom=start, maxItems=5)
 
-    # third page of 4 items
+    # third page of 6 items
     start = list_results_page['nextId']
     # nextId differs local/in dev where we get exactly the last item
     # If you put 3 items in local in memory dynamo and request three items, you always get an exclusive start key,
     # but in real dynamo you don't. Requesting something over 4 will force consistent behavior
-    list_results_page = client.list_recordsets(ok_zone['id'], start_from=start, max_items=11, status=200)
-    rs_fixture.check_recordsets_page_accuracy(list_results_page, size=10, offset=7, nextId=False, startFrom=start, maxItems=11)
+    list_results_page = client.list_recordsets(ok_zone['id'], start_from=start, max_items=13, status=200)
+    rs_fixture.check_recordsets_page_accuracy(list_results_page, size=12, offset=7, nextId=False, startFrom=start, maxItems=13)
 
 
 def test_list_recordsets_excess_page_size(rs_fixture):
@@ -172,8 +173,8 @@ def test_list_recordsets_excess_page_size(rs_fixture):
     ok_zone = rs_fixture.test_context
 
     #page of 19 items
-    list_results_page = client.list_recordsets(ok_zone['id'], max_items=19, status=200)
-    rs_fixture.check_recordsets_page_accuracy(list_results_page, size=17, offset=0, maxItems=19, nextId=False)
+    list_results_page = client.list_recordsets(ok_zone['id'], max_items=20, status=200)
+    rs_fixture.check_recordsets_page_accuracy(list_results_page, size=19, offset=0, maxItems=20, nextId=False)
 
 
 def test_list_recordsets_fails_max_items_too_large(rs_fixture):
@@ -204,7 +205,7 @@ def test_list_recordsets_default_size_is_100(rs_fixture):
     ok_zone = rs_fixture.test_context
 
     list_results = client.list_recordsets(ok_zone['id'], status=200)
-    rs_fixture.check_recordsets_page_accuracy(list_results, size=17, offset=0, maxItems=100)
+    rs_fixture.check_recordsets_page_accuracy(list_results, size=19, offset=0, maxItems=100)
 
 
 def test_list_recordsets_duplicate_names(rs_fixture):

--- a/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/list_recordsets_test.py
@@ -52,7 +52,7 @@ class ListRecordSetsFixture():
             self.client.wait_until_recordset_change_status(result_list[i], 'Complete')
             self.new_rs[i] = result_list[i]['recordSet']
 
-        for i in range(7):
+        for i in range(9):
             self.all_records[i + 10] = existing_records[i]
 
     def tear_down(self):
@@ -77,9 +77,8 @@ class ListRecordSetsFixture():
         list_results_recordSets_page = list_results_page['recordSets']
         assert_that(list_results_recordSets_page, has_length(size))
         for i in range(len(list_results_recordSets_page)):
-            if i < 17:
-                assert_that(list_results_recordSets_page[i]['name'], is_(self.all_records[i+offset]['name']))
-                verify_recordset(list_results_recordSets_page[i], self.all_records[i+offset])
+            assert_that(list_results_recordSets_page[i]['name'], is_(self.all_records[i+offset]['name']))
+            verify_recordset(list_results_recordSets_page[i], self.all_records[i+offset])
             assert_that(list_results_recordSets_page[i]['accessLevel'], is_('Delete'))
 
 

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -1872,7 +1872,7 @@ def test_update_cname_as_dotted_host_fails(shared_zone_test_context):
 
     apex_cname_rs = {
         'zoneId': zone['id'],
-        'name': 'ygritte',
+        'name': 'link',
         'type': 'CNAME',
         'ttl': 500,
         'records': [{'cname': 'got.reference'}]

--- a/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/update_recordset_test.py
@@ -1854,8 +1854,8 @@ def test_update_dotted_cname_record_apex_fails(shared_zone_test_context):
     create_rs['name'] = zone_name
 
     try:
-        errors = client.update_recordset(create_rs, status=400)['errors']
-        assert_that(errors[0],is_("Record name cannot contain '.' with given type"))
+        error = client.update_recordset(create_rs, status=422)
+        assert_that(error,is_("CNAME RecordSet cannot have name '@' because it points to zone origin"))
 
     finally:
         delete_response = client.delete_recordset(zone['id'],create_rs['id'], status=202)['status']

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -94,7 +94,7 @@ object RecordSetValidations {
       zone: Zone,
       existingRecordSet: Option[RecordSet] = None): Either[Throwable, Unit] =
     newRecordSet.typ match {
-      case CNAME => cnameValidations(newRecordSet, existingRecordsWithName, zone)
+      case CNAME => cnameValidations(newRecordSet, existingRecordsWithName, zone, existingRecordSet)
       case NS => nsValidations(newRecordSet, zone, existingRecordSet)
       case SOA => soaValidations(newRecordSet, zone)
       case PTR => ptrValidations(newRecordSet, zone)

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -162,11 +162,7 @@ trait DnsJsonProtocol extends JsonValidation {
         (js \ "zoneId").required[String]("Missing RecordSet.zoneId"),
         (js \ "name")
           .required[String]("Missing RecordSet.name")
-          .check("Record name must not exceed 255 characters" -> checkDomainNameLen)
-          .checkIf(recordType.isValid)(
-            "Record name cannot contain '.' with given type" ->
-              ((s: String) => !((recordTypeGet == CNAME) && nameContainsDots(s)))
-          ),
+          .check("Record name must not exceed 255 characters" -> checkDomainNameLen),
         recordType,
         (js \ "ttl")
           .required[Long]("Missing RecordSet.ttl")

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -186,22 +186,53 @@ class RecordSetValidationsSpec
     "typeSpecificValidations" should {
       "Run dotted hosts checks" should {
         val dottedARecord = rsOk.copy(name = "this.is.a.failure.")
-        "return a failure for any record with dotted hosts in forward zones" in {
+        "return a failure for any new record with dotted hosts in forward zones" in {
           leftValue(
             typeSpecificValidations(dottedARecord, List(), okZone)
           ) shouldBe an[InvalidRequest]
         }
-        "return a failure for any record with dotted hosts in forward zones (CNAME)" in {
+
+        "return a failure for any new record with dotted hosts in forward zones (CNAME)" in {
           leftValue(
             typeSpecificValidations(dottedARecord.copy(typ = CNAME), List(), okZone)
           ) shouldBe an[InvalidRequest]
         }
-        "return a failure for any record with dotted hosts in forward zones (NS)" in {
+
+        "return a failure for any new record with dotted hosts in forward zones (NS)" in {
           leftValue(
             typeSpecificValidations(dottedARecord.copy(typ = NS), List(), okZone)
           ) shouldBe an[InvalidRequest]
         }
+
+        "return a success for any existing record with dotted hosts in forward zones" in {
+          typeSpecificValidations(
+            dottedARecord,
+            List(),
+            okZone,
+            Some(dottedARecord.copy(ttl = 300))) should be(right)
+        }
+
+        "return a success for any existing record with dotted hosts in forward zones (CNAME)" in {
+          val dottedCNAMERecord = dottedARecord.copy(typ = CNAME)
+          typeSpecificValidations(
+            dottedCNAMERecord,
+            List(),
+            okZone,
+            Some(dottedCNAMERecord.copy(ttl = 300))) should be(right)
+        }
+
+        "return a failure for any existing record with dotted hosts in forward zones (NS)" in {
+          val dottedNSRecord = dottedARecord.copy(typ = NS)
+          leftValue(
+            typeSpecificValidations(
+              dottedNSRecord,
+              List(),
+              okZone,
+              Some(dottedNSRecord.copy(ttl = 300)))
+          ) shouldBe an[InvalidRequest]
+        }
       }
+
       "Skip dotted checks on SRV" should {
         "return success for an SRV record following convention with FQDN" in {
           val test = srv.copy(name = "_sip._tcp.example.com.")


### PR DESCRIPTION
Addendum to #703

I missed allowing updates to CNAME dotted hosts in my previous PR.

Changes in this pull request:
- remove initial JSON validation that doesn't allow CNAMEs to contain a dot
- Pass existing recordset through the CNAME validations so we can compare the new and existing recordset names in the `isNotDotted` method.
