### PR TITLE
pass RejectBatchChangeInput and ApproveBatchChangeInput from routes

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -106,6 +106,6 @@ object ChangeInputType extends Enumeration {
   val Add, DeleteRecordSet = Value
 }
 
-final case class RejectBatchChangeInput(reviewComment: Option[String])
+final case class RejectBatchChangeInput(reviewComment: Option[String] = None)
 
-final case class ApproveBatchChangeInput(reviewComment: Option[String])
+final case class ApproveBatchChangeInput(reviewComment: Option[String] = None)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -94,20 +94,20 @@ class BatchChangeService(
   def rejectBatchChange(
       batchChangeId: String,
       authPrincipal: AuthPrincipal,
-      rejectBatchChangeInput: Option[RejectBatchChangeInput]): BatchResult[BatchChange] =
+      rejectBatchChangeInput: RejectBatchChangeInput): BatchResult[BatchChange] =
     for {
       batchChange <- getExistingBatchChange(batchChangeId)
       _ <- validateBatchChangeRejection(batchChange, authPrincipal).toBatchResult
       rejectedBatchChange <- rejectBatchChange(
         batchChange,
-        rejectBatchChangeInput.flatMap(_.reviewComment),
+        rejectBatchChangeInput.reviewComment,
         authPrincipal.signedInUser.id)
     } yield rejectedBatchChange
 
   def approveBatchChange(
       batchChangeId: String,
       authPrincipal: AuthPrincipal,
-      approveBatchChangeInput: Option[ApproveBatchChangeInput]): BatchResult[BatchChange] =
+      approveBatchChangeInput: ApproveBatchChangeInput): BatchResult[BatchChange] =
     for {
       batchChange <- getExistingBatchChange(batchChangeId)
       _ <- validateBatchChangeApproval(batchChange, authPrincipal).toBatchResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -39,11 +39,11 @@ trait BatchChangeServiceAlgebra {
   def rejectBatchChange(
       batchChangeId: String,
       authPrincipal: AuthPrincipal,
-      rejectBatchChangeInput: Option[RejectBatchChangeInput]): BatchResult[BatchChange]
+      rejectBatchChangeInput: RejectBatchChangeInput): BatchResult[BatchChange]
 
   def approveBatchChange(
       batchChangeId: String,
       authPrincipal: AuthPrincipal,
-      approveBatchChangeInput: Option[ApproveBatchChangeInput]): BatchResult[BatchChange]
+      approveBatchChangeInput: ApproveBatchChangeInput): BatchResult[BatchChange]
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -87,8 +87,11 @@ trait BatchChangeRoute extends Directives {
       (post & path("zones" / "batchrecordchanges" / Segment / "reject")) { id =>
         monitor("Endpoint.rejectBatchChange") {
           entity(as[Option[RejectBatchChangeInput]]) { input =>
-            execute(batchChangeService.rejectBatchChange(id, authPrincipal, input)) { chg =>
-              complete(StatusCodes.OK, chg)
+            execute(
+              batchChangeService
+                .rejectBatchChange(id, authPrincipal, input.getOrElse(RejectBatchChangeInput()))) {
+              chg =>
+                complete(StatusCodes.OK, chg)
             }
           // TODO: Update response entity to return modified batch change
           }
@@ -97,7 +100,12 @@ trait BatchChangeRoute extends Directives {
         (post & path("zones" / "batchrecordchanges" / Segment / "approve")) { id =>
           monitor("Endpoint.approveBatchChange") {
             entity(as[Option[ApproveBatchChangeInput]]) { input =>
-              execute(batchChangeService.approveBatchChange(id, authPrincipal, input)) { chg =>
+              execute(
+                batchChangeService
+                  .approveBatchChange(
+                    id,
+                    authPrincipal,
+                    input.getOrElse(ApproveBatchChangeInput()))) { chg =>
                 complete(StatusCodes.OK, chg)
               }
             // TODO: Update response entity to return modified batch change

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -340,7 +340,7 @@ class BatchChangeServiceSpec
             .rejectBatchChange(
               batchChange.id,
               supportUserAuth,
-              Some(RejectBatchChangeInput(Some("review comment"))))
+              RejectBatchChangeInput(Some("review comment")))
             .value)
 
       result.status shouldBe BatchChangeStatus.Failed
@@ -363,7 +363,10 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.rejectBatchChange(batchChange.id, supportUserAuth, None).value)
+        leftResultOf(
+          underTest
+            .rejectBatchChange(batchChange.id, supportUserAuth, RejectBatchChangeInput())
+            .value)
 
       result shouldBe BatchChangeNotPendingApproval(batchChange.id)
     }
@@ -380,7 +383,8 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.rejectBatchChange(batchChange.id, auth, None).value)
+        leftResultOf(
+          underTest.rejectBatchChange(batchChange.id, auth, RejectBatchChangeInput()).value)
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -397,7 +401,8 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.rejectBatchChange(batchChange.id, auth, None).value)
+        leftResultOf(
+          underTest.rejectBatchChange(batchChange.id, auth, RejectBatchChangeInput()).value)
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -416,7 +421,10 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        rightResultOf(underTest.approveBatchChange(batchChange.id, supportUserAuth, None).value)
+        rightResultOf(
+          underTest
+            .approveBatchChange(batchChange.id, supportUserAuth, ApproveBatchChangeInput())
+            .value)
 
       result shouldBe batchChange
     }
@@ -433,7 +441,10 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.approveBatchChange(batchChange.id, supportUserAuth, None).value)
+        leftResultOf(
+          underTest
+            .approveBatchChange(batchChange.id, supportUserAuth, ApproveBatchChangeInput())
+            .value)
 
       result shouldBe BatchChangeNotPendingApproval(batchChange.id)
     }
@@ -450,7 +461,8 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.approveBatchChange(batchChange.id, auth, None).value)
+        leftResultOf(
+          underTest.approveBatchChange(batchChange.id, auth, ApproveBatchChangeInput()).value)
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -467,7 +479,8 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.approveBatchChange(batchChange.id, auth, None).value)
+        leftResultOf(
+          underTest.approveBatchChange(batchChange.id, auth, ApproveBatchChangeInput()).value)
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -347,7 +347,7 @@ class BatchChangeRoutingSpec
     def rejectBatchChange(
         batchChangeId: String,
         authPrincipal: AuthPrincipal,
-        rejectionComment: Option[RejectBatchChangeInput])
+        rejectionComment: RejectBatchChangeInput)
       : EitherT[IO, BatchChangeErrorResponse, BatchChange] =
       (batchChangeId, authPrincipal.isSystemAdmin) match {
         case ("pendingBatchId", true) => EitherT(IO.pure(genericValidResponse.asRight))
@@ -359,7 +359,7 @@ class BatchChangeRoutingSpec
     def approveBatchChange(
         batchChangeId: String,
         authPrincipal: AuthPrincipal,
-        rejectionComment: Option[ApproveBatchChangeInput])
+        rejectionComment: ApproveBatchChangeInput)
       : EitherT[IO, BatchChangeErrorResponse, BatchChange] =
       (batchChangeId, authPrincipal.isSystemAdmin) match {
         case ("pendingBatchId", true) => EitherT(IO.pure(genericValidResponse.asRight))
@@ -651,7 +651,7 @@ class BatchChangeRoutingSpec
       }
     }
 
-    "return OK no request entity is provided" in {
+    "return OK if no request entity is provided" in {
       Post("/zones/batchrecordchanges/pendingBatchId/reject") ~> batchChangeRoute(supportUserAuth) ~> check {
         status shouldBe OK
       }
@@ -702,7 +702,7 @@ class BatchChangeRoutingSpec
       }
     }
 
-    "return OK no request entity is provided" in {
+    "return OK if no request entity is provided" in {
       Post("/zones/batchrecordchanges/pendingBatchId/approve") ~> batchChangeRoute(supportUserAuth) ~> check {
         status shouldBe OK
       }


### PR DESCRIPTION
splitting up #748 into smaller PRs.

Changes in this pull request:
- in batch change routing turn the optional body on the reject batch change and approve batch change endpoints into instances of RejectBatchChangeInput and ApproveBatchChangeInput, respectively.
- We have to keep the entity as an option since it's only attribute is optional. Otherwise an `RequestEntityExpectedRejection` is raised.
