### PR TITLE
Batch change rejection email notifications

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -138,7 +138,8 @@ object Boot extends App {
         batchChangeValidations,
         batchChangeConverter,
         VinylDNSConfig.manualBatchReviewEnabled,
-        authPrincipalProvider)
+        authPrincipalProvider,
+        notifiers)
       val collectorRegistry = CollectorRegistry.defaultRegistry
       val vinyldnsService = new VinylDNSService(
         membershipService,

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -58,7 +58,7 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
     message.saveChanges()
     val transport = session.getTransport("smtp")
     transport.connect()
-    transport.sendMessage(message, message.getAllRecipients())
+    transport.sendMessage(message, message.getAllRecipients)
     transport.close()
   }
 
@@ -79,19 +79,35 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
       case _ => IO.unit
     }
 
-  def formatBatchChange(bc: BatchChange): String =
-    s"""<h1>Batch Change Results</h1>
+  def formatBatchChange(bc: BatchChange): String = {
+    val sb = new StringBuilder
+    // Batch change info
+    sb.append(s"""<h1>Batch Change Results</h1>
       | <b>Submitter:</b> ${bc.userName} <br/>
-      | ${bc.comments.map(comments => s"<b>Description:</b> ${comments}</br>").getOrElse("")}
+      | ${bc.comments.map(comments => s"<b>Description:</b> $comments</br>").getOrElse("")}
       | <b>Created:</b> ${bc.createdTimestamp.toString(DateTimeFormat.fullDateTime)} <br/>
       | <b>Id:</b> ${bc.id}<br/>
-      | <b>Status:</b> ${formatStatus(bc.approvalStatus, bc.status)}<br/>
-      | <table border = "1">
+      | <b>Status:</b> ${formatStatus(bc.approvalStatus, bc.status)}<br/>""".stripMargin)
+
+    // For manually reviewed e-mails, add additional info; e-mails are not sent for pending batch changes
+    if (bc.approvalStatus != AutoApproved) {
+      bc.reviewerId.foreach(reviewerId => sb.append(s"<b>Reviewer:</b> $reviewerId <br/>"))
+      bc.reviewComment.foreach(reviewComment =>
+        sb.append(s"<b>Review comment:</b> $reviewComment <br/>"))
+      bc.reviewTimestamp.foreach(reviewTimestamp =>
+        sb.append(
+          s"<b>Time reviewed:</b> ${reviewTimestamp.toString(DateTimeFormat.fullDateTime)} <br/>"))
+    }
+
+    // Single change data table
+    sb.append(s"""<table border = "1">
       |   <tr><th>#</th><th>Change Type</th><th>Record Type</th><th>Input Name</th>
       |       <th>TTL</th><th>Record Data</th><th>Status</th><th>Message</th></tr>
       |   ${bc.changes.zipWithIndex.map((formatSingleChange _).tupled).mkString("\n")}
       | </table>
-     """.stripMargin
+     """.stripMargin)
+    sb.toString
+  }
 
   def formatStatus(approval: BatchChangeApprovalStatus, status: BatchChangeStatus): String =
     (approval, status) match {

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -100,7 +100,7 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
     }
 
     // Single change data table
-    sb.append(s"""<table border = "1">
+    sb.append(s"""<br/><table border = "1">
       |   <tr><th>#</th><th>Change Type</th><th>Record Type</th><th>Input Name</th>
       |       <th>TTL</th><th>Record Data</th><th>Status</th><th>Message</th></tr>
       |   ${bc.changes.zipWithIndex.map((formatSingleChange _).tupled).mkString("\n")}

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -91,7 +91,6 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
 
     // For manually reviewed e-mails, add additional info; e-mails are not sent for pending batch changes
     if (bc.approvalStatus != AutoApproved) {
-      bc.reviewerId.foreach(reviewerId => sb.append(s"<b>Reviewer:</b> $reviewerId <br/>"))
       bc.reviewComment.foreach(reviewComment =>
         sb.append(s"<b>Review comment:</b> $reviewComment <br/>"))
       bc.reviewTimestamp.foreach(reviewTimestamp =>


### PR DESCRIPTION
Ties in e-mail notifications into batch change rejection (for pending batch changes). Notifications are already triggered upon implementation by the `RecordSetChangeHandler`.

Changes in this pull request:
- Notify upon e-mail rejection
- Update e-mail content so that non-`AutoApproved` batch changes include review info.
