### PR TITLE
add approval fields to batch responses

### DIFF
--- a/modules/api/functional_test/live_tests/batch/get_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/get_batch_change_test.py
@@ -23,6 +23,11 @@ def test_get_batch_change_success(shared_zone_test_context):
 
         result = client.get_batch_change(batch_change['id'], status=200)
         assert_that(result, is_(completed_batch))
+        assert_that(result['approvalStatus'], is_('AutoApproved'))
+        assert_that(result, is_not(has_key('reviewerId')))
+        assert_that(result, is_not(has_key('reviewerUserName')))
+        assert_that(result, is_not(has_key('reviewComment')))
+        assert_that(result, is_not(has_key('reviewTimestamp')))
     finally:
         for result_rs in to_delete:
             try:

--- a/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
@@ -93,6 +93,8 @@ class ListBatchChangeSummariesFixture():
             assert_that(summary["totalChanges"], equal_to(self.completed_changes[i + start_from]["totalChanges"]))
             assert_that(summary["status"], equal_to(self.completed_changes[i + start_from]["status"]))
             assert_that(summary["id"], equal_to(self.completed_changes[i + start_from]["id"]))
+            assert_that(summary["approvalStatus"], equal_to("AutoApproved"))
+            assert_that(summary, is_not(has_key("reviewerId")))
 
 
 @pytest.fixture(scope = "module")

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -460,8 +460,7 @@ class BatchChangeService(
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
       ignoreAccess: Boolean = false,
-      approvalStatus: Option[BatchChangeApprovalStatus] = None)
-    : BatchResult[BatchChangeSummaryList] = {
+      approvalStatus: Option[BatchChangeApprovalStatus] = None): BatchResult[BatchChangeSummaryList] = {
     val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
     for {
       listResults <- batchChangeRepo

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -125,6 +125,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
         ("systemMessage" -> sac.systemMessage) ~
         ("recordChangeId" -> sac.recordChangeId) ~
         ("recordSetId" -> sac.recordSetId) ~
+        ("validationErrors" -> Extraction.decompose(sac.validationErrors)) ~
         ("id" -> sac.id)
   }
 
@@ -141,6 +142,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
         ("systemMessage" -> sac.systemMessage) ~
         ("recordChangeId" -> sac.recordChangeId) ~
         ("recordSetId" -> sac.recordSetId) ~
+        ("validationErrors" -> Extraction.decompose(sac.validationErrors)) ~
         ("id" -> sac.id)
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -40,7 +40,7 @@ import vinyldns.core.TestMembershipData._
 import vinyldns.core.domain._
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.batch._
-import vinyldns.core.domain.membership.{Group, User}
+import vinyldns.core.domain.membership.{Group, ListUsersResults, User}
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record.{RecordType, _}
 import vinyldns.core.domain.zone.Zone
@@ -301,6 +301,12 @@ class BatchChangeServiceSpec
           case _ => None
         }
       }
+
+    override def getUsers(
+        userIds: Set[String],
+        startFrom: Option[String],
+        maxItems: Option[Int]): IO[ListUsersResults] =
+      IO.pure(ListUsersResults(Seq(superUser), None))
   }
 
   private val underTest = new BatchChangeService(
@@ -686,6 +692,26 @@ class BatchChangeServiceSpec
 
       val result = rightResultOf(underTest.getBatchChange(batchChange.id, auth).value)
       result shouldBe BatchChangeInfo(batchChange)
+    }
+
+    "Succeed with review information in result" in {
+      val batchChange =
+        BatchChange(
+          auth.userId,
+          auth.signedInUser.userName,
+          None,
+          DateTime.now,
+          List(),
+          ownerGroupId = Some(okGroup.id),
+          BatchChangeApprovalStatus.ManuallyApproved,
+          Some(superUser.id),
+          None,
+          Some(DateTime.now)
+        )
+      batchChangeRepo.save(batchChange)
+
+      val result = rightResultOf(underTest.getBatchChange(batchChange.id, auth).value)
+      result shouldBe BatchChangeInfo(batchChange, Some(okGroup.name), Some(superUser.userName))
     }
   }
 
@@ -1301,7 +1327,11 @@ class BatchChangeServiceSpec
           None,
           DateTime.now,
           List(),
-          approvalStatus = BatchChangeApprovalStatus.AutoApproved)
+          approvalStatus = BatchChangeApprovalStatus.ManuallyApproved,
+          reviewerId = Some(superUser.id),
+          reviewComment = Some("this looks good"),
+          reviewTimestamp = Some(DateTime.now)
+        )
       batchChangeRepo.save(batchChange)
 
       val result = rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value)
@@ -1313,7 +1343,9 @@ class BatchChangeServiceSpec
 
       result.batchChanges.length shouldBe 1
       result.batchChanges(0).createdTimestamp shouldBe batchChange.createdTimestamp
-      result.batchChanges(0).approvalStatus shouldBe BatchChangeApprovalStatus.AutoApproved
+      result.batchChanges(0).ownerGroupId shouldBe None
+      result.batchChanges(0).approvalStatus shouldBe BatchChangeApprovalStatus.ManuallyApproved
+      result.batchChanges(0).reviewerName shouldBe Some(superUser.userName)
     }
 
     "return a list of batchChangeSummaries if some exist" in {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1346,6 +1346,9 @@ class BatchChangeServiceSpec
       result.batchChanges(0).ownerGroupId shouldBe None
       result.batchChanges(0).approvalStatus shouldBe BatchChangeApprovalStatus.ManuallyApproved
       result.batchChanges(0).reviewerName shouldBe Some(superUser.userName)
+      result.batchChanges(0).reviewerId shouldBe Some(superUser.id)
+      result.batchChanges(0).reviewComment shouldBe Some("this looks good")
+      result.batchChanges(0).reviewTimestamp shouldBe batchChange.reviewTimestamp
     }
 
     "return a list of batchChangeSummaries if some exist" in {

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -21,7 +21,13 @@ import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.{ChangeSet, ListRecordSetResults, RecordSet, RecordSetRepository}
 import vinyldns.core.domain.zone.{ListZonesResults, Zone, ZoneRepository}
 import cats.effect._
-import vinyldns.core.domain.membership.{Group, GroupRepository}
+import vinyldns.core.domain.membership.{
+  Group,
+  GroupRepository,
+  ListUsersResults,
+  User,
+  UserRepository
+}
 import vinyldns.core.domain.zone.ZoneRepository.DuplicateZoneError
 
 // Empty implementations let our other test classes just edit with the methods they need
@@ -92,4 +98,23 @@ trait EmptyGroupRepo extends GroupRepository {
   def getGroupByName(groupName: String): IO[Option[Group]] = IO.pure(None)
 
   def getAllGroups(): IO[Set[Group]] = IO.pure(Set())
+}
+
+trait EmptyUserRepo extends UserRepository {
+  def getUser(userId: String): IO[Option[User]] = IO.pure(None)
+
+  def getUsers(
+      userIds: Set[String],
+      startFrom: Option[String],
+      maxItems: Option[Int]): IO[ListUsersResults] = IO.pure(ListUsersResults(List(), None))
+
+  def getAllUsers: IO[List[User]] = IO.pure(List())
+
+  def getUserByAccessKey(accessKey: String): IO[Option[User]] = IO.pure(None)
+
+  def getUserByName(userName: String): IO[Option[User]] = IO.pure(None)
+
+  def save(user: User): IO[User] = IO.pure(user)
+
+  def save(users: List[User]): IO[List[User]] = IO.pure(List())
 }

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -128,11 +128,12 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
         sc.createdTimestamp,
         changes,
         sc.ownerGroupId,
-        BatchChangeApprovalStatus.AutoApproved,
-        None,
-        None,
-        None,
-        sc.id)
+        sc.approvalStatus,
+        sc.reviewerId,
+        sc.reviewComment,
+        sc.reviewTimestamp,
+        sc.id
+      )
     } yield BatchChangeSummary(batchChange)
     val sorted = batchChangeSummaries.sortBy(_.createdTimestamp)
     val start = startFrom.getOrElse(0)

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -306,6 +306,7 @@ class BatchChangeJsonProtocolSpec
         ("systemMessage" -> "systemMessage") ~
         ("recordChangeId" -> decompose(None)) ~
         ("recordSetId" -> decompose(None)) ~
+        ("validationErrors" -> decompose(List())) ~
         ("id" -> "id") ~
         ("changeType" -> "Add")
     }
@@ -335,6 +336,7 @@ class BatchChangeJsonProtocolSpec
         ("systemMessage" -> "systemMessage") ~
         ("recordChangeId" -> decompose(None)) ~
         ("recordSetId" -> decompose(None)) ~
+        ("validationErrors" -> decompose(List())) ~
         ("id" -> "id") ~
         ("changeType" -> "DeleteRecordSet")
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -29,7 +29,7 @@ import vinyldns.api.domain.batch.BatchTransformations.{AddChangeForValidation, C
 import vinyldns.api.domain.batch.ChangeInputType._
 import vinyldns.api.domain.batch._
 import vinyldns.core.TestZoneData.okZone
-import vinyldns.core.domain.{InvalidIpv4Address, InvalidTTL, ZoneDiscoveryError}
+import vinyldns.core.domain.{InvalidIpv4Address, InvalidTTL, SingleChangeError, ZoneDiscoveryError}
 import vinyldns.core.domain.batch.SingleChangeStatus._
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordType._
@@ -292,6 +292,7 @@ class BatchChangeJsonProtocolSpec
         Some("systemMessage"),
         None,
         None,
+        List(SingleChangeError(barDiscoveryError)),
         id = "id")
       val result = SingleAddChangeSerializer.toJson(toJson)
 
@@ -306,7 +307,7 @@ class BatchChangeJsonProtocolSpec
         ("systemMessage" -> "systemMessage") ~
         ("recordChangeId" -> decompose(None)) ~
         ("recordSetId" -> decompose(None)) ~
-        ("validationErrors" -> decompose(List())) ~
+        ("validationErrors" -> decompose(List(SingleChangeError(barDiscoveryError)))) ~
         ("id" -> "id") ~
         ("changeType" -> "Add")
     }
@@ -324,7 +325,9 @@ class BatchChangeJsonProtocolSpec
         Some("systemMessage"),
         None,
         None,
-        id = "id")
+        List(SingleChangeError(barDiscoveryError)),
+        id = "id"
+      )
       val result = SingleDeleteChangeSerializer.toJson(toJson)
 
       result shouldBe ("zoneId" -> "zoneId") ~
@@ -336,7 +339,7 @@ class BatchChangeJsonProtocolSpec
         ("systemMessage" -> "systemMessage") ~
         ("recordChangeId" -> decompose(None)) ~
         ("recordSetId" -> decompose(None)) ~
-        ("validationErrors" -> decompose(List())) ~
+        ("validationErrors" -> decompose(List(SingleChangeError(barDiscoveryError)))) ~
         ("id" -> "id") ~
         ("changeType" -> "DeleteRecordSet")
     }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -124,7 +124,7 @@ object BatchChangeInfo {
       reviewerUserName,
       reviewComment,
       reviewTimestamp,
-      scheduledTime: Option[DateTime]
+      scheduledTime
     )
   }
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -95,11 +95,19 @@ case class BatchChangeInfo(
     id: String,
     status: BatchChangeStatus,
     ownerGroupName: Option[String],
+    approvalStatus: BatchChangeApprovalStatus,
+    reviewerId: Option[String],
+    reviewerUserName: Option[String],
+    reviewComment: Option[String],
+    reviewTimestamp: Option[DateTime],
     scheduledTime: Option[DateTime]
 )
 
 object BatchChangeInfo {
-  def apply(batchChange: BatchChange, ownerGroupName: Option[String] = None): BatchChangeInfo = {
+  def apply(
+      batchChange: BatchChange,
+      ownerGroupName: Option[String] = None,
+      reviewerUserName: Option[String] = None): BatchChangeInfo = {
     import batchChange._
     BatchChangeInfo(
       userId,
@@ -111,7 +119,12 @@ object BatchChangeInfo {
       id,
       status,
       ownerGroupName,
-      scheduledTime
+      approvalStatus,
+      reviewerId,
+      reviewerUserName,
+      reviewComment,
+      reviewTimestamp,
+      scheduledTime: Option[DateTime]
     )
   }
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -32,8 +32,12 @@ case class BatchChangeSummary(
     ownerGroupId: Option[String],
     id: String = UUID.randomUUID().toString,
     ownerGroupName: Option[String] = None,
-    scheduledTime: Option[DateTime] = None
-)
+    approvalStatus: BatchChangeApprovalStatus,
+    reviewerId: Option[String],
+    reviewerName: Option[String],
+    reviewComment: Option[String],
+    reviewTimestamp: Option[DateTime],
+    scheduledTime: Option[DateTime] = None)
 
 object BatchChangeSummary {
   def apply(batchChange: BatchChange): BatchChangeSummary =
@@ -47,6 +51,11 @@ object BatchChangeSummary {
       batchChange.ownerGroupId,
       batchChange.id,
       None,
+      batchChange.approvalStatus,
+      batchChange.reviewerId,
+      None,
+      batchChange.reviewComment,
+      batchChange.reviewTimestamp,
       batchChange.scheduledTime
     )
 
@@ -62,6 +71,11 @@ object BatchChangeSummary {
       ownerGroupId,
       id,
       ownerGroupName,
+      approvalStatus,
+      reviewerId,
+      reviewerUserName,
+      reviewComment,
+      reviewTimestamp,
       batchChangeInfo.scheduledTime
     )
   }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -265,6 +265,11 @@ class MySqlBatchChangeRepository
                   Option(res.string("owner_group_id")),
                   res.string("id"),
                   None,
+                  approvalStatus,
+                  Option(res.string("reviewer_id")),
+                  None,
+                  Option(res.string("review_comment")),
+                  res.timestampOpt("review_timestamp").map(st => new org.joda.time.DateTime(st)),
                   res.timestampOpt("scheduled_time").map(st => new org.joda.time.DateTime(st))
                 )
               }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -266,9 +266,9 @@ class MySqlBatchChangeRepository
                   res.string("id"),
                   None,
                   approvalStatus,
-                  Option(res.string("reviewer_id")),
+                  res.stringOpt("reviewer_id"),
                   None,
-                  Option(res.string("review_comment")),
+                  res.stringOpt("review_comment"),
                   res.timestampOpt("review_timestamp").map(st => new org.joda.time.DateTime(st)),
                   res.timestampOpt("scheduled_time").map(st => new org.joda.time.DateTime(st))
                 )


### PR DESCRIPTION
Part of #659 

Changes in this pull request:
- add batch change approval fields to batch change responses. Those fields are:
  - approvalStatus
  - reviewerId (optional)
  - reviewerName (optional)
  - reviewComment (optional)
  - reviewTimestamp (optional)

These values will return for Get BatchChange requests and List Batch Change requests. Approve and Reject batch changes and Create Batch Change already return all of the above fields except reviewerName which is consistent with not returning ownerGroupName in those responses.