### PR TITLE
add getAuthById to auth principal

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/domain/auth/MembershipAuthPrincipalProviderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/auth/MembershipAuthPrincipalProviderSpec.scala
@@ -110,5 +110,20 @@ class MembershipAuthPrincipalProviderSpec
         authPrincipal.memberGroupIds should contain theSameElementsAs Seq(okGroup.id, dummyGroup.id)
       }
     }
+    "return None if the userID does not exist" in {
+      val mockUserRepo = mock[UserRepository]
+      val mockMembershipRepo = mock[MembershipRepository]
+      val underTest = new MembershipAuthPrincipalProvider(mockUserRepo, mockMembershipRepo)
+
+      val user = okUser
+      val userId = user.id
+
+      doReturn(IO.pure(None))
+        .when(mockUserRepo)
+        .getUser(any[String])
+
+      val result = underTest.getAuthPrincipalByUserId(userId).unsafeRunSync()
+      result shouldBe None
+    }
   }
 }


### PR DESCRIPTION
split off #748 

In approveBatchChange, we will have the requesting userID, and the approver's authPrincipal.

But, we need the *requesting user* authPrincipal to flow back through the validations. To get that, need to be able to getAuthByUserId since thats the info we have
