### PR TITLE
the rest of the approval flow

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeReviewInfo.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeReviewInfo.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.domain.batch
+
+import org.joda.time.DateTime
+
+final case class BatchChangeReviewInfo(
+    reviewerId: String,
+    reviewComment: Option[String],
+    reviewTimestamp: DateTime = DateTime.now())

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -346,7 +346,7 @@ class BatchChangeService(
     val allNonFatal = allErrors.forall(!_.isFatal)
 
     if (allErrors.isEmpty) {
-      val changes = transformed.getValid.map(_.asNewStoredChange)
+      val changes = transformed.getValid.map(_.asStoredChange())
       BatchChange(
         auth.userId,
         auth.signedInUser.userName,
@@ -362,7 +362,7 @@ class BatchChangeService(
       val changes = transformed.zip(batchChangeInput.changes).map {
         case (validated, input) =>
           validated match {
-            case Valid(v) => v.asNewStoredChange
+            case Valid(v) => v.asStoredChange()
             case Invalid(e) => input.asNewStoredChange(e)
           }
       }
@@ -388,7 +388,7 @@ class BatchChangeService(
       reviewInfo: BatchChangeReviewInfo): Either[BatchChangeErrorResponse, BatchChange] =
     if (transformed.forall(_.isValid)) {
       val changes = transformed.getValid.zip(existingBatchChange.changes).map {
-        case (newValidation, existing) => newValidation.asStoredChangeWithId(existing.id)
+        case (newValidation, existing) => newValidation.asStoredChange(Some(existing.id))
       }
 
       BatchChange(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -16,6 +16,8 @@
 
 package vinyldns.api.domain.batch
 
+import java.util.UUID
+
 import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.ReverseZoneHelpers
 import vinyldns.api.domain.batch.BatchChangeInterfaces.ValidatedBatch
@@ -77,8 +79,7 @@ object BatchTransformations {
     val recordName: String
     val inputChange: ChangeInput
     val recordKey = RecordKey(zone.id, recordName, inputChange.typ)
-    def asNewStoredChange: SingleChange
-    def asStoredChangeWithId(changeId: String): SingleChange
+    def asStoredChange(changeId: Option[String] = None): SingleChange
     def isAddChangeForValidation: Boolean
     def isDeleteChangeForValidation: Boolean
   }
@@ -97,27 +98,8 @@ object BatchTransformations {
       inputChange: AddChangeInput,
       existingRecordTtl: Option[Long] = None)
       extends ChangeForValidation {
-    def asNewStoredChange: SingleChange = {
+    def asStoredChange(changeId: Option[String] = None): SingleChange = {
 
-      val ttl = inputChange.ttl.orElse(existingRecordTtl).getOrElse(VinylDNSConfig.defaultTtl)
-
-      SingleAddChange(
-        Some(zone.id),
-        Some(zone.name),
-        Some(recordName),
-        inputChange.inputName,
-        inputChange.typ,
-        ttl,
-        inputChange.record,
-        SingleChangeStatus.Pending,
-        None,
-        None,
-        None,
-        List.empty
-      )
-    }
-
-    def asStoredChangeWithId(changeId: String): SingleChange = {
       val ttl = inputChange.ttl.orElse(existingRecordTtl).getOrElse(VinylDNSConfig.defaultTtl)
 
       SingleAddChange(
@@ -133,7 +115,7 @@ object BatchTransformations {
         None,
         None,
         List.empty,
-        changeId
+        changeId.getOrElse(UUID.randomUUID().toString)
       )
     }
 
@@ -147,21 +129,7 @@ object BatchTransformations {
       recordName: String,
       inputChange: DeleteChangeInput)
       extends ChangeForValidation {
-    def asNewStoredChange: SingleChange =
-      SingleDeleteChange(
-        Some(zone.id),
-        Some(zone.name),
-        Some(recordName),
-        inputChange.inputName,
-        inputChange.typ,
-        SingleChangeStatus.Pending,
-        None,
-        None,
-        None,
-        List.empty
-      )
-
-    def asStoredChangeWithId(changeId: String): SingleChange =
+    def asStoredChange(changeId: Option[String] = None): SingleChange =
       SingleDeleteChange(
         Some(zone.id),
         Some(zone.name),
@@ -173,8 +141,9 @@ object BatchTransformations {
         None,
         None,
         List.empty,
-        changeId
+        changeId.getOrElse(UUID.randomUUID().toString)
       )
+
     def isAddChangeForValidation: Boolean = false
 
     def isDeleteChangeForValidation: Boolean = true


### PR DESCRIPTION
Note: this flow assumes that something happened outside the system (sync, zone create, etc) that makes the previously invalid change now invalid.

skipping checks because of approval (for something like lack or access) will come later when we need it