### PR TITLE
fix a test that travis hates

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Interfaces.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Interfaces.scala
@@ -60,15 +60,10 @@ object Interfaces {
         .handleError(e => Left(e))
     )
 
-  def withTimeout[A](theIo: => IO[A], duration: FiniteDuration, error: Throwable): Result[A] =
-    EitherT(
-      IO.race(timer.sleep(duration), theIo)
-        .map {
-          case Left(_) => Left(error)
-          case Right(a) => Right(a)
-        }
-        .handleError(e => Left(e))
-    )
+  def withTimeout[A](theIo: => IO[A], duration: FiniteDuration, error: Throwable): Result[A] = {
+    val timeOut = IO.sleep(duration) *> IO(error)
+    EitherT(IO.race(timeOut, theIo).handleError(e => Left(e)))
+  }
 
   /* Enhances IO to easily lift the io to a Result */
   implicit class IOResultImprovements(io: IO[_]) {

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.domain.zone
 
-import cats.scalatest.EitherMatchers
+import cats.scalatest.{EitherMatchers, EitherValues}
 import org.joda.time.DateTime
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -37,7 +37,8 @@ class ZoneConnectionValidatorSpec
     with MockitoSugar
     with BeforeAndAfterEach
     with ResultHelpers
-    with EitherMatchers {
+    with EitherMatchers
+    with EitherValues {
 
   private val mockDnsConnection = mock[DnsConnection]
   private val mockZoneView = mock[ZoneView]
@@ -246,9 +247,10 @@ class ZoneConnectionValidatorSpec
         .when(mockDnsConnection)
         .resolve(badZone.name, badZone.name, RecordType.SOA)
 
-      val result = leftResultOf(underTest.validateZoneConnections(badZone).value)
-      result shouldBe a[ConnectionFailed]
-      result.getMessage should include("Transfer connection invalid")
+      val result = underTest.validateZoneConnections(badZone).value.unsafeRunSync()
+      val error = result.leftValue
+      error shouldBe a[ConnectionFailed]
+      error.getMessage should include("Transfer connection invalid")
     }
     "isValidBackendId" should {
       val backend = DnsBackend("some-test-backend", testDefaultConnection, testDefaultConnection)


### PR DESCRIPTION
worth a shot.

pulling from timeout in https://typelevel.org/cats-effect/datatypes/io.html#race-conditions--race--racepair

seems functionally pretty much the same, but wondering if removing an IO will help us with this test thats failing on timeout