### PR TITLE
Add external-dns as an integration to Tools page

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -32,6 +32,7 @@ Thank you! If you have contributed in any way, but do not see your name here, pl
 - Luke Cori
 - Jearvon Dharrie
 - Andrew Dunn
+- David Grizzanti
 - Alejandro Guirao
 - Daniel Jin
 - Krista Khare

--- a/modules/docs/src/main/tut/tools.md
+++ b/modules/docs/src/main/tut/tools.md
@@ -16,5 +16,9 @@ There are a few existing tools for working with the VinylDNS API.
 - [vinyldns-js](https://github.com/vinyldns/vinyldns-js) - JavaScript client for use in Node.js
 - [terraform-provider-vinyldns](https://github.com/vinyldns/terraform-provider-vinyldns) - a Terraform provider for VinylDNS
 
+## Integrations
+
+- [external-dns](https://github.com/kubernetes-incubator/external-dns) - makes Kubernetes resources discoverable via public DNS servers
+
 ## Coming Soon
 - [vinyldns-ansible](https://github.com/vinyldns/vinyldns-ansible) - Ansible integration with VinylDNS

--- a/modules/docs/src/main/tut/tools.md
+++ b/modules/docs/src/main/tut/tools.md
@@ -18,7 +18,7 @@ There are a few existing tools for working with the VinylDNS API.
 
 ## Integrations
 
-- [external-dns](https://github.com/kubernetes-incubator/external-dns) - makes Kubernetes resources discoverable via public DNS servers
+- [external-dns](https://github.com/kubernetes-incubator/external-dns) - DNS provider-agnostic syncronization of Cloud Foundry and Kubernetes resources, including VinylDNS
 
 ## Coming Soon
 - [vinyldns-ansible](https://github.com/vinyldns/vinyldns-ansible) - Ansible integration with VinylDNS


### PR DESCRIPTION
Changes in this pull request:
- Add `external-dns` as a new "integration" to the tools page. I didn't mention the vinyl integration specifically in the external-dns line, let me know if you think that is needed/would read better