### PR TITLE
expand batch change statuses

### DIFF
--- a/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
@@ -21,7 +21,7 @@ def test_approve_pending_batch_change_success(shared_zone_test_context):
     try:
         result = client.create_batch_change(batch_change_input, status=202)
         get_batch = client.get_batch_change(result['id'])
-        assert_that(get_batch['status'], is_('Pending'))
+        assert_that(get_batch['status'], is_('PendingReview'))
         assert_that(get_batch['approvalStatus'], is_('PendingApproval'))
         assert_that(get_batch['changes'][0]['status'], is_('NeedsReview'))
         assert_that(get_batch['changes'][0]['validationErrors'][0]['errorType'], is_('ZoneDiscoveryError'))

--- a/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
@@ -22,7 +22,7 @@ def test_approve_pending_batch_change_success(shared_zone_test_context):
         result = client.create_batch_change(batch_change_input, status=202)
         get_batch = client.get_batch_change(result['id'])
         assert_that(get_batch['status'], is_('PendingReview'))
-        assert_that(get_batch['approvalStatus'], is_('PendingApproval'))
+        assert_that(get_batch['approvalStatus'], is_('PendingReview'))
         assert_that(get_batch['changes'][0]['status'], is_('NeedsReview'))
         assert_that(get_batch['changes'][0]['validationErrors'][0]['errorType'], is_('ZoneDiscoveryError'))
 

--- a/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/functional_test/live_tests/batch/list_batch_change_summaries_test.py
@@ -157,9 +157,9 @@ def test_list_batch_change_summaries_with_pending_status(list_fixture):
     Test listing a limited number of user's batch change summaries with maxItems parameter
     """
     client = list_fixture.client
-    batch_change_summaries_result = client.list_batch_change_summaries(status=200, approval_status="PendingApproval")
+    batch_change_summaries_result = client.list_batch_change_summaries(status=200, approval_status="PendingReview")
 
-    list_fixture.check_batch_change_summaries_page_accuracy(batch_change_summaries_result, size=0, approval_status="PendingApproval")
+    list_fixture.check_batch_change_summaries_page_accuracy(batch_change_summaries_result, size=0, approval_status="PendingReview")
 
 def test_list_batch_change_summaries_with_list_batch_change_summaries_with_no_changes_passes():
     """

--- a/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
@@ -17,7 +17,7 @@ def test_reject_pending_batch_change_success(shared_zone_test_context):
     result = client.create_batch_change(batch_change_input, status=202)
     get_batch = client.get_batch_change(result['id'])
     assert_that(get_batch['status'], is_('PendingReview'))
-    assert_that(get_batch['approvalStatus'], is_('PendingApproval'))
+    assert_that(get_batch['approvalStatus'], is_('PendingReview'))
     assert_that(get_batch['changes'][0]['status'], is_('NeedsReview'))
     assert_that(get_batch['changes'][0]['validationErrors'][0]['errorType'], is_('ZoneDiscoveryError'))
 
@@ -80,7 +80,7 @@ def test_reject_batch_change_fails_with_forbidden_error_for_non_system_admins(sh
 @pytest.mark.manual_batch_review
 def test_reject_batch_change_fails_when_not_pending_approval(shared_zone_test_context):
     """
-    Test rejecting a batch change fails if the batch is not PendingApproval
+    Test rejecting a batch change fails if the batch is not PendingReview
     """
     client = shared_zone_test_context.ok_vinyldns_client
     rejector = shared_zone_test_context.support_user_client
@@ -97,7 +97,7 @@ def test_reject_batch_change_fails_when_not_pending_approval(shared_zone_test_co
         to_delete = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
         error = rejector.reject_batch_change(completed_batch['id'], status=400)
         assert_that(error, is_("Batch change " + completed_batch['id'] +
-                               " is not pending approval, so it cannot be rejected."))
+                               " is not pending review, so it cannot be rejected."))
     finally:
         clear_zoneid_rsid_tuple_list(to_delete, client)
 

--- a/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
@@ -16,7 +16,7 @@ def test_reject_pending_batch_change_success(shared_zone_test_context):
     }
     result = client.create_batch_change(batch_change_input, status=202)
     get_batch = client.get_batch_change(result['id'])
-    assert_that(get_batch['status'], is_('Pending'))
+    assert_that(get_batch['status'], is_('PendingReview'))
     assert_that(get_batch['approvalStatus'], is_('PendingApproval'))
     assert_that(get_batch['changes'][0]['status'], is_('NeedsReview'))
     assert_that(get_batch['changes'][0]['validationErrors'][0]['errorType'], is_('ZoneDiscoveryError'))
@@ -24,7 +24,7 @@ def test_reject_pending_batch_change_success(shared_zone_test_context):
     rejector.reject_batch_change(result['id'], status=200)
     get_batch = client.get_batch_change(result['id'])
 
-    assert_that(get_batch['status'], is_('Failed'))
+    assert_that(get_batch['status'], is_('Rejected'))
     assert_that(get_batch['approvalStatus'], is_('ManuallyRejected'))
     assert_that(get_batch['reviewerId'], is_('support-user-id'))
     assert_that(get_batch['reviewerUserName'], is_('support-user'))

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -45,9 +45,9 @@ final case class BatchConversionError(change: SingleChange) extends BatchChangeE
 }
 final case class UnknownConversionError(message: String) extends BatchChangeErrorResponse
 
-final case class BatchChangeNotPendingApproval(id: String) extends BatchChangeErrorResponse {
+final case class BatchChangeNotPendingReview(id: String) extends BatchChangeErrorResponse {
   def message: String =
-    s"""Batch change $id is not pending approval, so it cannot be rejected."""
+    s"""Batch change $id is not pending review, so it cannot be rejected."""
 }
 
 final case class BatchRequesterNotFound(userId: String, userName: String)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -471,7 +471,7 @@ class BatchChangeService(
       batchChangeConverter
         .sendBatchForProcessing(batchChange, existingZones, existingRecordSets, ownerGroupId)
         .map(_.batchChange)
-    case PendingApproval if manualReviewEnabled =>
+    case PendingReview if manualReviewEnabled =>
       // save the change, will need to return to it later on approval
       batchChangeRepo.save(batchChange).toBatchResult
     case _ =>

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -379,7 +379,7 @@ class BatchChangeService(
         DateTime.now,
         changes,
         batchChangeInput.ownerGroupId,
-        BatchChangeApprovalStatus.PendingApproval,
+        BatchChangeApprovalStatus.PendingReview,
         scheduledTime = batchChangeInput.scheduledTime
       ).asRight
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -110,20 +110,20 @@ class BatchChangeValidations(
   def validateBatchChangeRejection(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    validateAuthorizedReviewer(authPrincipal, batchChange) |+| validateBatchChangePendingApproval(
+    validateAuthorizedReviewer(authPrincipal, batchChange) |+| validateBatchChangePendingReview(
       batchChange)
 
   def validateBatchChangeApproval(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
-    validateAuthorizedReviewer(authPrincipal, batchChange) |+| validateBatchChangePendingApproval(
+    validateAuthorizedReviewer(authPrincipal, batchChange) |+| validateBatchChangePendingReview(
       batchChange)
 
-  def validateBatchChangePendingApproval(
+  def validateBatchChangePendingReview(
       batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
     batchChange.approvalStatus match {
-      case BatchChangeApprovalStatus.PendingApproval => ().asRight
-      case _ => BatchChangeNotPendingApproval(batchChange.id).asLeft
+      case BatchChangeApprovalStatus.PendingReview => ().asRight
+      case _ => BatchChangeNotPendingReview(batchChange.id).asLeft
     }
 
   def validateAuthorizedReviewer(

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -73,7 +73,7 @@ object RecordSetChangeHandler {
       batchChangeOption <- batchChangeRepository.updateSingleChanges(singleChangeStatusUpdates)
       _ <- batchChangeOption.map { bc =>
         bc.status match {
-          case BatchChangeStatus.Pending =>
+          case BatchChangeStatus.PendingProcessing | BatchChangeStatus.PendingReview =>
             IO.unit
           case _ =>
             notifiers.notify(Notification(bc))

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -18,16 +18,20 @@ package vinyldns.api.notifier.email
 
 import vinyldns.core.notifier.{Notification, Notifier}
 import cats.effect.IO
-import vinyldns.core.domain.batch.BatchChange
+import vinyldns.core.domain.batch.{
+  BatchChange,
+  BatchChangeApprovalStatus,
+  SingleAddChange,
+  SingleChange,
+  SingleDeleteChange
+}
 import vinyldns.core.domain.membership.UserRepository
 import vinyldns.core.domain.membership.User
 import org.slf4j.LoggerFactory
 import javax.mail.internet.{InternetAddress, MimeMessage}
 import javax.mail.{Address, Message, Session}
+
 import scala.util.Try
-import vinyldns.core.domain.batch.SingleChange
-import vinyldns.core.domain.batch.SingleAddChange
-import vinyldns.core.domain.batch.SingleDeleteChange
 import vinyldns.core.domain.record.AData
 import vinyldns.core.domain.record.AAAAData
 import vinyldns.core.domain.record.CNAMEData
@@ -111,7 +115,7 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
   def formatStatus(approval: BatchChangeApprovalStatus, status: BatchChangeStatus): String =
     (approval, status) match {
       case (ManuallyRejected, _) => "Rejected"
-      case (PendingApproval, _) => "Pending Approval"
+      case (BatchChangeApprovalStatus.PendingReview, _) => "Pending Review"
       case (_, PartialFailure) => "Partially Failed"
       case (_, status) => status.toString
     }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -34,6 +34,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
   val batchChangeSerializers = Seq(
     JsonEnumV(ChangeInputType),
     JsonEnumV(SingleChangeStatus),
+    JsonEnumV(BatchChangeStatus),
     JsonEnumV(BatchChangeApprovalStatus),
     BatchChangeInputSerializer,
     ChangeInputSerializer,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -36,7 +36,7 @@ class BatchChangeRoute(
     case cnf: BatchChangeNotFound => complete(StatusCodes.NotFound, cnf.message)
     case una: UserNotAuthorizedError => complete(StatusCodes.Forbidden, una.message)
     case uct: BatchConversionError => complete(StatusCodes.BadRequest, uct)
-    case bcnpa: BatchChangeNotPendingApproval =>
+    case bcnpa: BatchChangeNotPendingReview =>
       complete(StatusCodes.BadRequest, bcnpa.message)
     case uce: UnknownConversionError => complete(StatusCodes.InternalServerError, uce)
     case brnf: BatchRequesterNotFound => complete(StatusCodes.NotFound, brnf.message)

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -133,7 +133,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
         DateTime.now(),
         List(singleAddChange, singleDelChange),
         Some("owner"),
-        BatchChangeApprovalStatus.PendingApproval
+        BatchChangeApprovalStatus.PendingReview
       )
 
       val expectedInput =

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -442,7 +442,7 @@ class BatchChangeServiceSpec
               RejectBatchChangeInput(Some("review comment")))
             .value)
 
-      result.status shouldBe BatchChangeStatus.Failed
+      result.status shouldBe BatchChangeStatus.Rejected
       result.approvalStatus shouldBe BatchChangeApprovalStatus.ManuallyRejected
       result.changes.foreach(_.status shouldBe SingleChangeStatus.Rejected)
       result.reviewComment shouldBe Some("review comment")

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -420,7 +420,7 @@ class BatchChangeServiceSpec
   }
 
   "rejectBatchChange" should {
-    "succeed if the batchChange is PendingApproval and reviewer is authorized" in {
+    "succeed if the batchChange is PendingReview and reviewer is authorized" in {
       val batchChange =
         BatchChange(
           auth.userId,
@@ -428,7 +428,7 @@ class BatchChangeServiceSpec
           None,
           DateTime.now,
           List(pendingChange),
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+          approvalStatus = BatchChangeApprovalStatus.PendingReview)
       batchChangeRepo.save(batchChange)
 
       doReturn(IO.unit).when(mockNotifier).notify(any[Notification[_]])
@@ -453,7 +453,7 @@ class BatchChangeServiceSpec
       verify(mockNotifier).notify(any[Notification[BatchChange]])
     }
 
-    "fail if the batchChange is not PendingApproval" in {
+    "fail if the batchChange is not PendingReview" in {
       val batchChange =
         BatchChange(
           auth.userId,
@@ -470,7 +470,7 @@ class BatchChangeServiceSpec
             .rejectBatchChange(batchChange.id, supportUserAuth, RejectBatchChangeInput())
             .value)
 
-      result shouldBe BatchChangeNotPendingApproval(batchChange.id)
+      result shouldBe BatchChangeNotPendingReview(batchChange.id)
     }
 
     "fail if the batchChange reviewer is not authorized" in {
@@ -481,7 +481,7 @@ class BatchChangeServiceSpec
           None,
           DateTime.now,
           List(),
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+          approvalStatus = BatchChangeApprovalStatus.PendingReview)
       batchChangeRepo.save(batchChange)
 
       val result =
@@ -491,7 +491,7 @@ class BatchChangeServiceSpec
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
 
-    "fail if the batchChange reviewer is not authorized and the batchChange is not Pending Approval" in {
+    "fail if the batchChange reviewer is not authorized and the batchChange is not Pending Review" in {
       val batchChange =
         BatchChange(
           auth.userId,
@@ -518,9 +518,9 @@ class BatchChangeServiceSpec
       DateTime.now,
       List(singleChangeGood, singleChangeNR),
       Some(authGrp.id),
-      BatchChangeApprovalStatus.PendingApproval
+      BatchChangeApprovalStatus.PendingReview
     )
-    "succeed if the batchChange is PendingApproval and reviewer is authorized" in {
+    "succeed if the batchChange is PendingReview and reviewer is authorized" in {
       batchChangeRepo.save(batchChangeNeedsApproval)
 
       val result =
@@ -546,7 +546,7 @@ class BatchChangeServiceSpec
       result.reviewTimestamp shouldBe defined
     }
 
-    "fail if the batchChange is not PendingApproval" in {
+    "fail if the batchChange is not PendingReview" in {
       val batchChange =
         batchChangeNeedsApproval.copy(approvalStatus = BatchChangeApprovalStatus.AutoApproved)
       batchChangeRepo.save(batchChange)
@@ -557,7 +557,7 @@ class BatchChangeServiceSpec
             .approveBatchChange(batchChange.id, supportUserAuth, ApproveBatchChangeInput())
             .value)
 
-      result shouldBe BatchChangeNotPendingApproval(batchChange.id)
+      result shouldBe BatchChangeNotPendingReview(batchChange.id)
     }
 
     "fail if the batchChange reviewer is not authorized" in {
@@ -572,7 +572,7 @@ class BatchChangeServiceSpec
       result shouldBe UserNotAuthorizedError(batchChangeNeedsApproval.id)
     }
 
-    "fail if the batchChange reviewer is not authorized and the batchChange is not Pending Approval" in {
+    "fail if the batchChange reviewer is not authorized and the batchChange is not Pending Review" in {
       val batchChange =
         batchChangeNeedsApproval.copy(approvalStatus = BatchChangeApprovalStatus.AutoApproved)
       batchChangeRepo.save(batchChange)
@@ -592,7 +592,7 @@ class BatchChangeServiceSpec
           None,
           DateTime.now,
           List(),
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+          approvalStatus = BatchChangeApprovalStatus.PendingReview)
       batchChangeRepo.save(batchChange)
 
       val result =
@@ -1397,7 +1397,7 @@ class BatchChangeServiceSpec
       DateTime.now,
       List(singleChangeGood, singleChangeNR),
       Some(authGrp.id),
-      BatchChangeApprovalStatus.PendingApproval
+      BatchChangeApprovalStatus.PendingReview
     )
     val asInput = BatchChangeInput(batchChangeNeedsApproval)
     val asAdds = asInput.changes.collect {
@@ -1549,7 +1549,7 @@ class BatchChangeServiceSpec
           None,
           DateTime.now,
           List(),
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+          approvalStatus = BatchChangeApprovalStatus.PendingReview)
       batchChangeRepo.save(batchChangeOne)
 
       val batchChangeTwo = BatchChange(
@@ -1565,14 +1565,14 @@ class BatchChangeServiceSpec
         underTest
           .listBatchChangeSummaries(
             auth,
-            approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval))
+            approvalStatus = Some(BatchChangeApprovalStatus.PendingReview))
           .value)
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
       result.startFrom shouldBe None
       result.ignoreAccess shouldBe false
-      result.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
+      result.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingReview)
 
       result.batchChanges.length shouldBe 1
       result.batchChanges(0).createdTimestamp shouldBe batchChangeOne.createdTimestamp
@@ -1798,7 +1798,7 @@ class BatchChangeServiceSpec
           .value)
       result.reviewComment shouldBe Some("batchSentToConverter")
     }
-    "not send to the converter, save the change if PendingApproval and MA enabled" in {
+    "not send to the converter, save the change if PendingReview and MA enabled" in {
       val batchChange =
         BatchChange(
           auth.userId,
@@ -1806,7 +1806,7 @@ class BatchChangeServiceSpec
           Some("checkConverter"),
           DateTime.now,
           List(),
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+          approvalStatus = BatchChangeApprovalStatus.PendingReview)
 
       val result = rightResultOf(
         underTestManualEnabled
@@ -1818,7 +1818,7 @@ class BatchChangeServiceSpec
       // saved in DB
       batchChangeRepo.getBatchChange(batchChange.id).unsafeRunSync() shouldBe defined
     }
-    "error if PendingApproval but MA disabled" in {
+    "error if PendingReview but MA disabled" in {
       val batchChange =
         BatchChange(
           auth.userId,
@@ -1826,7 +1826,7 @@ class BatchChangeServiceSpec
           Some("checkConverter"),
           DateTime.now,
           List(),
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+          approvalStatus = BatchChangeApprovalStatus.PendingReview)
 
       val result = leftResultOf(
         underTest

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -148,7 +148,7 @@ class BatchChangeValidationsSpec
     None,
     DateTime.now,
     List(),
-    approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+    approvalStatus = BatchChangeApprovalStatus.PendingReview)
 
   private val invalidPendingBatchChange = BatchChange(
     okUser.id,
@@ -284,13 +284,13 @@ class BatchChangeValidationsSpec
       ScheduledChangesDisabled)
   }
 
-  property("validateBatchChangePendingApproval: should succeed if batch change is PendingApproval") {
-    validateBatchChangePendingApproval(validPendingBatchChange) should be(right)
+  property("validateBatchChangePendingReview: should succeed if batch change is PendingReview") {
+    validateBatchChangePendingReview(validPendingBatchChange) should be(right)
   }
 
-  property("validateBatchChangePendingApproval: should fail if batch change is not PendingApproval") {
-    validateBatchChangePendingApproval(invalidPendingBatchChange) shouldBe
-      Left(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
+  property("validateBatchChangePendingReview: should fail if batch change is not PendingReview") {
+    validateBatchChangePendingReview(invalidPendingBatchChange) shouldBe
+      Left(BatchChangeNotPendingReview(invalidPendingBatchChange.id))
   }
 
   property("validateAuthorizedReviewer: should succeed if the reviewer is a super user") {
@@ -307,14 +307,14 @@ class BatchChangeValidationsSpec
   }
 
   property(
-    "validateBatchChangeRejection: should succeed if batch change is pending approval and reviewer" +
+    "validateBatchChangeRejection: should succeed if batch change is pending review and reviewer" +
       "is authorized") {
     validateBatchChangeRejection(validPendingBatchChange, supportUserAuth).value should be(right)
   }
 
-  property("validateBatchChangeRejection: should fail if batch change is not pending approval") {
+  property("validateBatchChangeRejection: should fail if batch change is not pending review") {
     validateBatchChangeRejection(invalidPendingBatchChange, supportUserAuth).value shouldBe
-      Left(BatchChangeNotPendingApproval(invalidPendingBatchChange.id))
+      Left(BatchChangeNotPendingReview(invalidPendingBatchChange.id))
   }
 
   property("validateBatchChangeRejection: should fail if reviewer is not authorized") {
@@ -323,7 +323,7 @@ class BatchChangeValidationsSpec
   }
 
   property(
-    "validateBatchChangeRejection: should fail if batch change is not pending approval and reviewer is not" +
+    "validateBatchChangeRejection: should fail if batch change is not pending review and reviewer is not" +
       "authorized") {
     validateBatchChangeRejection(invalidPendingBatchChange, okAuth).value shouldBe
       Left(UserNotAuthorizedError(invalidPendingBatchChange.id))

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -381,7 +381,7 @@ class BatchChangeJsonProtocolSpec
         time,
         List(add, delete),
         None,
-        BatchChangeApprovalStatus.AutoApproved,
+        BatchChangeApprovalStatus.PendingApproval,
         None,
         None,
         None,
@@ -393,7 +393,7 @@ class BatchChangeJsonProtocolSpec
         ("comments" -> "these be comments!") ~
         ("createdTimestamp" -> decompose(time)) ~
         ("changes" -> decompose(List(add, delete))) ~
-        ("status" -> decompose(BatchChangeStatus.Pending)) ~
+        ("status" -> decompose(BatchChangeStatus.PendingReview)) ~
         ("id" -> "someId") ~
         ("ownerGroupId" -> JNothing) ~
         ("scheduledTime" -> JNothing)

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -451,7 +451,7 @@ class BatchChangeJsonProtocolSpec
         ("comments" -> "these be comments!") ~
         ("createdTimestamp" -> decompose(time)) ~
         ("changes" -> decompose(List(add, delete))) ~
-        ("status" -> decompose(BatchChangeStatus.Pending)) ~
+        ("status" -> decompose(BatchChangeStatus.PendingProcessing)) ~
         ("id" -> "someId") ~
         ("ownerGroupId" -> decompose(Some("groupId"))) ~
         ("ownerGroupName" -> decompose(Some("groupName")))

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -381,7 +381,7 @@ class BatchChangeJsonProtocolSpec
         time,
         List(add, delete),
         None,
-        BatchChangeApprovalStatus.PendingApproval,
+        BatchChangeApprovalStatus.PendingReview,
         None,
         None,
         None,

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -154,13 +154,13 @@ class BatchChangeRoutingSpec()
     val batchChangeSummaryInfo2 = BatchChangeSummary(
       createBatchChangeResponse(
         Some("second"),
-        approvalStatus = BatchChangeApprovalStatus.PendingApproval))
+        approvalStatus = BatchChangeApprovalStatus.PendingReview))
     val batchChangeSummaryInfo3 = BatchChangeSummary(createBatchChangeResponse(Some("third")))
     val batchChangeSummaryInfo4 = BatchChangeSummary(
       createBatchChangeResponse(
         Some("fourth"),
         auth = dummyAuth,
-        approvalStatus = BatchChangeApprovalStatus.PendingApproval))
+        approvalStatus = BatchChangeApprovalStatus.PendingReview))
 
     val validResponseWithComments: BatchChange = createBatchChangeResponse(
       Some("validChangeWithComments"))
@@ -305,13 +305,13 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, 100, _, Some(BatchChangeApprovalStatus.PendingApproval)) =>
+          case (_, None, 100, _, Some(BatchChangeApprovalStatus.PendingReview)) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
                 startFrom = None,
                 nextId = None,
-                approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+                approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
               )
             )
 
@@ -332,14 +332,14 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, 100, true, Some(BatchChangeApprovalStatus.PendingApproval)) => {
+          case (_, None, 100, true, Some(BatchChangeApprovalStatus.PendingReview)) => {
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2, batchChangeSummaryInfo4),
                 startFrom = None,
                 nextId = None,
                 ignoreAccess = true,
-                approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+                approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
               )
             )
           }
@@ -353,13 +353,13 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, 100, false, Some(BatchChangeApprovalStatus.PendingApproval)) =>
+          case (_, None, 100, false, Some(BatchChangeApprovalStatus.PendingReview)) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
                 startFrom = None,
                 nextId = None,
-                approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+                approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
               )
             )
 
@@ -376,7 +376,7 @@ class BatchChangeRoutingSpec()
         case ("pendingBatchId", true) => EitherT(IO.pure(genericValidResponse.asRight))
         case ("pendingBatchId", false) =>
           EitherT(IO.pure(UserNotAuthorizedError("notAuthedID").asLeft))
-        case _ => EitherT(IO.pure(BatchChangeNotPendingApproval("batchId").asLeft))
+        case _ => EitherT(IO.pure(BatchChangeNotPendingReview("batchId").asLeft))
       }
 
     def approveBatchChange(
@@ -390,7 +390,7 @@ class BatchChangeRoutingSpec()
           EitherT(IO.pure(UserNotAuthorizedError("notAuthedID").asLeft))
         case ("notFoundUser", _) =>
           EitherT(IO.pure(BatchRequesterNotFound("someid", "somename").asLeft))
-        case (_, _) => EitherT(IO.pure(BatchChangeNotPendingApproval("batchId").asLeft))
+        case (_, _) => EitherT(IO.pure(BatchChangeNotPendingReview("batchId").asLeft))
       }
   }
 
@@ -621,8 +621,8 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "return user's Pending batch changes if approval status is `PendingApproval`" in {
-      Get("/zones/batchrecordchanges?approvalStatus=pendingapproval") ~>
+    "return user's Pending batch changes if approval status is `PendingReview`" in {
+      Get("/zones/batchrecordchanges?approvalStatus=PendingReview") ~>
         batchChangeRoute ~> check {
         status shouldBe OK
 
@@ -632,7 +632,7 @@ class BatchChangeRoutingSpec()
         resp.maxItems shouldBe 100
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
-        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
+        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingReview)
       }
     }
 
@@ -668,9 +668,9 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "return all Pending batch changes if ignoreAccess is true, approval status is `PendingApproval`," +
+    "return all Pending batch changes if ignoreAccess is true, approval status is `PendingReview`," +
       " and requester is a super user" in {
-      Get("/zones/batchrecordchanges?ignoreAccess=true&approvalStatus=PendingApproval") ~>
+      Get("/zones/batchrecordchanges?ignoreAccess=true&approvalStatus=PendingReview") ~>
         superUserRoute ~> check {
         status shouldBe OK
 
@@ -681,13 +681,13 @@ class BatchChangeRoutingSpec()
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
-        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingApproval)
+        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingReview)
       }
     }
   }
 
   "POST reject batch change" should {
-    "return OK if review comment is provided, batch change is PendingApproval, and reviewer is authorized" in {
+    "return OK if review comment is provided, batch change is PendingReview, and reviewer is authorized" in {
       Post("/zones/batchrecordchanges/pendingBatchId/reject").withEntity(HttpEntity(
         ContentTypes.`application/json`,
         compact(render("comments" -> "some comments")))) ~>
@@ -696,7 +696,7 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "return OK if comments are not provided, batch change is PendingApproval, and reviewer is authorized" in {
+    "return OK if comments are not provided, batch change is PendingReview, and reviewer is authorized" in {
       Post("/zones/batchrecordchanges/pendingBatchId/reject").withEntity(
         HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
         supportUserRoute ~> check {
@@ -728,7 +728,7 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "return BadRequest if batch change is not pending approval" in {
+    "return BadRequest if batch change is not pending review" in {
       Post("/zones/batchrecordchanges/batchId/reject").withEntity(
         HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
         supportUserRoute ~> check {
@@ -738,7 +738,7 @@ class BatchChangeRoutingSpec()
   }
 
   "POST approve batch change" should {
-    "return Accepted if review comment is provided, batch change is PendingApproval, and reviewer is authorized" in {
+    "return Accepted if review comment is provided, batch change is PendingReview, and reviewer is authorized" in {
       Post("/zones/batchrecordchanges/pendingBatchId/approve").withEntity(HttpEntity(
         ContentTypes.`application/json`,
         compact(render("comments" -> "some comments")))) ~>
@@ -747,7 +747,7 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "return Accepted if comments are not provided, batch change is PendingApproval, and reviewer is authorized" in {
+    "return Accepted if comments are not provided, batch change is PendingReview, and reviewer is authorized" in {
       Post("/zones/batchrecordchanges/pendingBatchId/approve").withEntity(
         HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
         supportUserRoute ~> check {
@@ -779,7 +779,7 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "return BadRequest if batch change is not pending approval" in {
+    "return BadRequest if batch change is not pending review" in {
       Post("/zones/batchrecordchanges/batchId/approve").withEntity(
         HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
         supportUserRoute ~> check {

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -632,8 +632,8 @@ class BatchChangeRoutingSpec()
         resp.maxItems shouldBe 100
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
-        resp.approvalStatus.get
-          .getClass() shouldBe Some(BatchChangeApprovalStatus.PendingReview).get.getClass()
+        resp.approvalStatus.toString() shouldBe Some(BatchChangeApprovalStatus.PendingReview)
+          .toString()
       }
     }
 
@@ -682,8 +682,8 @@ class BatchChangeRoutingSpec()
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
-        resp.approvalStatus.get
-          .getClass() shouldBe Some(BatchChangeApprovalStatus.PendingReview).get.getClass()
+        resp.approvalStatus.toString() shouldBe Some(BatchChangeApprovalStatus.PendingReview)
+          .toString()
       }
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -632,7 +632,8 @@ class BatchChangeRoutingSpec()
         resp.maxItems shouldBe 100
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
-        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingReview)
+        resp.approvalStatus.get
+          .getClass() shouldBe Some(BatchChangeApprovalStatus.PendingReview).get.getClass()
       }
     }
 
@@ -681,7 +682,8 @@ class BatchChangeRoutingSpec()
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
-        resp.approvalStatus shouldBe Some(BatchChangeApprovalStatus.PendingReview)
+        resp.approvalStatus.get
+          .getClass() shouldBe Some(BatchChangeApprovalStatus.PendingReview).get.getClass()
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -62,7 +62,8 @@ case class BatchChange(
  */
 object BatchChangeStatus extends Enumeration {
   type BatchChangeStatus = Value
-  val Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected, Scheduled = Value
+  val Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected, Scheduled =
+    Value
 
   def calculateBatchStatus(
       approvalStatus: BatchChangeApprovalStatus,

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -60,7 +60,7 @@ case class BatchChange(
  */
 object BatchChangeStatus extends Enumeration {
   type BatchChangeStatus = Value
-  val Pending, Complete, Failed, PartialFailure, Scheduled = Value
+  val Pending, PendingReview, Complete, Failed, PartialFailure, Rejected, Scheduled = Value
 
   def calculateBatchStatus(
       approvalStatus: BatchChangeApprovalStatus,
@@ -69,9 +69,10 @@ object BatchChangeStatus extends Enumeration {
       hasComplete: Boolean,
       isScheduled: Boolean): BatchChangeStatus =
     approvalStatus match {
+<<<<<<< HEAD
       case BatchChangeApprovalStatus.PendingApproval if isScheduled => BatchChangeStatus.Scheduled
-      case BatchChangeApprovalStatus.PendingApproval => BatchChangeStatus.Pending
-      case BatchChangeApprovalStatus.ManuallyRejected => BatchChangeStatus.Failed
+      case BatchChangeApprovalStatus.PendingApproval => BatchChangeStatus.PendingReview
+      case BatchChangeApprovalStatus.ManuallyRejected => BatchChangeStatus.Rejected
       case _ =>
         (hasPending, hasFailed, hasComplete) match {
           case (true, _, _) => BatchChangeStatus.Pending

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -57,7 +57,7 @@ case class BatchChange(
  - Failed means all changes are in failure state
  - PartialFailure means some have failed, the rest are complete
  - PendingProcessing if at least one change is still in pending state
- - PendingReview if approval status is PendingApproval
+ - PendingReview if approval status is PendingReview
  - Rejected if approval status is ManuallyRejected
  */
 object BatchChangeStatus extends Enumeration {
@@ -71,8 +71,8 @@ object BatchChangeStatus extends Enumeration {
       hasComplete: Boolean,
       isScheduled: Boolean): BatchChangeStatus =
     approvalStatus match {
-      case BatchChangeApprovalStatus.PendingApproval if isScheduled => BatchChangeStatus.Scheduled
-      case BatchChangeApprovalStatus.PendingApproval => BatchChangeStatus.PendingReview
+      case BatchChangeApprovalStatus.PendingReview if isScheduled => BatchChangeStatus.Scheduled
+      case BatchChangeApprovalStatus.PendingReview => BatchChangeStatus.PendingReview
       case BatchChangeApprovalStatus.ManuallyRejected => BatchChangeStatus.Rejected
       case _ =>
         (hasPending, hasFailed, hasComplete) match {
@@ -86,7 +86,7 @@ object BatchChangeStatus extends Enumeration {
 
 object BatchChangeApprovalStatus extends Enumeration {
   type BatchChangeApprovalStatus = Value
-  val AutoApproved, PendingApproval, ManuallyApproved, ManuallyRejected = Value
+  val AutoApproved, PendingReview, ManuallyApproved, ManuallyRejected = Value
 
   private val valueMap =
     BatchChangeApprovalStatus.values.map(v => v.toString.toLowerCase -> v).toMap

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -60,7 +60,7 @@ case class BatchChange(
  */
 object BatchChangeStatus extends Enumeration {
   type BatchChangeStatus = Value
-  val Pending, PendingReview, Complete, Failed, PartialFailure, Rejected, Scheduled = Value
+  val PendingProcessing, PendingReview, Complete, Failed, PartialFailure, Rejected, Scheduled = Value
 
   def calculateBatchStatus(
       approvalStatus: BatchChangeApprovalStatus,
@@ -69,13 +69,12 @@ object BatchChangeStatus extends Enumeration {
       hasComplete: Boolean,
       isScheduled: Boolean): BatchChangeStatus =
     approvalStatus match {
-<<<<<<< HEAD
       case BatchChangeApprovalStatus.PendingApproval if isScheduled => BatchChangeStatus.Scheduled
       case BatchChangeApprovalStatus.PendingApproval => BatchChangeStatus.PendingReview
       case BatchChangeApprovalStatus.ManuallyRejected => BatchChangeStatus.Rejected
       case _ =>
         (hasPending, hasFailed, hasComplete) match {
-          case (true, _, _) => BatchChangeStatus.Pending
+          case (true, _, _) => BatchChangeStatus.PendingProcessing
           case (false, true, true) => BatchChangeStatus.PartialFailure
           case (false, true, false) => BatchChangeStatus.Failed
           case _ => BatchChangeStatus.Complete

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -53,14 +53,16 @@ case class BatchChange(
 }
 
 /*
- - Pending if at least one change is still in pending state
  - Complete means all changes are in complete state
  - Failed means all changes are in failure state
  - PartialFailure means some have failed, the rest are complete
+ - PendingProcessing if at least one change is still in pending state
+ - PendingReview if approval status is PendingApproval
+ - Rejected if approval status is ManuallyRejected
  */
 object BatchChangeStatus extends Enumeration {
   type BatchChangeStatus = Value
-  val PendingProcessing, PendingReview, Complete, Failed, PartialFailure, Rejected, Scheduled = Value
+  val Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected, Scheduled = Value
 
   def calculateBatchStatus(
       approvalStatus: BatchChangeApprovalStatus,

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -59,6 +59,7 @@ case class BatchChange(
  - PendingProcessing if at least one change is still in pending state
  - PendingReview if approval status is PendingReview
  - Rejected if approval status is ManuallyRejected
+ - Scheduled if approval status is PendingReview and batch change is scheduled
  */
 object BatchChangeStatus extends Enumeration {
   type BatchChangeStatus = Value

--- a/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
@@ -64,12 +64,12 @@ class BatchChangeSpec extends WordSpec with Matchers {
     "calculate Pending status when approval status is PendingApproval" in {
       batchChangeBase
         .copy(approvalStatus = BatchChangeApprovalStatus.PendingApproval)
-        .status shouldBe BatchChangeStatus.Pending
+        .status shouldBe BatchChangeStatus.PendingReview
     }
     "calculate Failed status when approval status is ManuallyRejected" in {
       batchChangeBase
         .copy(approvalStatus = BatchChangeApprovalStatus.ManuallyRejected)
-        .status shouldBe BatchChangeStatus.Failed
+        .status shouldBe BatchChangeStatus.Rejected
     }
     "calculate Scheduled status when approval status is PendingApproval and scheduled time is set" in {
       batchChangeBase

--- a/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
@@ -46,7 +46,7 @@ class BatchChangeSpec extends WordSpec with Matchers {
 
   "BatchChange" should {
     "calculate Pending status based on SingleChanges" in {
-      batchChangeBase.status shouldBe BatchChangeStatus.Pending
+      batchChangeBase.status shouldBe BatchChangeStatus.PendingProcessing
     }
     "calculate PartialFailure status based on SingleChanges" in {
       batchChangeBase

--- a/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
@@ -61,9 +61,9 @@ class BatchChangeSpec extends WordSpec with Matchers {
         .copy(changes = List(completeChange))
         .status shouldBe BatchChangeStatus.Complete
     }
-    "calculate Pending status when approval status is PendingApproval" in {
+    "calculate Pending status when approval status is PendingReview" in {
       batchChangeBase
-        .copy(approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+        .copy(approvalStatus = BatchChangeApprovalStatus.PendingReview)
         .status shouldBe BatchChangeStatus.PendingReview
     }
     "calculate Failed status when approval status is ManuallyRejected" in {

--- a/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/batch/BatchChangeSpec.scala
@@ -71,10 +71,10 @@ class BatchChangeSpec extends WordSpec with Matchers {
         .copy(approvalStatus = BatchChangeApprovalStatus.ManuallyRejected)
         .status shouldBe BatchChangeStatus.Rejected
     }
-    "calculate Scheduled status when approval status is PendingApproval and scheduled time is set" in {
+    "calculate Scheduled status when approval status is PendingReview and scheduled time is set" in {
       batchChangeBase
         .copy(
-          approvalStatus = BatchChangeApprovalStatus.PendingApproval,
+          approvalStatus = BatchChangeApprovalStatus.PendingReview,
           scheduledTime = Some(DateTime.now))
         .status shouldBe BatchChangeStatus.Scheduled
     }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -655,7 +655,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
           retrieved <- repo.getBatchChange(chg.id)
         } yield retrieved
 
-      saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Pending
+      saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.PendingProcessing
     }
     "properly status check (pendingReview) when approvalStatus is PendingApproval" in {
       val chg = randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.PendingApproval)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -125,7 +125,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
     val timeBase: DateTime = DateTime.now
     val change_one: BatchChange = pendingBatchChange.copy(
       createdTimestamp = timeBase,
-      approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+      approvalStatus = BatchChangeApprovalStatus.PendingReview)
     val change_two: BatchChange =
       completeBatchChange.copy(createdTimestamp = timeBase.plus(1000), ownerGroupId = None)
     val otherUserBatchChange: BatchChange =
@@ -253,9 +253,9 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       areSame(f.unsafeRunSync(), Some(testBatch))
     }
 
-    "save/get a batch change with BatchChangeApprovalStatus.PendingApproval" in {
+    "save/get a batch change with BatchChangeApprovalStatus.PendingReview" in {
       val testBatch =
-        randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+        randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.PendingReview)
       val f =
         for {
           _ <- repo.save(testBatch)
@@ -465,7 +465,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
           retrieved <- repo.getBatchChangeSummaries(
             None,
-            approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval))
+            approvalStatus = Some(BatchChangeApprovalStatus.PendingReview))
         } yield retrieved
 
       // from most recent descending
@@ -657,8 +657,8 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
       saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.PendingProcessing
     }
-    "properly status check (pendingReview) when approvalStatus is PendingApproval" in {
-      val chg = randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+    "properly status check (pendingReview) when approvalStatus is PendingReview" in {
+      val chg = randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.PendingReview)
       val saved =
         for {
           _ <- repo.save(chg)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -657,7 +657,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
       saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Pending
     }
-    "properly status check (pending) when approvalStatus is PendingApproval" in {
+    "properly status check (pendingReview) when approvalStatus is PendingApproval" in {
       val chg = randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.PendingApproval)
       val saved =
         for {
@@ -665,7 +665,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
           retrieved <- repo.getBatchChange(chg.id)
         } yield retrieved
 
-      saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Pending
+      saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.PendingReview
     }
     "properly status check (complete)" in {
       val chg = randomBatchChange(
@@ -699,7 +699,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
       saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Failed
     }
-    "properly status check (failed) when approval status is ManuallyRejected" in {
+    "properly status check (rejected) when approval status is ManuallyRejected" in {
       val chg =
         randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.ManuallyRejected)
       val saved =
@@ -708,7 +708,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
           retrieved <- repo.getBatchChange(chg.id)
         } yield retrieved
 
-      saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Failed
+      saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Rejected
     }
   }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -293,7 +293,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       val savedTs = DateTime.now.secondOfDay().roundFloorCopy()
       val chg = randomBatchChange().copy(
         scheduledTime = Some(savedTs),
-        approvalStatus = BatchChangeApprovalStatus.PendingApproval)
+        approvalStatus = BatchChangeApprovalStatus.PendingReview)
 
       val saved =
         for {
@@ -330,7 +330,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
           retrieved <- repo.getBatchChangeSummaries(
             Some(pendingBatchChange.userId),
-            approvalStatus = Some(BatchChangeApprovalStatus.PendingApproval)
+            approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
           )
         } yield retrieved
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -398,7 +398,7 @@ class MySqlBatchChangeRepository
   def fromApprovalStatus(typ: BatchChangeApprovalStatus): Int =
     typ match {
       case BatchChangeApprovalStatus.AutoApproved => 1
-      case BatchChangeApprovalStatus.PendingApproval => 2
+      case BatchChangeApprovalStatus.PendingReview => 2
       case BatchChangeApprovalStatus.ManuallyApproved => 3
       case BatchChangeApprovalStatus.ManuallyRejected => 4
     }
@@ -406,7 +406,7 @@ class MySqlBatchChangeRepository
   def toApprovalStatus(key: Option[Int]): BatchChangeApprovalStatus =
     key match {
       case Some(1) => BatchChangeApprovalStatus.AutoApproved
-      case Some(2) => BatchChangeApprovalStatus.PendingApproval
+      case Some(2) => BatchChangeApprovalStatus.PendingReview
       case Some(3) => BatchChangeApprovalStatus.ManuallyApproved
       case Some(4) => BatchChangeApprovalStatus.ManuallyRejected
       case _ => BatchChangeApprovalStatus.AutoApproved


### PR DESCRIPTION
Part of #659 

Changes in this pull request:
- Instead of using the existing Pending and Failed statuses use PendingReview for a batch change in the pending state and use Rejected when a batch change is ManuallyRejected.
