### PR TITLE
Create new pytest marker for scheduled changes

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -270,7 +270,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
         clear_zoneid_rsid_tuple_list(to_delete, client)
 
 
-@pytest.mark.manual_batch_review
+@pytest.mark.scheduled_time
 def test_create_batch_change_with_scheduled_time_succeeds(shared_zone_test_context):
     """
     Test successfully creating a batch change with scheduled time set


### PR DESCRIPTION
Although scheduled changes requires manual review to be enabled, we want more flexibility in terms of when to test features related to scheduled changes.

Changes in this pull request:
- Use new `scheduled_changes` pytest marker
