### PR TITLE
Sched approval

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -16,6 +16,7 @@
 
 package vinyldns.api.domain.batch
 
+import org.joda.time.DateTime
 import vinyldns.api.domain.batch.BatchChangeInterfaces.ValidatedBatch
 import vinyldns.api.domain.batch.BatchTransformations.ChangeForValidation
 import vinyldns.core.domain.DomainValidationError
@@ -59,4 +60,9 @@ final case class BatchRequesterNotFound(userId: String, userName: String)
 case object ScheduledChangesDisabled extends BatchChangeErrorResponse {
   val message: String =
     "Cannot create a scheduled change, as it is currently disabled on this VinylDNS instance."
+}
+
+final case class ScheduledChangeNotDue(scheduledTime: DateTime) extends BatchChangeErrorResponse {
+  val message: String =
+    s"Cannot process scheduled change as it is not past the scheduled date of $scheduledTime"
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -117,7 +117,7 @@ class BatchChangeValidations(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
     validateAuthorizedReviewer(authPrincipal, batchChange) |+| validateBatchChangePendingReview(
-      batchChange)
+      batchChange) |+| validateScheduledApproval(batchChange)
 
   def validateBatchChangePendingReview(
       batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
@@ -133,6 +133,12 @@ class BatchChangeValidations(
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft
+    }
+
+  def validateScheduledApproval(batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
+    batchChange.scheduledTime match {
+      case Some(dt) if dt.isAfterNow => Left(ScheduledChangeNotDue(dt))
+      case _ => Right(())
     }
 
   /* input validations */

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -42,6 +42,7 @@ class BatchChangeRoute(
     case brnf: BatchRequesterNotFound => complete(StatusCodes.NotFound, brnf.message)
     case ScheduledChangesDisabled =>
       complete(StatusCodes.BadRequest, ScheduledChangesDisabled.message)
+    case scnpd: ScheduledChangeNotDue => complete(StatusCodes.Forbidden, scnpd.message)
   }
 
   final private val MAX_ITEMS_LIMIT: Int = 100

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -293,6 +293,23 @@ class BatchChangeValidationsSpec
       Left(BatchChangeNotPendingReview(invalidPendingBatchChange.id))
   }
 
+  property("validateScheduledApproval: should fail if scheduled time is not due") {
+    val dt = DateTime.now.plusDays(2)
+    val change = validPendingBatchChange.copy(scheduledTime = Some(dt))
+    validateScheduledApproval(change) shouldBe Left(ScheduledChangeNotDue(dt))
+  }
+
+  property("validateScheduledApproval: should succeed if scheduled time is due") {
+    val dt = DateTime.now.minusDays(2)
+    val change = validPendingBatchChange.copy(scheduledTime = Some(dt))
+    validateScheduledApproval(change) should be(right)
+  }
+
+  property("validateScheduledApproval: should succeed if scheduled time is not set") {
+    val change = validPendingBatchChange.copy(scheduledTime = None)
+    validateScheduledApproval(change) should be(right)
+  }
+
   property("validateAuthorizedReviewer: should succeed if the reviewer is a super user") {
     validateAuthorizedReviewer(superUserAuth, validPendingBatchChange) should be(right)
   }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -390,6 +390,8 @@ class BatchChangeRoutingSpec()
           EitherT(IO.pure(UserNotAuthorizedError("notAuthedID").asLeft))
         case ("notFoundUser", _) =>
           EitherT(IO.pure(BatchRequesterNotFound("someid", "somename").asLeft))
+        case ("schedNotPastDue", _) =>
+          EitherT(IO.pure(ScheduledChangeNotDue(DateTime.now).asLeft))
         case (_, _) => EitherT(IO.pure(BatchChangeNotPendingReview("batchId").asLeft))
       }
   }
@@ -762,6 +764,15 @@ class BatchChangeRoutingSpec()
         HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
         batchChangeRoute ~> check {
         status shouldBe Forbidden
+      }
+    }
+
+    "return Forbidden if scheduled change is not past due" in {
+      Post("/zones/batchrecordchanges/schedNotPastDue/approve").withEntity(
+        HttpEntity(ContentTypes.`application/json`, compact(render("")))) ~>
+        batchChangeRoute ~> check {
+        status shouldBe Forbidden
+        response.entity.toString should include("scheduled date")
       }
     }
 


### PR DESCRIPTION
Add check to make sure that a scheduled change is not past due when approving.

* `BatchChangeErrors` - added `ScheduledChangeNotDue` error type that will be raised in the event someone approves a batch change (i.e. processes) a scheduled change too soon.
* `BatchChangeValidations` - added a `validateScheduledApproval` function that raises the `ScheduledChangeNotDue` if the scheduled date is not past due
* `BatchChangeRouting` - added `ScheduledChangeNotDue` to `handleErrors` to return a `Forbidden`
