### PR TITLE
Require owner group ID for soft errors

### DIFF
--- a/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/reject_batch_change_test.py
@@ -12,7 +12,8 @@ def test_reject_pending_batch_change_success(shared_zone_test_context):
     batch_change_input = {
         "changes": [
             get_change_A_AAAA_json("zone.discovery.failure.", address="4.3.2.1")
-        ]
+        ],
+        "ownerGroupId": shared_zone_test_context.ok_group['id']
     }
     result = client.create_batch_change(batch_change_input, status=202)
     get_batch = client.get_batch_change(result['id'])

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -66,3 +66,8 @@ final case class ScheduledChangeNotDue(scheduledTime: DateTime) extends BatchCha
   val message: String =
     s"Cannot process scheduled change as it is not past the scheduled date of $scheduledTime"
 }
+
+case object ManualReviewRequiresOwnerGroup extends BatchChangeErrorResponse {
+  val message: String =
+    "Batch change requires owner group for manual review/scheduled changes."
+}

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -421,7 +421,11 @@ class BatchChangeService(
       // advance to manual review if this is scheduled OR manual review is ok
       val gotoManualReview = this.manualReviewEnabled && (isScheduled || allowManualReview)
       if (gotoManualReview) {
-        manualReviewResponse
+        if (batchChangeInput.ownerGroupId.isDefined) {
+          manualReviewResponse
+        } else {
+          ManualReviewRequiresOwnerGroup.asLeft
+        }
       } else {
         // Cannot go to manual review, and we have soft errors, so just return a failure
         errorResponse

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -40,6 +40,8 @@ class BatchChangeRoute(
       complete(StatusCodes.BadRequest, bcnpa.message)
     case uce: UnknownConversionError => complete(StatusCodes.InternalServerError, uce)
     case brnf: BatchRequesterNotFound => complete(StatusCodes.NotFound, brnf.message)
+    case ManualReviewRequiresOwnerGroup =>
+      complete(StatusCodes.BadRequest, ManualReviewRequiresOwnerGroup.message)
     case ScheduledChangesDisabled =>
       complete(StatusCodes.BadRequest, ScheduledChangesDisabled.message)
     case scnpd: ScheduledChangeNotDue => complete(StatusCodes.Forbidden, scnpd.message)

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1299,7 +1299,11 @@ class BatchChangeServiceSpec
   "return a BatchChange if all data inputs ok and manual review is enabled with scheduled" in {
     val result = underTestScheduledEnabled
       .buildResponse(
-        BatchChangeInput(None, List(apexAddA), scheduledTime = Some(DateTime.now)),
+        BatchChangeInput(
+          None,
+          List(apexAddA),
+          Some("owner-group-id"),
+          scheduledTime = Some(DateTime.now)),
         List(
           AddChangeForValidation(apexZone, "apex.test.com.", apexAddA).validNel
         ),
@@ -1329,7 +1333,7 @@ class BatchChangeServiceSpec
   "return a BatchChange ignoring allowManualReview flag if scheduled" in {
     val result = underTestScheduledEnabled
       .buildResponse(
-        BatchChangeInput(None, List(apexAddA), scheduledTime = Some(DateTime.now)),
+        BatchChangeInput(None, List(apexAddA), Some("owner-group-id"), Some(DateTime.now)),
         List(
           AddChangeForValidation(apexZone, "apex.test.com.", apexAddA).validNel,
           nonFatalError.invalidNel,
@@ -1361,7 +1365,7 @@ class BatchChangeServiceSpec
   "return a BatchChange in manual review if soft errors and scheduled" in {
     val result = underTestScheduledEnabled
       .buildResponse(
-        BatchChangeInput(None, List(apexAddA), scheduledTime = Some(DateTime.now)),
+        BatchChangeInput(None, List(apexAddA), Some("owner-group-id"), Some(DateTime.now)),
         List(
           AddChangeForValidation(apexZone, "apex.test.com.", apexAddA).validNel,
           nonFatalError.invalidNel,


### PR DESCRIPTION
When we hit soft errors upon submitting a batch change request, this will most likely be due to a `ZoneDiscoveryError`. In the event that the zone is shared, `ownerGroupId` is required so we are trying to preemptively require the field.

Changes in this pull request:
- Add owner group ID check for batch changes that are manual review with soft errors
- Update tests
