### PR TITLE
link to groups in the portal Manage Zone view

### DIFF
--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -72,6 +72,7 @@
                                                 ng-selected="updateZoneInfo.adminGroupName == group.name">
                                             {{group.name}} ({{group.description}})</option>
                                     </select>
+                                    <a href="/groups/{{ updateZoneInfo.adminGroupId  }}">View group</a>
                                 </div>
                             </div>
 
@@ -271,7 +272,8 @@
             <tbody>
                 <tr ng-repeat="rule in aclRules track by $index">
                     <td class="wrap-long-text">
-                        {{rule.displayName}}
+                        <a ng-if="rule.groupId != undefined" href="/groups/{{rule.groupId}}">{{rule.displayName}}</a>
+                        <span ng-if="rule.groupId == undefined">{{rule.displayName}}</span>
                     </td>
 
                     <td>

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -72,7 +72,7 @@
                                                 ng-selected="updateZoneInfo.adminGroupName == group.name">
                                             {{group.name}} ({{group.description}})</option>
                                     </select>
-                                    <a href="/groups/{{ updateZoneInfo.adminGroupId  }}">View group</a>
+                                    <a href="/groups/{{ updateZoneInfo.adminGroupId }}">View group</a>
                                 </div>
                             </div>
 


### PR DESCRIPTION
<img width="983" alt="portal Manage Zones view with links to group pages" src="https://user-images.githubusercontent.com/4439228/62395623-d6ed8180-b53e-11e9-98c3-0c089e9f2c26.png">

From a support perspective i find it annoying that I have to go to a zone to see an owner group or ACL group and then go to the Groups page to look up the group to see the members. Want to make the group names in the Manage Zones view link directly to the Group pages that list the members.

Changes in this pull request:
- Add a link under the admin group selection with a link to the current zone owner group
- Link the group name in ACL rules to the group page
