### PR TITLE
Implement domains requiring manual review (via batch change interface)

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -210,7 +210,7 @@ vinyldns {
   # FQDNs / IPs that require manual review upon submission in batch change interface
   # domain-list used for all record types except PTR
   # ip-list used exclusively for PTR records
-  domains-requiring-manual-review = {
+  manual-review-domains = {
     domain-list = [
       "needs-review.*"
     ]

--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -207,6 +207,21 @@ vinyldns {
     ]
   }
 
+  # FQDNs / IPs that require manual review upon submission in batch change interface
+  # domain-list used for all record types except PTR
+  # ip-list used exclusively for PTR records
+  domains-requiring-manual-review = {
+    domain-list = [
+      "needs-review.*"
+    ]
+    ip-list = [
+      "192.0.2.254",
+      "192.0.2.255",
+      "fd69:27cc:fe91:0:0:0:ffff:1",
+      "fd69:27cc:fe91:0:0:0:ffff:2"
+    ]
+  }
+
   # types of unowned records that users can access in shared zones
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 

--- a/docker/bind9/zones/1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa
+++ b/docker/bind9/zones/1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa
@@ -9,3 +9,4 @@ $ttl 38400
 4.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	www.vinyldns.
 5.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	mail.vinyldns.
 0.0.0.0.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0 IN  PTR high.value.domain.ip6.
+2.0.0.0.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0 IN  PTR needs.review.domain.ip6.

--- a/docker/bind9/zones/2.0.192.in-addr.arpa
+++ b/docker/bind9/zones/2.0.192.in-addr.arpa
@@ -12,3 +12,4 @@ $ttl 38400
 194			IN	CNAME 194.192/30.2.0.192.in-addr.arpa.
 195         IN  CNAME 195.192/30.2.0.192.in-addr.arpa.
 253         IN  PTR   high.value.domain.ip4.
+255         IN  PTR   needs.review.domain.ip4

--- a/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
@@ -46,9 +46,9 @@ def test_approve_pending_batch_change_success(shared_zone_test_context):
         to_delete = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
 
         assert_that(completed_batch['status'], is_('Complete'))
-        for i in xrange(len(completed_batch['changes'])):
-            assert_that(completed_batch['changes'][i]['status'], is_('Complete'))
-            assert_that(len(completed_batch['changes'][i]['validationErrors']), is_(0))
+        for change in completed_batch['changes']:
+            assert_that(change['status'], is_('Complete'))
+            assert_that(len(change['validationErrors']), is_(0))
         assert_that(completed_batch['approvalStatus'], is_('ManuallyApproved'))
         assert_that(completed_batch['reviewerId'], is_('support-user-id'))
         assert_that(completed_batch['reviewerUserName'], is_('support-user'))

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -860,6 +860,45 @@ def test_create_batch_change_with_high_value_domain_fails(shared_zone_test_conte
     assert_that(response[12], is_not(has_key("errors")))
 
 
+@pytest.mark.manual_batch_review
+def test_create_batch_change_with_domains_requiring_review_succeeds(shared_zone_test_context):
+    """
+    Test creating a batch change with an input name requiring review is accepted
+    """
+
+    rejecter = shared_zone_test_context.support_user_client
+    client = shared_zone_test_context.ok_vinyldns_client
+    batch_change_input = {
+        "ownerGroupId": shared_zone_test_context.ok_group['id'],
+        "comments": "this is optional",
+        "changes": [
+            get_change_A_AAAA_json("needs-review-add.ok."),
+            get_change_A_AAAA_json("needs-review-update.ok.", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json("needs-review-update.ok."),
+            get_change_A_AAAA_json("needs-review-delete.ok.", change_type="DeleteRecordSet"),
+            get_change_PTR_json("192.0.2.254"),
+            get_change_PTR_json("192.0.2.255", change_type="DeleteRecordSet"), # 255 exists already
+            get_change_PTR_json("192.0.2.255"),
+            get_change_PTR_json("192.0.2.255", change_type="DeleteRecordSet"),
+            get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:1"),
+            get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:2", change_type="DeleteRecordSet"), # ffff:2 exists already
+            get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:2"),
+            get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:2", change_type="DeleteRecordSet"),
+
+            get_change_A_AAAA_json("i-can-be-touched.ok.", address="1.1.1.1")
+        ]
+    }
+    response = None
+
+    try:
+        response = client.create_batch_change(batch_change_input, status=202)
+
+    finally:
+        # Clean up so data doesn't change
+        if response:
+            rejecter.reject_batch_change(response['id'], status=200)
+
+
 def test_create_batch_change_with_invalid_record_type_fails(shared_zone_test_context):
     """
     Test creating a batch change with invalid record type fails

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -892,6 +892,13 @@ def test_create_batch_change_with_domains_requiring_review_succeeds(shared_zone_
 
     try:
         response = client.create_batch_change(batch_change_input, status=202)
+        get_batch = client.get_batch_change(response['id'])
+        assert_that(get_batch['status'], is_('PendingReview'))
+        assert_that(get_batch['approvalStatus'], is_('PendingReview'))
+        for i in xrange(1, 11):
+            assert_that(get_batch['changes'][i]['status'], is_('NeedsReview'))
+            assert_that(get_batch['changes'][i]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
+        assert_that(get_batch['changes'][12]['validationErrors'], empty())
 
     finally:
         # Clean up so data doesn't change

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -113,6 +113,21 @@ vinyldns {
     ]
   }
 
+  # FQDNs / IPs that require manual review upon submission in batch change interface
+  # domain-list used for all record types except PTR
+  # ip-list used exclusively for PTR records
+  domains-requiring-manual-review = {
+    domain-list = [
+      "needs-review.*"
+    ]
+    ip-list = [
+      "192.0.2.254",
+      "192.0.2.255",
+      "fd69:27cc:fe91:0:0:0:ffff:1",
+      "fd69:27cc:fe91:0:0:0:ffff:2"
+    ]
+  }
+
   # types of unowned records that users can access in shared zones
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -116,7 +116,7 @@ vinyldns {
   # FQDNs / IPs that require manual review upon submission in batch change interface
   # domain-list used for all record types except PTR
   # ip-list used exclusively for PTR records
-  domains-requiring-manual-review = {
+  manual-review-domains = {
     domain-list = [
       "needs-review.*"
     ]

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -137,4 +137,11 @@ object VinylDNSConfig {
   lazy val scheduledChangesEnabled: Boolean = vinyldnsConfig
     .as[Option[Boolean]]("scheduled-changes-enabled")
     .getOrElse(false)
+
+  lazy val domainListRequiringManualReview: List[Regex] =
+    ZoneRecordValidations.toCaseIgnoredRegexList(
+      getOptionalStringList("domains-requiring-manual-review.domain-list"))
+
+  lazy val ipListRequiringManualReview: List[IpAddress] =
+    getOptionalStringList("domains-requiring-manual-review.ip-list").flatMap(ip => IpAddress(ip))
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -140,8 +140,8 @@ object VinylDNSConfig {
 
   lazy val domainListRequiringManualReview: List[Regex] =
     ZoneRecordValidations.toCaseIgnoredRegexList(
-      getOptionalStringList("domains-requiring-manual-review.domain-list"))
+      getOptionalStringList("manual-review-domains.domain-list"))
 
   lazy val ipListRequiringManualReview: List[IpAddress] =
-    getOptionalStringList("domains-requiring-manual-review.ip-list").flatMap(ip => IpAddress(ip))
+    getOptionalStringList("manual-review-domains.ip-list").flatMap(ip => IpAddress(ip))
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -91,7 +91,10 @@ class BatchChangeService(
       auth: AuthPrincipal,
       allowManualReview: Boolean): BatchResult[BatchChange] =
     for {
-      validationOutput <- applyBatchChangeValidationFlow(batchChangeInput, auth)
+      validationOutput <- applyBatchChangeValidationFlow(
+        batchChangeInput,
+        auth,
+        isReviewing = false)
       changeForConversion <- buildResponse(
         batchChangeInput,
         validationOutput.validatedChanges,
@@ -107,11 +110,12 @@ class BatchChangeService(
 
   def applyBatchChangeValidationFlow(
       batchChangeInput: BatchChangeInput,
-      auth: AuthPrincipal): BatchResult[BatchValidationFlowOutput] =
+      auth: AuthPrincipal,
+      isReviewing: Boolean): BatchResult[BatchValidationFlowOutput] =
     for {
       existingGroup <- getOwnerGroup(batchChangeInput.ownerGroupId)
       _ <- validateBatchChangeInput(batchChangeInput, existingGroup, auth)
-      inputValidatedSingleChanges = validateInputChanges(batchChangeInput.changes)
+      inputValidatedSingleChanges = validateInputChanges(batchChangeInput.changes, isReviewing)
       zoneMap <- getZonesForRequest(inputValidatedSingleChanges).toBatchResult
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)
       recordSets <- getExistingRecordSets(changesWithZones, zoneMap).toBatchResult
@@ -152,7 +156,7 @@ class BatchChangeService(
       reviewInfo = BatchChangeReviewInfo(
         authPrincipal.userId,
         approveBatchChangeInput.reviewComment)
-      validationOutput <- applyBatchChangeValidationFlow(asInput, requesterAuth)
+      validationOutput <- applyBatchChangeValidationFlow(asInput, requesterAuth, isReviewing = true)
       changeForConversion <- buildResponseForApprover(
         batchChange,
         asInput,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -94,7 +94,7 @@ class BatchChangeService(
       validationOutput <- applyBatchChangeValidationFlow(
         batchChangeInput,
         auth,
-        isReviewing = false)
+        isApproved = false)
       changeForConversion <- buildResponse(
         batchChangeInput,
         validationOutput.validatedChanges,
@@ -111,11 +111,11 @@ class BatchChangeService(
   def applyBatchChangeValidationFlow(
       batchChangeInput: BatchChangeInput,
       auth: AuthPrincipal,
-      isReviewing: Boolean): BatchResult[BatchValidationFlowOutput] =
+      isApproved: Boolean): BatchResult[BatchValidationFlowOutput] =
     for {
       existingGroup <- getOwnerGroup(batchChangeInput.ownerGroupId)
       _ <- validateBatchChangeInput(batchChangeInput, existingGroup, auth)
-      inputValidatedSingleChanges = validateInputChanges(batchChangeInput.changes, isReviewing)
+      inputValidatedSingleChanges = validateInputChanges(batchChangeInput.changes, isApproved)
       zoneMap <- getZonesForRequest(inputValidatedSingleChanges).toBatchResult
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)
       recordSets <- getExistingRecordSets(changesWithZones, zoneMap).toBatchResult
@@ -156,7 +156,7 @@ class BatchChangeService(
       reviewInfo = BatchChangeReviewInfo(
         authPrincipal.userId,
         approveBatchChangeInput.reviewComment)
-      validationOutput <- applyBatchChangeValidationFlow(asInput, requesterAuth, isReviewing = true)
+      validationOutput <- applyBatchChangeValidationFlow(asInput, requesterAuth, isApproved = true)
       changeForConversion <- buildResponseForApprover(
         batchChange,
         asInput,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -181,7 +181,7 @@ class BatchChangeValidations(
       case other =>
         InvalidBatchRecordType(other.toString, SupportedBatchChangeRecordTypes.get).invalidNel[Unit]
     }
-    typedChecks |+| isNotHighValueDomain(change)
+    typedChecks |+| isNotHighValueDomain(change) |+| doesNotRequireManualReview(change)
   }
 
   def validatePtrIp(ip: String): SingleValidation[Unit] = {
@@ -486,6 +486,18 @@ class BatchChangeValidations(
       case _ =>
         ZoneRecordValidations.isNotHighValueFqdn(
           VinylDNSConfig.highValueRegexList,
+          change.inputName)
+    }
+
+  def doesNotRequireManualReview(change: ChangeInput): SingleValidation[Unit] =
+    change.typ match {
+      case RecordType.PTR =>
+        ZoneRecordValidations.ipDoesNotRequireManualReview(
+          VinylDNSConfig.ipListRequiringManualReview,
+          change.inputName)
+      case _ =>
+        ZoneRecordValidations.domainDoesNotRequireManualReview(
+          VinylDNSConfig.domainListRequiringManualReview,
           change.inputName)
     }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
@@ -20,7 +20,11 @@ import cats.implicits._
 import cats.data._
 import com.comcast.ip4s.IpAddress
 import com.comcast.ip4s.interop.cats.implicits._
-import vinyldns.core.domain.{DomainValidationError, HighValueDomainError}
+import vinyldns.core.domain.{
+  DomainValidationError,
+  HighValueDomainError,
+  RecordRequiresManualReview
+}
 import vinyldns.core.domain.record.{NSData, RecordSet}
 
 import scala.util.matching.Regex
@@ -75,5 +79,23 @@ object ZoneRecordValidations {
       ().validNel
     } else {
       HighValueDomainError(ip).invalidNel
+    }
+
+  def domainDoesNotRequireManualReview(
+      regexList: List[Regex],
+      fqdn: String): ValidatedNel[DomainValidationError, Unit] =
+    if (!isStringInRegexList(regexList, fqdn)) {
+      ().validNel
+    } else {
+      RecordRequiresManualReview(fqdn).invalidNel
+    }
+
+  def ipDoesNotRequireManualReview(
+      regexList: List[IpAddress],
+      ip: String): ValidatedNel[DomainValidationError, Unit] =
+    if (!isIpInIpList(regexList, ip)) {
+      {}.validNel
+    } else {
+      RecordRequiresManualReview(ip).invalidNel
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
@@ -94,7 +94,7 @@ object ZoneRecordValidations {
       regexList: List[IpAddress],
       ip: String): ValidatedNel[DomainValidationError, Unit] =
     if (!isIpInIpList(regexList, ip)) {
-      {}.validNel
+      ().validNel
     } else {
       RecordRequiresManualReview(ip).invalidNel
     }

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -44,7 +44,7 @@ vinyldns {
   # FQDNs / IPs that require manual review upon submission in batch change interface
   # domain-list used for all record types except PTR
   # ip-list used exclusively for PTR records
-  domains-requiring-manual-review = {
+  manual-review-domains = {
     domain-list = [
       "needs-review.*"
     ]

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -41,6 +41,21 @@ vinyldns {
     ]
   }
 
+  # FQDNs / IPs that require manual review upon submission in batch change interface
+  # domain-list used for all record types except PTR
+  # ip-list used exclusively for PTR records
+  domains-requiring-manual-review = {
+    domain-list = [
+      "needs-review.*"
+    ]
+    ip-list = [
+      "192.0.2.254",
+      "192.0.2.255",
+      "fd69:27cc:fe91:0:0:0:ffff:1",
+      "fd69:27cc:fe91:0:0:0:ffff:2"
+    ]
+  }
+
   # types of unowned records that users can access in shared zones
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -196,7 +196,7 @@ class BatchChangeValidationsSpec
 
   property("validateInputChanges: should succeed if all inputs are good") {
     forAll(listOfN(3, validAChangeGen)) { input: List[ChangeInput] =>
-      val result = validateInputChanges(input)
+      val result = validateInputChanges(input, false)
       result.map(_ shouldBe valid)
     }
   }
@@ -355,7 +355,9 @@ class BatchChangeValidationsSpec
     val invalidIpv6Input =
       AddChangeInput("testbad.example.com.", RecordType.AAAA, ttl, AAAAData("invalidIpv6:123"))
     val result =
-      validateInputChanges(List(goodInput, goodAAAAInput, invalidDomainNameInput, invalidIpv6Input))
+      validateInputChanges(
+        List(goodInput, goodAAAAInput, invalidDomainNameInput, invalidIpv6Input),
+        false)
     result(0) shouldBe valid
     result(1) shouldBe valid
     result(2) should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
@@ -369,9 +371,9 @@ class BatchChangeValidationsSpec
     val changeIpV6 =
       AddChangeInput("fd69:27cc:fe91:0:0:0:0:ffff", RecordType.PTR, ttl, PTRData("test."))
 
-    val resultA = validateInputName(changeA)
-    val resultIpV4 = validateInputName(changeIpV4)
-    val resultIpV6 = validateInputName(changeIpV6)
+    val resultA = validateInputName(changeA, false)
+    val resultIpV4 = validateInputName(changeIpV4, false)
+    val resultIpV6 = validateInputName(changeIpV6, false)
 
     resultA should haveInvalid[DomainValidationError](
       HighValueDomainError("high-value-domain.foo."))
@@ -387,9 +389,9 @@ class BatchChangeValidationsSpec
     val changeIpV6 =
       AddChangeInput("fd69:27cc:fe91:0:0:0:ffff:1", RecordType.PTR, ttl, PTRData("test."))
 
-    val resultA = validateInputName(changeA)
-    val resultIpV4 = validateInputName(changeIpV4)
-    val resultIpV6 = validateInputName(changeIpV6)
+    val resultA = validateInputName(changeA, false)
+    val resultIpV4 = validateInputName(changeIpV4, false)
+    val resultIpV6 = validateInputName(changeIpV6, false)
 
     resultA should haveInvalid[DomainValidationError](
       RecordRequiresManualReview("needs-review.foo."))
@@ -398,10 +400,15 @@ class BatchChangeValidationsSpec
       RecordRequiresManualReview("fd69:27cc:fe91:0:0:0:ffff:1"))
   }
 
+  property("doesNotRequireManualReview: should succeed if user is reviewing") {
+    val changeA = AddChangeInput("needs-review.foo.", RecordType.A, ttl, AData("1.1.1.1"))
+    validateInputName(changeA, true) should beValid(())
+  }
+
   property("""validateInputName: should fail with a DomainValidationError for deletes
       |if validateHostName fails for an invalid domain name""".stripMargin) {
     val change = DeleteChangeInput("invalidDomainName$", RecordType.A)
-    val result = validateInputName(change)
+    val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
   }
 
@@ -409,7 +416,7 @@ class BatchChangeValidationsSpec
       |if validateHostName fails for an invalid domain name length""".stripMargin) {
     val invalidDomainName = Random.alphanumeric.take(256).mkString
     val change = DeleteChangeInput(invalidDomainName, RecordType.AAAA)
-    val result = validateInputName(change)
+    val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName(s"$invalidDomainName."))
       .and(haveInvalid[DomainValidationError](InvalidLength(s"$invalidDomainName.", 2, 255)))
   }
@@ -418,13 +425,13 @@ class BatchChangeValidationsSpec
       |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
     val invalidIp = "invalidIp.111"
     val change = DeleteChangeInput(invalidIp, RecordType.PTR)
-    val result = validateInputName(change)
+    val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidIPAddress(invalidIp))
   }
 
   property("validateAddChangeInput: should succeed if single addChangeInput is good for A Record") {
     forAll(validAChangeGen) { input: AddChangeInput =>
-      val result = validateAddChangeInput(input)
+      val result = validateAddChangeInput(input, false)
       result shouldBe valid
     }
   }
@@ -432,7 +439,7 @@ class BatchChangeValidationsSpec
   property(
     "validateAddChangeInput: should succeed if single addChangeInput is good for AAAA Record") {
     forAll(validAAAAChangeGen) { input: AddChangeInput =>
-      val result = validateAddChangeInput(input)
+      val result = validateAddChangeInput(input, false)
       result shouldBe valid
     }
   }
@@ -440,7 +447,7 @@ class BatchChangeValidationsSpec
   property("""validateAddChangeInput: should fail with a DomainValidationError
       |if validateHostName fails for an invalid domain name""".stripMargin) {
     val change = AddChangeInput("invalidDomainName$", RecordType.A, ttl, AData("1.1.1.1"))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
   }
 
@@ -448,7 +455,7 @@ class BatchChangeValidationsSpec
       |if validateHostName fails for an invalid domain name length""".stripMargin) {
     val invalidDomainName = Random.alphanumeric.take(256).mkString
     val change = AddChangeInput(invalidDomainName, RecordType.A, ttl, AData("1.1.1.1"))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName(s"$invalidDomainName."))
       .and(haveInvalid[DomainValidationError](InvalidLength(s"$invalidDomainName.", 2, 255)))
   }
@@ -458,7 +465,7 @@ class BatchChangeValidationsSpec
     forAll(choose[Long](0, 29)) { invalidTTL: Long =>
       val change =
         AddChangeInput("test.comcast.com.", RecordType.A, Some(invalidTTL), AData("1.1.1.1"))
-      val result = validateAddChangeInput(change)
+      val result = validateAddChangeInput(change, false)
       result should haveInvalid[DomainValidationError](
         InvalidTTL(invalidTTL, DomainValidations.TTL_MIN_LENGTH, DomainValidations.TTL_MAX_LENGTH))
     }
@@ -468,7 +475,7 @@ class BatchChangeValidationsSpec
       |if validateRecordData fails for an invalid ipv4 address""".stripMargin) {
     val invalidIpv4 = "invalidIpv4:123"
     val change = AddChangeInput("test.comcast.com.", RecordType.A, ttl, AData(invalidIpv4))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
     result should haveInvalid[DomainValidationError](InvalidIpv4Address(invalidIpv4))
   }
 
@@ -476,14 +483,14 @@ class BatchChangeValidationsSpec
       |if validateRecordData fails for an invalid ipv6 address""".stripMargin) {
     val invalidIpv6 = "invalidIpv6:123"
     val change = AddChangeInput("test.comcast.com.", RecordType.AAAA, ttl, AAAAData(invalidIpv6))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
     result should haveInvalid[DomainValidationError](InvalidIpv6Address(invalidIpv6))
   }
 
   property("validateAddChangeInput: should fail if A inputName includes a reverse zone address") {
     val invalidInputName = "test.1.2.3.in-addr.arpa."
     val badAChange = AddChangeInput(invalidInputName, RecordType.A, ttl, AData("1.1.1.1"))
-    val result = validateAddChangeInput(badAChange)
+    val result = validateAddChangeInput(badAChange, false)
     result should haveInvalid[DomainValidationError](
       RecordInReverseZoneError(invalidInputName, RecordType.A.toString))
   }
@@ -492,7 +499,7 @@ class BatchChangeValidationsSpec
     val invalidInputName = "test.1.2.3.ip6.arpa."
     val badAAAAChange =
       AddChangeInput(invalidInputName, RecordType.AAAA, ttl, AAAAData("1:2:3:4:5:6:7:8"))
-    val result = validateAddChangeInput(badAAAAChange)
+    val result = validateAddChangeInput(badAAAAChange, false)
     result should haveInvalid[DomainValidationError](
       RecordInReverseZoneError(invalidInputName, RecordType.AAAA.toString))
   }
@@ -502,7 +509,7 @@ class BatchChangeValidationsSpec
     val invalidCNAMERecordData = "$$$"
     val change =
       AddChangeInput("test.comcast.com.", RecordType.CNAME, ttl, CNAMEData(invalidCNAMERecordData))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
 
     result should haveInvalid[DomainValidationError](InvalidDomainName(s"$invalidCNAMERecordData."))
   }
@@ -512,7 +519,7 @@ class BatchChangeValidationsSpec
     val invalidCNAMERecordData = "s" * 256
     val change =
       AddChangeInput("test.comcast.com.", RecordType.CNAME, ttl, CNAMEData(invalidCNAMERecordData))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
 
     result should haveInvalid[DomainValidationError](
       InvalidLength(s"$invalidCNAMERecordData.", 2, 255))
@@ -522,7 +529,7 @@ class BatchChangeValidationsSpec
       |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
     val invalidIp = "invalidip.111."
     val change = AddChangeInput(invalidIp, RecordType.PTR, ttl, PTRData("test.comcast.com"))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
 
     result should haveInvalid[DomainValidationError](InvalidIPAddress(invalidIp))
   }
@@ -530,7 +537,7 @@ class BatchChangeValidationsSpec
   property("validateAddChangeInput: should fail with InvalidDomainName for invalid PTR record data") {
     val invalidPTRDname = "*invalidptrdname"
     val change = AddChangeInput("4.5.6.7", RecordType.PTR, ttl, PTRData(invalidPTRDname))
-    val result = validateAddChangeInput(change)
+    val result = validateAddChangeInput(change, false)
 
     result should haveInvalid[DomainValidationError](InvalidDomainName(s"$invalidPTRDname."))
   }
@@ -1423,13 +1430,13 @@ class BatchChangeValidationsSpec
 
   property("validateAddChangeInput: should succeed for a valid TXT addChangeInput") {
     val input = AddChangeInput("txt.ok.", RecordType.TXT, ttl, TXTData("test"))
-    val result = validateAddChangeInput(input)
+    val result = validateAddChangeInput(input, false)
     result shouldBe valid
   }
 
   property("validateAddChangeInput: should fail for a TXT addChangeInput with empty TXTData") {
     val input = AddChangeInput("txt.ok.", RecordType.TXT, ttl, TXTData(""))
-    val result = validateAddChangeInput(input)
+    val result = validateAddChangeInput(input, false)
     result should haveInvalid[DomainValidationError](InvalidLength("", 1, 64764))
   }
 
@@ -1437,21 +1444,21 @@ class BatchChangeValidationsSpec
     "validateAddChangeInput: should fail for a TXT addChangeInput with TXTData that is too many characters") {
     val txtData = "x" * 64765
     val input = AddChangeInput("txt.ok.", RecordType.TXT, ttl, TXTData(txtData))
-    val result = validateAddChangeInput(input)
+    val result = validateAddChangeInput(input, false)
     result should haveInvalid[DomainValidationError](InvalidLength(txtData, 1, 64764))
   }
 
   property("validateAddChangeInput: should succeed for a valid MX addChangeInput") {
     val input = AddChangeInput("mx.ok.", RecordType.MX, ttl, MXData(1, "foo.bar."))
-    val result = validateAddChangeInput(input)
+    val result = validateAddChangeInput(input, false)
     result shouldBe valid
   }
 
   property("validateAddChangeInput: should fail for a MX addChangeInput with invalid preference") {
     val inputSmall = AddChangeInput("mx.ok.", RecordType.MX, ttl, MXData(-1, "foo.bar."))
     val inputLarge = AddChangeInput("mx.ok.", RecordType.MX, ttl, MXData(1000000, "foo.bar."))
-    val resultSmall = validateAddChangeInput(inputSmall)
-    val resultLarge = validateAddChangeInput(inputLarge)
+    val resultSmall = validateAddChangeInput(inputSmall, false)
+    val resultLarge = validateAddChangeInput(inputLarge, false)
 
     resultSmall should haveInvalid[DomainValidationError](
       InvalidMxPreference(
@@ -1467,14 +1474,14 @@ class BatchChangeValidationsSpec
 
   property("validateAddChangeInput: should fail for a MX addChangeInput with invalid exchange") {
     val input = AddChangeInput("mx.ok.", RecordType.MX, ttl, MXData(1, "foo$.bar."))
-    val result = validateAddChangeInput(input)
+    val result = validateAddChangeInput(input, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName("foo$.bar."))
   }
 
   property(
     "validateAddChangeInput: should fail for a MX addChangeInput with invalid preference and exchange") {
     val input = AddChangeInput("mx.ok.", RecordType.MX, ttl, MXData(-1, "foo$.bar."))
-    val result = validateAddChangeInput(input)
+    val result = validateAddChangeInput(input, false)
     result should haveInvalid[DomainValidationError](
       InvalidMxPreference(
         -1,

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -169,4 +169,13 @@ final case class NewMultiRecordError(changeName: String, changeType: RecordType)
 final case class CnameAtZoneApexError(zoneName: String) extends DomainValidationError {
   def message: String = s"""CNAME cannot be the same name as zone "$zoneName"."""
 }
+
+final case class RecordRequiresManualReview(fqdn: String, fatal: Boolean = false)
+    extends DomainValidationError(fatal) {
+  def message: String =
+    s"""Record set with name "$fqdn" is configured to require manual review, but manual review is
+       |not enabled.""".stripMargin
+      .replaceAll("\n", " ")
+}
+
 // $COVERAGE-ON$

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -34,7 +34,7 @@ object DomainValidationErrorType extends Enumeration {
   InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
   CnameIsNotUniqueError, UserIsNotAuthorized, RecordNameNotUniqueInBatch, RecordInReverseZoneError,
   HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError, NewMultiRecordError,
-  CnameAtZoneApexError = Value
+  CnameAtZoneApexError, RecordRequiresManualReview = Value
 
   // $COVERAGE-OFF$
   def from(error: DomainValidationError): DomainValidationErrorType =
@@ -66,6 +66,7 @@ object DomainValidationErrorType extends Enumeration {
       case _: ExistingMultiRecordError => ExistingMultiRecordError
       case _: NewMultiRecordError => NewMultiRecordError
       case _: CnameAtZoneApexError => CnameAtZoneApexError
+      case _: RecordRequiresManualReview => RecordRequiresManualReview
     }
   // $COVERAGE-ON$
 }


### PR DESCRIPTION
Similar to existing high-value domains where we disallow certain records from being created via configuration, domains requiring manual review is a configured list that requires manual review (via batch interface) for the change to process. This PR takes care of only the batch interface process flow, with the record set restriction being handled separately.

Changes in this pull request:
- Add configuration (`manual-review-domains`) for changes that will automatically be flagged as non-fatal errors. If manual review is disabled, this will manifest as fatal errors. If manual review is enabled, these will be handled normally.
- Add tests
