### PR TITLE
validate scheduled time is in the future

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -276,7 +276,7 @@ def test_create_batch_change_with_scheduled_time_and_owner_group_succeeds(shared
     Test successfully creating a batch change with scheduled time and owner group set
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    dt = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+    dt = (datetime.datetime.now() + datetime.timedelta(1)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     batch_change_input = {
         "comments": "this is optional",

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -276,7 +276,7 @@ def test_create_batch_change_with_scheduled_time_and_owner_group_succeeds(shared
     Test successfully creating a batch change with scheduled time and owner group set
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    dt = (datetime.datetime.now() + datetime.timedelta(1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    dt = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     batch_change_input = {
         "comments": "this is optional",
@@ -298,7 +298,7 @@ def test_create_scheduled_batch_change_with_zone_discovery_error_without_owner_g
     Test creating a scheduled batch without owner group ID fails if there is a zone discovery error
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    dt = (datetime.datetime.now() + datetime.timedelta(1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    dt = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     batch_change_input = {
         "comments": "this is optional",
@@ -319,7 +319,7 @@ def test_create_scheduled_batch_change_with_scheduled_time_in_the_past_fails(sha
     Test creating a scheduled batch with a scheduled time in the past
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    yesterday = (datetime.datetime.now() - datetime.timedelta(1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     batch_change_input = {
         "comments": "this is optional",

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -62,6 +62,10 @@ case object ScheduledChangesDisabled extends BatchChangeErrorResponse {
     "Cannot create a scheduled change, as it is currently disabled on this VinylDNS instance."
 }
 
+case object ScheduledTimeMustBeInFuture extends BatchChangeErrorResponse {
+  val message: String = "Scheduled time must be in the future."
+}
+
 final case class ScheduledChangeNotDue(scheduledTime: DateTime) extends BatchChangeErrorResponse {
   val message: String =
     s"Cannot process scheduled change as it is not past the scheduled date of $scheduledTime"

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -107,12 +107,6 @@ class BatchChangeValidations(
         else NotAMemberOfOwnerGroup(groupId, authPrincipal.signedInUser.userName).invalidNel
     }
 
-//  def validateScheduledTime(scheduledTime: Option[DateTime]): SingleValidation[Unit] =
-//    (scheduledTime) match {
-//      case Some(dt) if dt.isBeforeNow => ScheduledTimeMustBeInFuture().invalidNel
-//      case _ => ().validNel
-//    }
-
   def validateBatchChangeRejection(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
@@ -513,11 +507,10 @@ class BatchChangeValidations(
   def validateScheduledChange(
       input: BatchChangeInput,
       scheduledChangesEnabled: Boolean): Either[BatchChangeErrorResponse, Unit] =
-    (scheduledChangesEnabled, input.scheduledTime.isEmpty) match {
-      case (_, true) => Right(())
-      case (true, false) if input.scheduledTime.get.isAfterNow() => Right(())
-      case (true, false) if !input.scheduledTime.get.isAfterNow() =>
-        Left(ScheduledTimeMustBeInFuture)
-      case (false, false) => Left(ScheduledChangesDisabled)
+    (scheduledChangesEnabled, input.scheduledTime) match {
+      case (_, None) => Right(())
+      case (true, Some(scheduledTime)) if scheduledTime.isAfterNow => Right(())
+      case (true, _) => Left(ScheduledTimeMustBeInFuture)
+      case (false, _) => Left(ScheduledChangesDisabled)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -44,6 +44,8 @@ class BatchChangeRoute(
       complete(StatusCodes.BadRequest, ManualReviewRequiresOwnerGroup.message)
     case ScheduledChangesDisabled =>
       complete(StatusCodes.BadRequest, ScheduledChangesDisabled.message)
+    case ScheduledTimeMustBeInFuture =>
+      complete(StatusCodes.BadRequest, ScheduledTimeMustBeInFuture.message)
     case scnpd: ScheduledChangeNotDue => complete(StatusCodes.Forbidden, scnpd.message)
   }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -28,10 +28,12 @@ sealed abstract class DomainValidationError(val isFatal: Boolean = true) {
 final case class ChangeLimitExceeded(limit: Int) extends DomainValidationError {
   def message: String = s"Cannot request more than $limit changes in a single batch change request"
 }
+
 final case class BatchChangeIsEmpty(limit: Int) extends DomainValidationError {
   def message: String =
     s"Batch change contained no changes. Batch change must have at least one change, up to a maximum of $limit changes."
 }
+
 final case class GroupDoesNotExist(id: String) extends DomainValidationError {
   def message: String = s"""Group with ID "$id" was not found"""
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -35,6 +35,7 @@ final case class BatchChangeIsEmpty(limit: Int) extends DomainValidationError {
 final case class GroupDoesNotExist(id: String) extends DomainValidationError {
   def message: String = s"""Group with ID "$id" was not found"""
 }
+
 final case class NotAMemberOfOwnerGroup(ownerGroupId: String, userName: String)
     extends DomainValidationError {
   def message: String =


### PR DESCRIPTION
For scheduled changes we don't want users setting a time in the past.

Changes in this pull request:
- if scheduled changes are enabled check that the scheduled time is after the current time

I went the current time, but we could easily change it to an hour from the current time or some other set time from the current time.