### PR TITLE
Fix docker releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,7 @@ lazy val portalDockerSettings = Seq(
   dockerCommands ++= Seq(
     Cmd("USER", "root"), // switch to root so we can install netcat
     ExecCmd("RUN", "apk", "add", "--update", "--no-cache", "netcat-openbsd", "bash"),
-    Cmd("USER", "1001:0") // switch back to the daemon user
+    Cmd("USER", "1001:0") // switch back to the user that runs the process
   ),
 
   credentials in Docker := Seq(Credentials(Path.userHome / ".ivy2" / ".dockerCredentials"))

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ lazy val apiDockerSettings = Seq(
   dockerExposedVolumes := Seq("/opt/docker/conf"), // mount extra config to the classpath
 
   // add extra libs to class path via mount
-  scriptClasspath in bashScriptDefines ~= (cp => cp :+ "/opt/docker/lib_extra/*"),
+  scriptClasspath in bashScriptDefines ~= (cp => cp :+ "${app_home}/../lib_extra/*"),
 
   // adds config file to mount
   bashScriptExtraDefines += """addJava "-Dconfig.file=${app_home}/../conf/application.conf"""",
@@ -134,7 +134,7 @@ lazy val apiDockerSettings = Seq(
   dockerCommands ++= Seq(
     Cmd("USER", "root"), // switch to root so we can install netcat
     ExecCmd("RUN", "apk", "add", "--update", "--no-cache", "netcat-openbsd", "bash"),
-    Cmd("USER", "daemon") // switch back to the daemon user
+    Cmd("USER", "1001:0") // switch back to the daemon user
   ),
   composeFile := baseDirectory.value.getAbsolutePath + "/../../docker/docker-compose.yml"
 )
@@ -148,21 +148,25 @@ lazy val portalDockerSettings = Seq(
   dockerExposedVolumes := Seq("/opt/docker/conf"), // mount extra config to the classpath
 
   // add extra libs to class path via mount
-  scriptClasspath in bashScriptDefines ~= (cp => cp :+ "/opt/docker/lib_extra/*"),
+  scriptClasspath in bashScriptDefines ~= (cp => cp :+ "${app_home}/../lib_extra/*"),
 
   // adds config file to mount
-  bashScriptExtraDefines += """addJava "-Dconfig.file=/opt/docker/conf/application.conf"""",
-  bashScriptExtraDefines += """addJava "-Dlogback.configurationFile=/opt/docker/conf/logback.xml"""",
+  bashScriptExtraDefines += """addJava "-Dconfig.file=${app_home}/../conf/application.conf"""",
+  bashScriptExtraDefines += """addJava "-Dlogback.configurationFile=${app_home}/../conf/logback.xml"""",
 
   // this is the default version, can be overridden
   bashScriptExtraDefines += s"""addJava "-Dvinyldns.base-version=${(version in ThisBuild).value}"""",
 
+  // needed to avoid access issue in play for the RUNNING_PID
+  // https://github.com/lightbend/sbt-reactive-app/issues/177
+  bashScriptExtraDefines += s"""addJava "-Dplay.server.pidfile.path=/dev/null"""",
+
   // wait for mysql
-  bashScriptExtraDefines += "(cd /opt/docker/ && ./wait-for-dependencies.sh && cd -)",
+  bashScriptExtraDefines += "(cd ${app_home}/../ && ls && ./wait-for-dependencies.sh && cd -)",
   dockerCommands ++= Seq(
     Cmd("USER", "root"), // switch to root so we can install netcat
     ExecCmd("RUN", "apk", "add", "--update", "--no-cache", "netcat-openbsd", "bash"),
-    Cmd("USER", "daemon") // switch back to the daemon user
+    Cmd("USER", "1001:0") // switch back to the daemon user
   ),
 
   credentials in Docker := Seq(Credentials(Path.userHome / ".ivy2" / ".dockerCredentials"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "5.0.0")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.3.7")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.23")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.25")
 
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")
 


### PR DESCRIPTION
There was an issue starting the docker containers due to how native packager
works where we were seeing issues with the container being able to start.

The issue was that we were assuming a "daemon" user to run the containers under.
At some point this changed to "1001:0".  As a result, there were not sufficient
privileges to start the containers because the "daemon" user was invalid or did
not have access to the scripts created by sbt native packager.

* `build.sbt` - update the user to "1001:0" for our custom install.  Cleaned up the hardcoded references in the script extras to `/opt/docker` to use the variable `app_home` instead.
* `plugins.sbt` - updated to the latest sbt native packager

