### PR TITLE
add review confirmation to DNS Change form

### DIFF
--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -587,8 +587,17 @@ class VinylDNS @Inject()(
     // $COVERAGE-OFF$
     val json = request.body.asJson
     val payload = json.map(Json.stringify)
+    val queryParameters = new HashMap[String, java.util.List[String]]()
+    for {
+      (name, values) <- request.queryString
+    } queryParameters.put(name, values.asJava)
     val vinyldnsRequest =
-      new VinylDNSRequest("POST", s"$vinyldnsServiceBackend", "zones/batchrecordchanges", payload)
+      new VinylDNSRequest(
+        "POST",
+        s"$vinyldnsServiceBackend",
+        "zones/batchrecordchanges",
+        payload,
+        parameters = queryParameters)
     executeRequest(vinyldnsRequest, request.user).map(response => {
       logger.info(response.body)
       Status(response.status)(response.body)

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -2,7 +2,8 @@
 
 @content = {
 <!-- PAGE CONTENT -->
-<div class="right_col" role="main" ng-init="batchChangeLimit = @meta.batchChangeLimit; defaultTtl = @meta.defaultTtl">
+<div class="right_col" role="main" ng-init="batchChangeLimit = @meta.batchChangeLimit; defaultTtl = @meta.defaultTtl;
+    manualReviewEnabled = @meta.manualBatchChangeReviewEnabled">
 
     <!-- BREADCRUMB -->
     <ul class="breadcrumb">
@@ -98,7 +99,7 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                <tr ng-repeat="change in newBatch.changes track by $index" ng-class="{changeError: change.errors}">
+                                <tr ng-repeat="change in newBatch.changes track by $index" ng-class="{changeError: change.errors && !allowManualReview, softError: change.errors && allowManualReview}">
                                     <td><span>{{$index + 1}}</span></td>
                                     <td>
                                         <select class="form-control changeType" ng-model="change.changeType">
@@ -228,10 +229,10 @@
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">
-                                <button type="button" id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange()">Submit</button>
+                                <button type="button" id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange(manualReviewEnabled)">Submit</button>
                             </div>
                             <div ng-if="formStatus=='pendingConfirm'" class="pull-right">
-                                <span>Are you sure you want to submit this DNS change request?</span>
+                                <span>{{confirmationPrompt}}</span>
                                 <button class="btn btn-default" ng-click="cancelSubmit()">Cancel</button>
                                 <button class="btn btn-success" type="submit" ng-click="confirmSubmit(createBatchChangeForm)">Confirm</button>
                             </div>

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -99,7 +99,7 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                <tr ng-repeat="change in newBatch.changes track by $index" ng-class="{changeError: change.errors && !allowManualReview, softError: change.errors && allowManualReview}">
+                                <tr ng-repeat="change in newBatch.changes track by $index" ng-class="{changeError: change.errors && !softErrors, softError: softErrors}">
                                     <td><span>{{$index + 1}}</span></td>
                                     <td>
                                         <select class="form-control changeType" ng-model="change.changeType">
@@ -232,7 +232,7 @@
                                 <button type="button" id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange(manualReviewEnabled)">Submit</button>
                             </div>
                             <div ng-if="formStatus=='pendingConfirm'" class="pull-right">
-                                <span>{{confirmationPrompt}}</span>
+                                <span>{{ confirmationPrompt }}</span>
                                 <button class="btn btn-default" ng-click="cancelSubmit()">Cancel</button>
                                 <button class="btn btn-success" type="submit" ng-click="confirmSubmit(createBatchChangeForm)">Confirm</button>
                             </div>

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -376,6 +376,10 @@ label.switch {
     background: rgba(255, 0, 0, 0.32);
 }
 
+.softError {
+    background: rgb(240,173,78, 0.32);
+}
+
 .batch-label {
     color: #73879C;
 }

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -37,6 +37,9 @@
             $scope.ownerGroupError = false;
             $scope.formStatus = "pendingSubmit";
             $scope.scheduledOption = false;
+            $scope.allowManualReview = false;
+            $scope.confirmationPrompt = "Are you sure you want to submit this batch change request?";
+            $scope.manualReviewEnabled;
 
             $scope.addSingleChange = function() {
                 $scope.newBatch.changes.push({changeType: "Add", type: "A+PTR"});
@@ -93,7 +96,7 @@
 
                 formatData(payload);
 
-                return batchChangeService.createBatchChange(payload)
+                return batchChangeService.createBatchChange(payload, $scope.allowManualReview)
                     .then(success)
                     .catch(function (error){
                         if(error.data.errors || error.status !== 400 || typeof error.data == "string"){
@@ -101,10 +104,18 @@
                         } else {
                             $scope.newBatch.changes = error.data;
                             $scope.batchChangeErrors = true;
-                            $scope.ownerGroupError = error.data.flatMap(d => d.errors)
-                                .some(e => e.includes('owner group ID must be specified for record'));
-                            $scope.formStatus = "pendingSubmit";
-                            $scope.alerts.push({type: 'danger', content: 'Errors found. Please correct and submit again.'});
+                            $scope.listOfErrors = error.data.flatMap(d => d.errors)
+                            $scope.ownerGroupError = $scope.listOfErrors.some(e => e.includes('owner group ID must be specified for record'));
+                            var hardErrors = $scope.listOfErrors.every(e => ['Zone Discovery Failed'].includes(e));
+                            if ($scope.manualReviewEnabled && !hardErrors) {
+                                $scope.allowManualReview = true;
+                                $scope.formStatus = "pendingConfirm";
+                                $scope.alerts.push({type: 'warning', content: 'Issues found. Please correct or submit for review.'});
+                                $scope.confirmationPrompt = "Would you like to submit this change for review?"
+                            } else {
+                                $scope.formStatus = "pendingSubmit";
+                                $scope.alerts.push({type: 'danger', content: 'Errors found. Please correct and submit again.'});
+                            }
                         }
                     });
             };
@@ -114,8 +125,9 @@
                 $scope.newBatch.changes.splice(changeNumber, 1);
             };
 
-            $scope.submitChange = function() {
+            $scope.submitChange = function(manualReviewEnabled) {
                 $scope.formStatus = "pendingConfirm";
+                $scope.manualReviewEnabled = manualReviewEnabled;
             }
 
             $scope.getLocalTimeZone = function() {

--- a/modules/portal/public/lib/batch-change/batch-change-new.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-new.controller.js
@@ -35,6 +35,7 @@
             $scope.alerts = [];
             $scope.batchChangeErrors = false;
             $scope.ownerGroupError = false;
+            $scope.softErrors = false;
             $scope.formStatus = "pendingSubmit";
             $scope.scheduledOption = false;
             $scope.allowManualReview = false;
@@ -49,6 +50,8 @@
 
             $scope.cancelSubmit = function() {
                 $scope.formStatus = "pendingSubmit";
+                $scope.allowManualReview = false;
+                $scope.confirmationPrompt = "Are you sure you want to submit this batch change request?";
             };
 
             $scope.confirmSubmit = function(form) {
@@ -106,13 +109,15 @@
                             $scope.batchChangeErrors = true;
                             $scope.listOfErrors = error.data.flatMap(d => d.errors)
                             $scope.ownerGroupError = $scope.listOfErrors.some(e => e.includes('owner group ID must be specified for record'));
-                            var hardErrors = $scope.listOfErrors.every(e => ['Zone Discovery Failed'].includes(e));
+                            var hardErrors = $scope.listOfErrors.every(e => ['Zone Discovery Failed', 'Record set with name'].includes(e));
                             if ($scope.manualReviewEnabled && !hardErrors) {
                                 $scope.allowManualReview = true;
+                                $scope.softErrors = true;
                                 $scope.formStatus = "pendingConfirm";
-                                $scope.alerts.push({type: 'warning', content: 'Issues found. Please correct or submit for review.'});
+                                $scope.alerts.push({type: 'warning', content: 'Issues found that require manual review. Please correct or confirm submission for review.'});
                                 $scope.confirmationPrompt = "Would you like to submit this change for review?"
                             } else {
+                                $scope.softErrors = false;
                                 $scope.formStatus = "pendingSubmit";
                                 $scope.alerts.push({type: 'danger', content: 'Errors found. Please correct and submit again.'});
                             }

--- a/modules/portal/public/lib/batch-change/batch-change.service.js
+++ b/modules/portal/public/lib/batch-change/batch-change.service.js
@@ -25,8 +25,11 @@
                 return $http.get(url);
             };
 
-            this.createBatchChange = function (data) {
-                var url = '/api/dnschanges';
+            this.createBatchChange = function (data, allowManualReview) {
+                var params = {
+                    "allowManualReview": allowManualReview
+                }
+                var url = utilityService.urlBuilder('/api/dnschanges', params);
                 return $http.post(url, data, {headers: utilityService.getCsrfHeader()});
             };
 


### PR DESCRIPTION
Trying this out. We may or may not decide to go with it.

Changes in this pull request:
- If manual review is enabled and the user submits a batch change with only soft errors we'll ask them to confirm they want to proceed to manual review. 
- change the alert message and change background colors to the warning yellow instead of danger red.
- Note: This first pass only includes the Zone Discovery Failed error message.

![DNS-Change-Review-Confirmation](https://user-images.githubusercontent.com/4439228/62644529-518c1780-b918-11e9-9a03-d95787b82f9d.png)

What else can we do in the portal to mitigate questions users might have about the review process?