### PR TITLE
JSON deserialization and protobuf changes for remove single DNS record entry

### DIFF
--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -418,11 +418,21 @@ def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address="1.1.1.
             }
         }
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": record_type
-        }
+        if change_type == "DeleteRecord":
+            json = {
+                "changeType": "DeleteRecord",
+                "inputName": input_name,
+                "type": record_type,
+                "record": {
+                    "address": address
+                }
+            }
+        else:
+            json = {
+                "changeType": "DeleteRecordSet",
+                "inputName": input_name,
+                "type": record_type
+            }
     return json
 
 def get_change_CNAME_json(input_name, ttl=200, cname="test.com", change_type="Add"):

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -267,7 +267,7 @@ class BatchChangeService(
           }
           .getOrElse(add)
           .validNel
-      case del: DeleteChangeForValidation => del.validNel
+      case del: DeleteRRSetChangeForValidation => del.validNel
     }
 
   def getOwnerGroup(ownerGroupId: Option[String]): BatchResult[Option[Group]] = {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -176,7 +176,10 @@ class BatchChangeValidations(
       isApproved: Boolean): ValidatedBatch[ChangeInput] =
     input.map {
       case a: AddChangeInput => validateAddChangeInput(a, isApproved).map(_ => a)
-      case d: DeleteChangeInput => validateInputName(d, isApproved).map(_ => d)
+      case d: DeleteRRSetChangeInput => validateInputName(d, isApproved).map(_ => d)
+      // TODO: Add DeleteRecordChangeInput validations
+      case _: DeleteRecordChangeInput =>
+        UnsupportedOperation("DeleteRecordChangeInput").invalidNel
     }
 
   def validateAddChangeInput(
@@ -257,10 +260,10 @@ class BatchChangeValidations(
           auth,
           isApproved,
           batchOwnerGroupId)
-      case deleteUpdate: DeleteChangeForValidation
+      case deleteUpdate: DeleteRRSetChangeForValidation
           if changeGroups.containsAddChangeForValidation(deleteUpdate.recordKey) =>
         validateDeleteUpdateWithContext(deleteUpdate, existingRecords, auth, isApproved)
-      case del: DeleteChangeForValidation =>
+      case del: DeleteRRSetChangeForValidation =>
         validateDeleteWithContext(del, existingRecords, auth, isApproved)
     }
   }
@@ -292,7 +295,7 @@ class BatchChangeValidations(
       ().validNel
 
   def validateDeleteWithContext(
-      change: DeleteChangeForValidation,
+      change: DeleteRRSetChangeForValidation,
       existingRecords: ExistingRecordSets,
       auth: AuthPrincipal,
       isApproved: Boolean): SingleValidation[ChangeForValidation] = {
@@ -341,7 +344,7 @@ class BatchChangeValidations(
   }
 
   def validateDeleteUpdateWithContext(
-      change: DeleteChangeForValidation,
+      change: DeleteRRSetChangeForValidation,
       existingRecords: ExistingRecordSets,
       auth: AuthPrincipal,
       isApproved: Boolean): SingleValidation[ChangeForValidation] = {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -88,7 +88,12 @@ object BatchTransformations {
     def apply(zone: Zone, recordName: String, changeInput: ChangeInput): ChangeForValidation =
       changeInput match {
         case a: AddChangeInput => AddChangeForValidation(zone, recordName, a)
-        case d: DeleteChangeInput => DeleteChangeForValidation(zone, recordName, d)
+        case d: DeleteRRSetChangeInput =>
+          DeleteRRSetChangeForValidation(zone, recordName, d)
+        // TODO: Support DeleteRecordChangeInput in ChangeForValidation
+        case _: DeleteRecordChangeInput =>
+          throw new UnsupportedOperationException(
+            "DeleteRecordChangeInput is not yet implemented/supported in VinylDNS.")
       }
   }
 
@@ -124,10 +129,10 @@ object BatchTransformations {
     def isDeleteChangeForValidation: Boolean = false
   }
 
-  final case class DeleteChangeForValidation(
+  final case class DeleteRRSetChangeForValidation(
       zone: Zone,
       recordName: String,
-      inputChange: DeleteChangeInput)
+      inputChange: DeleteRRSetChangeInput)
       extends ChangeForValidation {
     def asStoredChange(changeId: Option[String] = None): SingleChange =
       SingleDeleteRRSetChange(

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -23,7 +23,8 @@ import vinyldns.core.domain.batch.{
   BatchChangeApprovalStatus,
   SingleAddChange,
   SingleChange,
-  SingleDeleteRRSetChange
+  SingleDeleteRRSetChange,
+  SingleDeleteRecordChange
 }
 import vinyldns.core.domain.membership.UserRepository
 import vinyldns.core.domain.membership.User
@@ -145,6 +146,22 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
     case SingleDeleteRRSetChange(_, _, _, inputName, typ, status, systemMessage, _, _, _, _) =>
       s"""<tr><td>${index + 1}</td><td>Delete</td><td>$typ</td><td>$inputName</td>
         |     <td></td><td></td><td>$status</td><td>${systemMessage.getOrElse("")}</td></tr>"""
+    case SingleDeleteRecordChange(
+        _,
+        _,
+        _,
+        inputName,
+        typ,
+        recordData,
+        status,
+        systemMessage,
+        _,
+        _,
+        _,
+        _) =>
+      s"""<tr><td>${index + 1}</td><td>Delete</td><td>$typ</td><td>$inputName</td>
+         |     <td></td><td>$recordData</td><td>$status</td><td>${systemMessage
+        .getOrElse("")}</td></tr>"""
   }
 
   def formatRecordData(rd: RecordData): String = rd match {

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -73,7 +73,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       asAdd.recordSetId shouldBe None
     }
     "Convert a DeleteChangeInput into SingleDeleteRRSetChange" in {
-      val changeA = DeleteChangeInput("some.test.com", A)
+      val changeA = DeleteRRSetChangeInput("some.test.com", A)
       val converted = changeA.asNewStoredChange(NonEmptyList.of(ZoneDiscoveryError("test")))
 
       converted shouldBe a[SingleDeleteRRSetChange]
@@ -124,7 +124,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       )
 
       val expectedDelChange =
-        DeleteChangeInput("testRname.testZoneName.", A)
+        DeleteRRSetChangeInput("testRname.testZoneName.", A)
 
       val change = BatchChange(
         "userId",

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1686,7 +1686,7 @@ class BatchChangeServiceSpec
 
     "return a BatchChangeErrorList if all data inputs are valid/soft failures, scheduled, " +
       "and manual review is disabled" in {
-      val delete = DeleteChangeInput("some.test.delete.", RecordType.TXT)
+      val delete = DeleteRRSetChangeInput("some.test.delete.", RecordType.TXT)
       val result = underTest
         .buildResponse(
           BatchChangeInput(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -490,7 +490,7 @@ class BatchChangeServiceSpec
       val noTtl = AddChangeInput("no-ttl-add.test.com", RecordType.A, None, AData("1.1.1.1"))
       val withTtl =
         AddChangeInput("with-ttl-add-2.test.com", RecordType.A, Some(900), AData("1.1.1.1"))
-      val noTtlDel = DeleteChangeInput("non-apex.test.com.", RecordType.TXT)
+      val noTtlDel = DeleteRRSetChangeInput("non-apex.test.com.", RecordType.TXT)
       val noTtlUpdate =
         AddChangeInput("non-apex.test.com.", RecordType.TXT, None, TXTData("hello"))
 
@@ -1544,7 +1544,7 @@ class BatchChangeServiceSpec
 
     "return a BatchChange if all data inputs are valid/soft failures and manual review is enabled and owner group ID " +
       "is provided" in {
-      val delete = DeleteChangeInput("some.test.delete.", RecordType.TXT)
+      val delete = DeleteRRSetChangeInput("some.test.delete.", RecordType.TXT)
       val result = underTestManualEnabled
         .buildResponse(
           BatchChangeInput(None, List(apexAddA, onlyBaseAddAAAA, delete), Some("owner-group-ID")),
@@ -1666,7 +1666,7 @@ class BatchChangeServiceSpec
     }
 
     "return a BatchChangeErrorList if all data inputs are valid/soft failures and manual review is disabled" in {
-      val delete = DeleteChangeInput("some.test.delete.", RecordType.TXT)
+      val delete = DeleteRRSetChangeInput("some.test.delete.", RecordType.TXT)
       val result = underTest
         .buildResponse(
           BatchChangeInput(None, List(apexAddA, onlyBaseAddAAAA, delete)),
@@ -1731,7 +1731,7 @@ class BatchChangeServiceSpec
 
     "return a BatchChangeErrorList if all data inputs are valid/soft failures, manual review is enabled, " +
       "but batch change allowManualReview attribute is false" in {
-      val delete = DeleteChangeInput("some.test.delete.", RecordType.TXT)
+      val delete = DeleteRRSetChangeInput("some.test.delete.", RecordType.TXT)
       val result = underTestManualEnabled
         .buildResponse(
           BatchChangeInput(None, List(apexAddA, onlyBaseAddAAAA, delete)),

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -115,31 +115,31 @@ class BatchChangeValidationsSpec
     "private-update",
     AddChangeInput("private-update", RecordType.A, ttl, AAAAData("1.2.3.4")))
 
-  private val updatePrivateDeleteChange = DeleteChangeForValidation(
+  private val updatePrivateDeleteChange = DeleteRRSetChangeForValidation(
     okZone,
     "private-update",
-    DeleteChangeInput("private-update", RecordType.A))
+    DeleteRRSetChangeInput("private-update", RecordType.A))
 
   private val updateSharedAddChange = AddChangeForValidation(
     sharedZone,
     "shared-update",
     AddChangeInput("shared-update", RecordType.AAAA, ttl, AAAAData("1:2:3:4:5:6:7:8")))
 
-  private val updateSharedDeleteChange = DeleteChangeForValidation(
+  private val updateSharedDeleteChange = DeleteRRSetChangeForValidation(
     sharedZone,
     "shared-update",
-    DeleteChangeInput("shared-update", RecordType.AAAA))
+    DeleteRRSetChangeInput("shared-update", RecordType.AAAA))
 
-  private val deletePrivateChange = DeleteChangeForValidation(
+  private val deletePrivateChange = DeleteRRSetChangeForValidation(
     okZone,
     "private-delete",
-    DeleteChangeInput("private-delete", RecordType.A)
+    DeleteRRSetChangeInput("private-delete", RecordType.A)
   )
 
-  private val deleteSharedChange = DeleteChangeForValidation(
+  private val deleteSharedChange = DeleteRRSetChangeForValidation(
     sharedZone,
     "shared-delete",
-    DeleteChangeInput("shared-delete", RecordType.AAAA)
+    DeleteRRSetChangeInput("shared-delete", RecordType.AAAA)
   )
 
   private val validPendingBatchChange = BatchChange(
@@ -494,7 +494,7 @@ class BatchChangeValidationsSpec
 
   property("""validateInputName: should fail with a DomainValidationError for deletes
       |if validateHostName fails for an invalid domain name""".stripMargin) {
-    val change = DeleteChangeInput("invalidDomainName$", RecordType.A)
+    val change = DeleteRRSetChangeInput("invalidDomainName$", RecordType.A)
     val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
   }
@@ -502,7 +502,7 @@ class BatchChangeValidationsSpec
   property("""validateInputName: should fail with a DomainValidationError for deletes
       |if validateHostName fails for an invalid domain name length""".stripMargin) {
     val invalidDomainName = Random.alphanumeric.take(256).mkString
-    val change = DeleteChangeInput(invalidDomainName, RecordType.AAAA)
+    val change = DeleteRRSetChangeInput(invalidDomainName, RecordType.AAAA)
     val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName(s"$invalidDomainName."))
       .and(haveInvalid[DomainValidationError](InvalidLength(s"$invalidDomainName.", 2, 255)))
@@ -511,7 +511,7 @@ class BatchChangeValidationsSpec
   property("""validateInputName: PTR should fail with InvalidIPAddress for deletes
       |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
     val invalidIp = "invalidIp.111"
-    val change = DeleteChangeInput(invalidIp, RecordType.PTR)
+    val change = DeleteRRSetChangeInput(invalidIp, RecordType.PTR)
     val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidIPAddress(invalidIp))
   }
@@ -704,7 +704,10 @@ class BatchChangeValidationsSpec
       "update",
       AddChangeInput("update.ok.", RecordType.A, ttl, AData("1.2.3.4")))
     val deleteUpdateA =
-      DeleteChangeForValidation(okZone, "Update", DeleteChangeInput("update.ok.", RecordType.A))
+      DeleteRRSetChangeForValidation(
+        okZone,
+        "Update",
+        DeleteRRSetChangeInput("update.ok.", RecordType.A))
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
@@ -723,10 +726,10 @@ class BatchChangeValidationsSpec
       okZone.addACLRule(writeAcl),
       "update",
       AddChangeInput("update.ok.", RecordType.A, ttl, AData("1.2.3.4")))
-    val deleteUpdateA = DeleteChangeForValidation(
+    val deleteUpdateA = DeleteRRSetChangeForValidation(
       okZone.addACLRule(writeAcl),
       "update",
-      DeleteChangeInput("update.ok.", RecordType.A))
+      DeleteRRSetChangeInput("update.ok.", RecordType.A))
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
@@ -747,10 +750,10 @@ class BatchChangeValidationsSpec
       okZone.addACLRule(readAcl),
       "update",
       AddChangeInput("update.ok.", RecordType.A, ttl, AData("1.2.3.4")))
-    val deleteUpdateA = DeleteChangeForValidation(
+    val deleteUpdateA = DeleteRRSetChangeForValidation(
       okZone.addACLRule(readAcl),
       "update",
-      DeleteChangeInput("update.ok.", RecordType.A))
+      DeleteRRSetChangeInput("update.ok.", RecordType.A))
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
@@ -769,10 +772,10 @@ class BatchChangeValidationsSpec
       okZone,
       "does-not-exist",
       AddChangeInput("does-not-exist.ok.", RecordType.A, ttl, AData("1.2.3.4")))
-    val deleteUpdateA = DeleteChangeForValidation(
+    val deleteUpdateA = DeleteRRSetChangeForValidation(
       okZone,
       "does-not-exist",
-      DeleteChangeInput("does-not-exist.ok.", RecordType.A))
+      DeleteRRSetChangeInput("does-not-exist.ok.", RecordType.A))
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List()),
@@ -796,7 +799,10 @@ class BatchChangeValidationsSpec
       "mx",
       AddChangeInput("mx.shared.", RecordType.MX, ttl, MXData(200, "mx")))
     val deleteUpdateA =
-      DeleteChangeForValidation(sharedZone, "mx", DeleteChangeInput("mx.shared.", RecordType.MX))
+      DeleteRRSetChangeForValidation(
+        sharedZone,
+        "mx",
+        DeleteRRSetChangeInput("mx.shared.", RecordType.MX))
     val result = validateChangesWithContext(
       List(addUpdateA.validNel, deleteUpdateA.validNel),
       ExistingRecordSets(List(existingRecord)),
@@ -815,10 +821,10 @@ class BatchChangeValidationsSpec
       okZone,
       "existing",
       AddChangeInput("existing.ok.", RecordType.A, ttl, AData("1.2.3.4")))
-    val deleteCname = DeleteChangeForValidation(
+    val deleteCname = DeleteRRSetChangeForValidation(
       okZone,
       "existing",
-      DeleteChangeInput("existing.ok.", RecordType.CNAME))
+      DeleteRRSetChangeInput("existing.ok.", RecordType.CNAME))
     val result = validateChangesWithContext(
       List(addA.validNel, deleteCname.validNel),
       ExistingRecordSets(List(existingCname)),
@@ -906,10 +912,10 @@ class BatchChangeValidationsSpec
       validZone,
       "existingCname",
       AddChangeInput("existingCname.ok.", RecordType.CNAME, ttl, CNAMEData("cname")))
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       validZone,
       "existingCname",
-      DeleteChangeInput("existingCname.ok.", RecordType.A))
+      DeleteRRSetChangeInput("existingCname.ok.", RecordType.A))
     val existingA = rsOk.copy(zoneId = addCname.zone.id, name = addCname.recordName)
     val newRecordSetList = existingA :: recordSetList
     val result = validateChangesWithContext(
@@ -949,10 +955,10 @@ class BatchChangeValidationsSpec
       "30",
       AddChangeInput("30.2.0.192.in-addr.arpa.", RecordType.CNAME, ttl, CNAMEData("cname"))
     )
-    val deletePtr = DeleteChangeForValidation(
+    val deletePtr = DeleteRRSetChangeForValidation(
       validIp4ReverseZone,
       "30",
-      DeleteChangeInput("192.0.2.30", RecordType.PTR))
+      DeleteRRSetChangeInput("192.0.2.30", RecordType.PTR))
     val ptr4 = ptrIp4.copy(zoneId = validIp4ReverseZone.id)
     val result = validateChangesWithContext(
       List(addCname.validNel, deletePtr.validNel),
@@ -1188,10 +1194,10 @@ class BatchChangeValidationsSpec
 
   property(
     "validateChangesWithContext: should succeed for DeleteChangeForValidation if record exists") {
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       validZone,
       "Record-exists",
-      DeleteChangeInput("record-exists.ok.", RecordType.A))
+      DeleteRRSetChangeInput("record-exists.ok.", RecordType.A))
     val existingDeleteRecord =
       rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName.toLowerCase)
     val result = validateChangesWithContext(
@@ -1207,10 +1213,10 @@ class BatchChangeValidationsSpec
   property(
     """validateChangesWithContext: should fail DeleteChangeForValidation with RecordDoesNotExist
       |if record does not exist""".stripMargin) {
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       validZone,
       "record-does-not-exist",
-      DeleteChangeInput("record-does-not-exist.ok.", RecordType.A))
+      DeleteRRSetChangeInput("record-does-not-exist.ok.", RecordType.A))
     val result =
       validateChangesWithContext(
         List(deleteA.validNel),
@@ -1225,10 +1231,10 @@ class BatchChangeValidationsSpec
 
   property("""validateChangesWithContext: should succeed for DeleteChangeForValidation
       |if record set status is Active""".stripMargin) {
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       validZone,
       "Active-record-status",
-      DeleteChangeInput("active-record-status", RecordType.A))
+      DeleteRRSetChangeInput("active-record-status", RecordType.A))
     val existingDeleteRecord = rsOk.copy(
       zoneId = deleteA.zone.id,
       name = deleteA.recordName.toLowerCase,
@@ -1246,7 +1252,10 @@ class BatchChangeValidationsSpec
   property("""validateChangesWithContext: should succeed for DeleteChangeForValidation
       |if user has group admin access"""".stripMargin) {
     val deleteA =
-      DeleteChangeForValidation(validZone, "valid", DeleteChangeInput("valid.ok.", RecordType.A))
+      DeleteRRSetChangeForValidation(
+        validZone,
+        "valid",
+        DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
       List(deleteA.validNel),
@@ -1261,7 +1270,10 @@ class BatchChangeValidationsSpec
   property(""" validateChangesWithContext: should fail for DeleteChangeForValidation
       | if user is superUser with no other access""".stripMargin) {
     val deleteA =
-      DeleteChangeForValidation(validZone, "valid", DeleteChangeInput("valid.ok.", RecordType.A))
+      DeleteRRSetChangeForValidation(
+        validZone,
+        "valid",
+        DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
       List(deleteA.validNel),
@@ -1275,11 +1287,11 @@ class BatchChangeValidationsSpec
 
   property(
     "validateChangesWithContext: should succeed for DeleteChangeForValidation if user has necessary ACL rule") {
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       validZone.addACLRule(
         ACLRule(accessLevel = AccessLevel.Delete, userId = Some(notAuth.userId))),
       "valid",
-      DeleteChangeInput("valid.ok.", RecordType.A))
+      DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
       List(deleteA.validNel),
@@ -1294,10 +1306,10 @@ class BatchChangeValidationsSpec
   property(
     """validateChangesWithContext: should fail DeleteChangeForValidation with UserIsNotAuthorized if user
       |is not a superuser, doesn't have group admin access, or doesn't have necessary ACL rule""".stripMargin) {
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       validZone.addACLRule(ACLRule(accessLevel = AccessLevel.Write, userId = Some(notAuth.userId))),
       "valid",
-      DeleteChangeInput("valid.ok.", RecordType.A))
+      DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
       List(deleteA.validNel),
@@ -1322,7 +1334,10 @@ class BatchChangeValidationsSpec
       AddChangeInput("test.com.", RecordType.CNAME, ttl, CNAMEData("thing.com.")))
 
     val deleteA =
-      DeleteChangeForValidation(okZone, "delete", DeleteChangeInput("delete.ok.", RecordType.A))
+      DeleteRRSetChangeForValidation(
+        okZone,
+        "delete",
+        DeleteRRSetChangeInput("delete.ok.", RecordType.A))
     val addCname = AddChangeForValidation(
       okZone,
       "delete",
@@ -1331,10 +1346,10 @@ class BatchChangeValidationsSpec
       okZone,
       "delete-this",
       AddChangeInput("delete-this.ok.", RecordType.A, ttl, AData("10.1.1.1")))
-    val deleteCname = DeleteChangeForValidation(
+    val deleteCname = DeleteRRSetChangeForValidation(
       okZone,
       "delete",
-      DeleteChangeInput("delete-this.ok.", RecordType.CNAME))
+      DeleteRRSetChangeInput("delete-this.ok.", RecordType.CNAME))
     val existingA = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val existingCname =
       rsOk.copy(zoneId = deleteCname.zone.id, name = deleteCname.recordName, typ = RecordType.CNAME)
@@ -1365,7 +1380,7 @@ class BatchChangeValidationsSpec
     val existingA = rsOk.copy(name = "new")
 
     val deleteA =
-      DeleteChangeForValidation(okZone, "new", DeleteChangeInput("new.ok.", RecordType.A))
+      DeleteRRSetChangeForValidation(okZone, "new", DeleteRRSetChangeInput("new.ok.", RecordType.A))
     val addA = AddChangeForValidation(
       okZone,
       "test",
@@ -1397,7 +1412,10 @@ class BatchChangeValidationsSpec
       rsOk.copy(name = "new", typ = RecordType.CNAME, records = List(CNAMEData("hey.ok.")))
 
     val deleteCname =
-      DeleteChangeForValidation(okZone, "new", DeleteChangeInput("new.ok.", RecordType.CNAME))
+      DeleteRRSetChangeForValidation(
+        okZone,
+        "new",
+        DeleteRRSetChangeInput("new.ok.", RecordType.CNAME))
     val addA = AddChangeForValidation(
       okZone,
       "test",
@@ -1426,7 +1444,10 @@ class BatchChangeValidationsSpec
       rsOk.copy(name = "new", typ = RecordType.CNAME, records = List(CNAMEData("hey.ok.")))
 
     val deleteCname =
-      DeleteChangeForValidation(okZone, "new", DeleteChangeInput("new.ok.", RecordType.CNAME))
+      DeleteRRSetChangeForValidation(
+        okZone,
+        "new",
+        DeleteRRSetChangeInput("new.ok.", RecordType.CNAME))
     val addCname = AddChangeForValidation(
       okZone,
       "new",
@@ -1447,10 +1468,10 @@ class BatchChangeValidationsSpec
       typ = RecordType.CNAME,
       records = List(CNAMEData("existing.cname.")))
 
-    val deleteUpdateCname = DeleteChangeForValidation(
+    val deleteUpdateCname = DeleteRRSetChangeForValidation(
       okZone,
       "name-conflict",
-      DeleteChangeInput("existing.ok.", RecordType.CNAME))
+      DeleteRRSetChangeInput("existing.ok.", RecordType.CNAME))
     val addUpdateCname = AddChangeForValidation(
       okZone,
       "name-conflict",
@@ -1481,10 +1502,10 @@ class BatchChangeValidationsSpec
       typ = RecordType.PTR,
       records = List(PTRData("hey.there.")))
 
-    val deletePtr = DeleteChangeForValidation(
+    val deletePtr = DeleteRRSetChangeForValidation(
       validIp4ReverseZone,
       "193",
-      DeleteChangeInput("192.0.2.193", RecordType.PTR))
+      DeleteRRSetChangeInput("192.0.2.193", RecordType.PTR))
     val addCname = AddChangeForValidation(
       validIp4ReverseZone,
       "193",
@@ -1507,10 +1528,10 @@ class BatchChangeValidationsSpec
       typ = RecordType.PTR,
       records = List(PTRData("hey.ok.")))
 
-    val deletePtr = DeleteChangeForValidation(
+    val deletePtr = DeleteRRSetChangeForValidation(
       validIp4ReverseZone,
       "193",
-      DeleteChangeInput("192.0.2.193", RecordType.PTR))
+      DeleteRRSetChangeInput("192.0.2.193", RecordType.PTR))
     val addPtr = AddChangeForValidation(
       validIp4ReverseZone,
       "193",
@@ -1531,10 +1552,10 @@ class BatchChangeValidationsSpec
       typ = RecordType.PTR,
       records = List(PTRData("existing.ptr.")))
 
-    val deleteUpdatePtr = DeleteChangeForValidation(
+    val deleteUpdatePtr = DeleteRRSetChangeForValidation(
       validIp4ReverseZone,
       "193",
-      DeleteChangeInput("192.0.2.193", RecordType.PTR))
+      DeleteRRSetChangeInput("192.0.2.193", RecordType.PTR))
     val addUpdatePtr = AddChangeForValidation(
       validIp4ReverseZone,
       "193",
@@ -1662,10 +1683,10 @@ class BatchChangeValidationsSpec
       name = "name-conflict",
       typ = RecordType.MX,
       records = List(MXData(1, "foo.bar.")))
-    val deleteMx = DeleteChangeForValidation(
+    val deleteMx = DeleteRRSetChangeForValidation(
       okZone,
       "name-conflict",
-      DeleteChangeInput("name-conflict", RecordType.MX))
+      DeleteRRSetChangeInput("name-conflict", RecordType.MX))
     val addMx = AddChangeForValidation(
       okZone,
       "name-conflict",
@@ -2000,26 +2021,26 @@ class BatchChangeValidationsSpec
     val existingCname = cname.copy(name = "existing.dotted.cname")
     val existingMX = mx.copy(name = "existing.dotted.mx")
     val existingTXT = txt.copy(name = "existing.dotted.txt")
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.a",
-      DeleteChangeInput("existing.dotted.a.ok.", RecordType.A))
-    val deleteAAAA = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.a.ok.", RecordType.A))
+    val deleteAAAA = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.aaaa",
-      DeleteChangeInput("existing.dotted.aaaa.ok.", RecordType.AAAA))
-    val deleteCname = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.aaaa.ok.", RecordType.AAAA))
+    val deleteCname = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.cname",
-      DeleteChangeInput("existing.dotted.cname.ok.", RecordType.CNAME))
-    val deleteMX = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.cname.ok.", RecordType.CNAME))
+    val deleteMX = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.mx",
-      DeleteChangeInput("existing.dotted.mx.ok.", RecordType.MX))
-    val deleteTXT = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.mx.ok.", RecordType.MX))
+    val deleteTXT = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.txt",
-      DeleteChangeInput("existing.dotted.txt.ok.", RecordType.TXT))
+      DeleteRRSetChangeInput("existing.dotted.txt.ok.", RecordType.TXT))
     val result = validateChangesWithContext(
       List(
         deleteA.validNel,
@@ -2048,26 +2069,26 @@ class BatchChangeValidationsSpec
     val existingMX = mx.copy(name = "existing.dotted.mx")
     val existingTXT = txt.copy(name = "existing.dotted.txt")
 
-    val deleteA = DeleteChangeForValidation(
+    val deleteA = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.a",
-      DeleteChangeInput("existing.dotted.a.ok.", RecordType.A))
-    val deleteAAAA = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.a.ok.", RecordType.A))
+    val deleteAAAA = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.aaaa",
-      DeleteChangeInput("existing.dotted.aaaa.ok.", RecordType.AAAA))
-    val deleteCname = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.aaaa.ok.", RecordType.AAAA))
+    val deleteCname = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.cname",
-      DeleteChangeInput("existing.dotted.cname.ok.", RecordType.CNAME))
-    val deleteMX = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.cname.ok.", RecordType.CNAME))
+    val deleteMX = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.mx",
-      DeleteChangeInput("existing.dotted.mx.ok.", RecordType.MX))
-    val deleteTXT = DeleteChangeForValidation(
+      DeleteRRSetChangeInput("existing.dotted.mx.ok.", RecordType.MX))
+    val deleteTXT = DeleteRRSetChangeForValidation(
       okZone,
       "existing.dotted.txt",
-      DeleteChangeInput("existing.dotted.txt.ok.", RecordType.TXT))
+      DeleteRRSetChangeInput("existing.dotted.txt.ok.", RecordType.TXT))
 
     val addUpdateA = AddChangeForValidation(
       okZone,

--- a/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.mockito.MockitoSugar
 import vinyldns.api.CatsHelpers
 import javax.mail.{Provider, Session, Transport, URLName}
 import java.util.Properties
+
 import vinyldns.core.domain.membership.UserRepository
 import vinyldns.core.notifier.Notification
 import javax.mail.internet.InternetAddress
@@ -29,17 +30,13 @@ import org.mockito.ArgumentCaptor
 import cats.effect.IO
 import javax.mail.{Address, Message}
 import vinyldns.core.domain.membership.User
-import vinyldns.core.domain.batch.BatchChange
+import _root_.vinyldns.core.domain.batch._
 import org.joda.time.DateTime
-import vinyldns.core.domain.batch.BatchChangeApprovalStatus
-import vinyldns.core.domain.batch.SingleChange
-import vinyldns.core.domain.batch.SingleAddChange
-import vinyldns.core.domain.batch.SingleDeleteRRSetChange
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.record.AData
-import _root_.vinyldns.core.domain.batch.SingleChangeStatus
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+
 import scala.collection.JavaConverters._
 import vinyldns.core.notifier.NotifierConfig
 
@@ -225,6 +222,9 @@ class EmailNotifierSpec
             row.contains(ac.ttl.toString) should be(true)
           case _: SingleDeleteRRSetChange =>
             row.contains("Delete") should be(true)
+          case dc: SingleDeleteRecordChange =>
+            row.contains("Delete") should be(true)
+            row.contains(dc.recordData) should be(true)
         }
       }
 

--- a/modules/core/src/main/protobuf/VinylDNSProto.proto
+++ b/modules/core/src/main/protobuf/VinylDNSProto.proto
@@ -180,6 +180,10 @@ message SingleAddChange {
   required RecordData recordData = 2;
 }
 
+message SingleDeleteRecordChange {
+  required RecordData recordData = 1;
+}
+
 message SingleChangeData {
   required bytes data = 1;
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -180,4 +180,8 @@ final case class RecordRequiresManualReview(fqdn: String, fatal: Boolean = false
       .replaceAll("\n", " ")
 }
 
+final case class UnsupportedOperation(operation: String) extends DomainValidationError {
+  def message: String = s"$operation is not yet implemented/supported in VinylDNS."
+}
+
 // $COVERAGE-ON$

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -34,7 +34,7 @@ object DomainValidationErrorType extends Enumeration {
   InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
   CnameIsNotUniqueError, UserIsNotAuthorized, RecordNameNotUniqueInBatch, RecordInReverseZoneError,
   HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError, NewMultiRecordError,
-  CnameAtZoneApexError, RecordRequiresManualReview = Value
+  CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation = Value
 
   // $COVERAGE-OFF$
   def from(error: DomainValidationError): DomainValidationErrorType =
@@ -67,6 +67,7 @@ object DomainValidationErrorType extends Enumeration {
       case _: NewMultiRecordError => NewMultiRecordError
       case _: CnameAtZoneApexError => CnameAtZoneApexError
       case _: RecordRequiresManualReview => RecordRequiresManualReview
+      case _: UnsupportedOperation => UnsupportedOperation
     }
   // $COVERAGE-ON$
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
@@ -45,6 +45,8 @@ sealed trait SingleChange {
       add.copy(status = SingleChangeStatus.Failed, systemMessage = Some(error))
     case delete: SingleDeleteRRSetChange =>
       delete.copy(status = SingleChangeStatus.Failed, systemMessage = Some(error))
+    case delete: SingleDeleteRecordChange =>
+      delete.copy(status = SingleChangeStatus.Failed, systemMessage = Some(error))
   }
 
   def withProcessingError(message: Option[String], failedRecordChangeId: String): SingleChange =
@@ -55,6 +57,11 @@ sealed trait SingleChange {
           systemMessage = message,
           recordChangeId = Some(failedRecordChangeId))
       case delete: SingleDeleteRRSetChange =>
+        delete.copy(
+          status = SingleChangeStatus.Failed,
+          systemMessage = message,
+          recordChangeId = Some(failedRecordChangeId))
+      case delete: SingleDeleteRecordChange =>
         delete.copy(
           status = SingleChangeStatus.Failed,
           systemMessage = message,
@@ -72,16 +79,24 @@ sealed trait SingleChange {
         status = SingleChangeStatus.Complete,
         recordChangeId = Some(completeRecordChangeId),
         recordSetId = Some(recordSetId))
+    case delete: SingleDeleteRecordChange =>
+      delete.copy(
+        status = SingleChangeStatus.Complete,
+        recordChangeId = Some(completeRecordChangeId),
+        recordSetId = Some(recordSetId))
   }
 
   def reject: SingleChange = this match {
     case sad: SingleAddChange => sad.copy(status = SingleChangeStatus.Rejected)
     case sdc: SingleDeleteRRSetChange => sdc.copy(status = SingleChangeStatus.Rejected)
+    case sdrc: SingleDeleteRecordChange => sdrc.copy(status = SingleChangeStatus.Rejected)
   }
 
   def cancel: SingleChange = this match {
     case sad: SingleAddChange => sad.copy(status = SingleChangeStatus.Cancelled)
     case sdc: SingleDeleteRRSetChange => sdc.copy(status = SingleChangeStatus.Cancelled)
+    // TODO: Implement cancel once DeleteRecord is connected in batch change process flow
+    case _ => throw new RuntimeException("Not yet implemented")
   }
 }
 
@@ -107,6 +122,21 @@ final case class SingleDeleteRRSetChange(
     recordName: Option[String],
     inputName: String,
     typ: RecordType,
+    status: SingleChangeStatus,
+    systemMessage: Option[String],
+    recordChangeId: Option[String],
+    recordSetId: Option[String],
+    validationErrors: List[SingleChangeError] = List.empty,
+    id: String = UUID.randomUUID().toString)
+    extends SingleChange
+
+final case class SingleDeleteRecordChange(
+    zoneId: Option[String],
+    zoneName: Option[String],
+    recordName: Option[String],
+    inputName: String,
+    typ: RecordType,
+    recordData: RecordData,
     status: SingleChangeStatus,
     systemMessage: Option[String],
     recordChangeId: Option[String],

--- a/modules/core/src/test/scala/vinyldns/core/protobuf/BatchChangeProtobufConversionsSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/protobuf/BatchChangeProtobufConversionsSpec.scala
@@ -19,7 +19,12 @@ package vinyldns.core.protobuf
 import cats.scalatest.EitherMatchers
 import org.scalatest.{EitherValues, Matchers, WordSpec}
 import vinyldns.core.domain.{HighValueDomainError, SingleChangeError, ZoneDiscoveryError}
-import vinyldns.core.domain.batch.{SingleAddChange, SingleChangeStatus, SingleDeleteRRSetChange}
+import vinyldns.core.domain.batch.{
+  SingleAddChange,
+  SingleChangeStatus,
+  SingleDeleteRRSetChange,
+  SingleDeleteRecordChange
+}
 import vinyldns.core.domain.record.{AData, RecordType}
 
 class BatchChangeProtobufConversionsSpec
@@ -46,12 +51,26 @@ class BatchChangeProtobufConversionsSpec
     List(testDVError),
     "id"
   )
-  private val testDeleteChange = SingleDeleteRRSetChange(
+  private val testDeleteRRSetChange = SingleDeleteRRSetChange(
     Some("zoneId"),
     Some("zoneName"),
     Some("recordName"),
     "inputName",
     RecordType.A,
+    SingleChangeStatus.Pending,
+    Some("systemMessage"),
+    Some("recordChangeId"),
+    Some("recordSetId"),
+    List(testDVError, SingleChangeError(HighValueDomainError("hvd"))),
+    "id"
+  )
+  private val testDeleteRecordChange = SingleDeleteRecordChange(
+    Some("zoneId"),
+    Some("zoneName"),
+    Some("recordName"),
+    "inputName",
+    RecordType.A,
+    AData("1.1.1.1"),
     SingleChangeStatus.Pending,
     Some("systemMessage"),
     Some("recordChangeId"),
@@ -69,10 +88,13 @@ class BatchChangeProtobufConversionsSpec
     }
 
     "round trip single delete changes with all values provided" in {
-      val pb = toPB(testDeleteChange)
-      val roundTrip = fromPB(pb.toOption.get)
+      val rrSetPb = toPB(testDeleteRRSetChange)
+      val recordPb = toPB(testDeleteRecordChange)
+      val rrSetRoundTrip = fromPB(rrSetPb.toOption.get)
+      val recordRoundTrip = fromPB(recordPb.toOption.get)
 
-      roundTrip shouldBe Right(testDeleteChange)
+      rrSetRoundTrip shouldBe Right(testDeleteRRSetChange)
+      recordRoundTrip shouldBe Right(testDeleteRecordChange)
     }
 
     "round trip single add changes when optional values are not present" in {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -215,6 +215,8 @@ class MySqlBatchChangeRepositoryIntegrationSpec
           sad.copy(recordName = sad.recordName.map(name => s"updated-$name"))
         case sdc: SingleDeleteRRSetChange =>
           sdc.copy(recordName = sdc.recordName.map(name => s"updated-$name"))
+        case sdc: SingleDeleteRecordChange =>
+          sdc.copy(recordName = sdc.recordName.map(name => s"updated-$name"))
       }
       val updatedBatch = batchChange.copy(
         comments = Some("updated comments"),


### PR DESCRIPTION
Prerequisite for remove single DNS record entry feature.

Changes in this pull request:
- Update protobuf for `SingleDeleteChange` to include an optional `recordData`
- Update unmarshalling to expect the correct data and output the correct types

Outstanding:
- Update unit and functional tests