### PR TITLE
add DNS Change review ability to portal

### DIFF
--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -99,9 +99,10 @@ class FrontendController @Inject()(
   }
 
   def index(): Action[AnyContent] = userAction.async { implicit request =>
+    val canReview = request.user.isSuper || request.user.isSupport
     Future(
       Ok(views.html.batchChanges
-        .batchChanges(request.user.userName, request.user.isSuper, request.user.isSupport)))
+        .batchChanges(request.user.userName, canReview)))
   }
 
   def viewAllGroups(): Action[AnyContent] = userAction.async { implicit request =>
@@ -122,16 +123,18 @@ class FrontendController @Inject()(
   }
 
   def viewAllBatchChanges(): Action[AnyContent] = userAction.async { implicit request =>
+    val canReview = request.user.isSuper || request.user.isSupport
     Future(
       Ok(views.html.batchChanges
-        .batchChanges(request.user.userName, request.user.isSuper, request.user.isSupport)))
+        .batchChanges(request.user.userName, canReview)))
   }
 
   def viewBatchChange(batchId: String): Action[AnyContent] = userAction.async { implicit request =>
     logger.info(s"View Batch Change for $batchId")
+    val canReview = request.user.isSuper || request.user.isSupport
     Future(
       Ok(views.html.batchChanges
-        .batchChangeDetail(request.user.userName, request.user.isSuper, request.user.isSupport)))
+        .batchChangeDetail(request.user.userName, canReview)))
   }
 
   def viewNewBatchChange(): Action[AnyContent] = userAction.async { implicit request =>

--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -129,7 +129,9 @@ class FrontendController @Inject()(
 
   def viewBatchChange(batchId: String): Action[AnyContent] = userAction.async { implicit request =>
     logger.info(s"View Batch Change for $batchId")
-    Future(Ok(views.html.batchChanges.batchChangeDetail(request.user.userName)))
+    Future(
+      Ok(views.html.batchChanges
+        .batchChangeDetail(request.user.userName, request.user.isSuper, request.user.isSupport)))
   }
 
   def viewNewBatchChange(): Action[AnyContent] = userAction.async { implicit request =>

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -628,8 +628,44 @@ class VinylDNS @Inject()(
         Status(response.status)(response.body)
           .withHeaders(cacheHeaders: _*)
       })
+    // $COVERAGE-ON$
+  }
+
+  def approveBatchChange(batchChangeId: String): Action[AnyContent] = userAction.async {
+    implicit request =>
+      // $COVERAGE-OFF$
+      val json = request.body.asJson
+      val payload = json.map(Json.stringify)
+      val vinyldnsRequest =
+        new VinylDNSRequest(
+          "POST",
+          s"$vinyldnsServiceBackend",
+          s"zones/batchrecordchanges/$batchChangeId/approve",
+          payload)
+      executeRequest(vinyldnsRequest, request.user).map(response => {
+        Status(response.status)(response.body)
+          .withHeaders(cacheHeaders: _*)
+      })
       // $COVERAGE-ON$
   }
+
+  def rejectBatchChange(batchChangeId: String): Action[AnyContent] =
+    userAction.async { implicit request =>
+      // $COVERAGE-OFF$
+      val json = request.body.asJson
+      val payload = json.map(Json.stringify)
+      val vinyldnsRequest =
+        new VinylDNSRequest(
+          "POST",
+          s"$vinyldnsServiceBackend",
+          s"zones/batchrecordchanges/$batchChangeId/reject",
+          payload)
+      executeRequest(vinyldnsRequest, request.user).map(response => {
+        Status(response.status)(response.body)
+          .withHeaders(cacheHeaders: _*)
+      })
+      // $COVERAGE-ON$
+    }
 
   def lockUser(userId: String): Action[AnyContent] = userAction.async { implicit request =>
     if (request.user.isSuper) {

--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -155,7 +155,7 @@
                                 </td>
                                 <td class="wrap-long-text">
                                     <p ng-repeat="error in change.validationErrors">
-                                        {{error.message}}
+                                        {{error.message ? error.message : error}}
                                     </p>
                                     {{change.systemMessage}}
                                 </td>

--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -1,4 +1,4 @@
-@(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
+@(rootAccountName: String, rootAccountSuperAdmin: Boolean, rootAccountSupportAdmin: Boolean)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 
 @content = {
 <!-- PAGE CONTENT -->
@@ -163,6 +163,29 @@
                             </tbody>
                         </table>
                     </div>
+                </div>
+                @if(rootAccountSuperAdmin || rootAccountSupportAdmin) {
+                    <div ng-if="batch.approvalStatus == 'PendingReview'" class="panel panel-default">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">Review DNS Change</h3>
+                        </div>
+                        <div class="panel-body">
+                            <label>Review Comment (optional):</label> <input type="text" ng-model="reviewComment">
+                        </div>
+                        <div class="panel-footer clearfix">
+                            <div ng-if="!reviewType" class="pull-right">
+                                <button class="btn btn-success" ng-click="approve()">Approve</button>
+                                <button class="btn btn-danger" ng-click="reject()">Reject</button>
+                            </div>
+                            <div ng-if="reviewType" class="pull-right">
+                                <span>{{ reviewConfirmationMsg }}</span>
+                                <button class="btn btn-default" ng-click="cancelReview()">Cancel Review</button>
+                                <button ng-if="reviewType == 'approve'" class="btn btn-success" ng-click="confirmApprove()">Confirm Approval</button>
+                                <button ng-if="reviewType == 'reject'" class="btn btn-danger" ng-click="confirmReject()">Confirm Rejection</button>
+                            </div>
+                        </div>
+                    </div>
+                }
                 </div>
             </div>
         </div>

--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -118,7 +118,7 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr ng-repeat="change in batch.changes|filter:query">
+                            <tr ng-repeat="change in batch.changes|filter:query" ng-class="{changeError: change.outstandingErrors}">
                                 <td ng-bind="change.changeType"></td>
                                 <td class="wrap-long-text">{{change.inputName}}</td>
                                 <td class="wrap-long-text">{{change.recordName}}</td>
@@ -170,7 +170,7 @@
                             <h3 class="panel-title">Review DNS Change</h3>
                         </div>
                         <div class="panel-body">
-                            <label>Review Comment (optional):</label> <input type="text" ng-model="reviewComment">
+                            <label>Review Comment (optional):</label> <input type="text" ng-model="$parent.reviewComment">
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="!reviewType" class="pull-right">

--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -1,4 +1,4 @@
-@(rootAccountName: String, rootAccountSuperAdmin: Boolean, rootAccountSupportAdmin: Boolean)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
+@(rootAccountName: String, rootAccountCanReview: Boolean)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 
 @content = {
 <!-- PAGE CONTENT -->
@@ -164,7 +164,7 @@
                         </table>
                     </div>
                 </div>
-                @if(rootAccountSuperAdmin || rootAccountSupportAdmin) {
+                @if(rootAccountCanReview) {
                     <div ng-if="batch.approvalStatus == 'PendingReview'" class="panel panel-default">
                         <div class="panel-heading">
                             <h3 class="panel-title">Review DNS Change</h3>
@@ -190,7 +190,6 @@
             </div>
         </div>
     </div>
-</div>
 <modal modal-id="cancel_batch_change" modal-title="Cancel DNS Change" modal-size="modal-sm">
     <modal-body>
         <p>Are you sure you want to cancel this DNS Change?</p>
@@ -202,6 +201,7 @@
             </span>
     </modal-footer>
 </modal>
+</div>
 }
 
 @plugins = {}

--- a/modules/portal/app/views/batchChanges/batchChanges.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChanges.scala.html
@@ -1,4 +1,4 @@
-@(rootAccountName: String, rootAccountSuperAdmin: Boolean, rootAccountSupportAdmin: Boolean)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
+@(rootAccountName: String, rootAccountCanReview: Boolean)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 
 @content = {
 <!-- PAGE CONTENT -->
@@ -23,7 +23,7 @@
             </div>
         </div>
 
-        @if(rootAccountSuperAdmin || rootAccountSupportAdmin) {
+        @if(rootAccountCanReview) {
         <div class="panel panel-default panel-tabs">
             <ul class="nav nav-tabs bar_tabs">
                 <li class="active"><a href="#myRequests" data-toggle="tab" ng-click="getAllRequests(false)">My Requests</a></li>
@@ -137,7 +137,7 @@
 
                     </div>
                 </div>
-                @if(rootAccountSuperAdmin || rootAccountSupportAdmin){
+                @if(rootAccountCanReview){
             </div>
         </div>
         </div>

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -59,6 +59,8 @@ GET           /api/dnschanges/:id                @controllers.VinylDNS.getBatchC
 GET           /api/dnschanges                    @controllers.VinylDNS.listBatchChanges
 POST          /api/dnschanges                    @controllers.VinylDNS.newBatchChange
 POST          /api/dnschanges/:id/cancel         @controllers.VinylDNS.cancelBatchChange(id: String)
+POST          /api/dnschanges/:id/approve        @controllers.VinylDNS.approveBatchChange(id: String)
+POST          /api/dnschanges/:id/reject         @controllers.VinylDNS.rejectBatchChange(id: String)
 
 GET           /callback/:id                      @controllers.VinylDNS.oidcCallback(id: String)
 GET           /callback/set-oidc-session/:id              @controllers.VinylDNS.setOidcSession(id: String)

--- a/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
@@ -78,7 +78,15 @@
                     .approveBatchChange($scope.batch.id, $scope.reviewComment)
                     .then(success)
                     .catch(function (error) {
-                        handleError(error, 'batchChangesService::approveBatchChange-failure');
+                        if (error.data) {
+                            for(var i = 0; i < $scope.batch.changes.length; i++) {
+                                if (error.data[i].errors) {
+                                    $scope.batch.changes[i].validationErrors = error.data[i].errors
+                                }
+                            }
+                        } else {
+                            handleError(error, 'batchChangesService::approveBatchChange-failure');
+                        }
                     });
             };
 

--- a/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
@@ -78,12 +78,14 @@
                     .approveBatchChange($scope.batch.id, $scope.reviewComment)
                     .then(success)
                     .catch(function (error) {
-                        if (error.data) {
-                            for(var i = 0; i < $scope.batch.changes.length; i++) {
+                        if (typeof error.data == "object") {
+                            for(var i = 0; i < error.data.length; i++) {
                                 if (error.data[i].errors) {
                                     $scope.batch.changes[i].validationErrors = error.data[i].errors
                                 }
                             }
+                            var errorAlert = {data: "Issues still remain, cannot approve DNS Change. Resolve all outstanding issues or reject the DNS Change.", status: error.status}
+                            handleError(errorAlert, 'batchChangesService::approveBatchChange-failure');
                         } else {
                             handleError(error, 'batchChangesService::approveBatchChange-failure');
                         }

--- a/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
@@ -82,6 +82,7 @@
                             for(var i = 0; i < error.data.length; i++) {
                                 if (error.data[i].errors) {
                                     $scope.batch.changes[i].validationErrors = error.data[i].errors
+                                    $scope.batch.changes[i].outstandingErrors = true
                                 }
                             }
                             var errorAlert = {data: "Issues still remain, cannot approve DNS Change. Resolve all outstanding issues or reject the DNS Change.", status: error.status}

--- a/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
@@ -83,6 +83,8 @@
                                 if (error.data[i].errors) {
                                     $scope.batch.changes[i].validationErrors = error.data[i].errors
                                     $scope.batch.changes[i].outstandingErrors = true
+                                } else {
+                                    $scope.batch.changes[i].validationErrors = []
                                 }
                             }
                             var errorAlert = {data: "Issues still remain, cannot approve DNS Change. Resolve all outstanding issues or reject the DNS Change.", status: error.status}

--- a/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-change-detail.controller.js
@@ -22,6 +22,9 @@
 
             $scope.batch = {};
             $scope.alerts = [];
+            $scope.reviewComment;
+            $scope.reviewConfirmationMsg;
+            $scope.reviewType;
 
             $scope.getBatchChange = function(batchChangeId) {
                 function success(response) {
@@ -48,6 +51,48 @@
                 id = id.substring(id.lastIndexOf('/') + 1);
 
                 $scope.getBatchChange(id);
+                $scope.cancelReview();
+            };
+
+            $scope.approve = function() {
+                $scope.reviewConfirmationMsg = "Are you sure you want to approve this DNS Change?"
+                $scope.reviewType = "approve";
+            }
+
+            $scope.reject = function() {
+                $scope.reviewConfirmationMsg = "Are you sure you want to reject this DNS Change?"
+                $scope.reviewType = "reject";
+            }
+
+            $scope.cancelReview = function() {
+                $scope.reviewConfirmationMsg = null;
+                $scope.reviewType = null;
+            }
+
+            $scope.confirmApprove = function() {
+                function success(response) {
+                    $scope.refresh();
+                }
+
+                return batchChangeService
+                    .approveBatchChange($scope.batch.id, $scope.reviewComment)
+                    .then(success)
+                    .catch(function (error) {
+                        handleError(error, 'batchChangesService::approveBatchChange-failure');
+                    });
+            };
+
+            $scope.confirmReject = function() {
+                function success(response) {
+                    $scope.refresh();
+                }
+
+                return batchChangeService
+                    .rejectBatchChange($scope.batch.id, $scope.reviewComment)
+                    .then(success)
+                    .catch(function (error) {
+                        handleError(error, 'batchChangesService::rejectBatchChange-failure');
+                    });
             };
 
             function handleError(error, type) {

--- a/modules/portal/public/lib/batch-change/batch-change.service.js
+++ b/modules/portal/public/lib/batch-change/batch-change.service.js
@@ -46,5 +46,16 @@
                 return $http.post(url, null, {headers: utilityService.getCsrfHeader()});
             };
 
+            this.approveBatchChange = function (id, reviewComment) {
+                var url = '/api/dnschanges/' + id + '/approve';
+                var data = reviewComment ? {'reviewComment': reviewComment} : {};
+                return $http.post(url, data, {headers: utilityService.getCsrfHeader()});
+            };
+
+            this.rejectBatchChange = function (id, reviewComment) {
+                var url = '/api/dnschanges/' + id + '/reject';
+                var data = reviewComment ? {'reviewComment': reviewComment} : {};
+                return $http.post(url, data, {headers: utilityService.getCsrfHeader()});
+            };
         });
 })();

--- a/modules/portal/public/lib/batch-change/batch-change.spec.js
+++ b/modules/portal/public/lib/batch-change/batch-change.spec.js
@@ -99,10 +99,13 @@ describe('BatchChange', function(){
 
                 expect(batchChangeService.approveBatchChange).toHaveBeenCalled();
 
-                deferred.reject({data: "Batch change with id notPendingBatchChange is not pending review.", status: 400});
+                var errorData = {data: [{changeType: "Add", inputName: "onofe.ok.", type: "A", ttl: 7200, record: {address: "1.1.1.1"}},
+                {changeType: "Add", inputName: "wfonef.wfoefn.", type: "A", ttl: 7200, record: {address: "1.1.1.1"}, errors: ['Zone Discovery Failed: zone for "wfonef.wfoefn." doesn\'t exists']}]}
+
+                deferred.reject({data: errorData, status: 400});
                 this.rootScope.$apply();
 
-                expect(this.scope.alerts).toEqual([{ type: 'danger', content: 'HTTP 400 (undefined): Batch change with id notPendingBatchChange is not pending review.' }]);
+                expect(this.scope.alerts).toEqual([{ type: 'danger', content: "HTTP 400 (undefined): Issues still remain, cannot approve DNS Change. Resolve all outstanding issues or reject the DNS Change." }]);
             }));
         });
 

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -216,6 +216,19 @@ trait TestApplicationData { this: Mockito =>
       | }
     """.stripMargin)
 
+  val hobbitBatchChange: JsValue = Json.parse(s"""{
+      | "userId":               "vinyl",
+      | "userName":             "vinyl201",
+      | "comments":             "this is optional",
+      | "createdTimestamp":     "2018-05-08T18:46:34Z",
+      | "ownerGroupId":         "f42385e4-5675-38c0-b42f-64105e743bfe",
+      | "changes":              [],
+      | "status":               "Complete",
+      | "id":                   "937191c4-b1fd-4ab5-abb4-9553a65b44ab",
+      | "approvalStatus":       "AutoApproved"
+      | }
+    """.stripMargin)
+
   val groupList: JsObject = Json.obj("groups" -> Json.arr(hobbitGroup))
   val emptyGroupList: JsObject = Json.obj("groups" -> Json.arr())
 

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -2511,6 +2511,174 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
       }
     }
 
+    ".cancelBatchChange" should {
+      "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendPOST(p"/batchrecordchanges/123/cancel") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitBatchChange)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockUserAccessor,
+              client,
+              components,
+              crypto)
+            val result =
+              underTest.cancelBatchChange("123")(FakeRequest(POST, s"/api/dnschanges/123/cancel"))
+
+            status(result) mustEqual 401
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              "You are not logged in. Please login to continue.")
+          }
+        }
+      }
+      "return forbidden (403) if user account is locked" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendPOST(p"/batchrecordchanges/123/cancel") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitBatchChange)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockLockedUserAccessor,
+              client,
+              components,
+              crypto)
+            val result = underTest.cancelBatchChange("123")(
+              FakeRequest(POST, s"/api/dnschanges/123/cancel")
+                .withSession(
+                  "username" -> lockedFrodoUser.userName,
+                  "accessKey" -> lockedFrodoUser.accessKey))
+
+            status(result) mustEqual 403
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              s"User account for `${lockedFrodoUser.userName}` is locked.")
+          }
+        }
+      }
+    }
+
+    ".approveBatchChange" should {
+      "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendPOST(p"/batchrecordchanges/123/approve") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitBatchChange)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockUserAccessor,
+              client,
+              components,
+              crypto)
+            val result =
+              underTest.approveBatchChange("123")(FakeRequest(POST, s"/api/dnschanges/123/approve"))
+
+            status(result) mustEqual 401
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              "You are not logged in. Please login to continue.")
+          }
+        }
+      }
+      "return forbidden (403) if user account is locked" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendPOST(p"/batchrecordchanges/123/approve") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitBatchChange)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockLockedUserAccessor,
+              client,
+              components,
+              crypto)
+            val result = underTest.approveBatchChange("123")(
+              FakeRequest(POST, s"/api/dnschanges/123/approve")
+                .withSession(
+                  "username" -> lockedFrodoUser.userName,
+                  "accessKey" -> lockedFrodoUser.accessKey))
+
+            status(result) mustEqual 403
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              s"User account for `${lockedFrodoUser.userName}` is locked.")
+          }
+        }
+      }
+    }
+
+    ".rejectBatchChange" should {
+      "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendPOST(p"/batchrecordchanges/123/reject") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitBatchChange)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockUserAccessor,
+              client,
+              components,
+              crypto)
+            val result =
+              underTest.rejectBatchChange("123")(FakeRequest(POST, s"/api/dnschanges/123/reject"))
+
+            status(result) mustEqual 401
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              "You are not logged in. Please login to continue.")
+          }
+        }
+      }
+      "return forbidden (403) if user account is locked" in new WithApplication(app) {
+        Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {
+          case backendPOST(p"/batchrecordchanges/123/reject") =>
+            defaultActionBuilder {
+              Results.Ok(hobbitBatchChange)
+            }
+        } { implicit port =>
+          WsTestClient.withClient { client =>
+            val underTest = TestVinylDNS(
+              testConfigLdap,
+              mockLdapAuthenticator,
+              mockLockedUserAccessor,
+              client,
+              components,
+              crypto)
+            val result = underTest.rejectBatchChange("123")(
+              FakeRequest(POST, s"/api/dnschanges/123/reject")
+                .withSession(
+                  "username" -> lockedFrodoUser.userName,
+                  "accessKey" -> lockedFrodoUser.accessKey))
+
+            status(result) mustEqual 403
+            hasCacheHeaders(result)
+            contentAsString(result) must beEqualTo(
+              s"User account for `${lockedFrodoUser.userName}` is locked.")
+          }
+        }
+      }
+    }
+
     ".listBatchChanges" should {
       "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
         Server.withRouter(ServerConfig(port = Some(simulatedBackendPort), mode = Mode.Test)) {


### PR DESCRIPTION
Changes in this pull request:
- For super and support users give them the ability to approve or reject pending DNS Changes through the portal
