### PR TITLE
update send to manual review logic

### DIFF
--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -553,13 +553,16 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, u'GET', self.headers, **kwargs)
         return data
 
-    def create_batch_change(self, batch_change_input, **kwargs):
+    def create_batch_change(self, batch_change_input, allow_manual_review=True, **kwargs):
         """
         Creates a new batch change
         :param batch_change_input: the batchchange to be created
+        :param allow_manual_review: if true and manual review is enabled soft failure are treated as hard failures
         :return: the content of the response
         """
         url = urljoin(self.index_url, u'/zones/batchrecordchanges')
+        if allow_manual_review is not None:
+            url = url + (u'?' + u'allowManualReview={0}'.format(allow_manual_review))
         response, data = self.make_request(url, u'POST', self.headers, json.dumps(batch_change_input), **kwargs)
         return data
 

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -557,7 +557,7 @@ class VinylDNSClient(object):
         """
         Creates a new batch change
         :param batch_change_input: the batchchange to be created
-        :param allow_manual_review: if true and manual review is enabled soft failure are treated as hard failures
+        :param allow_manual_review: if true and manual review is enabled soft failures are treated as hard failures
         :return: the content of the response
         """
         url = urljoin(self.index_url, u'/zones/batchrecordchanges')

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -424,13 +424,11 @@ class BatchChangeService(
     } else if (noErrors && !isScheduled) {
       // There are no errors and this is not scheduled, so process immediately
       processNowResponse
-    } else if (this.manualReviewEnabled && noErrors && isScheduled) {
-      // There are no errors and this is scheduled, so advance to manual review
-      manualReviewResponse
     } else if (this.manualReviewEnabled && allowManualReview) {
-      // we have soft errors
-      // advance to manual review if manual review is ok
-      if (batchChangeInput.ownerGroupId.isDefined) {
+      if ((noErrors && isScheduled) || batchChangeInput.ownerGroupId.isDefined) {
+        // There are no errors and this is scheduled
+        // or we have soft errors and owner group is defined
+        // advance to manual review if manual review is ok
         manualReviewResponse
       } else {
         ManualReviewRequiresOwnerGroup.asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -424,20 +424,20 @@ class BatchChangeService(
     } else if (noErrors && !isScheduled) {
       // There are no errors and this is not scheduled, so process immediately
       processNowResponse
-    } else {
+    } else if (this.manualReviewEnabled && noErrors && isScheduled) {
+      // There are no errors and this is scheduled, so advance to manual review
+      manualReviewResponse
+    } else if (this.manualReviewEnabled && allowManualReview) {
       // we have soft errors
-      // advance to manual review if this is scheduled OR manual review is ok
-      val gotoManualReview = this.manualReviewEnabled && (isScheduled || allowManualReview)
-      if (gotoManualReview) {
-        if (batchChangeInput.ownerGroupId.isDefined) {
-          manualReviewResponse
-        } else {
-          ManualReviewRequiresOwnerGroup.asLeft
-        }
+      // advance to manual review if manual review is ok
+      if (batchChangeInput.ownerGroupId.isDefined) {
+        manualReviewResponse
       } else {
-        // Cannot go to manual review, and we have soft errors, so just return a failure
-        errorResponse
+        ManualReviewRequiresOwnerGroup.asLeft
       }
+    } else {
+      // Cannot go to manual review, and we have soft errors, so just return a failure
+      errorResponse
     }
   }
 


### PR DESCRIPTION
Changes in this pull request in the BatchChangeService `buildResponse` method:
- if a manual review is enabled, a batch change has no errors, and is scheduled it goes to manual review. since there are no errors on the changes we don't need to verify if an owner group ID is present. (note: if manual review is disabled the batch change will fail earlier in the `applyBatchChangeValidationFlow`)
- if manual review is enabled system-wide and allowManualReview attribute on a batch is true it will go  to manual review if an owner group ID is specified, otherwise returns a ManualReviewRequiresOwnerGroup error.
