### PR TITLE
portal DNS Changes enhancements

### DIFF
--- a/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeDetail.scala.html
@@ -40,6 +40,7 @@
             <div class="col-md-12">
                 <p><strong>ID:</strong> {{batch.id}}</p>
                 <p><strong>Submitted:</strong> {{batch.createdTimestamp}}</p>
+                <p ng-if="'@rootAccountName' != batch.userName"><strong>Submitter:</strong> {{batch.userName}}</p>
                 <p ng-if="batch.comments"><strong>Description:</strong> {{batch.comments}}</p>
                 @if(meta.sharedDisplayEnabled) {
                     <p ng-if="batch.ownerGroupName"><strong>Record Owner Group:</strong> {{batch.ownerGroupName}}</p>
@@ -87,7 +88,7 @@
                         <div class="clearfix">
                             <div class="btn-group">
                                 <button class="btn btn-default" ng-click="refresh()"><span class="fa fa-refresh"></span> Refresh</button>
-                                <button  ng-if="batch.approvalStatus == 'PendingReview'" class="btn btn-default" ng-click="cancelChange()">
+                                <button ng-if="batch.approvalStatus == 'PendingReview' && '@rootAccountName' == batch.userName" class="btn btn-default" ng-click="cancelChange()">
                                     Cancel Changes
                                 </button>
                             </div>

--- a/modules/portal/app/views/batchChanges/batchChanges.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChanges.scala.html
@@ -74,6 +74,7 @@
                             <thead>
                                 <tr>
                                     <th>Submitted</th>
+                                    <th ng-if="ignoreAccess">Submitter</th>
                                     <th>ID</th>
                                     <th>Change Count</th>
                                     <th>Status</th>
@@ -84,6 +85,7 @@
                             <tbody>
                                 <tr ng-repeat="batchChange in batchChanges|filter:query">
                                     <td ng-bind="batchChange.createdTimestamp"></td>
+                                    <td ng-if="ignoreAccess" ng-bind="batchChange.userName"></td>
                                     <td><a href="/dnschanges/{{batchChange.id}}">{{batchChange.id}}</a></td>
                                     <td ng-bind="batchChange.totalChanges"></td>
                                     <td>
@@ -102,7 +104,7 @@
                                            ng-href="/dnschanges/{{ batchChange.id }}">
                                             View
                                         </a>
-                                        <a type="button" ng-if="batchChange.approvalStatus == 'PendingReview'" class="btn btn-warning btn-rounded"
+                                        <a type="button" ng-if="canCancelBatchChange(batchChange, '@rootAccountName')" class="btn btn-warning btn-rounded"
                                            ng-click="cancelChange(batchChange)">
                                             Cancel
                                         </a>

--- a/modules/portal/public/lib/batch-change/batch-changes.controller.js
+++ b/modules/portal/public/lib/batch-change/batch-changes.controller.js
@@ -140,6 +140,10 @@
                 $scope.currentBatchChange = null;
             }
 
+            $scope.canCancelBatchChange = function(batchChange, accountName) {
+                return batchChange.approvalStatus == 'PendingReview' && accountName == batchChange.userName;
+            }
+
             $timeout($scope.refreshBatchChanges, 0);
         });
 })();


### PR DESCRIPTION
A couple things that irked me in the DNS Changes area of the portal.

Changes in this pull request:
- Only show the Cancel button if a DNS Change has an approvalStatus of `PendingReview` **AND** the logged in account is the creator of the DNS Change. 
- In the "All Requests" tab add a column for Submitter and show the userName of who made the DNS Change.
- In the DNS Change details page show the submitter username if the logged in user didn't create the batch change.

<img width="1643" alt="Screen Shot 2019-08-21 at 10 14 18 AM" src="https://user-images.githubusercontent.com/4439228/63441696-d3dc0780-c3ff-11e9-8b41-2c58cde42e20.png">