### PR TITLE
[WIP] [DeleteRecord] Update add-update validations for multi-record in batch change interface

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -3182,16 +3182,13 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
         def existing_err(name, type):
             return 'RecordSet with name {} and type {} cannot be updated in a single '.format(name, type) +\
                    'Batch Change because it contains multiple DNS records (2).'
-        def new_err(name, type):
-            return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-               'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name, type)
 
         assert_error(response[0], error_messages=[existing_err("multi.ok.", "A")])
-        assert_error(response[1], error_messages=[existing_err("multi.ok.", "A"), new_err("multi.ok.", "A")])
-        assert_error(response[2], error_messages=[existing_err("multi.ok.", "A"), new_err("multi.ok.", "A")])
+        assert_successful_change_in_error_response(response[1], input_name="multi.ok.", record_data="1.2.3.4")
+        assert_successful_change_in_error_response(response[2], input_name="multi.ok.", record_data="4.5.6.7")
         assert_error(response[3], error_messages=[existing_err("multi-txt.ok.", "TXT")])
-        assert_error(response[4], error_messages=[existing_err("multi-txt.ok.", "TXT"), new_err("multi-txt.ok.", "TXT")])
-        assert_error(response[5], error_messages=[existing_err("multi-txt.ok.", "TXT"), new_err("multi-txt.ok.", "TXT")])
+        assert_successful_change_in_error_response(response[4], input_name="multi-txt.ok.", record_type="TXT", record_data="some-multi-text")
+        assert_successful_change_in_error_response(response[5], input_name="multi-txt.ok.", record_type="TXT", record_data="more-multi-text")
         assert_error(response[6], error_messages=[existing_err("multi-del.ok.", "A")])
         assert_error(response[7], error_messages=[existing_err("multi-txt-del.ok.", "TXT")])
     finally:

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -268,6 +268,7 @@ class BatchChangeService(
           .getOrElse(add)
           .validNel
       case del: DeleteRRSetChangeForValidation => del.validNel
+      case del: DeleteRecordChangeForValidation => del.validNel
     }
 
   def getOwnerGroup(ownerGroupId: Option[String]): BatchResult[Option[Group]] = {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -81,7 +81,8 @@ object BatchTransformations {
     val recordKey = RecordKey(zone.id, recordName, inputChange.typ)
     def asStoredChange(changeId: Option[String] = None): SingleChange
     def isAddChangeForValidation: Boolean
-    def isDeleteChangeForValidation: Boolean
+    def isDeleteRRSetChangeForValidation: Boolean
+    def isDeleteRecordChangeForValidation: Boolean
   }
 
   object ChangeForValidation {
@@ -126,7 +127,9 @@ object BatchTransformations {
 
     def isAddChangeForValidation: Boolean = true
 
-    def isDeleteChangeForValidation: Boolean = false
+    def isDeleteRRSetChangeForValidation: Boolean = false
+
+    def isDeleteRecordChangeForValidation: Boolean = false
   }
 
   final case class DeleteRRSetChangeForValidation(
@@ -151,7 +154,37 @@ object BatchTransformations {
 
     def isAddChangeForValidation: Boolean = false
 
-    def isDeleteChangeForValidation: Boolean = true
+    def isDeleteRRSetChangeForValidation: Boolean = true
+
+    def isDeleteRecordChangeForValidation: Boolean = false
+  }
+
+  final case class DeleteRecordChangeForValidation(
+      zone: Zone,
+      recordName: String,
+      inputChange: DeleteRecordChangeInput)
+      extends ChangeForValidation {
+    def asStoredChange(changeId: Option[String] = None): SingleChange =
+      SingleDeleteRecordChange(
+        Some(zone.id),
+        Some(zone.name),
+        Some(recordName),
+        inputChange.inputName,
+        inputChange.typ,
+        inputChange.record,
+        SingleChangeStatus.Pending,
+        None,
+        None,
+        None,
+        List.empty,
+        changeId.getOrElse(UUID.randomUUID().toString)
+      )
+
+    def isAddChangeForValidation: Boolean = false
+
+    def isDeleteRRSetChangeForValidation: Boolean = false
+
+    def isDeleteRecordChangeForValidation: Boolean = true
   }
 
   final case class BatchConversionOutput(
@@ -171,7 +204,7 @@ object BatchTransformations {
 
     def containsDeleteChangeForValidation(recordKey: RecordKey): Boolean = {
       val changeList = getList(recordKey)
-      changeList.nonEmpty && changeList.exists(_.isDeleteChangeForValidation)
+      changeList.nonEmpty && changeList.exists(_.isDeleteRRSetChangeForValidation)
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1840,7 +1840,7 @@ class BatchChangeValidationsSpec
   }
 
   property(
-    "validateChangesWithContext: fail on update/delete to a multi record existing RecordSet if multi disabled") {
+    "validateChangesWithContext: fail on delete to a multi record existing RecordSet if multi disabled") {
     val existing = List(
       sharedZoneRecord.copy(
         name = updateSharedAddChange.recordName,
@@ -1867,8 +1867,7 @@ class BatchChangeValidationsSpec
       Some(okGroup.id)
     )
 
-    result(0) should haveInvalid[DomainValidationError](
-      ExistingMultiRecordError(updateSharedAddChange.inputChange.inputName, existing(0)))
+    result(0) shouldBe valid
     result(1) should haveInvalid[DomainValidationError](
       ExistingMultiRecordError(updateSharedDeleteChange.inputChange.inputName, existing(0)))
     result(2) should haveInvalid[DomainValidationError](
@@ -1922,7 +1921,7 @@ class BatchChangeValidationsSpec
     result(5) shouldBe valid
   }
 
-  property("validateChangesWithContext: fail on add/update to a multi record if multi disabled") {
+  property("validateChangesWithContext: succeed on add/update to a multi record if multi disabled") {
     val existing = List(
       sharedZoneRecord.copy(
         name = updateSharedAddChange.recordName,
@@ -1960,10 +1959,8 @@ class BatchChangeValidationsSpec
     )
 
     result(0) shouldBe valid
-    result(1) should haveInvalid[DomainValidationError](
-      NewMultiRecordError(update1.inputChange.inputName, update1.inputChange.typ))
-    result(2) should haveInvalid[DomainValidationError](
-      NewMultiRecordError(update2.inputChange.inputName, update2.inputChange.typ))
+    result(1) shouldBe valid
+    result(2) shouldBe valid
     result(3) should haveInvalid[DomainValidationError](
       NewMultiRecordError(add1.inputChange.inputName, add1.inputChange.typ))
     result(4) should haveInvalid[DomainValidationError](


### PR DESCRIPTION
In preparation for `DeleteRecord` validation logic, the add-update changes can be updated to allow multi-record as we still fail on the delete-update change if existing record set has multiple DNS entries.

Changes in this pull request:
- Allow add-updates to have multiple records (though pure adds are still disallowed)
- Update tests

-----
Edit: Changing to WIP status since this may get bottled up into the removal of our `enable-multi-record-batch-update` flag.