### PR TITLE
relax list group ignoreAccess assertions

### DIFF
--- a/modules/api/functional_test/live_tests/membership/list_my_groups_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_my_groups_test.py
@@ -30,11 +30,6 @@ class ListGroupsSearchContext(object):
                 pass
             raise
 
-    def verify_ignore_access(self, results):
-        assert_that(len(results['groups']), greater_than(50))
-        assert_that(results['maxItems'], is_(100))
-        assert_that(results['ignoreAccess'], is_(True))
-
     def tear_down(self):
         clear_zones(self.client)
         clear_groups(self.client)
@@ -176,7 +171,9 @@ def test_list_my_groups_with_ignore_access_true(list_my_groups_context):
 
     results = list_my_groups_context.client.list_my_groups(ignore_access=True, status=200)
 
-    list_my_groups_context.verify_ignore_access(results)
+    assert_that(len(results['groups']), greater_than(50))
+    assert_that(results['maxItems'], is_(100))
+    assert_that(results['ignoreAccess'], is_(True))
 
     my_results = list_my_groups_context.client.list_my_groups(status=200)
     my_results['groups'] = sorted(my_results['groups'], key=lambda x: x['name'])
@@ -191,7 +188,9 @@ def test_list_my_groups_as_support_user(list_my_groups_context):
 
     results = list_my_groups_context.support_user_client.list_my_groups(status=200)
 
-    list_my_groups_context.verify_ignore_access(results)
+    assert_that(len(results['groups']), greater_than(50))
+    assert_that(results['maxItems'], is_(100))
+    assert_that(results['ignoreAccess'], is_(False))
 
 def test_list_my_groups_as_support_user_with_ignore_access_true(list_my_groups_context):
     """
@@ -200,4 +199,6 @@ def test_list_my_groups_as_support_user_with_ignore_access_true(list_my_groups_c
 
     results = list_my_groups_context.support_user_client.list_my_groups(ignore_access=True, status=200)
 
-    list_my_groups_context.verify_ignore_access(results)
+    assert_that(len(results['groups']), greater_than(50))
+    assert_that(results['maxItems'], is_(100))
+    assert_that(results['ignoreAccess'], is_(True))

--- a/modules/api/functional_test/live_tests/membership/list_my_groups_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_my_groups_test.py
@@ -31,13 +31,9 @@ class ListGroupsSearchContext(object):
             raise
 
     def verify_ignore_access(self, results):
-        assert_that(results, has_length(3))  # 3 fields
-
         assert_that(len(results['groups']), greater_than(50))
-        assert_that(results, is_not(has_key('groupNameFilter')))
-        assert_that(results, is_not(has_key('startFrom')))
-        assert_that(results, is_not(has_key('nextId')))
         assert_that(results['maxItems'], is_(100))
+        assert_that(results['ignoreAccess'], is_(True))
 
     def tear_down(self):
         clear_zones(self.client)


### PR DESCRIPTION
Changes in this pull request:
- different test environments may have more or less groups so relax the "ignoreAccess" assertions to just ensure all groups are greater than my groups, and ignoreAccess is true.
