### PR TITLE
[DeleteRecord] Refactor change validation map

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1631,8 +1631,7 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=["Record \"delete-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="update-nonexistent.ok.", record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="AAAA", record_data="1::1",
-                                               error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
+        assert_successful_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="AAAA", record_data="1::1")
         assert_failed_change_in_error_response(response[11], input_name="delete-unauthorized.dummy.", record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["User \"ok\" is not authorized."])
         assert_failed_change_in_error_response(response[12], input_name="update-unauthorized.dummy.", record_type="AAAA", record_data="1::1",
@@ -1854,8 +1853,7 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=['Record "non-existent-delete.ok." Does Not Exist: cannot delete a record that does not exist.'])
         assert_failed_change_in_error_response(response[11], input_name="non-existent-update.ok.", record_type="CNAME", change_type="DeleteRecordSet",
                                                error_messages=['Record "non-existent-update.ok." Does Not Exist: cannot delete a record that does not exist.'])
-        assert_failed_change_in_error_response(response[12], input_name="non-existent-update.ok.", record_type="CNAME", record_data="test.com.",
-                                               error_messages=['Record "non-existent-update.ok." Does Not Exist: cannot delete a record that does not exist.'])
+        assert_successful_change_in_error_response(response[12], input_name="non-existent-update.ok.", record_type="CNAME", record_data="test.com.")
         assert_failed_change_in_error_response(response[13], input_name="delete-unauthorized.dummy.", record_type="CNAME", change_type="DeleteRecordSet",
                                                error_messages=['User "ok" is not authorized.'])
         assert_failed_change_in_error_response(response[14], input_name="update-unauthorized.dummy.", record_type="CNAME", change_type="DeleteRecordSet",
@@ -2112,8 +2110,7 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist
         assert_failed_change_in_error_response(response[11], input_name="192.0.2.199", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"192.0.2.199\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[12], ttl=300, input_name="192.0.2.200", record_type="PTR", record_data="has-updated.ptr.",
-                                                   error_messages=["Record \"192.0.2.200\" Does Not Exist: cannot delete a record that does not exist."])
+        assert_successful_change_in_error_response(response[12], ttl=300, input_name="192.0.2.200", record_type="PTR", record_data="has-updated.ptr.")
         assert_failed_change_in_error_response(response[13], input_name="192.0.2.200", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"192.0.2.200\" Does Not Exist: cannot delete a record that does not exist."])
 
@@ -2245,8 +2242,7 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist, failure on update with double add
         assert_failed_change_in_error_response(response[7], input_name="fd69:27cc:fe91:1000::60", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"fd69:27cc:fe91:1000::60\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[8], ttl=300, input_name="fd69:27cc:fe91:1000::65", record_type="PTR", record_data="has-updated.ptr.",
-                                                   error_messages=["Record \"fd69:27cc:fe91:1000::65\" Does Not Exist: cannot delete a record that does not exist."])
+        assert_successful_change_in_error_response(response[8], ttl=300, input_name="fd69:27cc:fe91:1000::65", record_type="PTR", record_data="has-updated.ptr.")
         assert_failed_change_in_error_response(response[9], input_name="fd69:27cc:fe91:1000::65", record_type="PTR", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"fd69:27cc:fe91:1000::65\" Does Not Exist: cannot delete a record that does not exist."])
 
@@ -2403,8 +2399,7 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=["Record \"delete-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[7], input_name="update-nonexistent.ok.", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[8], input_name="update-nonexistent.ok.", record_type="TXT", record_data="test",
-                                               error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
+        assert_successful_change_in_error_response(response[8], input_name="update-nonexistent.ok.", record_type="TXT", record_data="test")
         assert_failed_change_in_error_response(response[9], input_name="delete-unauthorized.dummy.", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["User \"ok\" is not authorized."])
         assert_failed_change_in_error_response(response[10], input_name="update-unauthorized.dummy.", record_type="TXT", record_data="test",
@@ -2579,8 +2574,7 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
                                                error_messages=["Record \"delete-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
         assert_failed_change_in_error_response(response[9], input_name="update-nonexistent.ok.", record_type="MX", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Record \"update-nonexistent.ok.\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="MX", record_data={"preference": 1000, "exchange": "foo.bar."},
-                                               error_messages=['Record "update-nonexistent.ok." Does Not Exist: cannot delete a record that does not exist.'])
+        assert_successful_change_in_error_response(response[10], input_name="update-nonexistent.ok.", record_type="MX", record_data={"preference": 1000, "exchange": "foo.bar."})
         assert_failed_change_in_error_response(response[11], input_name="delete-unauthorized.dummy.", record_type="MX", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["User \"ok\" is not authorized."])
         assert_failed_change_in_error_response(response[12], input_name="update-unauthorized.dummy.", record_type="MX", record_data={"preference": 1000, "exchange": "foo.bar."},

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1803,7 +1803,7 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_CNAME_json("update-unauthorized.dummy.", ttl=300),
             get_change_CNAME_json("existing-cname2.parent.com.", change_type="DeleteRecordSet"),
             get_change_CNAME_json("existing-cname2.parent.com."),
-            get_change_CNAME_json("existing-cname2.parent.com.", ttl=350)
+            get_change_CNAME_json("existing-cname2.parent.com.", cname="test2.com.")
         ]
     }
 
@@ -1864,7 +1864,7 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[16], input_name="existing-cname2.parent.com.", record_type="CNAME", change_type="DeleteRecordSet")
         assert_failed_change_in_error_response(response[17], input_name="existing-cname2.parent.com.", record_type="CNAME", record_data="test.com.",
                                                error_messages=["Record Name \"existing-cname2.parent.com.\" Not Unique In Batch Change: cannot have multiple \"CNAME\" records with the same name."])
-        assert_failed_change_in_error_response(response[18], input_name="existing-cname2.parent.com.", record_type="CNAME", record_data="test.com.", ttl=350,
+        assert_failed_change_in_error_response(response[18], input_name="existing-cname2.parent.com.", record_type="CNAME", record_data="test2.com.",
                                                error_messages=["Record Name \"existing-cname2.parent.com.\" Not Unique In Batch Change: cannot have multiple \"CNAME\" records with the same name."])
 
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -104,7 +104,7 @@ class BatchChangeService(
       serviceCompleteBatch <- convertOrSave(
         changeForConversion,
         validationOutput.existingZones,
-        validationOutput.existingRecordSets,
+        validationOutput.changeGroups.existingRecordSets,
         batchChangeInput.ownerGroupId)
     } yield serviceCompleteBatch
 
@@ -120,15 +120,13 @@ class BatchChangeService(
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)
       recordSets <- getExistingRecordSets(changesWithZones, zoneMap).toBatchResult
       withTtl = doTtlMapping(changesWithZones, recordSets)
-      changeGroups = ChangeForValidationMap(withTtl.getValid, recordSets)
+      changeGroups = ChangeForValidationMap(withTtl, recordSets)
       validatedSingleChanges = validateChangesWithContext(
-        withTtl,
         changeGroups,
-        recordSets,
         auth,
         isApproved,
         batchChangeInput.ownerGroupId)
-    } yield BatchValidationFlowOutput(validatedSingleChanges, zoneMap, recordSets, changeGroups)
+    } yield BatchValidationFlowOutput(validatedSingleChanges, zoneMap, changeGroups)
 
   def rejectBatchChange(
       batchChangeId: String,
@@ -169,7 +167,7 @@ class BatchChangeService(
       serviceCompleteBatch <- convertOrSave(
         changeForConversion,
         validationOutput.existingZones,
-        validationOutput.existingRecordSets,
+        validationOutput.changeGroups.existingRecordSets,
         batchChange.ownerGroupId)
     } yield serviceCompleteBatch
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -104,7 +104,7 @@ class BatchChangeService(
       serviceCompleteBatch <- convertOrSave(
         changeForConversion,
         validationOutput.existingZones,
-        validationOutput.changeGroups.existingRecordSets,
+        validationOutput.groupedChanges.existingRecordSets,
         batchChangeInput.ownerGroupId)
     } yield serviceCompleteBatch
 
@@ -120,13 +120,13 @@ class BatchChangeService(
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)
       recordSets <- getExistingRecordSets(changesWithZones, zoneMap).toBatchResult
       withTtl = doTtlMapping(changesWithZones, recordSets)
-      changeGroups = ChangeForValidationMap(withTtl, recordSets)
+      groupedChanges = ChangeForValidationMap(withTtl, recordSets)
       validatedSingleChanges = validateChangesWithContext(
-        changeGroups,
+        groupedChanges,
         auth,
         isApproved,
         batchChangeInput.ownerGroupId)
-    } yield BatchValidationFlowOutput(validatedSingleChanges, zoneMap, changeGroups)
+    } yield BatchValidationFlowOutput(validatedSingleChanges, zoneMap, groupedChanges)
 
   def rejectBatchChange(
       batchChangeId: String,
@@ -167,7 +167,7 @@ class BatchChangeService(
       serviceCompleteBatch <- convertOrSave(
         changeForConversion,
         validationOutput.existingZones,
-        validationOutput.changeGroups.existingRecordSets,
+        validationOutput.groupedChanges.existingRecordSets,
         batchChange.ownerGroupId)
     } yield serviceCompleteBatch
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -120,13 +120,15 @@ class BatchChangeService(
       changesWithZones = zoneDiscovery(inputValidatedSingleChanges, zoneMap)
       recordSets <- getExistingRecordSets(changesWithZones, zoneMap).toBatchResult
       withTtl = doTtlMapping(changesWithZones, recordSets)
+      changeGroups = ChangeForValidationMap(withTtl.getValid, recordSets)
       validatedSingleChanges = validateChangesWithContext(
         withTtl,
+        changeGroups,
         recordSets,
         auth,
         isApproved,
         batchChangeInput.ownerGroupId)
-    } yield BatchValidationFlowOutput(validatedSingleChanges, zoneMap, recordSets)
+    } yield BatchValidationFlowOutput(validatedSingleChanges, zoneMap, recordSets, changeGroups)
 
   def rejectBatchChange(
       batchChangeId: String,
@@ -268,6 +270,7 @@ class BatchChangeService(
           .getOrElse(add)
           .validNel
       case del: DeleteRRSetChangeForValidation => del.validNel
+      case del: DeleteRecordChangeForValidation => del.validNel
     }
 
   def getOwnerGroup(ownerGroupId: Option[String]): BatchResult[Option[Group]] = {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -240,7 +240,7 @@ class BatchChangeValidations(
     // Updates are a combination of an add and delete for a record with the same name and type in a zone.
     changeGroups.changes.mapValid {
       case addUpdate: AddChangeForValidation
-          if changeGroups.getChangeForValidationDeletes(addUpdate.recordKey).nonEmpty =>
+          if changeGroups.containsValidDeleteChanges(addUpdate.recordKey) =>
         validateAddUpdateWithContext(
           addUpdate,
           changeGroups,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -240,7 +240,8 @@ class BatchChangeValidations(
     // Updates are a combination of an add and delete for a record with the same name and type in a zone.
     changeGroups.changes.mapValid {
       case addUpdate: AddChangeForValidation
-          if changeGroups.containsValidDeleteChanges(addUpdate.recordKey) =>
+          if changeGroups.containsValidDeleteChanges(addUpdate.recordKey) ||
+            changeGroups.containsFullRecordDelete(addUpdate.recordKey) =>
         validateAddUpdateWithContext(
           addUpdate,
           changeGroups,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -419,10 +419,7 @@ class BatchChangeValidations(
       val recordKey = RecordKey(cnameChange.zone.id, cnameChange.recordName, recordType)
       val proposedAdds = groupedChanges.getProposedAdds(recordKey)
 
-      recordType match {
-        case CNAME => proposedAdds.size > 1 // We are checking on the CNAME
-        case _ => proposedAdds.nonEmpty
-      }
+      proposedAdds.exists(_ != cnameChange.inputChange.record)
     }
 
     if (duplicateNameChangeInBatch) {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -483,7 +483,7 @@ class BatchChangeValidations(
       groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
     val existingRecordSetsMatch = existingRecordSets.getRecordSetMatch(zoneId, recordName)
 
-    val hasNonDeletedExistingRs = existingRecordSetsMatch.find { rs =>
+    val incompatibleDnsRRSetExists = existingRecordSetsMatch.find { rs =>
       val recordKey = RecordKey(zoneId, recordName, rs.typ)
       val containsAdds = groupedChanges.containsProposedAdds(recordKey)
       val proposedDeletes = groupedChanges.getProposedDeletes(recordKey)
@@ -494,7 +494,7 @@ class BatchChangeValidations(
       containsAdds || !containsFullDelete
     }
 
-    hasNonDeletedExistingRs match {
+    incompatibleDnsRRSetExists match {
       case Some(rs) => CnameIsNotUniqueError(inputName, rs.typ).invalidNel
       case None => ().validNel
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -455,11 +455,11 @@ class BatchChangeValidations(
         groupedChanges.existingRecordSets.getRecordSetMatch(zoneId, recordName).map(_.typ)
     }
 
-    val incompatibleExistingRecordType = existingRecordTypesMatch.find { recordType =>
+    val incompatibleRecordType = existingRecordTypesMatch.find { recordType =>
       groupedChanges.getProposedRecordData(RecordKey(zoneId, recordName, recordType)).nonEmpty
     }
 
-    incompatibleExistingRecordType match {
+    incompatibleRecordType match {
       case Some(recordType) => CnameIsNotUniqueError(inputName, recordType).invalidNel
       case None => ().validNel
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -240,7 +240,7 @@ class BatchChangeValidations(
     // Updates are a combination of an add and delete for a record with the same name and type in a zone.
     changeGroups.changes.mapValid {
       case addUpdate: AddChangeForValidation
-          if changeGroups.getChangeForValidationChanges(addUpdate.recordKey).containsDeletes =>
+          if changeGroups.getChangeForValidationDeletes(addUpdate.recordKey).nonEmpty =>
         validateAddUpdateWithContext(
           addUpdate,
           changeGroups,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -358,7 +358,7 @@ class BatchChangeValidations(
       ownerGroupId: Option[String]): SingleValidation[ChangeForValidation] = {
     val typedValidations = change.inputChange.typ match {
       case A | AAAA | MX =>
-        incompatibleRecordExistsOrWillExist(
+        incompatibleRecordExists(
           change.zone.id,
           change.recordName,
           change.inputChange.inputName,
@@ -367,7 +367,7 @@ class BatchChangeValidations(
           newRecordSetIsNotMulti(change, groupedChanges) |+|
           newRecordSetIsNotDotted(change)
       case CNAME =>
-        incompatibleRecordExistsOrWillExist(
+        incompatibleRecordExists(
           change.zone.id,
           change.recordName,
           change.inputChange.inputName,
@@ -376,7 +376,7 @@ class BatchChangeValidations(
           cnameHasUniqueNameInBatch(change, groupedChanges) |+|
           newRecordSetIsNotDotted(change)
       case TXT | PTR =>
-        incompatibleRecordExistsOrWillExist(
+        incompatibleRecordExists(
           change.zone.id,
           change.recordName,
           change.inputChange.inputName,
@@ -439,7 +439,7 @@ class BatchChangeValidations(
       case None => ().validNel
     }
 
-  def incompatibleRecordExistsOrWillExist(
+  def incompatibleRecordExists(
       zoneId: String,
       recordName: String,
       inputName: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -225,8 +225,14 @@ object BatchTransformations {
         }
         .flatten
 
+      val hasFullRecordSetDelete = changes.contains {
+        case _: DeleteRRSetChangeForValidation => true
+        case _ => false
+      }
+
       new ValidationChanges(addChangeRecordDataList.toSet,
         deleteChangeSet,
+        hasFullRecordSetDelete,
         existingRecords,
         addChangeTtlList.toSet.flatten)
     }
@@ -235,6 +241,7 @@ object BatchTransformations {
   final case class ValidationChanges(
                                       proposedAdds: Set[RecordData],
                                       proposedDeletes: Set[RecordData],
+                                      hasFullRecordSetDelete: Boolean,
                                       existingRecords: Set[RecordData],
                                       ttls: Set[Long])
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -178,10 +178,12 @@ object BatchTransformations {
       recordSetChanges: List[RecordSetChange])
 
   final case class ChangeForValidationMap(
-      changes: List[ChangeForValidation],
+      changes: ValidatedBatch[ChangeForValidation],
       existingRecordSets: ExistingRecordSets) {
+    import BatchChangeInterfaces._
+
     val innerMap: Map[RecordKey, ValidationChanges] = {
-      changes.groupBy(_.recordKey).map { keyChangesTuple =>
+      changes.getValid.groupBy(_.recordKey).map { keyChangesTuple =>
         val (recordKey, changeList) = keyChangesTuple
         val (addChanges, deleteChangeList) =
           changeList.partition(_.isAddChangeForValidation)
@@ -254,7 +256,6 @@ object BatchTransformations {
   final case class BatchValidationFlowOutput(
       validatedChanges: ValidatedBatch[ChangeForValidation],
       existingZones: ExistingZones,
-      existingRecordSets: ExistingRecordSets,
       changeGroups: ChangeForValidationMap
   )
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -190,14 +190,11 @@ object BatchTransformations {
       }
     }
 
+    def getExistingRecordSet(recordKey: RecordKey): Option[RecordSet] =
+      existingRecordSets.get(recordKey)
+
     def getProposedAdds(recordKey: RecordKey): Set[RecordData] =
       innerMap.get(recordKey).map(_.proposedAdds).toSet.flatten
-
-    def getProposedDeletes(recordKey: RecordKey): Set[RecordData] =
-      innerMap.get(recordKey).map(_.proposedDeletes).toSet.flatten
-
-    def getExistingRecordData(recordKey: RecordKey): Set[RecordData] =
-      innerMap.get(recordKey).map(_.existingRecordData).toSet.flatten
 
     // The new, net record data factoring in existing records, deletes and adds
     // If record is not edited in batch, will fallback to look up record in existing
@@ -210,12 +207,6 @@ object BatchTransformations {
 
     def getLogicalChangeType(recordKey: RecordKey): Option[LogicalChangeType] =
       innerMap.get(recordKey).map(_.logicalChangeType)
-
-    def containsProposedAdds(recordKey: RecordKey): Boolean =
-      getProposedAdds(recordKey).nonEmpty
-
-    def containsProposedDeletes(recordKey: RecordKey): Boolean =
-      getProposedDeletes(recordKey).nonEmpty
   }
 
   object ValidationChanges {
@@ -256,19 +247,12 @@ object BatchTransformations {
         case (false, false) => LogicalChangeType.NotEditedInBatch
       }
 
-      new ValidationChanges(
-        addChangeRecordDataSet,
-        deleteChangeSet,
-        existingRecords,
-        proposedRecordData,
-        logicalChangeType)
+      new ValidationChanges(addChangeRecordDataSet, proposedRecordData, logicalChangeType)
     }
   }
 
   final case class ValidationChanges(
       proposedAdds: Set[RecordData],
-      proposedDeletes: Set[RecordData],
-      existingRecordData: Set[RecordData],
       proposedRecordData: Set[RecordData],
       logicalChangeType: LogicalChangeType)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -196,8 +196,8 @@ object BatchTransformations {
     def getProposedDeletes(recordKey: RecordKey): Set[RecordData] =
       innerMap.get(recordKey).map(_.proposedDeletes).toSet.flatten
 
-    def getExistingRecordSets(recordKey: RecordKey): Set[RecordData] =
-      innerMap.get(recordKey).map(_.existingRecords).toSet.flatten
+    def getExistingRecordData(recordKey: RecordKey): Set[RecordData] =
+      innerMap.get(recordKey).map(_.existingRecordData).toSet.flatten
 
     // The new, net record data factoring in existing records, deletes and adds
     // If record is not edited in batch, will fallback to look up record in existing
@@ -268,7 +268,7 @@ object BatchTransformations {
   final case class ValidationChanges(
       proposedAdds: Set[RecordData],
       proposedDeletes: Set[RecordData],
-      existingRecords: Set[RecordData],
+      existingRecordData: Set[RecordData],
       proposedRecordData: Set[RecordData],
       logicalChangeType: LogicalChangeType)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -67,9 +67,6 @@ object BatchTransformations {
     def get(recordKey: RecordKey): Option[RecordSet] =
       get(recordKey.zoneId, recordKey.recordName, recordKey.recordType)
 
-    def containsRecordSetMatch(zoneId: String, name: String): Boolean =
-      recordSetMap.contains(zoneId, name.toLowerCase)
-
     def getRecordSetMatch(zoneId: String, name: String): List[RecordSet] =
       recordSetMap.getOrElse((zoneId, name.toLowerCase), List())
   }
@@ -149,6 +146,7 @@ object BatchTransformations {
     def isAddChangeForValidation: Boolean = false
   }
 
+  // $COVERAGE-OFF$
   final case class DeleteRecordChangeForValidation(
       zone: Zone,
       recordName: String,
@@ -172,6 +170,8 @@ object BatchTransformations {
 
     def isAddChangeForValidation: Boolean = false
   }
+
+  // $COVERAGE-ON$
 
   final case class BatchConversionOutput(
       batchChange: BatchChange,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -205,6 +205,9 @@ object BatchTransformations {
     // There is a distinction between having a delete in the batch and having a valid delete
     def containsValidDeleteChanges(recordKey: RecordKey): Boolean =
       innerMap.get(recordKey).exists(_.proposedDeletes.nonEmpty)
+
+    def containsFullRecordDelete(recordKey: RecordKey): Boolean =
+      innerMap.get(recordKey).exists(_.hasFullRecordSetDelete)
   }
 
   object ValidationChanges {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -200,8 +200,13 @@ object BatchTransformations {
       innerMap.get(recordKey).map(_.existingRecords).toSet.flatten
 
     // The new, net record data factoring in existing records, deletes and adds
-    def getProposedRecordData(recordKey: RecordKey): Set[RecordData] =
-      innerMap.get(recordKey).map(_.proposedRecordData).toSet.flatten
+    // If record is not edited in batch, will fallback to look up record in existing
+    // records
+    def getProposedRecordData(recordKey: RecordKey): Set[RecordData] = {
+      val batchRecordData = innerMap.get(recordKey).map(_.proposedRecordData)
+      lazy val existingRecordData = existingRecordSets.get(recordKey).map(_.records.toSet)
+      batchRecordData.getOrElse(existingRecordData.getOrElse(Set()))
+    }
 
     def getLogicalChangeType(recordKey: RecordKey): Option[LogicalChangeType] =
       innerMap.get(recordKey).map(_.logicalChangeType)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -189,24 +189,25 @@ object BatchTransformations {
       }
     }
 
-    def getChangeForValidationAdds(recordKey: RecordKey): Set[RecordData] =
+    def getProposedAdds(recordKey: RecordKey): Set[RecordData] =
       innerMap.get(recordKey).map(_.proposedAdds).toSet.flatten
 
-    def addChangesNotUnique(recordKey: RecordKey): Boolean = {
-      val validationChanges = innerMap.get(recordKey)
-      validationChanges.exists { c =>
-        c.proposedAdds.size > 1 || c.proposedAddTtls.size > 1
-      }
-    }
+    def getProposedAddTtls(recordKey: RecordKey): Set[Long] =
+      innerMap.get(recordKey).map(_.proposedAddTtls).toSet.flatten
 
-    def containsAddChanges(recordKey: RecordKey): Boolean =
-      getChangeForValidationAdds(recordKey).nonEmpty
+    def getProposedDeletes(recordKey: RecordKey): Set[RecordData] =
+      innerMap.get(recordKey).map(_.proposedDeletes).toSet.flatten
 
-    // There is a distinction between having a delete in the batch and having a valid delete
-    def containsValidDeleteChanges(recordKey: RecordKey): Boolean =
-      innerMap.get(recordKey).exists(_.proposedDeletes.nonEmpty)
+    def getExistingRecordSets(recordKey: RecordKey): Set[RecordData] =
+      innerMap.get(recordKey).map(_.existingRecords).toSet.flatten
 
-    def containsFullRecordDelete(recordKey: RecordKey): Boolean =
+    def containsProposedAdds(recordKey: RecordKey): Boolean =
+      getProposedAdds(recordKey).nonEmpty
+
+    def containsProposedDeletes(recordKey: RecordKey): Boolean =
+      getProposedDeletes(recordKey).nonEmpty
+
+    def hasFullRecordSetDelete(recordKey: RecordKey): Boolean =
       innerMap.get(recordKey).exists(_.hasFullRecordSetDelete)
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -196,13 +196,23 @@ class BatchChangeServiceSpec
 
   override protected def beforeEach(): Unit = batchChangeRepo.clear()
 
-  private def makeRS(zoneId: String, name: String, typ: RecordType): RecordSet =
-    RecordSet(zoneId, name, typ, 100, RecordSetStatus.Active, DateTime.now())
+  private def makeRS(
+      zoneId: String,
+      name: String,
+      typ: RecordType,
+      recordData: Option[List[RecordData]] = None): RecordSet = {
+    val records = recordData.getOrElse(List())
+    RecordSet(zoneId, name, typ, 100, RecordSetStatus.Active, DateTime.now(), records = records)
+  }
 
   private val existingApex: RecordSet =
     makeRS(apexAddForVal.zone.id, apexAddForVal.recordName, SOA)
   private val existingNonApex: RecordSet =
-    makeRS(nonApexAddForVal.zone.id, nonApexAddForVal.recordName, TXT)
+    makeRS(
+      nonApexAddForVal.zone.id,
+      nonApexAddForVal.recordName,
+      TXT,
+      recordData = Some(List(TXTData("some data"))))
   private val existingPtr: RecordSet =
     makeRS(ptrAddForVal.zone.id, ptrAddForVal.recordName, PTR)
   private val existingPtrDelegated: RecordSet =

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -789,8 +789,7 @@ class BatchChangeValidationsSpec
       false,
       None)
 
-    result(0) should haveInvalid[DomainValidationError](
-      RecordDoesNotExist(deleteUpdateA.inputChange.inputName))
+    result(0) shouldBe valid
     result(1) should haveInvalid[DomainValidationError](
       RecordDoesNotExist(deleteUpdateA.inputChange.inputName))
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -671,14 +671,16 @@ class BatchChangeValidationsSpec
     )
 
     val result = validateChangesWithContext(
-      List(
-        addA1.validNel,
-        existingA.validNel,
-        existingCname.validNel,
-        addA2.validNel,
-        duplicateNameCname.validNel,
-        duplicateNamePTR.validNel),
-      ExistingRecordSets(existingRsList),
+      ChangeForValidationMap(
+        List(
+          addA1.validNel,
+          existingA.validNel,
+          existingCname.validNel,
+          addA2.validNel,
+          duplicateNameCname.validNel,
+          duplicateNamePTR.validNel),
+        ExistingRecordSets(existingRsList)
+      ),
       okAuth,
       false,
       None
@@ -709,8 +711,9 @@ class BatchChangeValidationsSpec
         "Update",
         DeleteRRSetChangeInput("update.ok.", RecordType.A))
     val result = validateChangesWithContext(
-      List(addUpdateA.validNel, deleteUpdateA.validNel),
-      ExistingRecordSets(List(existingRecord)),
+      ChangeForValidationMap(
+        List(addUpdateA.validNel, deleteUpdateA.validNel),
+        ExistingRecordSets(List(existingRecord))),
       okAuth,
       false,
       None)
@@ -731,8 +734,9 @@ class BatchChangeValidationsSpec
       "update",
       DeleteRRSetChangeInput("update.ok.", RecordType.A))
     val result = validateChangesWithContext(
-      List(addUpdateA.validNel, deleteUpdateA.validNel),
-      ExistingRecordSets(List(existingRecord)),
+      ChangeForValidationMap(
+        List(addUpdateA.validNel, deleteUpdateA.validNel),
+        ExistingRecordSets(List(existingRecord))),
       notAuth,
       false,
       None)
@@ -755,8 +759,9 @@ class BatchChangeValidationsSpec
       "update",
       DeleteRRSetChangeInput("update.ok.", RecordType.A))
     val result = validateChangesWithContext(
-      List(addUpdateA.validNel, deleteUpdateA.validNel),
-      ExistingRecordSets(List(existingRecord)),
+      ChangeForValidationMap(
+        List(addUpdateA.validNel, deleteUpdateA.validNel),
+        ExistingRecordSets(List(existingRecord))),
       notAuth,
       false,
       None)
@@ -777,8 +782,9 @@ class BatchChangeValidationsSpec
       "does-not-exist",
       DeleteRRSetChangeInput("does-not-exist.ok.", RecordType.A))
     val result = validateChangesWithContext(
-      List(addUpdateA.validNel, deleteUpdateA.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(
+        List(addUpdateA.validNel, deleteUpdateA.validNel),
+        ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -804,8 +810,9 @@ class BatchChangeValidationsSpec
         "mx",
         DeleteRRSetChangeInput("mx.shared.", RecordType.MX))
     val result = validateChangesWithContext(
-      List(addUpdateA.validNel, deleteUpdateA.validNel),
-      ExistingRecordSets(List(existingRecord)),
+      ChangeForValidationMap(
+        List(addUpdateA.validNel, deleteUpdateA.validNel),
+        ExistingRecordSets(List(existingRecord))),
       okAuth,
       false,
       None)
@@ -826,8 +833,9 @@ class BatchChangeValidationsSpec
       "existing",
       DeleteRRSetChangeInput("existing.ok.", RecordType.CNAME))
     val result = validateChangesWithContext(
-      List(addA.validNel, deleteCname.validNel),
-      ExistingRecordSets(List(existingCname)),
+      ChangeForValidationMap(
+        List(addA.validNel, deleteCname.validNel),
+        ExistingRecordSets(List(existingCname))),
       okAuth,
       false,
       None)
@@ -847,8 +855,7 @@ class BatchChangeValidationsSpec
           records = List(CNAMEData("cname")))
         val newRecordSetList = existingCNAMERecord :: recordSetList
         val result = validateChangesWithContext(
-          List(input.validNel),
-          ExistingRecordSets(newRecordSetList),
+          ChangeForValidationMap(List(input.validNel), ExistingRecordSets(newRecordSetList)),
           okAuth,
           false,
           None)
@@ -863,8 +870,7 @@ class BatchChangeValidationsSpec
     forAll(validAddChangeForValidationGen) { input: AddChangeForValidation =>
       val result =
         validateChangesWithContext(
-          List(input.validNel),
-          ExistingRecordSets(recordSetList),
+          ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           okAuth,
           false,
           None)
@@ -878,8 +884,7 @@ class BatchChangeValidationsSpec
     List(rsOk, aaaa, ptrIp4, ptrIp6).foreach { recordSet =>
       forAll(generateValidAddChangeForValidation(recordSet)) { input: AddChangeForValidation =>
         val result = validateChangesWithContext(
-          List(input.validNel),
-          ExistingRecordSets(recordSetList),
+          ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           okAuth,
           false,
           None)
@@ -895,8 +900,7 @@ class BatchChangeValidationsSpec
         zoneId = input.zone.id,
         name = input.recordName.toUpperCase) :: recordSetList
       val result = validateChangesWithContext(
-        List(input.validNel),
-        ExistingRecordSets(existingRecordSetList),
+        ChangeForValidationMap(List(input.validNel), ExistingRecordSets(existingRecordSetList)),
         okAuth,
         false,
         None)
@@ -919,8 +923,9 @@ class BatchChangeValidationsSpec
     val existingA = rsOk.copy(zoneId = addCname.zone.id, name = addCname.recordName)
     val newRecordSetList = existingA :: recordSetList
     val result = validateChangesWithContext(
-      List(addCname.validNel, deleteA.validNel),
-      ExistingRecordSets(newRecordSetList),
+      ChangeForValidationMap(
+        List(addCname.validNel, deleteA.validNel),
+        ExistingRecordSets(newRecordSetList)),
       okAuth,
       false,
       None)
@@ -938,8 +943,7 @@ class BatchChangeValidationsSpec
     val existingA = rsOk.copy(zoneId = addCname.zone.id, name = addCname.recordName)
     val newRecordSetList = existingA :: recordSetList
     val result = validateChangesWithContext(
-      List(addCname.validNel),
-      ExistingRecordSets(newRecordSetList),
+      ChangeForValidationMap(List(addCname.validNel), ExistingRecordSets(newRecordSetList)),
       okAuth,
       false,
       None)
@@ -961,8 +965,9 @@ class BatchChangeValidationsSpec
       DeleteRRSetChangeInput("192.0.2.30", RecordType.PTR))
     val ptr4 = ptrIp4.copy(zoneId = validIp4ReverseZone.id)
     val result = validateChangesWithContext(
-      List(addCname.validNel, deletePtr.validNel),
-      ExistingRecordSets(List(ptr4)),
+      ChangeForValidationMap(
+        List(addCname.validNel, deletePtr.validNel),
+        ExistingRecordSets(List(ptr4))),
       okAuth,
       false,
       None)
@@ -984,8 +989,7 @@ class BatchChangeValidationsSpec
     )
     val existingRecordPTR = ptrIp6.copy(zoneId = addCname.zone.id, name = addCname.recordName)
     val result = validateChangesWithContext(
-      List(addCname.validNel),
-      ExistingRecordSets(List(existingRecordPTR)),
+      ChangeForValidationMap(List(addCname.validNel), ExistingRecordSets(List(existingRecordPTR))),
       okAuth,
       false,
       None)
@@ -1009,8 +1013,9 @@ class BatchChangeValidationsSpec
       "new",
       AddChangeInput("new.ok.", RecordType.CNAME, ttl, CNAMEData("hey.ok.com.")))
     val result = validateChangesWithContext(
-      List(addA.validNel, addAAAA.validNel, addCname.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(
+        List(addA.validNel, addAAAA.validNel, addCname.validNel),
+        ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -1035,8 +1040,9 @@ class BatchChangeValidationsSpec
       "testAAAA",
       AddChangeInput("testAAAA.ok.", RecordType.AAAA, ttl, AAAAData("1:2:3:4:5:6:7:8")))
     val result = validateChangesWithContext(
-      List(addA.validNel, addAAAA.validNel, addDuplicateCname.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(
+        List(addA.validNel, addAAAA.validNel, addDuplicateCname.validNel),
+        ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -1064,8 +1070,9 @@ class BatchChangeValidationsSpec
       "testAAAA",
       AddChangeInput("testAAAA.ok.", RecordType.CNAME, ttl, CNAMEData("hey2.ok.com.")))
     val result = validateChangesWithContext(
-      List(addA.validNel, addCname.validNel, addDuplicateCname.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(
+        List(addA.validNel, addCname.validNel, addDuplicateCname.validNel),
+        ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -1094,8 +1101,9 @@ class BatchChangeValidationsSpec
       "193",
       AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData("hey.ok.com.")))
     val result = validateChangesWithContext(
-      List(addA.validNel, addPtr.validNel, addDuplicatePtr.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(
+        List(addA.validNel, addPtr.validNel, addDuplicatePtr.validNel),
+        ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -1111,8 +1119,7 @@ class BatchChangeValidationsSpec
       AddChangeInput("valid.ok.", RecordType.A, ttl, AData("1.1.1.1")))
     val result =
       validateChangesWithContext(
-        List(addA.validNel),
-        ExistingRecordSets(recordSetList),
+        ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
         okAuth,
         false,
         None)
@@ -1127,8 +1134,7 @@ class BatchChangeValidationsSpec
       "valid",
       AddChangeInput("valid.ok.", RecordType.A, ttl, AData("1.1.1.1")))
     val result = validateChangesWithContext(
-      List(addA.validNel),
-      ExistingRecordSets(recordSetList),
+      ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
       AuthPrincipal(superUser, Seq.empty),
       false,
       None)
@@ -1145,8 +1151,7 @@ class BatchChangeValidationsSpec
     )
     val result =
       validateChangesWithContext(
-        List(addA.validNel),
-        ExistingRecordSets(recordSetList),
+        ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
         notAuth,
         false,
         None)
@@ -1160,8 +1165,7 @@ class BatchChangeValidationsSpec
     forAll(validAddChangeForValidationGen) { input: AddChangeForValidation =>
       val result =
         validateChangesWithContext(
-          List(input.validNel),
-          ExistingRecordSets(recordSetList),
+          ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           notAuth,
           false,
           None)
@@ -1182,8 +1186,7 @@ class BatchChangeValidationsSpec
       "existing",
       AddChangeInput("existing.ok.", RecordType.PTR, ttl, CNAMEData("ptrdname.")))
     val result = validateChangesWithContext(
-      List(addCname.validNel, addPtr.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(List(addCname.validNel, addPtr.validNel), ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -1201,8 +1204,9 @@ class BatchChangeValidationsSpec
     val existingDeleteRecord =
       rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName.toLowerCase)
     val result = validateChangesWithContext(
-      List(deleteA.validNel),
-      ExistingRecordSets(List(existingDeleteRecord)),
+      ChangeForValidationMap(
+        List(deleteA.validNel),
+        ExistingRecordSets(List(existingDeleteRecord))),
       okAuth,
       false,
       None)
@@ -1219,8 +1223,7 @@ class BatchChangeValidationsSpec
       DeleteRRSetChangeInput("record-does-not-exist.ok.", RecordType.A))
     val result =
       validateChangesWithContext(
-        List(deleteA.validNel),
-        ExistingRecordSets(recordSetList),
+        ChangeForValidationMap(List(deleteA.validNel), ExistingRecordSets(recordSetList)),
         okAuth,
         false,
         None)
@@ -1240,8 +1243,9 @@ class BatchChangeValidationsSpec
       name = deleteA.recordName.toLowerCase,
       status = RecordSetStatus.Active)
     val result = validateChangesWithContext(
-      List(deleteA.validNel),
-      ExistingRecordSets(List(existingDeleteRecord)),
+      ChangeForValidationMap(
+        List(deleteA.validNel),
+        ExistingRecordSets(List(existingDeleteRecord))),
       okAuth,
       false,
       None)
@@ -1258,8 +1262,9 @@ class BatchChangeValidationsSpec
         DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
-      List(deleteA.validNel),
-      ExistingRecordSets(List(existingDeleteRecord)),
+      ChangeForValidationMap(
+        List(deleteA.validNel),
+        ExistingRecordSets(List(existingDeleteRecord))),
       okAuth,
       false,
       None)
@@ -1276,8 +1281,9 @@ class BatchChangeValidationsSpec
         DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
-      List(deleteA.validNel),
-      ExistingRecordSets(List(existingDeleteRecord)),
+      ChangeForValidationMap(
+        List(deleteA.validNel),
+        ExistingRecordSets(List(existingDeleteRecord))),
       AuthPrincipal(superUser, Seq.empty),
       false,
       None)
@@ -1294,8 +1300,9 @@ class BatchChangeValidationsSpec
       DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
-      List(deleteA.validNel),
-      ExistingRecordSets(List(existingDeleteRecord)),
+      ChangeForValidationMap(
+        List(deleteA.validNel),
+        ExistingRecordSets(List(existingDeleteRecord))),
       notAuth,
       false,
       None)
@@ -1312,8 +1319,9 @@ class BatchChangeValidationsSpec
       DeleteRRSetChangeInput("valid.ok.", RecordType.A))
     val existingDeleteRecord = rsOk.copy(zoneId = deleteA.zone.id, name = deleteA.recordName)
     val result = validateChangesWithContext(
-      List(deleteA.validNel),
-      ExistingRecordSets(List(existingDeleteRecord)),
+      ChangeForValidationMap(
+        List(deleteA.validNel),
+        ExistingRecordSets(List(existingDeleteRecord))),
       notAuth,
       false,
       None)
@@ -1354,14 +1362,16 @@ class BatchChangeValidationsSpec
     val existingCname =
       rsOk.copy(zoneId = deleteCname.zone.id, name = deleteCname.recordName, typ = RecordType.CNAME)
     val result = validateChangesWithContext(
-      List(
-        addDuplicateA.validNel,
-        addDuplicateCname.validNel,
-        deleteA.validNel,
-        addCname.validNel,
-        addA.validNel,
-        deleteCname.validNel),
-      ExistingRecordSets(List(existingA, existingCname)),
+      ChangeForValidationMap(
+        List(
+          addDuplicateA.validNel,
+          addDuplicateCname.validNel,
+          deleteA.validNel,
+          addCname.validNel,
+          addA.validNel,
+          deleteCname.validNel),
+        ExistingRecordSets(List(existingA, existingCname))
+      ),
       okAuth,
       false,
       None
@@ -1398,11 +1408,13 @@ class BatchChangeValidationsSpec
       "193",
       AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData("test.ok.")))
     val result = validateChangesWithContext(
-      List(deleteA.validNel, addA.validNel, addAAAA.validNel, addCname.validNel, addPtr.validNel),
-      ExistingRecordSets(List(existingA)),
+      ChangeForValidationMap(
+        List(deleteA.validNel, addA.validNel, addAAAA.validNel, addCname.validNel, addPtr.validNel),
+        ExistingRecordSets(List(existingA))),
       okAuth,
       false,
-      None)
+      None
+    )
     result.map(_ shouldBe valid)
   }
 
@@ -1430,11 +1442,13 @@ class BatchChangeValidationsSpec
       AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData("test.ok.")))
 
     val result = validateChangesWithContext(
-      List(deleteCname.validNel, addA.validNel, addAAAA.validNel, addPtr.validNel),
-      ExistingRecordSets(List(existingCname)),
+      ChangeForValidationMap(
+        List(deleteCname.validNel, addA.validNel, addAAAA.validNel, addPtr.validNel),
+        ExistingRecordSets(List(existingCname))),
       okAuth,
       false,
-      None)
+      None
+    )
     result.map(_ shouldBe valid)
   }
 
@@ -1453,8 +1467,9 @@ class BatchChangeValidationsSpec
       "new",
       AddChangeInput("new.ok.", RecordType.CNAME, ttl, CNAMEData("updateData.com")))
     val result = validateChangesWithContext(
-      List(deleteCname.validNel, addCname.validNel),
-      ExistingRecordSets(List(existingCname)),
+      ChangeForValidationMap(
+        List(deleteCname.validNel, addCname.validNel),
+        ExistingRecordSets(List(existingCname))),
       okAuth,
       false,
       None)
@@ -1482,11 +1497,13 @@ class BatchChangeValidationsSpec
       AddChangeInput("add.ok.", RecordType.CNAME, ttl, CNAMEData("new.add.cname.")))
 
     val result = validateChangesWithContext(
-      List(deleteUpdateCname.validNel, addUpdateCname.validNel, addCname.validNel),
-      ExistingRecordSets(List(existingCname)),
+      ChangeForValidationMap(
+        List(deleteUpdateCname.validNel, addUpdateCname.validNel, addCname.validNel),
+        ExistingRecordSets(List(existingCname))),
       okAuth,
       false,
-      None)
+      None
+    )
 
     result(0) shouldBe valid
     result(1) should haveInvalid[DomainValidationError](
@@ -1512,8 +1529,9 @@ class BatchChangeValidationsSpec
       AddChangeInput("test.ok.", RecordType.CNAME, ttl, CNAMEData("hey2.there.")))
 
     val result = validateChangesWithContext(
-      List(deletePtr.validNel, addCname.validNel),
-      ExistingRecordSets(List(existingPtr)),
+      ChangeForValidationMap(
+        List(deletePtr.validNel, addCname.validNel),
+        ExistingRecordSets(List(existingPtr))),
       okAuth,
       false,
       None)
@@ -1537,8 +1555,9 @@ class BatchChangeValidationsSpec
       "193",
       AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData("updateData.com")))
     val result = validateChangesWithContext(
-      List(deletePtr.validNel, addPtr.validNel),
-      ExistingRecordSets(List(existingPtr)),
+      ChangeForValidationMap(
+        List(deletePtr.validNel, addPtr.validNel),
+        ExistingRecordSets(List(existingPtr))),
       okAuth,
       false,
       None)
@@ -1566,8 +1585,9 @@ class BatchChangeValidationsSpec
       AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData("new.add.ptr.")))
 
     val result = validateChangesWithContext(
-      List(deleteUpdatePtr.validNel, addUpdatePtr.validNel, addPtr.validNel),
-      ExistingRecordSets(List(existingPtr)),
+      ChangeForValidationMap(
+        List(deleteUpdatePtr.validNel, addUpdatePtr.validNel, addPtr.validNel),
+        ExistingRecordSets(List(existingPtr))),
       okAuth,
       false,
       None)
@@ -1650,8 +1670,7 @@ class BatchChangeValidationsSpec
 
     val result =
       validateChangesWithContext(
-        List(addMX.validNel),
-        ExistingRecordSets(List(existingMX)),
+        ChangeForValidationMap(List(addMX.validNel), ExistingRecordSets(List(existingMX))),
         okAuth,
         false,
         None)
@@ -1669,8 +1688,7 @@ class BatchChangeValidationsSpec
       AddChangeInput("name-conflict", RecordType.MX, ttl, MXData(2, "foo.bar.")))
 
     val result = validateChangesWithContext(
-      List(addMx.validNel, addMx2.validNel),
-      ExistingRecordSets(List()),
+      ChangeForValidationMap(List(addMx.validNel, addMx2.validNel), ExistingRecordSets(List())),
       okAuth,
       false,
       None)
@@ -1693,8 +1711,9 @@ class BatchChangeValidationsSpec
       AddChangeInput("name-conflict", RecordType.MX, ttl, MXData(1, "foo.bar.")))
 
     val result = validateChangesWithContext(
-      List(deleteMx.validNel, addMx.validNel),
-      ExistingRecordSets(List(existingMx)),
+      ChangeForValidationMap(
+        List(deleteMx.validNel, addMx.validNel),
+        ExistingRecordSets(List(existingMx))),
       okAuth,
       false,
       None)
@@ -1703,23 +1722,25 @@ class BatchChangeValidationsSpec
 
   property("validateChangesWithContext: should properly validate changes with owner group ID") {
     val result = validateChangesWithContext(
-      List(
-        createPrivateAddChange,
-        createSharedAddChange,
-        updatePrivateAddChange,
-        updatePrivateDeleteChange,
-        updateSharedAddChange,
-        updateSharedDeleteChange,
-        deletePrivateChange,
-        deleteSharedChange
-      ).map(_.validNel),
-      ExistingRecordSets(
+      ChangeForValidationMap(
         List(
-          rsOk.copy(name = "private-update"),
-          sharedZoneRecord.copy(name = "shared-update"),
-          rsOk.copy(name = "private-delete"),
-          sharedZoneRecord.copy(name = "shared-delete")
-        )),
+          createPrivateAddChange,
+          createSharedAddChange,
+          updatePrivateAddChange,
+          updatePrivateDeleteChange,
+          updateSharedAddChange,
+          updateSharedDeleteChange,
+          deletePrivateChange,
+          deleteSharedChange
+        ).map(_.validNel),
+        ExistingRecordSets(
+          List(
+            rsOk.copy(name = "private-update"),
+            sharedZoneRecord.copy(name = "shared-update"),
+            rsOk.copy(name = "private-delete"),
+            sharedZoneRecord.copy(name = "shared-delete")
+          ))
+      ),
       AuthPrincipal(okUser, Seq(abcGroup.id, okGroup.id)),
       false,
       Some("some-owner-group-id")
@@ -1730,23 +1751,25 @@ class BatchChangeValidationsSpec
 
   property("validateChangesWithContext: should properly validate changes without owner group ID") {
     val result = validateChangesWithContext(
-      List(
-        createPrivateAddChange,
-        createSharedAddChange,
-        updatePrivateAddChange,
-        updatePrivateDeleteChange,
-        updateSharedAddChange,
-        updateSharedDeleteChange,
-        deletePrivateChange,
-        deleteSharedChange
-      ).map(_.validNel),
-      ExistingRecordSets(
+      ChangeForValidationMap(
         List(
-          rsOk.copy(name = "private-update"),
-          sharedZoneRecordNoOwnerGroup.copy(name = "shared-update"),
-          rsOk.copy(name = "private-delete"),
-          sharedZoneRecord.copy(name = "shared-delete")
-        )),
+          createPrivateAddChange,
+          createSharedAddChange,
+          updatePrivateAddChange,
+          updatePrivateDeleteChange,
+          updateSharedAddChange,
+          updateSharedDeleteChange,
+          deletePrivateChange,
+          deleteSharedChange
+        ).map(_.validNel),
+        ExistingRecordSets(
+          List(
+            rsOk.copy(name = "private-update"),
+            sharedZoneRecordNoOwnerGroup.copy(name = "shared-update"),
+            rsOk.copy(name = "private-delete"),
+            sharedZoneRecord.copy(name = "shared-delete")
+          ))
+      ),
       AuthPrincipal(okUser, Seq(abcGroup.id, okGroup.id)),
       false,
       None
@@ -1769,8 +1792,9 @@ class BatchChangeValidationsSpec
   property(
     "validateChangesWithContext: should fail deleting record for normal user not in owner group in shared zone") {
     val result = validateChangesWithContext(
-      List(deleteSharedChange.validNel),
-      ExistingRecordSets(List(sharedZoneRecord.copy(name = "shared-delete"))),
+      ChangeForValidationMap(
+        List(deleteSharedChange.validNel),
+        ExistingRecordSets(List(sharedZoneRecord.copy(name = "shared-delete")))),
       dummyAuth,
       false,
       None)
@@ -1782,8 +1806,9 @@ class BatchChangeValidationsSpec
   property(
     "validateChangesWithContext: should delete record without owner group for normal user in shared zone") {
     val result = validateChangesWithContext(
-      List(deleteSharedChange.validNel),
-      ExistingRecordSets(List(sharedZoneRecord.copy(name = "shared-delete"))),
+      ChangeForValidationMap(
+        List(deleteSharedChange.validNel),
+        ExistingRecordSets(List(sharedZoneRecord.copy(name = "shared-delete")))),
       okAuth,
       false,
       None)
@@ -1793,8 +1818,9 @@ class BatchChangeValidationsSpec
 
   property("validateChangesWithContext: should delete record for zone admin in shared zone") {
     val result = validateChangesWithContext(
-      List(deleteSharedChange.validNel),
-      ExistingRecordSets(List(sharedZoneRecord.copy(name = "shared-delete"))),
+      ChangeForValidationMap(
+        List(deleteSharedChange.validNel),
+        ExistingRecordSets(List(sharedZoneRecord.copy(name = "shared-delete")))),
       sharedAuth,
       false,
       None)
@@ -1816,15 +1842,17 @@ class BatchChangeValidationsSpec
     )
 
     val result = underTest.validateChangesWithContext(
-      List(
-        updateSharedAddChange.validNel,
-        updateSharedDeleteChange.validNel,
-        deleteSharedChange.validNel,
-        updatePrivateAddChange.validNel,
-        updatePrivateDeleteChange.validNel,
-        deletePrivateChange.validNel
+      ChangeForValidationMap(
+        List(
+          updateSharedAddChange.validNel,
+          updateSharedDeleteChange.validNel,
+          deleteSharedChange.validNel,
+          updatePrivateAddChange.validNel,
+          updatePrivateDeleteChange.validNel,
+          deletePrivateChange.validNel
+        ),
+        ExistingRecordSets(existing)
       ),
-      ExistingRecordSets(existing),
       okAuth,
       false,
       Some(okGroup.id)
@@ -1853,15 +1881,17 @@ class BatchChangeValidationsSpec
     )
 
     val result = underTestMultiDisabled.validateChangesWithContext(
-      List(
-        updateSharedAddChange.validNel,
-        updateSharedDeleteChange.validNel,
-        deleteSharedChange.validNel,
-        updatePrivateAddChange.validNel,
-        updatePrivateDeleteChange.validNel,
-        deletePrivateChange.validNel
+      ChangeForValidationMap(
+        List(
+          updateSharedAddChange.validNel,
+          updateSharedDeleteChange.validNel,
+          deleteSharedChange.validNel,
+          updatePrivateAddChange.validNel,
+          updatePrivateDeleteChange.validNel,
+          deletePrivateChange.validNel
+        ),
+        ExistingRecordSets(existing)
       ),
-      ExistingRecordSets(existing),
       okAuth,
       false,
       Some(okGroup.id)
@@ -1899,15 +1929,17 @@ class BatchChangeValidationsSpec
     )
 
     val result = underTest.validateChangesWithContext(
-      List(
-        updateSharedDeleteChange.validNel,
-        update1.validNel,
-        update2.validNel,
-        add1.validNel,
-        add2.validNel,
-        updatePrivateAddChange.validNel
+      ChangeForValidationMap(
+        List(
+          updateSharedDeleteChange.validNel,
+          update1.validNel,
+          update2.validNel,
+          add1.validNel,
+          add2.validNel,
+          updatePrivateAddChange.validNel
+        ),
+        ExistingRecordSets(existing)
       ),
-      ExistingRecordSets(existing),
       okAuth,
       false,
       Some(okGroup.id)
@@ -1945,15 +1977,17 @@ class BatchChangeValidationsSpec
     )
 
     val result = underTestMultiDisabled.validateChangesWithContext(
-      List(
-        updateSharedDeleteChange.validNel,
-        update1.validNel,
-        update2.validNel,
-        add1.validNel,
-        add2.validNel,
-        updatePrivateAddChange.validNel
+      ChangeForValidationMap(
+        List(
+          updateSharedDeleteChange.validNel,
+          update1.validNel,
+          update2.validNel,
+          add1.validNel,
+          add2.validNel,
+          updatePrivateAddChange.validNel
+        ),
+        ExistingRecordSets(existing)
       ),
-      ExistingRecordSets(existing),
       okAuth,
       false,
       Some(okGroup.id)
@@ -2001,11 +2035,13 @@ class BatchChangeValidationsSpec
 
     val result =
       validateChangesWithContext(
-        List(addA.validNel, addAAAA.validNel, addCNAME.validNel, addMX.validNel, addTXT.validNel),
-        ExistingRecordSets(List()),
+        ChangeForValidationMap(
+          List(addA.validNel, addAAAA.validNel, addCNAME.validNel, addMX.validNel, addTXT.validNel),
+          ExistingRecordSets(List())),
         okAuth,
         false,
-        None)
+        None
+      )
 
     result(0) should haveInvalid[DomainValidationError](ZoneDiscoveryError("dotted.a.ok."))
     result(1) should haveInvalid[DomainValidationError](ZoneDiscoveryError("dotted.aaaa.ok."))
@@ -2042,13 +2078,15 @@ class BatchChangeValidationsSpec
       "existing.dotted.txt",
       DeleteRRSetChangeInput("existing.dotted.txt.ok.", RecordType.TXT))
     val result = validateChangesWithContext(
-      List(
-        deleteA.validNel,
-        deleteAAAA.validNel,
-        deleteCname.validNel,
-        deleteMX.validNel,
-        deleteTXT.validNel),
-      ExistingRecordSets(List(existingA, existingAAAA, existingCname, existingMX, existingTXT)),
+      ChangeForValidationMap(
+        List(
+          deleteA.validNel,
+          deleteAAAA.validNel,
+          deleteCname.validNel,
+          deleteMX.validNel,
+          deleteTXT.validNel),
+        ExistingRecordSets(List(existingA, existingAAAA, existingCname, existingMX, existingTXT))
+      ),
       okAuth,
       false,
       None
@@ -2116,19 +2154,21 @@ class BatchChangeValidationsSpec
       AddChangeInput("existing.dotted.txt.ok.", RecordType.TXT, Some(700), TXTData("testing")))
 
     val result = validateChangesWithContext(
-      List(
-        addUpdateA.validNel,
-        addUpdateAAAA.validNel,
-        addUpdateCNAME.validNel,
-        addUpdateMX.validNel,
-        addUpdateTXT.validNel,
-        deleteA.validNel,
-        deleteAAAA.validNel,
-        deleteCname.validNel,
-        deleteMX.validNel,
-        deleteTXT.validNel
+      ChangeForValidationMap(
+        List(
+          addUpdateA.validNel,
+          addUpdateAAAA.validNel,
+          addUpdateCNAME.validNel,
+          addUpdateMX.validNel,
+          addUpdateTXT.validNel,
+          deleteA.validNel,
+          deleteAAAA.validNel,
+          deleteCname.validNel,
+          deleteMX.validNel,
+          deleteTXT.validNel
+        ),
+        ExistingRecordSets(List(existingA, existingAAAA, existingCname, existingMX, existingTXT))
       ),
-      ExistingRecordSets(List(existingA, existingAAAA, existingCname, existingMX, existingTXT)),
       okAuth,
       false,
       None

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -584,4 +584,14 @@ class BatchChangeJsonProtocolSpec
         s"Comment length must not exceed $MAX_COMMENT_LENGTH characters.".invalidNel
     }
   }
+
+  "Round-trip serialization/deserialization of DeleteRecordChangeInput" should {
+    "succeed" in {
+      val deleteRecordChangeInput =
+        DeleteRecordChangeInput("recordName.zoneName.", A, AData("3.2.4.1"))
+      DeleteRecordChangeInputSerializer.fromJson(
+        DeleteRecordChangeInputSerializer.toJson(deleteRecordChangeInput)) shouldBe
+        deleteRecordChangeInput.validNel
+    }
+  }
 }


### PR DESCRIPTION
Pre-requisite to updating `DeleteRecord` validations.

Refactors `ChangeForValidationMap` to consolidate information to use for `DeleteRecord` validation logic and batch change converter.

Changes in this pull request:
- Refactor `ChangeForValidationMap`. Mapping of `RecordKey` is no longer to applicable `ChangeForValidation`s, but instead to consolidated record data.
- New `LogicalChangeType` attribute added to tag the net type of DNS change resulting from all of the batch inputs and existing DNS records. Possible values are `Add`, `FullDelete` (i.e. record will no longer exist), `Update` and `NotEditedInBatch` (should never hit this case)
- Update unit tests

Changes in validation (following) PR:
- Update access validations for delete record
- Update validations to make sure that delete requests are valid