### PR TITLE
update ManualReviewRequiresOwnerGroup error message

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -315,7 +315,7 @@ def test_create_scheduled_batch_change_with_zone_discovery_error_without_owner_g
 
     errors = client.create_batch_change(batch_change_input, status=400)
 
-    assert_that(errors, is_("Batch change requires owner group for manual review/scheduled changes."))
+    assert_that(errors, is_("Batch change requires owner group for manual review."))
 
 
 @pytest.mark.manual_batch_review
@@ -400,7 +400,7 @@ def test_create_batch_change_with_zone_discovery_error_without_owner_group_fails
 
     errors = client.create_batch_change(batch_change_input, status=400)
 
-    assert_that(errors, is_("Batch change requires owner group for manual review/scheduled changes."))
+    assert_that(errors, is_("Batch change requires owner group for manual review."))
 
 
 def test_create_batch_change_with_updates_deletes_success(shared_zone_test_context):

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -73,5 +73,5 @@ final case class ScheduledChangeNotDue(scheduledTime: DateTime) extends BatchCha
 
 case object ManualReviewRequiresOwnerGroup extends BatchChangeErrorResponse {
   val message: String =
-    "Batch change requires owner group for manual review/scheduled changes."
+    "Batch change requires owner group for manual review."
 }


### PR DESCRIPTION
Changes in this pull request:
- removed "scheduled changes" from the error message "Batch change requires owner group for manual review/scheduled changes." since scheduled changes don't require a batch change owner group.
