### PR TITLE
Revalidate scheduled batch changes

### DIFF
--- a/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/approve_batch_change_test.py
@@ -61,7 +61,7 @@ def test_approve_pending_batch_change_success(shared_zone_test_context):
     finally:
         clear_zoneid_rsid_tuple_list(to_delete, client)
         if to_disconnect:
-            approver.abandon_zones(to_disconnect['id'], status=202)
+            approver.abandon_zones([to_disconnect['id']], status=202)
 
 @pytest.mark.manual_batch_review
 def test_approve_pending_batch_change_fails_if_there_are_still_errors(shared_zone_test_context):

--- a/modules/api/functional_test/live_tests/batch/revalidate_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/revalidate_batch_change_test.py
@@ -1,0 +1,123 @@
+from hamcrest import *
+from utils import *
+
+@pytest.mark.serial
+@pytest.mark.manual_batch_review
+def test_revalidate_pending_batch_change_success(shared_zone_test_context):
+    """
+    Test revalidating a batch change succeeds for a support user
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    approver = shared_zone_test_context.support_user_client
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("test-approve-success.not.loaded.", address="4.3.2.1"),
+            get_change_A_AAAA_json("needs-review.not.loaded.", address="4.3.2.1"),
+            get_change_A_AAAA_json("zone-name-flagged-for-manual-review.zone.requires.review.")
+        ],
+        "ownerGroupId": shared_zone_test_context.ok_group['id']
+    }
+
+    to_delete = []
+    to_disconnect = None
+    try:
+        result = client.create_batch_change(batch_change_input, status=202)
+        get_batch = client.get_batch_change(result['id'])
+        assert_that(get_batch['status'], is_('PendingReview'))
+        assert_that(get_batch['approvalStatus'], is_('PendingReview'))
+        assert_that(get_batch['changes'][0]['status'], is_('NeedsReview'))
+        assert_that(get_batch['changes'][0]['validationErrors'][0]['errorType'], is_('ZoneDiscoveryError'))
+        assert_that(get_batch['changes'][1]['status'], is_('NeedsReview'))
+        assert_that(get_batch['changes'][1]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
+        assert_that(get_batch['changes'][2]['status'], is_('NeedsReview'))
+        assert_that(get_batch['changes'][2]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
+
+        # need to create the zone so the change can succeed
+        zone = {
+            'name': 'not.loaded.',
+            'email': 'test@test.com',
+            'adminGroupId': shared_zone_test_context.ok_group['id'],
+            'backendId': 'func-test-backend',
+            'shared': True
+        }
+        zone_create = approver.create_zone(zone, status=202)
+        to_disconnect = zone_create['zone']
+        approver.wait_until_zone_active(to_disconnect['id'])
+
+        revalidated = approver.revalidate_batch_change(result['id'], status=200)
+
+        assert_that(revalidated['status'], is_('PendingReview'))
+        assert_that(revalidated['changes'][0]['status'], is_('Pending'))
+        assert_that(len(revalidated['changes'][0]['validationErrors']), is_(0))
+        assert_that(revalidated['changes'][1]['status'], is_('NeedsReview'))
+        assert_that(revalidated['changes'][1]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
+        assert_that(revalidated['changes'][2]['status'], is_('NeedsReview'))
+        assert_that(revalidated['changes'][2]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
+    finally:
+        clear_zoneid_rsid_tuple_list(to_delete, client)
+        if to_disconnect:
+            approver.abandon_zones(to_disconnect['id'], status=202)
+
+
+@pytest.mark.manual_batch_review
+def test_revalidate_scheduled_batch_change_fails_if_it_is_not_pending_review(shared_zone_test_context):
+    """
+    Test revalidating a batch change fails if it is not pending review
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    approver = shared_zone_test_context.support_user_client
+
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("scheduled-record.shared.", address="4.3.2.1"),
+        ],
+        "ownerGroupId": shared_zone_test_context.ok_group['id']
+    }
+    to_delete = []
+    try:
+        result = client.create_batch_change(batch_change_input, status=202)
+        completed_batch = client.wait_until_batch_change_completed(result)
+        to_delete = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
+        assert_that(completed_batch['status'], is_('Complete'))
+        assert_that(completed_batch['approvalStatus'], is_('AutoApproved'))
+        assert_that(completed_batch['changes'][0]['status'], is_('Complete'))
+
+        error = approver.revalidate_batch_change(result['id'], status=400)
+        assert_that(error, contains_string("Batch change " + result['id'] + " is not pending review"))
+    finally:
+        clear_zoneid_rsid_tuple_list(to_delete, client)
+
+
+@pytest.mark.manual_batch_review
+def test_revalidate_batch_change_with_invalid_batch_change_id_fails(shared_zone_test_context):
+    """
+    Test revalidating a batch change with invalid batch change ID
+    """
+
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    error = client.revalidate_batch_change("some-id", status=404)
+    assert_that(error, is_("Batch change with id some-id cannot be found"))
+
+
+@pytest.mark.manual_batch_review
+def test_revalidating_batch_change_fails_with_forbidden_error_for_non_system_admins(shared_zone_test_context):
+    """
+    Test revalidating a batch change if the reviewer is not a super user or support user
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("no-owner-group-id.ok.", address="4.3.2.1")
+        ]
+    }
+    to_delete = []
+
+    try:
+        result = client.create_batch_change(batch_change_input, status=202)
+        completed_batch = client.wait_until_batch_change_completed(result)
+        to_delete = [(change['zoneId'], change['recordSetId']) for change in completed_batch['changes']]
+        error = client.revalidate_batch_change(completed_batch['id'], status=403)
+        assert_that(error, is_("User does not have access to item " + completed_batch['id']))
+    finally:
+        clear_zoneid_rsid_tuple_list(to_delete, client)

--- a/modules/api/functional_test/live_tests/batch/revalidate_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/revalidate_batch_change_test.py
@@ -11,7 +11,7 @@ def test_revalidate_pending_batch_change_success(shared_zone_test_context):
     approver = shared_zone_test_context.support_user_client
     batch_change_input = {
         "changes": [
-            get_change_A_AAAA_json("test-approve-success.not.loaded.", address="4.3.2.1"),
+            get_change_A_AAAA_json("test-revalidate-success.not.loaded.", address="4.3.2.1"),
             get_change_A_AAAA_json("needs-review.not.loaded.", address="4.3.2.1"),
             get_change_A_AAAA_json("zone-name-flagged-for-manual-review.zone.requires.review.")
         ],
@@ -56,7 +56,7 @@ def test_revalidate_pending_batch_change_success(shared_zone_test_context):
     finally:
         clear_zoneid_rsid_tuple_list(to_delete, client)
         if to_disconnect:
-            approver.abandon_zones(to_disconnect['id'], status=202)
+            approver.abandon_zones([to_disconnect['id']], status=202)
 
 
 @pytest.mark.manual_batch_review

--- a/modules/api/functional_test/live_tests/zones/update_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/update_zone_test.py
@@ -776,7 +776,7 @@ def test_user_cannot_update_zone_to_nonmember_admin_group(shared_zone_test_conte
     zone_update = shared_zone_test_context.ok_zone
     zone_update['adminGroupId'] = shared_zone_test_context.history_group['id']
 
-    shared_zone_test_context.ok_vinyldns_client.update_zone(zone_update, status=403)
+    shared_zone_test_context.ok_vinyldns_client.update_zone(zone_update, status=(400, 403))
 
 
 @pytest.mark.serial

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -611,6 +611,16 @@ class VinylDNSClient(object):
         _, data = self.make_request(url, u'POST', self.headers, **kwargs)
         return data
 
+    def revalidate_batch_change(self, batch_change_id, **kwargs):
+        """
+        Revalidates an existing batch change that is pending manual review
+        :param batch_change_id: ID of the batch change to revalidate
+        :return: the content of the response
+        """
+        url = urljoin(self.index_url, u'/zones/batchrecordchanges/{0}/revalidate'.format(batch_change_id))
+        _, data = self.make_request(url, u'POST', self.headers, **kwargs)
+        return data
+
     def list_batch_change_summaries(self, start_from=None, max_items=None, ignore_access=False, approval_status=None, **kwargs):
         """
         Gets list of user's batch change summaries

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -48,5 +48,7 @@ trait BatchChangeServiceAlgebra {
       approveBatchChangeInput: ApproveBatchChangeInput): BatchResult[BatchChange]
 
   def cancelBatchChange(id: String, auth: AuthPrincipal): BatchResult[BatchChange]
+
+  def revalidateBatchChange(id: String, auth: AuthPrincipal): BatchResult[BatchChange]
 }
 // $COVERAGE-ON$

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -126,7 +126,7 @@ class BatchChangeValidations(
       authPrincipal: AuthPrincipal,
       isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit] =
     validateAuthorizedReviewer(authPrincipal, batchChange, isTestChange) |+| validateBatchChangePendingReview(
-      batchChange) |+| validateScheduledApproval(batchChange)
+      batchChange)
 
   def validateBatchChangeCancellation(
       batchChange: BatchChange,
@@ -151,12 +151,6 @@ class BatchChangeValidations(
       ().asRight
     } else {
       UserNotAuthorizedError(batchChange.id).asLeft
-    }
-
-  def validateScheduledApproval(batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
-    batchChange.scheduledTime match {
-      case Some(dt) if dt.isAfterNow => Left(ScheduledChangeNotDue(dt))
-      case _ => Right(())
     }
 
   def validateCreatorCancellation(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -56,7 +56,7 @@ trait BatchChangeValidationsAlgebra {
       authPrincipal: AuthPrincipal,
       bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit]
 
-  def validateBatchChangeApproval(
+  def validateBatchChangeReview(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal,
       isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit]
@@ -110,7 +110,7 @@ class BatchChangeValidations(
       case (None, _) => ().validNel
       case (Some(groupId), None) => GroupDoesNotExist(groupId).invalidNel
       case (Some(groupId), Some(_)) =>
-        if (authPrincipal.isGroupMember(groupId) || authPrincipal.isSuper) ().validNel
+        if (authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin) ().validNel
         else NotAMemberOfOwnerGroup(groupId, authPrincipal.signedInUser.userName).invalidNel
     }
 
@@ -121,7 +121,7 @@ class BatchChangeValidations(
     validateAuthorizedReviewer(authPrincipal, batchChange, bypassTestValidation) |+| validateBatchChangePendingReview(
       batchChange)
 
-  def validateBatchChangeApproval(
+  def validateBatchChangeReview(
       batchChange: BatchChange,
       authPrincipal: AuthPrincipal,
       isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit] =

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -47,7 +47,7 @@ class BatchChangeRoute(
       complete(StatusCodes.BadRequest, ScheduledChangesDisabled.message)
     case ScheduledTimeMustBeInFuture =>
       complete(StatusCodes.BadRequest, ScheduledTimeMustBeInFuture.message)
-    case scnpd: ScheduledChangeNotDue => complete(StatusCodes.Forbidden, scnpd.message)
+    case scnd: ScheduledChangeNotDue => complete(StatusCodes.Forbidden, scnd.message)
   }
 
   final private val MAX_ITEMS_LIMIT: Int = 100

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -138,6 +138,13 @@ class BatchChangeRoute(
               complete(StatusCodes.OK, chg)
             }
           }
+        } ~
+        path("zones" / "batchrecordchanges" / Segment / "revalidate") { id =>
+          (post & monitor("Endpoint.revalidateBatchChange")) {
+            authenticateAndExecute(batchChangeService.revalidateBatchChange(id, _)) { chg =>
+              complete(StatusCodes.OK, chg)
+            }
+          }
         }
 
     if (VinylDNSConfig.manualBatchReviewEnabled) standardBatchChangeRoutes ~ manualBatchReviewRoutes

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -318,23 +318,6 @@ class BatchChangeValidationsSpec
       Left(BatchChangeNotPendingReview(invalidPendingBatchChange.id))
   }
 
-  property("validateScheduledApproval: should fail if scheduled time is not due") {
-    val dt = DateTime.now.plusDays(2)
-    val change = validPendingBatchChange.copy(scheduledTime = Some(dt))
-    validateScheduledApproval(change) shouldBe Left(ScheduledChangeNotDue(dt))
-  }
-
-  property("validateScheduledApproval: should succeed if scheduled time is due") {
-    val dt = DateTime.now.minusDays(2)
-    val change = validPendingBatchChange.copy(scheduledTime = Some(dt))
-    validateScheduledApproval(change) should be(right)
-  }
-
-  property("validateScheduledApproval: should succeed if scheduled time is not set") {
-    val change = validPendingBatchChange.copy(scheduledTime = None)
-    validateScheduledApproval(change) should be(right)
-  }
-
   property("validateAuthorizedReviewer: should succeed if the reviewer is a super user") {
     validateAuthorizedReviewer(superUserAuth, validPendingBatchChange, false) should be(right)
   }

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -676,6 +676,23 @@ class VinylDNS @Inject()(
       // $COVERAGE-ON$
     }
 
+  def revalidateBatchChange(batchChangeId: String): Action[AnyContent] =
+    userAction.async { implicit request =>
+      // $COVERAGE-OFF$
+      val json = request.body.asJson
+      val payload = json.map(Json.stringify)
+      val vinyldnsRequest =
+        new VinylDNSRequest(
+          "POST",
+          s"$vinyldnsServiceBackend",
+          s"zones/batchrecordchanges/$batchChangeId/revalidate")
+      executeRequest(vinyldnsRequest, request.user).map(response => {
+        Status(response.status)(response.body)
+          .withHeaders(cacheHeaders: _*)
+      })
+      // $COVERAGE-ON$
+    }
+
   def lockUser(userId: String): Action[AnyContent] = userAction.async { implicit request =>
     if (request.user.isSuper) {
       val vinyldnsRequest =

--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -175,6 +175,7 @@
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="!reviewType" class="pull-right">
+                                <button ng-if="batch.status == 'Scheduled'" class="btn btn-info" ng-click="revalidate()">Revalidate</button>
                                 <button class="btn btn-success" ng-click="approve()">Approve</button>
                                 <button class="btn btn-danger" ng-click="reject()">Reject</button>
                             </div>

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -58,6 +58,7 @@ POST          /api/dnschanges                    @controllers.VinylDNS.newBatchC
 POST          /api/dnschanges/:id/cancel         @controllers.VinylDNS.cancelBatchChange(id: String)
 POST          /api/dnschanges/:id/approve        @controllers.VinylDNS.approveBatchChange(id: String)
 POST          /api/dnschanges/:id/reject         @controllers.VinylDNS.rejectBatchChange(id: String)
+POST          /api/dnschanges/:id/revalidate     @controllers.VinylDNS.revalidateBatchChange(id: String)
 
 GET           /callback/:id                      @controllers.VinylDNS.oidcCallback(id: String)
 GET           /callback/set-oidc-session/:id              @controllers.VinylDNS.setOidcSession(id: String)

--- a/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
@@ -108,6 +108,21 @@
                     });
             };
 
+            $scope.revalidate = function() {
+                function success(response) {
+                    var alert = utilityService.success('DNS Change re-validated.', response, 'revalidateBatchChange: revalidateBatchChange successful');
+                    $scope.alerts.push(alert);
+                    $scope.refresh();
+                }
+
+                return batchChangeService
+                    .revalidateBatchChange($scope.batch.id)
+                    .then(success)
+                    .catch(function (error) {
+                        handleError(error, 'batchChangesService::revalidateBatchChange-failure');
+                    });
+            };
+
             function handleError(error, type) {
                 var alert = utilityService.failure(error, type);
                 $scope.alerts.push(alert);

--- a/modules/portal/public/lib/dns-change/dns-change.service.js
+++ b/modules/portal/public/lib/dns-change/dns-change.service.js
@@ -60,5 +60,10 @@
                 var data = reviewComment ? {'reviewComment': reviewComment} : {};
                 return $http.post(url, data, {headers: utilityService.getCsrfHeader()});
             };
+
+            this.revalidateBatchChange = function (id) {
+                var url = '/api/dnschanges/' + id + '/revalidate';
+                return $http.post(url, {}, {headers: utilityService.getCsrfHeader()});
+            };
         });
 })();


### PR DESCRIPTION
working out the idea of how to revalidate a batch change that is scheduled before its scheduled date and time. Currently on batch change approval we validate the scheduled time is in the past (and hard fail if it's not) before we validate the SingleChanges in the batch.

Changes in this pull request:
In the batch change approval flow:
  - move the scheduled time validation after the SingleChange validations
  - If there are still SingleChange errors on the scheduled batch change after the revalidation, return `BatchChangeFailedApproval`.
  - If there's no SingleChange errors but the scheduled time is still in the future return `ScheduledChangeNotDue`.
  - If there are no errors and the scheduled time is past, then the approval is accepted.
 - add a `revalidate` endpoint that only revalidates a scheduled batch change, does not attempt to approve the zone.
- add a Revalidate button to scheduled DNS Changes in the portal