### PR TITLE
dont assign ownership to configured list

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -231,6 +231,11 @@ vinyldns {
   manual-batch-review-enabled = true
 
   scheduled-changes-enabled = true
+
+  # FQDNs that will not have owner groups assigned on new changes
+  batch-access-skipped-fqdns = [
+    "batch-access-skip-test.*"
+  ]
 }
 
 akka {

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -2715,7 +2715,8 @@ def test_create_batch_change_for_shared_zone_owner_group_applied_logic(shared_zo
             get_change_A_AAAA_json("update-without-existing-owner-group.shared.", address="1.2.3.4"),
             get_change_A_AAAA_json("update-without-existing-owner-group.shared.", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json("update-with-existing-owner-group.shared.", address="1.2.3.4"),
-            get_change_A_AAAA_json("update-with-existing-owner-group.shared.", change_type="DeleteRecordSet")
+            get_change_A_AAAA_json("update-with-existing-owner-group.shared.", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json("batch-access-skip-test.shared", address="1.2.3.4")
         ],
         "ownerGroupId": "shared-zone-group"
     }
@@ -2755,11 +2756,15 @@ def test_create_batch_change_for_shared_zone_owner_group_applied_logic(shared_zo
                                               input_name="update-with-existing-owner-group.shared.", record_data="1.2.3.4")
         assert_change_success_response_values(result['changes'], zone=shared_zone, index=4, record_name="update-with-existing-owner-group",
                                               input_name="update-with-existing-owner-group.shared.", change_type="DeleteRecordSet", record_data=None)
+        assert_change_success_response_values(result['changes'], zone=shared_zone, index=5, record_name="batch-access-skip-test",
+                                              input_name="batch-access-skip-test.shared.", record_data="1.2.3.4")
 
         for (zoneId, recordSetId) in to_delete:
             get_recordset = shared_client.get_recordset(zoneId, recordSetId, status=200)
             if get_recordset['recordSet']['name'] == "update-with-existing-owner-group":
                 assert_that(get_recordset['recordSet']['ownerGroupId'], is_(shared_record_group['id']))
+            elif get_recordset['recordSet']['name'] == "batch-access-skip-test":
+                assert_that(get_recordset['recordSet'], is_not(has_key('ownerGroupId')))
             else:
                 assert_that(get_recordset['recordSet']['ownerGroupId'], is_(batch_change_input['ownerGroupId']))
 

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -26,6 +26,10 @@ def verify_recordset(actual, expected):
     assert_that(actual, has_key('created'))
     assert_that(actual['status'], is_not(none()))
     assert_that(actual['id'], is_not(none()))
+    if 'ownerGroupId' in expected:
+        assert_that(actual['ownerGroupId'], is_(expected['ownerGroupId']))
+    else:
+        assert_that(actual, is_not(has_key('ownerGroupId')))
     actual_records = [json.dumps(x) for x in actual['records']]
     expected_records = [json.dumps(x) for x in expected['records']]
     for expected_record in expected_records:

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -155,4 +155,9 @@ vinyldns {
   # feature flag for manual batch review
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true
+
+  # FQDNs that will not have owner groups assigned on new changes
+  batch-access-skipped-fqdns = [
+    "batch-access-skip-test.*"
+  ]
 }

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -131,7 +131,10 @@ object Boot extends App {
         messageQueue.healthCheck :: connectionValidator.healthCheck(healthCheckTimeout) ::
           loaderResponse.healthChecks)
       val batchChangeConverter =
-        new BatchChangeConverter(repositories.batchChangeRepository, messageQueue)
+        new BatchChangeConverter(
+          repositories.batchChangeRepository,
+          messageQueue,
+          VinylDNSConfig.batchAccessSkippedFqdnList)
       val authPrincipalProvider =
         new MembershipAuthPrincipalProvider(
           repositories.userRepository,

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -135,6 +135,10 @@ object VinylDNSConfig {
     .as[Option[Boolean]]("manual-batch-review-enabled")
     .getOrElse(false)
 
+  lazy val batchAccessSkippedFqdnList: List[Regex] =
+    ZoneRecordValidations.toCaseIgnoredRegexList(
+      getOptionalStringList("batch-access-skipped-fqdns"))
+
   // defines nibble boundary for ipv6 zone discovery
   // (min of 2, max of 3 means zones of form X.X.ip6-arpa. and X.X.X.ip6-arpa. will be discovered)
   lazy val v6DiscoveryBoundaries: IO[V6DiscoveryNibbleBoundaries] =

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -137,4 +137,9 @@ vinyldns {
 
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true
+
+  # FQDNs that will not have owner groups assigned on new changes
+  batch-access-skipped-fqdns = [
+    "batch-access-skip-test.*"
+  ]
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -461,6 +461,23 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
       result shouldBe defined
       result.foreach(_.recordSet.ownerGroupId shouldBe None)
     }
+
+    "generate record set without applying owner group ID for specifically excluded domains" in {
+      val addChangeFwdRegex =
+        makeSingleAddChange("access-skip-fwd", AAAAData("2:3:4:5:6:7:8:9"), AAAA, sharedZone)
+      val addChangeRevRegex =
+        makeSingleAddChange("1", PTRData("access-skip-fwd.test"), PTR, sharedReverseZone)
+
+      val result =
+        underTest.generateAddChange(
+          NonEmptyList.of(addChangeFwdRegex, addChangeRevRegex),
+          existingZones,
+          okUser.id,
+          Some("new-owner-group-id")
+        )
+      result shouldBe defined
+      result.foreach(_.recordSet.ownerGroupId shouldBe None)
+    }
   }
 
   "generateUpdateChange" should {


### PR DESCRIPTION
untested, need to add.

this _should_ skip assigning ownership to records that are within a configured list. note that if the records already have an assignment, that wont be cleared.