### PR TITLE
Global ACLs

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -231,6 +231,17 @@ vinyldns {
   manual-batch-review-enabled = true
 
   scheduled-changes-enabled = true
+
+  global-acl-rules = [
+    {
+      group-ids: ["global-acl-group-id"],
+      fqdn-regex-list: [".*shared."]
+    },
+    {
+      group-ids: ["another-global-acl-group"],
+      fqdn-regex-list: [".*ok."]
+    }
+  ]
 }
 
 akka {

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -3004,7 +3004,7 @@ def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fai
     Test delete change in batch for a record in a shared zone for an unassociated user not belonging to the record owner group fails
     """
     shared_client = shared_zone_test_context.shared_zone_vinyldns_client
-    dummy_client = shared_zone_test_context.dummy_vinyldns_client
+    unassociated_client = shared_zone_test_context.unassociated_client
     shared_zone = shared_zone_test_context.shared_zone
     shared_group = shared_zone_test_context.shared_record_group
     create_rs = None
@@ -3021,9 +3021,9 @@ def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fai
         create_rs = shared_client.create_recordset(shared_delete, status=202)
         shared_client.wait_until_recordset_change_status(create_rs, 'Complete')
 
-        response = dummy_client.create_batch_change(batch_change_input, status=400)
+        response = unassociated_client.create_batch_change(batch_change_input, status=400)
 
-        assert_failed_change_in_error_response(response[0], input_name="shared-delete.shared.", change_type="DeleteRecordSet", error_messages=['User "dummy" is not authorized.'])
+        assert_failed_change_in_error_response(response[0], input_name="shared-delete.shared.", change_type="DeleteRecordSet", error_messages=['User "list-group-user" is not authorized.'])
 
     finally:
         if create_rs:
@@ -3092,6 +3092,103 @@ def test_create_batch_update_record_in_shared_zone_for_unassociated_user_in_owne
             delete_rs = shared_client.delete_recordset(shared_zone['id'], create_rs['recordSet']['id'], status=202)
             shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
+
+def test_create_batch_with_global_acl_rule_applied_succeeds(shared_zone_test_context):
+    """
+    Test that a user with a relevant global acl rule can update forward and reverse records, regardless of their current ownership
+    """
+    shared_client = shared_zone_test_context.shared_zone_vinyldns_client
+    dummy_client = shared_zone_test_context.dummy_vinyldns_client
+    shared_zone = shared_zone_test_context.shared_zone
+    ok_client = shared_zone_test_context.ok_vinyldns_client
+    classless_base_zone = shared_zone_test_context.classless_base_zone
+    create_a_rs = None
+    create_ptr_rs = None
+    dummy_group_id = shared_zone_test_context.dummy_group['id']
+
+    a_record = get_recordset_json(shared_zone, "global-a", "A", [{"address": '1.1.1.1'}], 200, "shared-zone-group")
+    ptr_record = get_recordset_json(classless_base_zone, "44", "PTR", [{'ptrdname': 'foo.'}], 200, None)
+
+    batch_change_input = {
+        "ownerGroupId": dummy_group_id,
+        "changes": [
+            get_change_A_AAAA_json("global-a.shared.", record_type="A", ttl=200, address="192.0.2.44"),
+            get_change_PTR_json("192.0.2.44", ptrdname="global-a.shared."),
+            get_change_A_AAAA_json("global-a.shared.", record_type="A", change_type="DeleteRecordSet"),
+            get_change_PTR_json("192.0.2.44", change_type="DeleteRecordSet")
+        ]
+    }
+
+    try:
+        create_a_rs = shared_client.create_recordset(a_record, status=202)
+        shared_client.wait_until_recordset_change_status(create_a_rs, 'Complete')
+
+        create_ptr_rs = ok_client.create_recordset(ptr_record, status=202)
+        ok_client.wait_until_recordset_change_status(create_ptr_rs, 'Complete')
+
+        result = dummy_client.create_batch_change(batch_change_input, status=202)
+        completed_batch = dummy_client.wait_until_batch_change_completed(result)
+
+        assert_change_success_response_values(completed_batch['changes'], zone=shared_zone, index=0, record_name="global-a", ttl=200,
+                                              record_type="A", input_name="global-a.shared.", record_data="192.0.2.44")
+        assert_change_success_response_values(completed_batch['changes'], zone=classless_base_zone, index=1, record_name="44",
+                                              record_type="PTR", input_name="192.0.2.44", record_data= "global-a.shared.")
+        assert_change_success_response_values(completed_batch['changes'], zone=shared_zone, index=2, record_name="global-a", ttl=200,
+                                              record_type="A", input_name="global-a.shared.", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(completed_batch['changes'], zone=classless_base_zone, index=3, record_name="44",
+                                              record_type="PTR", input_name="192.0.2.44", record_data=None, change_type="DeleteRecordSet")
+
+    finally:
+        if create_a_rs:
+            retrieved = shared_client.get_recordset(shared_zone['id'], create_a_rs['recordSet']['id'])
+            retrieved_rs = retrieved['recordSet']
+
+            assert_that(retrieved_rs['ownerGroupId'], is_('shared-zone-group'))
+            assert_that(retrieved_rs['ownerGroupName'], is_('testSharedZoneGroup'))
+
+            delete_a_rs = shared_client.delete_recordset(shared_zone['id'], create_a_rs['recordSet']['id'], status=202)
+            shared_client.wait_until_recordset_change_status(delete_a_rs, 'Complete')
+
+        if create_ptr_rs:
+            retrieved = dummy_client.get_recordset(shared_zone['id'], create_ptr_rs['recordSet']['id'])
+            retrieved_rs = retrieved['recordSet']
+
+            assert_that(retrieved_rs, is_not(has_key('ownerGroupId')))
+            assert_that(retrieved_rs, is_not(has_key('dummy-group')))
+
+            delete_ptr_rs = ok_client.delete_recordset(classless_base_zone['id'], create_ptr_rs['recordSet']['id'], status=202)
+            ok_client.wait_until_recordset_change_status(delete_ptr_rs, 'Complete')
+
+
+def test_create_batch_with_irrelevant_global_acl_rule_applied_fails(shared_zone_test_context):
+    """
+    Test that a user with an irrelevant global acl rule cannot update an owned records
+    """
+    test_user_client = shared_zone_test_context.test_user_client
+    shared_client = shared_zone_test_context.shared_zone_vinyldns_client
+    shared_zone = shared_zone_test_context.shared_zone
+    create_a_rs = None
+
+    a_record = get_recordset_json(shared_zone, "global-a", "A", [{"address": '1.1.1.1'}], 200, "shared-zone-group")
+
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("global-a.shared.", record_type="A", address="192.0.2.44"),
+            get_change_A_AAAA_json("global-a.shared.", record_type="A", change_type="DeleteRecordSet"),
+        ]
+    }
+
+    try:
+        create_a_rs = shared_client.create_recordset(a_record, status=202)
+        shared_client.wait_until_recordset_change_status(create_a_rs, 'Complete')
+
+        response = test_user_client.create_batch_change(batch_change_input, status=400)
+        assert_failed_change_in_error_response(response[0], input_name="global-a.shared.", record_type="A", change_type="Add", record_data="192.0.2.44", error_messages=['User "testuser" is not authorized.'])
+
+    finally:
+        if create_a_rs:
+            delete_a_rs = shared_client.delete_recordset(shared_zone['id'], create_a_rs['recordSet']['id'], status=202)
+            shared_client.wait_until_recordset_change_status(delete_a_rs, 'Complete')
 
 @pytest.mark.skip_production
 def test_create_batch_duplicates_add_check(shared_zone_test_context):
@@ -3193,7 +3290,7 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
 
 
 @pytest.mark.manual_batch_review
-def test_zone_name_requiring_manual_review(shared_zone_test_context):
+def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_context):
     """
     Confirm that individual changes matching zone names requiring review get correctly flagged for manual review
     """

--- a/modules/api/functional_test/live_tests/shared_zone_test_context.py
+++ b/modules/api/functional_test/live_tests/shared_zone_test_context.py
@@ -13,6 +13,8 @@ class SharedZoneTestContext(object):
         self.dummy_vinyldns_client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'dummyAccessKey', 'dummySecretKey')
         self.shared_zone_vinyldns_client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'sharedZoneUserAccessKey', 'sharedZoneUserSecretKey')
         self.support_user_client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'supportUserAccessKey', 'supportUserSecretKey')
+        self.unassociated_client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'listGroupAccessKey', 'listGroupSecretKey')
+        self.test_user_client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, 'testUserAccessKey', 'testUserSecretKey')
 
         self.dummy_group = None
         self.ok_group = None
@@ -365,8 +367,8 @@ class SharedZoneTestContext(object):
         """
         clear_zones(self.dummy_vinyldns_client)
         clear_zones(self.ok_vinyldns_client)
-        clear_groups(self.dummy_vinyldns_client)
-        clear_groups(self.ok_vinyldns_client)
+        clear_groups(self.dummy_vinyldns_client, "global-acl-group-id")
+        clear_groups(self.ok_vinyldns_client, "global-acl-group-id")
 
     def confirm_member_in_group(self, client, group):
         retries = 2

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -25,17 +25,17 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 import vinyldns.api._
 import vinyldns.api.domain.access.AccessValidations
-import vinyldns.core.domain.HighValueDomainError
 import vinyldns.api.domain.zone._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData.testConnection
+import vinyldns.core.domain.HighValueDomainError
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
 import vinyldns.core.domain.record.RecordType._
+import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.{Zone, ZoneRepository, ZoneStatus}
 import vinyldns.dynamodb.repository.{DynamoDBRecordSetRepository, DynamoDBRepositorySettings}
-import vinyldns.core.domain.record._
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -242,7 +242,7 @@ class RecordSetServiceIntegrationSpec
       mock[RecordChangeRepository],
       mock[UserRepository],
       TestMessageQueue,
-      AccessValidations)
+      new AccessValidations())
   }
 
   def tearDown(): Unit = ()

--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneServiceIntegrationSpec.scala
@@ -24,14 +24,14 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 import scalikejdbc.DB
 import vinyldns.api.domain.access.AccessValidations
-import vinyldns.api.{MySqlApiIntegrationSpec, ResultHelpers}
 import vinyldns.api.domain.record.RecordSetChangeGenerator
 import vinyldns.api.engine.TestMessageQueue
+import vinyldns.api.{MySqlApiIntegrationSpec, ResultHelpers}
+import vinyldns.core.TestMembershipData.{okAuth, okUser}
+import vinyldns.core.TestZoneData.okZone
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{GroupRepository, UserRepository}
 import vinyldns.core.domain.record._
-import vinyldns.core.TestZoneData.okZone
-import vinyldns.core.TestMembershipData.{okAuth, okUser}
 import vinyldns.core.domain.zone._
 
 import scala.concurrent.Await
@@ -117,7 +117,7 @@ class ZoneServiceIntegrationSpec
       mock[ZoneConnectionValidator],
       TestMessageQueue,
       new ZoneValidations(1000),
-      AccessValidations
+      new AccessValidations()
     )
   }
 

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -155,4 +155,15 @@ vinyldns {
   # feature flag for manual batch review
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true
+
+  global-acl-rules = [
+    {
+      group-ids: ["global-acl-group-id"],
+      fqdn-regex-list: [".*shared."]
+    },
+    {
+      group-ids: ["another-global-acl-group"],
+      fqdn-regex-list: [".*ok."]
+    }
+  ]
 }

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -137,4 +137,7 @@ vinyldns {
     min = 5
     max = 20
   }
+
+  # Global ACLs defaults to an empty list
+  global-acl-rules = []
 }

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -25,7 +25,7 @@ import vinyldns.api.crypto.Crypto
 import com.comcast.ip4s._
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.EnumerationReader._
-import vinyldns.api.domain.access.{GlobalAcl, SystemGlobalAcls}
+import vinyldns.api.domain.access.{GlobalAcl, GlobalAcls}
 import vinyldns.api.domain.batch.V6DiscoveryNibbleBoundaries
 import vinyldns.api.domain.zone.ZoneRecordValidations
 import vinyldns.core.domain.DomainHelpers
@@ -136,8 +136,8 @@ object VinylDNSConfig {
     .as[Option[Boolean]]("manual-batch-review-enabled")
     .getOrElse(false)
 
-  lazy val globalAcl: IO[SystemGlobalAcls] =
-    loadConfigF[IO, List[GlobalAcl]](vinyldnsConfig, "global-acl-rules").map(SystemGlobalAcls)
+  lazy val globalAcl: IO[GlobalAcls] =
+    loadConfigF[IO, List[GlobalAcl]](vinyldnsConfig, "global-acl-rules").map(GlobalAcls)
 
   // defines nibble boundary for ipv6 zone discovery
   // (min of 2, max of 3 means zones of form X.X.ip6-arpa. and X.X.X.ip6-arpa. will be discovered)

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -25,6 +25,7 @@ import vinyldns.api.crypto.Crypto
 import com.comcast.ip4s._
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.EnumerationReader._
+import vinyldns.api.domain.access.{GlobalAcl, SystemGlobalAcls}
 import vinyldns.api.domain.batch.V6DiscoveryNibbleBoundaries
 import vinyldns.api.domain.zone.ZoneRecordValidations
 import vinyldns.core.domain.DomainHelpers
@@ -134,6 +135,9 @@ object VinylDNSConfig {
   lazy val manualBatchReviewEnabled: Boolean = vinyldnsConfig
     .as[Option[Boolean]]("manual-batch-review-enabled")
     .getOrElse(false)
+
+  lazy val globalAcl: IO[SystemGlobalAcls] =
+    loadConfigF[IO, List[GlobalAcl]](vinyldnsConfig, "global-acl-rules").map(SystemGlobalAcls)
 
   // defines nibble boundary for ipv6 zone discovery
   // (min of 2, max of 3 means zones of form X.X.ip6-arpa. and X.X.X.ip6-arpa. will be discovered)

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
@@ -203,10 +203,7 @@ class AccessValidations(globalAcls: GlobalAcls = GlobalAcls(List.empty))
       val aclAccess = getAccessFromAcl(auth, recordName, recordType, zone)
       if (aclAccess == AccessLevel.NoAccess) AccessLevel.Read else aclAccess
     case globalAclUser
-        if recordType == RecordType.PTR && globalAcls
-          .hasGlobalReverseAcl(globalAclUser, recordData) =>
-      AccessLevel.Delete
-    case globalAclUser if globalAcls.hasGlobalAcl(globalAclUser, recordName, zone) =>
+        if globalAcls.isAuthorized(globalAclUser, recordName, recordType, zone, recordData) =>
       AccessLevel.Delete
     case _ => getAccessFromAcl(auth, recordName, recordType, zone)
   }

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
@@ -26,7 +26,7 @@ import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.zone.AccessLevel.AccessLevel
 import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone}
 
-class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.empty))
+class AccessValidations(globalAcls: GlobalAcls = GlobalAcls(List.empty))
     extends AccessValidationsAlgebra {
 
   def canSeeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
@@ -26,7 +26,8 @@ import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.zone.AccessLevel.AccessLevel
 import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone}
 
-object AccessValidations extends AccessValidationAlgebra {
+class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.empty))
+    extends AccessValidationAlgebra {
 
   def canSeeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =
     ensuring(
@@ -190,6 +191,8 @@ object AccessValidations extends AccessValidationAlgebra {
     case support if support.isSystemAdmin =>
       val aclAccess = getAccessFromAcl(auth, recordName, recordType, zone)
       if (aclAccess == AccessLevel.NoAccess) AccessLevel.Read else aclAccess
+    case globalAclUser if globalAcls.hasGlobalAcl(globalAclUser, recordName, zone) =>
+      AccessLevel.Delete
     case _ => getAccessFromAcl(auth, recordName, recordType, zone)
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
@@ -21,13 +21,13 @@ import vinyldns.api.VinylDNSConfig
 import vinyldns.api.domain.ReverseZoneHelpers
 import vinyldns.api.domain.zone._
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.record.RecordType
+import vinyldns.core.domain.record.{RecordData, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.zone.AccessLevel.AccessLevel
 import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone}
 
 class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.empty))
-    extends AccessValidationAlgebra {
+    extends AccessValidationsAlgebra {
 
   def canSeeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =
     ensuring(
@@ -49,8 +49,9 @@ class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.emp
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit] = {
-    val accessLevel = getAccessLevel(auth, recordName, recordType, zone)
+      zone: Zone,
+      recordData: List[RecordData] = List.empty): Either[Throwable, Unit] = {
+    val accessLevel = getAccessLevel(auth, recordName, recordType, zone, None, recordData)
     ensuring(
       NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to create " +
         s"$recordName.${zone.name}"))(
@@ -62,8 +63,10 @@ class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.emp
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] = {
-    val accessLevel = getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId)
+      recordOwnerGroupId: Option[String],
+      newRecordData: List[RecordData] = List.empty): Either[Throwable, Unit] = {
+    val accessLevel =
+      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId, newRecordData)
     ensuring(
       NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to update " +
         s"$recordName.${zone.name}"))(
@@ -75,22 +78,29 @@ class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.emp
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] =
+      recordOwnerGroupId: Option[String],
+      existingRecordData: List[RecordData] = List.empty): Either[Throwable, Unit] =
     ensuring(
       NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to delete " +
-        s"$recordName.${zone.name}"))(
-      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) == AccessLevel.Delete)
+        s"$recordName.${zone.name}"))(getAccessLevel(
+      auth,
+      recordName,
+      recordType,
+      zone,
+      recordOwnerGroupId,
+      existingRecordData) == AccessLevel.Delete)
 
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit] =
+      recordOwnerGroupId: Option[String],
+      recordData: List[RecordData] = List.empty): Either[Throwable, Unit] =
     ensuring(
       NotAuthorizedError(s"User ${auth.signedInUser.userName} does not have access to view " +
         s"$recordName.${zone.name}"))(
-      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId) != AccessLevel.NoAccess
+      getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId, recordData) != AccessLevel.NoAccess
     )
 
   def getListAccessLevels(
@@ -181,7 +191,8 @@ class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.emp
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String] = None): AccessLevel = auth match {
+      recordOwnerGroupId: Option[String] = None,
+      recordData: List[RecordData] = List.empty): AccessLevel = auth match {
     case testUser if testUser.isTestUser && !zone.isTest => AccessLevel.NoAccess
     case admin if admin.isGroupMember(zone.adminGroupId) =>
       AccessLevel.Delete
@@ -191,6 +202,10 @@ class AccessValidations(globalAcls: SystemGlobalAcls = SystemGlobalAcls(List.emp
     case support if support.isSystemAdmin =>
       val aclAccess = getAccessFromAcl(auth, recordName, recordType, zone)
       if (aclAccess == AccessLevel.NoAccess) AccessLevel.Read else aclAccess
+    case globalAclUser
+        if recordType == RecordType.PTR && globalAcls
+          .hasGlobalReverseAcl(globalAclUser, recordData) =>
+      AccessLevel.Delete
     case globalAclUser if globalAcls.hasGlobalAcl(globalAclUser, recordName, zone) =>
       AccessLevel.Delete
     case _ => getAccessFromAcl(auth, recordName, recordType, zone)

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidationsAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidationsAlgebra.scala
@@ -18,11 +18,12 @@ package vinyldns.api.domain.access
 
 import vinyldns.api.domain.zone.{RecordSetInfo, RecordSetListInfo}
 import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.record.RecordData
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.zone.AccessLevel.AccessLevel
 import vinyldns.core.domain.zone.Zone
 
-trait AccessValidationAlgebra {
+trait AccessValidationsAlgebra {
 
   def canSeeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit]
 
@@ -35,28 +36,32 @@ trait AccessValidationAlgebra {
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
-      zone: Zone): Either[Throwable, Unit]
+      zone: Zone,
+      recordData: List[RecordData] = List.empty): Either[Throwable, Unit]
 
   def canUpdateRecordSet(
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
+      recordOwnerGroupId: Option[String],
+      newRecordData: List[RecordData] = List.empty): Either[Throwable, Unit]
 
   def canDeleteRecordSet(
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
+      recordOwnerGroupId: Option[String],
+      existingRecordData: List[RecordData] = List.empty): Either[Throwable, Unit]
 
   def canViewRecordSet(
       auth: AuthPrincipal,
       recordName: String,
       recordType: RecordType,
       zone: Zone,
-      recordOwnerGroupId: Option[String]): Either[Throwable, Unit]
+      recordOwnerGroupId: Option[String],
+      recordData: List[RecordData] = List.empty): Either[Throwable, Unit]
 
   def getListAccessLevels(
       auth: AuthPrincipal,

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
@@ -26,8 +26,10 @@ import scala.util.matching.Regex
 
 final case class GlobalAcl(groupIds: List[String], fqdnRegexList: List[String])
 
-final case class SystemGlobalAcls(acls: List[GlobalAcl]) {
-  val aclMap: Map[String, List[Regex]] = {
+final case class GlobalAcls(acls: List[GlobalAcl]) {
+
+  // Create a map of Group ID -> Regexes valid for that group id
+  private val aclMap: Map[String, List[Regex]] = {
     val tuples = for {
       acl <- acls
       groupId <- acl.groupIds

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
@@ -68,6 +68,5 @@ final case class GlobalAcls(acls: List[GlobalAcl]) {
         val fqdn = if (recordName.endsWith(".")) recordName else s"$recordName.${zone.name}"
         isAuthorized(authPrincipal, fqdn)
     }
-    //}
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
@@ -57,14 +57,17 @@ final case class GlobalAcls(acls: List[GlobalAcl]) {
 
     recordType match {
       case RecordType.PTR =>
-        recordData
+        val ptrs = recordData
           .collect {
             case p: PTRData => p.ptrdname
           }
-          .forall(isAuthorized(authPrincipal, _))
+
+        // forall returns true if the list is empty
+        ptrs.nonEmpty && ptrs.forall(isAuthorized(authPrincipal, _))
       case _ =>
         val fqdn = if (recordName.endsWith(".")) recordName else s"$recordName.${zone.name}"
         isAuthorized(authPrincipal, fqdn)
     }
+    //}
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
@@ -61,7 +61,7 @@ final case class GlobalAcls(acls: List[GlobalAcl]) {
           .collect {
             case p: PTRData => p.ptrdname
           }
-          .exists(isAuthorized(authPrincipal, _))
+          .forall(isAuthorized(authPrincipal, _))
       case _ =>
         val fqdn = if (recordName.endsWith(".")) recordName else s"$recordName.${zone.name}"
         isAuthorized(authPrincipal, fqdn)

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.domain.access
+
+import vinyldns.api.domain.zone.ZoneRecordValidations
+import vinyldns.core.domain.DomainHelpers
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.zone.Zone
+
+import scala.util.matching.Regex
+
+final case class GlobalAcl(groupIds: List[String], fqdnRegexList: List[String])
+
+final case class SystemGlobalAcls(acls: List[GlobalAcl]) {
+  val aclMap: Map[String, List[Regex]] = {
+    val tuples = for {
+      acl <- acls
+      groupId <- acl.groupIds
+      regex = ZoneRecordValidations.toCaseIgnoredRegexList(acl.fqdnRegexList)
+    } yield groupId -> regex
+
+    tuples.groupBy(_._1).map {
+      case (groupId, regexes) => groupId -> regexes.flatMap(_._2)
+    }
+  }
+
+  def hasGlobalAcl(authPrincipal: AuthPrincipal, record: String, zone: Zone): Boolean = {
+    val regexList = authPrincipal.memberGroupIds.flatMap(aclMap.getOrElse(_, List.empty)).toList
+    val fqdn =
+      if (record.endsWith(".")) record.toLowerCase
+      else DomainHelpers.ensureTrailingDot(s"$record.${zone.name}".toLowerCase)
+    ZoneRecordValidations.isStringInRegexList(regexList, fqdn)
+  }
+}

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -27,13 +27,13 @@ import vinyldns.core.domain.zone.{Zone, ZoneCommandResult, ZoneRepository}
 import vinyldns.core.queue.MessageQueue
 import cats.data._
 import cats.effect.IO
-import vinyldns.api.domain.access.AccessValidationAlgebra
+import vinyldns.api.domain.access.AccessValidationsAlgebra
 
 object RecordSetService {
   def apply(
       dataAccessor: ApiDataAccessor,
       messageQueue: MessageQueue,
-      accessValidation: AccessValidationAlgebra): RecordSetService =
+      accessValidation: AccessValidationsAlgebra): RecordSetService =
     new RecordSetService(
       dataAccessor.zoneRepository,
       dataAccessor.groupRepository,
@@ -52,7 +52,7 @@ class RecordSetService(
     recordChangeRepository: RecordChangeRepository,
     userRepository: UserRepository,
     messageQueue: MessageQueue,
-    accessValidation: AccessValidationAlgebra)
+    accessValidation: AccessValidationsAlgebra)
     extends RecordSetServiceAlgebra {
 
   import RecordSetValidations._

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain.zone
 
 import cats.implicits._
-import vinyldns.api.domain.access.AccessValidationAlgebra
+import vinyldns.api.domain.access.AccessValidationsAlgebra
 import vinyldns.api.{Interfaces, VinylDNSConfig}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.api.repository.ApiDataAccessor
@@ -32,7 +32,7 @@ object ZoneService {
       connectionValidator: ZoneConnectionValidatorAlgebra,
       messageQueue: MessageQueue,
       zoneValidations: ZoneValidations,
-      accessValidation: AccessValidationAlgebra): ZoneService =
+      accessValidation: AccessValidationsAlgebra): ZoneService =
     new ZoneService(
       dataAccessor.zoneRepository,
       dataAccessor.groupRepository,
@@ -53,7 +53,7 @@ class ZoneService(
     connectionValidator: ZoneConnectionValidatorAlgebra,
     messageQueue: MessageQueue,
     zoneValidations: ZoneValidations,
-    accessValidation: AccessValidationAlgebra)
+    accessValidation: AccessValidationsAlgebra)
     extends ZoneServiceAlgebra {
 
   import accessValidation._

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -182,6 +182,20 @@ object TestDataLoader {
     isTest = true
   )
 
+  final val globalACLGroup = Group(
+    name = "globalACLGroup",
+    id = "global-acl-group-id",
+    email = "email",
+    memberIds = Set(okUser.id, dummyUser.id),
+    adminUserIds = Set(okUser.id, dummyUser.id))
+
+  final val anotherGlobalACLGroup = Group(
+    name = "globalACLGroup",
+    id = "another-global-acl-group",
+    email = "email",
+    memberIds = Set(testUser.id),
+    adminUserIds = Set(testUser.id))
+
   // NOTE: this is intentionally not a flagged test zone for validating our test users cannot access regular zone info
   // All other test zones should be flagged as test
   final val nonTestSharedZone = Zone(
@@ -221,9 +235,17 @@ object TestDataLoader {
       }
       _ <- toDelete.map(zoneRepo.save).parSequence
       _ <- groupRepo.save(sharedZoneGroup)
+      _ <- groupRepo.save(globalACLGroup)
+      _ <- groupRepo.save(anotherGlobalACLGroup)
       _ <- membershipRepo.addMembers(
         groupId = "shared-zone-group",
         memberUserIds = Set(sharedZoneUser.id))
+      _ <- membershipRepo.addMembers(
+        groupId = "global-acl-group-id",
+        memberUserIds = Set(okUser.id, dummyUser.id))
+      _ <- membershipRepo.addMembers(
+        groupId = "another-global-acl-group",
+        memberUserIds = Set(testUser.id))
       _ <- zoneRepo.save(sharedZone)
       _ <- zoneRepo.save(nonTestSharedZone)
     } yield ()

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
@@ -49,7 +49,7 @@ class AccessValidationsSpec
   private val badGroupReadAcl =
     ACLRule(AccessLevel.Read, userId = None, groupId = Some("bad-group"))
 
-  private val accessValidationTest = AccessValidations
+  private val accessValidationTest = new AccessValidations()
   private val groupIds = Seq(okGroup.id, twoUserGroup.id)
   private val userAccessNone = okUser.copy(id = "NoAccess")
   private val userAuthNone = AuthPrincipal(userAccessNone, groupIds)
@@ -142,58 +142,44 @@ class AccessValidationsSpec
 
   "canAddRecordSet" should {
     "return a NotAuthorizedError if the user has AccessLevel.NoAccess" in {
-      val mockRecordSet = mock[RecordSet]
-
       val error = leftValue(
         accessValidationTest
-          .canAddRecordSet(userAuthNone, mockRecordSet.name, mockRecordSet.typ, zoneInNone))
+          .canAddRecordSet(userAuthNone, "test", RecordType.A, zoneInNone))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user has AccessLevel.Read" in {
-      val mockRecordSet = mock[RecordSet]
-
       val error = leftValue(
         accessValidationTest
-          .canAddRecordSet(userAuthRead, mockRecordSet.name, mockRecordSet.typ, zoneInRead))
+          .canAddRecordSet(userAuthRead, "test", RecordType.A, zoneInRead))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return true if the user has AccessLevel.Write" in {
-      val mockRecordSet = mock[RecordSet]
-      accessValidationTest.canAddRecordSet(
-        userAuthWrite,
-        mockRecordSet.name,
-        mockRecordSet.typ,
-        zoneInWrite) should be(right)
+      accessValidationTest.canAddRecordSet(userAuthWrite, "test", RecordType.A, zoneInWrite) should be(
+        right)
     }
 
     "return true if the user has AccessLevel.Delete" in {
-      val mockRecordSet = mock[RecordSet]
-      accessValidationTest.canAddRecordSet(
-        userAuthDelete,
-        mockRecordSet.name,
-        mockRecordSet.typ,
-        zoneInDelete) should be(right)
+      accessValidationTest.canAddRecordSet(userAuthDelete, "test", RecordType.A, zoneInDelete) should be(
+        right)
     }
 
     "return a NotAuthorizedError if the user is a test user in a non-test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
 
       val error = leftValue(
         accessValidationTest
-          .canAddRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, okZone))
+          .canAddRecordSet(auth, "test", RecordType.A, okZone))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return access as calculated if the user is a test user in a test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
       val zone = okZone.copy(isTest = true)
 
       accessValidationTest
-        .canAddRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, zone) should be(right)
+        .canAddRecordSet(auth, "test", RecordType.A, zone) should be(right)
     }
     "return true if recordset is NS and user is in the admin group" in {
       val zone = okZone
@@ -211,55 +197,35 @@ class AccessValidationsSpec
   }
   "canUpdateRecordSet" should {
     "return a NotAuthorizedError if the user has AccessLevel.NoAccess" in {
-      val mockRecordSet = mock[RecordSet]
-
       val error = leftValue(
         accessValidationTest
-          .canUpdateRecordSet(
-            userAuthNone,
-            mockRecordSet.name,
-            mockRecordSet.typ,
-            zoneInNone,
-            mockRecordSet.ownerGroupId))
+          .canUpdateRecordSet(userAuthNone, "test", RecordType.A, zoneInNone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user has AccessLevel.Read" in {
-      val mockRecordSet = mock[RecordSet]
-
       val error = leftValue(
         accessValidationTest
-          .canUpdateRecordSet(
-            userAuthRead,
-            mockRecordSet.name,
-            mockRecordSet.typ,
-            zoneInRead,
-            mockRecordSet.ownerGroupId))
+          .canUpdateRecordSet(userAuthRead, "test", RecordType.A, zoneInRead, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return true if the user has AccessLevel.Write" in {
-      val mockRecordSet = mock[RecordSet]
       accessValidationTest.canUpdateRecordSet(
         userAuthWrite,
-        mockRecordSet.name,
-        mockRecordSet.typ,
+        "test",
+        RecordType.A,
         zoneInWrite,
-        mockRecordSet.ownerGroupId) should be(right)
+        None) should be(right)
     }
 
     "return true if the user has AccessLevel.Delete" in {
-      val mockRecordSet = mock[RecordSet]
       val userAccess = okUser.copy(id = "Delete")
       val userAuth = AuthPrincipal(userAccess, groupIds)
       val userAcl = ACLRule(AccessLevel.Delete, userId = Some(userAuth.userId), groupId = None)
       val zoneIn = zoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
-      accessValidationTest.canUpdateRecordSet(
-        userAuth,
-        mockRecordSet.name,
-        mockRecordSet.typ,
-        zoneIn,
-        mockRecordSet.ownerGroupId) should be(right)
+      accessValidationTest.canUpdateRecordSet(userAuth, "test", RecordType.A, zoneIn, None) should be(
+        right)
     }
 
     "return true if the user is in the owner group and the zone is shared" in {
@@ -291,173 +257,136 @@ class AccessValidationsSpec
     }
 
     "return a NotAuthorizedError if the user is a test user in a non-test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
 
       val error = leftValue(
         accessValidationTest
-          .canUpdateRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, okZone, None))
+          .canUpdateRecordSet(auth, "test", RecordType.A, okZone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return access as calculated if the user is a test user in a test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
       val zone = okZone.copy(isTest = true)
 
       accessValidationTest
-        .canUpdateRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, zone, None) should be(
-        right)
+        .canUpdateRecordSet(auth, "test", RecordType.A, zone, None) should be(right)
     }
   }
 
   "canDeleteRecordSet" should {
     "return a NotAuthorizedError if the user has AccessLevel.NoAccess" in {
-      val mockRecordSet = mock[RecordSet]
-
-      val error = leftValue(accessValidationTest
-        .canDeleteRecordSet(userAuthNone, mockRecordSet.name, mockRecordSet.typ, zoneInNone, None))
+      val error = leftValue(
+        accessValidationTest
+          .canDeleteRecordSet(userAuthNone, "test", RecordType.A, zoneInNone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user has AccessLevel.Read" in {
-      val mockRecordSet = mock[RecordSet]
-
-      val error = leftValue(accessValidationTest
-        .canDeleteRecordSet(userAuthRead, mockRecordSet.name, mockRecordSet.typ, zoneInRead, None))
+      val error = leftValue(
+        accessValidationTest
+          .canDeleteRecordSet(userAuthRead, "test", RecordType.A, zoneInRead, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user has AccessLevel.Write" in {
-      val mockRecordSet = mock[RecordSet]
-
       val error = leftValue(
         accessValidationTest
-          .canDeleteRecordSet(
-            userAuthWrite,
-            mockRecordSet.name,
-            mockRecordSet.typ,
-            zoneInWrite,
-            None))
+          .canDeleteRecordSet(userAuthWrite, "test", RecordType.A, zoneInWrite, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return true if the user has AccessLevel.Delete" in {
-      val mockRecordSet = mock[RecordSet]
       accessValidationTest.canDeleteRecordSet(
         userAuthDelete,
-        mockRecordSet.name,
-        mockRecordSet.typ,
+        "test",
+        RecordType.A,
         zoneInDelete,
         None) should be(right)
     }
 
     "return a NotAuthorizedError if the user is a test user in a non-test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
 
       val error = leftValue(
         accessValidationTest
-          .canDeleteRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, okZone, None))
+          .canDeleteRecordSet(auth, "test", RecordType.A, okZone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return access as calculated if the user is a test user in a test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
       val zone = okZone.copy(isTest = true)
 
       accessValidationTest
-        .canDeleteRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, zone, None) should be(
-        right)
+        .canDeleteRecordSet(auth, "test", RecordType.A, zone, None) should be(right)
     }
   }
 
   "canViewRecordSet" should {
     "return a NotAuthorizedError if the user has AccessLevel.NoAccess" in {
-      val mockRecordSet = mock[RecordSet]
-
       val error = leftValue(
         accessValidationTest
-          .canViewRecordSet(
-            userAuthNone,
-            mockRecordSet.name,
-            mockRecordSet.typ,
-            zoneInNone,
-            mockRecordSet.ownerGroupId))
+          .canViewRecordSet(userAuthNone, "test", RecordType.A, zoneInNone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return true if the user has AccessLevel.Read" in {
-      val mockRecordSet = mock[RecordSet]
-      accessValidationTest.canViewRecordSet(
-        userAuthRead,
-        mockRecordSet.name,
-        mockRecordSet.typ,
-        zoneInRead,
-        mockRecordSet.ownerGroupId) should be(right)
+      accessValidationTest.canViewRecordSet(userAuthRead, "test", RecordType.A, zoneInRead, None) should be(
+        right)
     }
 
     "return true if the user has AccessLevel.Write" in {
-      val mockRecordSet = mock[RecordSet]
-
-      accessValidationTest.canViewRecordSet(
-        userAuthWrite,
-        mockRecordSet.name,
-        mockRecordSet.typ,
-        zoneInWrite,
-        mockRecordSet.ownerGroupId) should be(right)
+      accessValidationTest.canViewRecordSet(userAuthWrite, "test", RecordType.A, zoneInWrite, None) should be(
+        right)
     }
 
     "return true if the user has AccessLevel.Delete" in {
-      val mockRecordSet = mock[RecordSet]
       accessValidationTest.canViewRecordSet(
         userAuthDelete,
-        mockRecordSet.name,
-        mockRecordSet.typ,
+        "test",
+        RecordType.A,
         zoneInDelete,
-        mockRecordSet.ownerGroupId) should be(right)
+        None) should be(right)
     }
 
     "return true if the user is in the recordSet owner group and the recordSet is in a shared zone" in {
-      val mockRecordSet = sharedZoneRecord
+      val recordSet = sharedZoneRecord
       accessValidationTest.canViewRecordSet(
         okAuth,
-        mockRecordSet.name,
-        mockRecordSet.typ,
+        recordSet.name,
+        recordSet.typ,
         sharedZone,
-        mockRecordSet.ownerGroupId) should be(right)
+        recordSet.ownerGroupId) should be(right)
     }
 
     "return a NotAuthorizedError if the user is in the recordSet owner group but it is not in a shared zone" in {
-      val mockRecordSet = notSharedZoneRecordWithOwnerGroup
+      val recordSet = notSharedZoneRecordWithOwnerGroup
       val error = leftValue(
         accessValidationTest.canViewRecordSet(
           okAuth,
-          mockRecordSet.name,
-          mockRecordSet.typ,
+          recordSet.name,
+          recordSet.typ,
           zoneNotAuthorized,
-          mockRecordSet.ownerGroupId))
+          recordSet.ownerGroupId))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user is a test user in a non-test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
 
       val error = leftValue(
         accessValidationTest
-          .canViewRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, okZone, None))
+          .canViewRecordSet(auth, "test", RecordType.A, okZone, None))
       error shouldBe a[NotAuthorizedError]
     }
 
     "return access as calculated if the user is a test user in a test zone" in {
-      val mockRecordSet = mock[RecordSet]
       val auth = okAuth.copy(signedInUser = testUser)
       val zone = okZone.copy(isTest = true)
 
       accessValidationTest
-        .canViewRecordSet(auth, mockRecordSet.name, mockRecordSet.typ, zone, None) should be(right)
+        .canViewRecordSet(auth, "test", RecordType.A, zone, None) should be(right)
     }
   }
 
@@ -540,13 +469,12 @@ class AccessValidationsSpec
     }
 
     "return the result of getAccessLevel if the user is support but also an admin" in {
-      val mockRecordSet = mock[RecordSet]
       val supportAuth =
         okAuth.copy(signedInUser = okAuth.signedInUser.copy(isSupport = true))
       val result = accessValidationTest.getAccessLevel(
         supportAuth,
-        mockRecordSet.name,
-        mockRecordSet.typ,
+        "test",
+        RecordType.A,
         okZone,
         None)
       result shouldBe AccessLevel.Delete
@@ -570,7 +498,6 @@ class AccessValidationsSpec
     }
 
     "return the result of getAccessLevel if user is not admin/super" in {
-      val mockRecordSet = mock[RecordSet]
       val userAccess = okUser.copy(id = "Read")
       val userAuth = AuthPrincipal(userAccess, groupIds)
       val userAcl = ACLRule(AccessLevel.Read, userId = Some(userAuth.userId), groupId = None)
@@ -579,8 +506,8 @@ class AccessValidationsSpec
       val result =
         accessValidationTest.getAccessLevel(
           userAuth,
-          mockRecordSet.name,
-          mockRecordSet.typ,
+          "test",
+          RecordType.A,
           zoneIn,
           None)
       result shouldBe AccessLevel.Read

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
@@ -471,12 +471,8 @@ class AccessValidationsSpec
     "return the result of getAccessLevel if the user is support but also an admin" in {
       val supportAuth =
         okAuth.copy(signedInUser = okAuth.signedInUser.copy(isSupport = true))
-      val result = accessValidationTest.getAccessLevel(
-        supportAuth,
-        "test",
-        RecordType.A,
-        okZone,
-        None)
+      val result =
+        accessValidationTest.getAccessLevel(supportAuth, "test", RecordType.A, okZone, None)
       result shouldBe AccessLevel.Delete
     }
 
@@ -504,12 +500,7 @@ class AccessValidationsSpec
       val zoneIn = zoneNotAuthorized.copy(acl = ZoneACL(Set(userAcl)))
 
       val result =
-        accessValidationTest.getAccessLevel(
-          userAuth,
-          "test",
-          RecordType.A,
-          zoneIn,
-          None)
+        accessValidationTest.getAccessLevel(userAuth, "test", RecordType.A, zoneIn, None)
       result shouldBe AccessLevel.Read
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
@@ -33,7 +33,7 @@ class GlobalAclSpec
   import vinyldns.core.TestZoneData._
 
   private val globalAcls = GlobalAcls(
-    List(GlobalAcl(List(okGroup.id, dummyGroup.id), List(".*foo.*", ".*bar.com"))))
+    List(GlobalAcl(List(okGroup.id, dummyGroup.id), List(".*foo.*", ".*bar.com."))))
 
   "isAuthorized" should {
     "return false if the acl list is empty" in {
@@ -47,6 +47,22 @@ class GlobalAclSpec
     }
     "normalizes the record name before testing" in {
       globalAcls.isAuthorized(okAuth, "foo.", RecordType.A, okZone, Nil) shouldBe true
+    }
+    "return true for a PTR record when all PTR records match an acl" in {
+      globalAcls.isAuthorized(
+        okAuth,
+        "foo",
+        RecordType.PTR,
+        zoneIp4,
+        List(PTRData("foo.com"), PTRData("bar.com"))) shouldBe true
+    }
+    "return false for a PTR record if one of the PTR records does not match an acl" in {
+      globalAcls.isAuthorized(
+        okAuth,
+        "foo",
+        RecordType.PTR,
+        zoneIp4,
+        List(PTRData("foo.com"), PTRData("blah.net"))) shouldBe false
     }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
@@ -64,5 +64,14 @@ class GlobalAclSpec
         zoneIp4,
         List(PTRData("foo.com"), PTRData("blah.net"))) shouldBe false
     }
+    "return false for a PTR record if the record data is empty" in {
+      globalAcls.isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, Nil) shouldBe false
+    }
+    "return false for a PTR record if the ACL is empty" in {
+      GlobalAcls(Nil).isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, List(PTRData("foo.com"))) shouldBe false
+    }
+    "return false for a PTR record if the ACL is empty and the record data is empty" in {
+      GlobalAcls(Nil).isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, Nil) shouldBe false
+    }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.domain.access
+
+import cats.scalatest.EitherMatchers
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpecLike}
+import vinyldns.api.ResultHelpers
+import vinyldns.core.domain.record.{PTRData, RecordType}
+
+class GlobalAclSpec
+    extends WordSpecLike
+    with Matchers
+    with MockitoSugar
+    with ResultHelpers
+    with EitherMatchers {
+
+  import vinyldns.core.TestMembershipData._
+  import vinyldns.core.TestZoneData._
+
+  private val globalAcls = GlobalAcls(
+    List(GlobalAcl(List(okGroup.id, dummyGroup.id), List(".*foo.*", ".*bar.com"))))
+
+  "isAuthorized" should {
+    "return false if the acl list is empty" in {
+      GlobalAcls(Nil).isAuthorized(okAuth, "foo", RecordType.A, okZone, Nil) shouldBe false
+    }
+    "return true if the user and record are in the acl" in {
+      globalAcls.isAuthorized(okAuth, "foo", RecordType.A, okZone, Nil) shouldBe true
+    }
+    "return true for a PTR record if the user and record match an acl" in {
+      globalAcls.isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, List(PTRData("foo.com"))) shouldBe true
+    }
+    "normalizes the record name before testing" in {
+      globalAcls.isAuthorized(okAuth, "foo.", RecordType.A, okZone, Nil) shouldBe true
+    }
+  }
+}

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -65,7 +65,7 @@ class BatchChangeServiceSpec
 
   private val nonFatalError = ZoneDiscoveryError("test")
 
-  private val validations = new BatchChangeValidations(10, AccessValidations)
+  private val validations = new BatchChangeValidations(10, new AccessValidations())
   private val ttl = Some(200L)
 
   private val apexAddA = AddChangeInput("apex.test.com", RecordType.A, ttl, AData("1.1.1.1"))

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -49,10 +49,11 @@ class BatchChangeValidationsSpec
   import vinyldns.api.IpAddressGenerator._
 
   private val maxChanges = 10
+  private val accessValidations = new AccessValidations()
   private val underTest =
-    new BatchChangeValidations(maxChanges, AccessValidations, multiRecordEnabled = true)
+    new BatchChangeValidations(maxChanges, accessValidations, multiRecordEnabled = true)
   private val underTestMultiDisabled =
-    new BatchChangeValidations(maxChanges, AccessValidations, multiRecordEnabled = false)
+    new BatchChangeValidations(maxChanges, accessValidations, multiRecordEnabled = false)
 
   import underTest._
 
@@ -278,7 +279,7 @@ class BatchChangeValidationsSpec
       scheduledTime = Some(DateTime.now))
     val bcv = new BatchChangeValidations(
       maxChanges,
-      AccessValidations,
+      accessValidations,
       multiRecordEnabled = true,
       scheduledChangesEnabled = false)
     bcv.validateBatchChangeInput(input, None, okAuth).value.unsafeRunSync() shouldBe Left(
@@ -293,7 +294,7 @@ class BatchChangeValidationsSpec
       scheduledTime = Some(DateTime.now.minusHours(1)))
     val bcv = new BatchChangeValidations(
       maxChanges,
-      AccessValidations,
+      accessValidations,
       multiRecordEnabled = true,
       scheduledChangesEnabled = true)
     bcv.validateBatchChangeInput(input, None, okAuth).value.unsafeRunSync() shouldBe Left(

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -68,7 +68,7 @@ class RecordSetServiceSpec
     mockRecordChangeRepo,
     mockUserRepo,
     mockMessageQueue,
-    AccessValidations)
+    new AccessValidations())
 
   "addRecordSet" should {
     "return the recordSet change as the result" in {

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -74,7 +74,7 @@ class ZoneServiceSpec
     TestConnectionValidator,
     mockMessageQueue,
     new ZoneValidations(1000),
-    AccessValidations)
+    new AccessValidations())
 
   private val createZoneAuthorized = CreateZoneInput(
     "ok.zone.recordsets.",


### PR DESCRIPTION
Changes in this pull request:
- `GlobalACLs` - captures logic around testing a user's `AuthPrincipal` for access to a zone
- `AccessValidations` - modified the `getAccessLevel` to consult the `GlobalACLs` for a user to determine if the user has access.  `AccessValidations` now also takes `GlobalACLs`
- `VinylDNSConfig` - load the `GlobalACLs` from the config file
- `Boot` - load two separate `AccessValidations`.  One is used exclusively for batch changes that _will_ consult the configured global acls.  The other one used by the normal record set interface will not consult the global acls.  This is a TODO for cleanup
