### PR TITLE
Set the maxItems to 1000 like list groups

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -196,6 +196,14 @@ object TestDataLoader {
     memberIds = Set(testUser.id),
     adminUserIds = Set(testUser.id))
 
+  final val duGroup = Group(
+    name = "duGroup",
+    id = "duGroup-id",
+    email = "test@test.com",
+    memberIds = listOfDummyUsers.map(_.id).toSet + testUser.id,
+    adminUserIds = listOfDummyUsers.map(_.id).toSet + testUser.id
+  )
+
   // NOTE: this is intentionally not a flagged test zone for validating our test users cannot access regular zone info
   // All other test zones should be flagged as test
   final val nonTestSharedZone = Zone(
@@ -237,6 +245,7 @@ object TestDataLoader {
       _ <- groupRepo.save(sharedZoneGroup)
       _ <- groupRepo.save(globalACLGroup)
       _ <- groupRepo.save(anotherGlobalACLGroup)
+      _ <- groupRepo.save(duGroup)
       _ <- membershipRepo.addMembers(
         groupId = "shared-zone-group",
         memberUserIds = Set(sharedZoneUser.id))
@@ -246,6 +255,7 @@ object TestDataLoader {
       _ <- membershipRepo.addMembers(
         groupId = "another-global-acl-group",
         memberUserIds = Set(testUser.id))
+      _ <- membershipRepo.addMembers(groupId = duGroup.id, memberUserIds = duGroup.memberIds)
       _ <- zoneRepo.save(sharedZone)
       _ <- zoneRepo.save(nonTestSharedZone)
     } yield ()

--- a/modules/portal/public/lib/services/groups/service.groups.js
+++ b/modules/portal/public/lib/services/groups/service.groups.js
@@ -54,9 +54,9 @@ angular.module('service.groups', [])
             return $http.put(url, data, {headers: utilityService.getCsrfHeader()});
         };
 
-        this.getGroupMemberList = function (uuid, id, count) {
+        this.getGroupMemberList = function (uuid) {
             var url = '/api/groups/' + uuid + '/members';
-            url = this.urlBuilder(url, { 'startFrom': id, 'maxItems': count });
+            url = this.urlBuilder(url, { maxItems: 1000 });
             return $http.get(url);
         };
 

--- a/modules/portal/public/lib/services/groups/service.groups.spec.js
+++ b/modules/portal/public/lib/services/groups/service.groups.spec.js
@@ -174,11 +174,9 @@ describe('Service: groupsService', function () {
 
     it('getGroupMemberList method should return 200 with valid group', function (done) {
         var uuid = 123;
-        var id = 12;
-        var count = 2;
         var url = '/api/groups/:groupId/members';
         this.$httpBackend.whenRoute('GET', url).respond(200, getJSONFixture('mockGroupGetMemberList.json'));
-        this.groupsService.getGroupMemberList(uuid, id, count)
+        this.groupsService.getGroupMemberList(uuid)
             .then(function (response) {
                 expect(response.status).toBe(200);
                 done();
@@ -191,11 +189,9 @@ describe('Service: groupsService', function () {
 
     it('getGroupMemberList method should return 400 with invalid group', function (done) {
         var uuid = 123;
-        var id = 12;
-        var count = 2;
         var url = '/api/groups/:groupId/members';
         this.$httpBackend.whenRoute('GET', url).respond(400, getJSONFixture('mockGroupGetMemberList.json'));
-        this.groupsService.getGroupMemberList(uuid, id, count)
+        this.groupsService.getGroupMemberList(uuid)
             .then(function (response) {
                 fail('getGroupMemberList expected 400, but got ' + response.status.toString());
                 done();
@@ -208,11 +204,9 @@ describe('Service: groupsService', function () {
 
     it('getGroupMemberList method should return 403 with invalid group', function (done) {
         var uuid = 123;
-        var id = 12;
-        var count = 2;
         var url = '/api/groups/:groupId/members';
         this.$httpBackend.whenRoute('GET', url).respond(403, getJSONFixture('mockGroupGetMemberList.json'));
-        this.groupsService.getGroupMemberList(uuid, id, count)
+        this.groupsService.getGroupMemberList(uuid)
             .then(function (response) {
                 fail('getGroupMemberList expected 403, but got ' + response.status.toString());
                 done();
@@ -225,11 +219,9 @@ describe('Service: groupsService', function () {
 
     it('getGroupMemberList method should return 503 with invalid group', function (done) {
         var uuid = 123;
-        var id = 12;
-        var count = 2;
         var url = '/api/groups/:groupId/members';
         this.$httpBackend.whenRoute('GET', url).respond(503, getJSONFixture('mockGroupGetMemberList.json'));
-        this.groupsService.getGroupMemberList(uuid, id, count)
+        this.groupsService.getGroupMemberList(uuid)
             .then(function (response) {
                 fail('getGroupMemberList expected 503, but got ' + response.status.toString());
                 done();


### PR DESCRIPTION
Following the same pattern we did for list groups, where we just set the default page size to 1000 when listing members.

- `service.groups.js` - modified the call to `getGroupMembers` to hard code the page size to 1000
- `service.groups.spec.js` - fixed unit tests
- `TestDataLoader` - added a sample group for dummy users that has all dummy users (200 of them) for simple testing.
