### PR TITLE
[DeleteRecord] Delete record validations

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -249,11 +249,11 @@ class BatchChangeValidations(
       // These cases MUST be below adds because:
       // - order matters
       // - all AddChangeForValidations are covered by this point
-      case del
+      case delete
           if groupedChanges
-            .getLogicalChangeType(del.recordKey)
+            .getLogicalChangeType(delete.recordKey)
             .contains(LogicalChangeType.FullDelete) =>
-        validateDeleteWithContext(del, groupedChanges, auth, isApproved)
+        validateDeleteWithContext(delete, groupedChanges, auth, isApproved)
       case deleteUpdate =>
         validateDeleteUpdateWithContext(deleteUpdate, groupedChanges, auth, isApproved)
     }
@@ -281,7 +281,7 @@ class BatchChangeValidations(
     else
       ().validNel
 
-  def ensureDeleteRecordEntryExists(
+  def ensureRecordExists(
       change: ChangeForValidation,
       groupedChanges: ChangeForValidationMap): SingleValidation[Unit] =
     change match {
@@ -309,7 +309,7 @@ class BatchChangeValidations(
           userCanDeleteRecordSet(change, auth, rs.ownerGroupId, rs.records) |+|
             existingRecordSetIsNotMulti(change, rs) |+|
             zoneDoesNotRequireManualReview(change, isApproved) |+|
-            ensureDeleteRecordEntryExists(change, groupedChanges)
+            ensureRecordExists(change, groupedChanges)
         case None => RecordDoesNotExist(change.inputChange.inputName).invalidNel
       }
     validations.map(_ => change)
@@ -361,7 +361,7 @@ class BatchChangeValidations(
           userCanUpdateRecordSet(change, auth, rs.ownerGroupId, adds) |+|
             existingRecordSetIsNotMulti(change, rs) |+|
             zoneDoesNotRequireManualReview(change, isApproved) |+|
-            ensureDeleteRecordEntryExists(change, groupedChanges)
+            ensureRecordExists(change, groupedChanges)
         case None =>
           RecordDoesNotExist(change.inputChange.inputName).invalidNel
       }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -147,7 +147,6 @@ object BatchTransformations {
     def isAddChangeForValidation: Boolean = false
   }
 
-  // $COVERAGE-OFF$
   final case class DeleteRecordChangeForValidation(
       zone: Zone,
       recordName: String,
@@ -171,8 +170,6 @@ object BatchTransformations {
 
     def isAddChangeForValidation: Boolean = false
   }
-
-  // $COVERAGE-ON$
 
   final case class BatchConversionOutput(
       batchChange: BatchChange,

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.core.domain
 
-import vinyldns.core.domain.record.{RecordSet, RecordType}
+import vinyldns.core.domain.record.{RecordData, RecordSet, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
 
 // $COVERAGE-OFF$
@@ -182,6 +182,11 @@ final case class RecordRequiresManualReview(fqdn: String, fatal: Boolean = false
 
 final case class UnsupportedOperation(operation: String) extends DomainValidationError {
   def message: String = s"$operation is not yet implemented/supported in VinylDNS."
+}
+
+final case class DeleteRecordDataDoesNotExist(inputName: String, recordData: RecordData)
+    extends DomainValidationError {
+  def message: String = s"Record data $recordData does not exist for $inputName."
 }
 
 // $COVERAGE-ON$

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -34,7 +34,8 @@ object DomainValidationErrorType extends Enumeration {
   InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
   CnameIsNotUniqueError, UserIsNotAuthorized, RecordNameNotUniqueInBatch, RecordInReverseZoneError,
   HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError, NewMultiRecordError,
-  CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation = Value
+  CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
+  DeleteRecordDataDoesNotExist = Value
 
   // $COVERAGE-OFF$
   def from(error: DomainValidationError): DomainValidationErrorType =
@@ -68,6 +69,7 @@ object DomainValidationErrorType extends Enumeration {
       case _: CnameAtZoneApexError => CnameAtZoneApexError
       case _: RecordRequiresManualReview => RecordRequiresManualReview
       case _: UnsupportedOperation => UnsupportedOperation
+      case _: DeleteRecordDataDoesNotExist => DeleteRecordDataDoesNotExist
     }
   // $COVERAGE-ON$
 }


### PR DESCRIPTION
Support deleting a single DNS entry in batch change validations

Changes in this pull request:
- Add new error type for `DeleteRecord`
- Update batch change validation logic
- Add/update unit tests
