### PR TITLE
[DeleteRecord] Remove multi-record config

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -55,15 +55,15 @@ def assert_change_success_response_values(changes_json, zone, index, record_name
     assert_that(changes_json[index]['id'], is_not(none()))
     assert_that(changes_json[index]['changeType'], is_(change_type))
     assert_that(record_type, is_in(['A', 'AAAA', 'CNAME', 'PTR', 'TXT', 'MX']))
-    if record_type in ["A", "AAAA"] and change_type == "Add":
+    if record_type in ["A", "AAAA"] and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['address'], is_(record_data))
-    elif record_type == "CNAME" and change_type == "Add":
+    elif record_type == "CNAME" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['cname'], is_(record_data))
-    elif record_type == "PTR" and change_type == "Add":
+    elif record_type == "PTR" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['ptrdname'], is_(record_data))
-    elif record_type == "TXT" and change_type == "Add":
+    elif record_type == "TXT" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['text'], is_(record_data))
-    elif record_type == "MX" and change_type == "Add":
+    elif record_type == "MX" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['preference'], is_(record_data['preference']))
         assert_that(changes_json[index]['record']['exchange'], is_(record_data['exchange']))
     return
@@ -1444,7 +1444,7 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
         # context validations: conflicting recordsets, unauthorized error
         assert_failed_change_in_error_response(response[7], input_name=existing_a_fqdn, record_data="1.2.3.4",
                                                error_messages=[
-                                                   "Record \"" + existing_a_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_a_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[8], input_name=existing_cname_fqdn,
                                                record_data="1.2.3.4",
                                                error_messages=[
@@ -1670,7 +1670,7 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[7], input_name=existing_aaaa_fqdn, record_type="AAAA",
                                                record_data="1::1",
                                                error_messages=[
-                                                   "Record \"" + existing_aaaa_fqdn+ "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_aaaa_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[8], input_name=existing_cname_fqdn, record_type="AAAA",
                                                record_data="1::1",
                                                error_messages=[
@@ -1955,7 +1955,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[14], input_name=existing_cname_fqdn,
                                                record_type="CNAME", record_data="test.com.",
                                                error_messages=[
-                                                   "Record \"" + existing_cname_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add.",
+                                                   'Record "' + existing_cname_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.',
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_cname_fqdn + "\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[15], input_name=existing_reverse_fqdn, record_type="CNAME",
                                                record_data="duplicate.in.db.",
@@ -2250,7 +2250,7 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
 
         # context validations: existing cname recordset
         assert_failed_change_in_error_response(response[11], input_name="192.0.2.193", record_type="PTR", record_data="existing-ptr.",
-                                               error_messages=['Record "192.0.2.193" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add.'])
+                                               error_messages=['Record "192.0.2.193" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[12], input_name="192.0.2.199", record_type="PTR", record_data="existing-cname.",
                                                error_messages=['CNAME Conflict: CNAME record names must be unique. Existing record with name "192.0.2.199" and type "CNAME" conflicts with this record.'])
 
@@ -2464,7 +2464,7 @@ def test_ipv6_ptr_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[5], input_name="fd69:27cc:fe91:1000::bbbb", record_type="PTR",
                                                record_data="existing.ptr.",
                                                error_messages=[
-                                                   "Record \"fd69:27cc:fe91:1000::bbbb\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "fd69:27cc:fe91:1000::bbbb" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -2635,7 +2635,7 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[5], input_name=existing_txt_fqdn, record_type="TXT",
                                                record_data="test",
                                                error_messages=[
-                                                   "Record \"" + existing_txt_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_txt_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[6], input_name=existing_cname_fqdn, record_type="TXT",
                                                record_data="test",
                                                error_messages=[
@@ -2858,7 +2858,7 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[8], input_name=existing_mx_fqdn, record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=[
-                                                   "Record \"" + existing_mx_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_mx_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[9], input_name=existing_cname_fqdn, record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=[
@@ -3757,9 +3757,26 @@ def test_create_batch_with_irrelevant_global_acl_rule_applied_fails(shared_zone_
 @pytest.mark.skip_production
 def test_create_batch_duplicates_add_check(shared_zone_test_context):
     """
-    Test recordsets with multiple records cannot be added in batch (relies on config, skip-prod)
+    Test record sets with multiple records can be added in batch only if they are new creates (relies on skip-prod)
     """
     client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    classless_base_zone = shared_zone_test_context.classless_base_zone
+
+    # record sets to setup
+    a_name = generate_record_name()
+    a_fqdn = a_name + ".ok."
+    a_existing = get_recordset_json(ok_zone, a_name, "A", [{ "address": "1.1.1.1" }], 200)
+
+    ptr_existing = get_recordset_json(classless_base_zone, "45", "PTR", [{"ptrdname": "existing.ptr."}], 200)
+
+    txt_name = generate_record_name()
+    txt_fqdn = txt_name + ".ok."
+    txt_existing = get_recordset_json(ok_zone, txt_name, "TXT", [{ "text": "hello" }], 200)
+
+    mx_name = generate_record_name()
+    mx_fqdn = mx_name + ".ok."
+    mx_existing = get_recordset_json(ok_zone, mx_name, "MX", [{"preference": 1, "exchange": "foo.bar."}], 100)
 
     batch_change_input = {
         "comments": "this is optional",
@@ -3773,98 +3790,219 @@ def test_create_batch_duplicates_add_check(shared_zone_test_context):
             get_change_MX_json("multi-mx.ok.", preference=0),
             get_change_MX_json("multi-mx.ok.", preference=1000, exchange="bar.foo."),
 
-            # adding an HVD so this will fail if accidentally run against wrong config
-            get_change_A_AAAA_json("high-value-domain")
+            get_change_A_AAAA_json(a_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_fqdn, address="4.5.6.7"),
+            get_change_PTR_json("192.0.2.45", ptrdname="multi.test"),
+            get_change_PTR_json("192.0.2.45", ptrdname="multi2.test"),
+            get_change_TXT_json(txt_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_fqdn, text="more-multi-text"),
+            get_change_MX_json(mx_fqdn, preference=0),
+            get_change_MX_json(mx_fqdn, preference=1000, exchange="bar.foo.")
         ]
     }
 
-    response = client.create_batch_change(batch_change_input, status=400)
+    def err(name):
+        return 'Record "{}" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'.format(name)
 
-    def err(name, type):
-        return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-               'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name, type)
+    to_delete = []
+    try:
+        for rs in [a_existing, ptr_existing, txt_existing, mx_existing]:
+            create_result = client.create_recordset(rs, status=202)
+            to_delete.append(client.wait_until_recordset_change_status(create_result, 'Complete'))
 
-    assert_error(response[0], error_messages=[err("multi.ok.", "A")])
-    assert_error(response[1], error_messages=[err("multi.ok.", "A")])
-    assert_error(response[2], error_messages=[err("192.0.2.44", "PTR")])
-    assert_error(response[3], error_messages=[err("192.0.2.44", "PTR")])
-    assert_error(response[4], error_messages=[err("multi-txt.ok.", "TXT")])
-    assert_error(response[5], error_messages=[err("multi-txt.ok.", "TXT")])
-    assert_error(response[6], error_messages=[err("multi-mx.ok.", "MX")])
-    assert_error(response[7], error_messages=[err("multi-mx.ok.", "MX")])
+        result = client.create_batch_change(batch_change_input, status=400)
+
+        assert_successful_change_in_error_response(result[0], input_name="multi.ok.", record_data="1.2.3.4")
+        assert_successful_change_in_error_response(result[1], input_name="multi.ok.", record_data="4.5.6.7")
+        assert_successful_change_in_error_response(result[2], input_name="192.0.2.44", record_type="PTR", record_data="multi.test.")
+        assert_successful_change_in_error_response(result[3], input_name="192.0.2.44", record_type="PTR", record_data="multi2.test.")
+        assert_successful_change_in_error_response(result[4], input_name="multi-txt.ok.", record_type="TXT", record_data="some-multi-text")
+        assert_successful_change_in_error_response(result[5], input_name="multi-txt.ok.", record_type="TXT", record_data="more-multi-text")
+        assert_successful_change_in_error_response(result[6], input_name="multi-mx.ok.", record_type="MX", record_data={"preference": 0, "exchange": "foo.bar."})
+        assert_successful_change_in_error_response(result[7], input_name="multi-mx.ok.", record_type="MX", record_data={"preference": 1000, "exchange": "bar.foo."})
+
+        assert_failed_change_in_error_response(result[8], input_name=a_fqdn, record_data="1.2.3.4", error_messages=[err(a_fqdn)])
+        assert_failed_change_in_error_response(result[9], input_name=a_fqdn, record_data="4.5.6.7", error_messages=[err(a_fqdn)])
+        assert_failed_change_in_error_response(result[10], input_name="192.0.2.45", record_type="PTR", record_data="multi.test.", error_messages=[err("192.0.2.45")])
+        assert_failed_change_in_error_response(result[11], input_name="192.0.2.45", record_type="PTR", record_data="multi2.test.", error_messages=[err("192.0.2.45")])
+        assert_failed_change_in_error_response(result[12], input_name=txt_fqdn,  record_type="TXT", record_data="some-multi-text", error_messages=[err(txt_fqdn)])
+        assert_failed_change_in_error_response(result[13], input_name=txt_fqdn, record_type="TXT", record_data="more-multi-text", error_messages=[err(txt_fqdn)])
+        assert_failed_change_in_error_response(result[14], input_name=mx_fqdn, record_type="MX", record_data={"preference":0, "exchange":"foo.bar."}, error_messages=[err(mx_fqdn)])
+        assert_failed_change_in_error_response(result[15], input_name=mx_fqdn, record_type="MX", record_data={"preference":1000, "exchange":"bar.foo."}, error_messages=[err(mx_fqdn)])
+
+    finally:
+        clear_recordset_list(to_delete, client)
 
 
 @pytest.mark.skip_production
 def test_create_batch_duplicates_update_check(shared_zone_test_context):
     """
-    Test recordsets with multiple records cannot be edited in batch (relies on config, skip-prod)
+    Test record sets with multiple records can be added, updated and deleted in batch (relies on skip-prod)
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone = shared_zone_test_context.ok_zone
 
     # record sets to setup
-    a_update_name = generate_record_name()
-    a_update_fqdn = a_update_name + ".ok."
-    a_update = get_recordset_json(ok_zone, a_update_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+    a_update_record_set_name = generate_record_name()
+    a_update_record_set_fqdn = a_update_record_set_name + ".ok."
+    a_update_record_set = get_recordset_json(ok_zone, a_update_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
 
-    txt_update_name = generate_record_name()
-    txt_update_fqdn = txt_update_name + ".ok."
-    txt_update = get_recordset_json(ok_zone, txt_update_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+    txt_update_record_set_name = generate_record_name()
+    txt_update_record_set_fqdn = txt_update_record_set_name + ".ok."
+    txt_update_record_set = get_recordset_json(ok_zone, txt_update_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
 
-    a_delete_name = generate_record_name()
-    a_delete_fqdn = a_delete_name + ".ok."
-    a_delete = get_recordset_json(ok_zone, a_delete_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+    a_update_record_full_name = generate_record_name()
+    a_update_record_full_fqdn = a_update_record_full_name + ".ok."
+    a_update_record_full = get_recordset_json(ok_zone, a_update_record_full_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
 
-    txt_delete_name = generate_record_name()
-    txt_delete_fqdn = txt_delete_name + ".ok."
-    txt_delete = get_recordset_json(ok_zone, txt_delete_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+    txt_update_record_full_name = generate_record_name()
+    txt_update_record_full_fqdn = txt_update_record_full_name + ".ok."
+    txt_update_record_full = get_recordset_json(ok_zone, txt_update_record_full_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_name = generate_record_name()
+    a_update_record_fqdn = a_update_record_name + ".ok."
+    a_update_record = get_recordset_json(ok_zone, a_update_record_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_name = generate_record_name()
+    txt_update_record_fqdn = txt_update_record_name + ".ok."
+    txt_update_record = get_recordset_json(ok_zone, txt_update_record_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_only_name = generate_record_name()
+    a_update_record_only_fqdn = a_update_record_only_name + ".ok."
+    a_update_record_only = get_recordset_json(ok_zone, a_update_record_only_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_only_name = generate_record_name()
+    txt_update_record_only_fqdn = txt_update_record_only_name + ".ok."
+    txt_update_record_only = get_recordset_json(ok_zone, txt_update_record_only_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_set_name = generate_record_name()
+    a_delete_record_set_fqdn = a_delete_record_set_name + ".ok."
+    a_delete_record_set = get_recordset_json(ok_zone, a_delete_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_set_name = generate_record_name()
+    txt_delete_record_set_fqdn = txt_delete_record_set_name + ".ok."
+    txt_delete_record_set = get_recordset_json(ok_zone, txt_delete_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_name = generate_record_name()
+    a_delete_record_fqdn = a_delete_record_name + ".ok."
+    a_delete_record = get_recordset_json(ok_zone, a_delete_record_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_name = generate_record_name()
+    txt_delete_record_fqdn = txt_delete_record_name + ".ok."
+    txt_delete_record = get_recordset_json(ok_zone, txt_delete_record_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_and_record_set_name = generate_record_name()
+    a_delete_record_and_record_set_fqdn = a_delete_record_and_record_set_name + ".ok."
+    a_delete_record_and_record_set = get_recordset_json(ok_zone, a_delete_record_and_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_and_record_set_name = generate_record_name()
+    txt_delete_record_and_record_set_fqdn = txt_delete_record_and_record_set_name + ".ok."
+    txt_delete_record_and_record_set = get_recordset_json(ok_zone, txt_delete_record_and_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
 
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_fqdn, address="1.2.3.4"),
-            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
+            ## Updates
+            # Add + DeleteRRSet
+            get_change_A_AAAA_json(a_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="4.5.6.7"),
 
-            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_fqdn, text="some-multi-text"),
-            get_change_TXT_json(txt_update_fqdn, text="more-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="more-multi-text"),
 
-            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecordSet"),
+            # Add + DeleteRecord (full delete)
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.2", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="4.5.6.7"),
 
-            # adding an HVD so this will fail if accidentally run against wrong config
-            get_change_A_AAAA_json("high-value-domain")
+            get_change_TXT_json(txt_update_record_full_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="again", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="more-multi-text"),
+
+            # Add + single DeleteRecord
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="4.5.6.7"),
+
+            get_change_TXT_json(txt_update_record_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_fqdn, text="more-multi-text"),
+
+            # Single DeleteRecord
+            get_change_A_AAAA_json(a_update_record_only_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_only_fqdn, text="hello", change_type="DeleteRecord"),
+
+            ## Full deletes
+            # Delete RRSet
+            get_change_A_AAAA_json(a_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+
+            # DeleteRecord (full delete)
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.2", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="again", change_type="DeleteRecord"),
+
+            # DeleteRecord + DeleteRRSet
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet")
         ]
     }
 
     to_delete = []
     try:
-        for rs in [a_update, txt_update, a_delete, txt_delete]:
+        for rs in [a_update_record_set, txt_update_record_set, a_update_record_full, txt_update_record_full, a_update_record, txt_update_record, a_update_record_only, txt_update_record_only,
+                   a_delete_record_set, txt_delete_record_set, a_delete_record, txt_delete_record, a_delete_record_and_record_set, txt_delete_record_and_record_set]:
             create_rs = client.create_recordset(rs, status=202)
             to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
 
-        response = client.create_batch_change(batch_change_input, status=400)
+        result = client.create_batch_change(batch_change_input, status=202)
+        client.wait_until_batch_change_completed(result)
 
-        def existing_err(name, type):
-            return 'RecordSet with name {} and type {} cannot be updated in a single '.format(name, type) + \
-                   'Batch Change because it contains multiple DNS records (2).'
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=0, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=2, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=3, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=4, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=5, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="more-multi-text")
 
-        def new_err(name, type):
-            return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-                   'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name,
-                                                                                                               type)
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=6, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=7, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.2", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=8, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=9, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=10, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="again", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=12, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="more-multi-text")
 
-        assert_error(response[0], error_messages=[existing_err(a_update_fqdn, "A")])
-        assert_error(response[1], error_messages=[existing_err(a_update_fqdn, "A"), new_err(a_update_fqdn, "A")])
-        assert_error(response[2], error_messages=[existing_err(a_update_fqdn, "A"), new_err(a_update_fqdn, "A")])
-        assert_error(response[3], error_messages=[existing_err(txt_update_fqdn, "TXT")])
-        assert_error(response[4],
-                     error_messages=[existing_err(txt_update_fqdn, "TXT"), new_err(txt_update_fqdn, "TXT")])
-        assert_error(response[5],
-                     error_messages=[existing_err(txt_update_fqdn, "TXT"), new_err(txt_update_fqdn, "TXT")])
-        assert_error(response[6], error_messages=[existing_err(a_delete_fqdn, "A")])
-        assert_error(response[7], error_messages=[existing_err(txt_delete_fqdn, "TXT")])
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=14, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=15, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=16, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=17, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=18, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=19, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=20, input_name=a_update_record_only_fqdn, record_name=a_update_record_only_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=21, input_name=txt_update_record_only_fqdn, record_name=txt_update_record_only_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=22, input_name=a_delete_record_set_fqdn, record_name=a_delete_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=23, input_name=txt_delete_record_set_fqdn, record_name=txt_delete_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=24, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=25, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.2", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=26, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=27, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="again", change_type="DeleteRecord")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=28, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=29, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=30, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=31, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -3903,9 +4041,9 @@ def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_co
             rejecter.reject_batch_change(response['id'], status=200)
 
 
-def test_create_batch_delete_record_fails(shared_zone_test_context):
+def test_create_batch_delete_record_succeeds(shared_zone_test_context):
     """
-    Test creating batch change with DeleteRecord change input type is not recognized
+    Test creating batch change with DeleteRecord change input type is recognized
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone = shared_zone_test_context.ok_zone
@@ -3918,19 +4056,111 @@ def test_create_batch_delete_record_fails(shared_zone_test_context):
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json(rs_fqdn, change_type="DeleteRecord")
+            get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecord")
         ]
     }
 
-    create_rs = None
-    try:
-        create_rs = client.create_recordset(rs_to_create, status=202)
-        client.wait_until_recordset_change_status(create_rs, 'Complete')
+    to_delete = []
 
-        # TODO: Update this when DeleteRecord is supported
-        client.create_batch_change(batch_change_input, status=400)
+    create_rs = client.create_recordset(rs_to_create, status=202)
+    to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+    result = client.create_batch_change(batch_change_input, status=202)
+    client.wait_until_batch_change_completed(result)
+
+
+@pytest.mark.serial
+def test_create_batch_delete_record_access_checks(shared_zone_test_context):
+    """
+    Test access for full-delete DeleteRecord (delete) and non-full-delete DeleteRecord (update)
+    """
+    ok_client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    dummy_client = shared_zone_test_context.dummy_vinyldns_client
+    dummy_group_id = shared_zone_test_context.dummy_group['id']
+
+    a_delete_acl = generate_acl_rule('Delete', groupId=dummy_group_id, recordMask='.*', recordTypes=['A'])
+    txt_write_acl = generate_acl_rule('Write', groupId=dummy_group_id, recordMask='.*', recordTypes=['TXT'])
+
+    a_update_name = generate_record_name()
+    a_update_fqdn = a_update_name + ".ok."
+    a_update = get_recordset_json(ok_zone, a_update_name, "A", [{"address": "1.1.1.1"}])
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(ok_zone, a_delete_name, "A", [{"address": "1.1.1.1"}])
+
+    txt_update_name = generate_record_name()
+    txt_update_fqdn = txt_update_name + ".ok."
+    txt_update = get_recordset_json(ok_zone, txt_update_name, "TXT", [{"text": "test"}])
+
+    txt_delete_name = generate_record_name()
+    txt_delete_fqdn = txt_delete_name + ".ok."
+    txt_delete = get_recordset_json(ok_zone, txt_delete_name, "TXT", [{"text": "test"}])
+
+    batch_change_input = {
+        "comments": "Testing DeleteRecord access levels",
+        "changes": [
+            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
+            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_fqdn, text="updated text"),
+            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecord")
+        ]
+    }
+
+    to_delete = []
+    try:
+        add_ok_acl_rules(shared_zone_test_context, [a_delete_acl, txt_write_acl])
+
+        for create_json in [a_update, a_delete, txt_update, txt_delete]:
+            create_result = ok_client.create_recordset(create_json, status=202)
+            to_delete.append(ok_client.wait_until_recordset_change_status(create_result, 'Complete'))
+
+        response = dummy_client.create_batch_change(batch_change_input, status=400)
+
+        assert_successful_change_in_error_response(response[0], input_name=a_update_fqdn, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_successful_change_in_error_response(response[1], input_name=a_update_fqdn, record_data="4.5.6.7")
+        assert_successful_change_in_error_response(response[2], input_name=a_delete_fqdn, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_successful_change_in_error_response(response[3], input_name=txt_update_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecord")
+        assert_successful_change_in_error_response(response[4], input_name=txt_update_fqdn, record_type="TXT", record_data="updated text")
+        assert_failed_change_in_error_response(response[5], input_name=txt_delete_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecord",
+                                               error_messages=['User "dummy" is not authorized.'])
 
     finally:
-        if create_rs:
-            delete_rs = client.delete_recordset(ok_zone['id'], create_rs['recordSet']['id'], status=202)
-            client.wait_until_recordset_change_status(delete_rs, 'Complete')
+        clear_ok_acl_rules(shared_zone_test_context)
+        clear_recordset_list(to_delete, ok_client)
+
+
+def test_create_batch_delete_record_for_invalid_record_data_fails(shared_zone_test_context):
+    """
+    Test delete record failure for non-existent record and non-existent record data
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(shared_zone_test_context.ok_zone, a_delete_fqdn, "A", [{"address": "1.1.1.1"}])
+
+    batch_change_input = {
+        "comments": "test delete record failures",
+        "changes": [
+            get_change_A_AAAA_json("delete-non-existent-record.ok.", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_delete_fqdn, address="4.5.6.7", change_type="DeleteRecord")
+        ]
+    }
+
+    to_delete = []
+    try:
+        create_rs = client.create_recordset(a_delete, status=202)
+        to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+        errors = client.create_batch_change(batch_change_input, status=400)
+        assert_failed_change_in_error_response(errors[0], input_name="delete-non-existent-record.ok.", record_data="1.1.1.1", change_type="DeleteRecord",
+                                               error_messages=['Record "delete-non-existent-record.ok." Does Not Exist: cannot delete a record that does not exist.'])
+        assert_failed_change_in_error_response(errors[1], input_name=a_delete_fqdn, record_data="4.5.6.7", change_type="DeleteRecord",
+                                               error_messages=['Record data AData(4.5.6.7) does not exist for "' + a_delete_fqdn + '".'])
+
+    finally:
+        clear_recordset_list(to_delete, client)

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -427,7 +427,7 @@ def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address="1.1.1.
     else:
         if change_type == "DeleteRecord":
             json = {
-                "changeType": "DeleteRecord",
+                "changeType": change_type,
                 "inputName": input_name,
                 "type": record_type,
                 "record": {
@@ -495,11 +495,21 @@ def get_change_TXT_json(input_name, record_type="TXT", ttl=200, text="test", cha
             }
         }
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": record_type
-        }
+        if change_type == "DeleteRecord":
+            json = {
+                "changeType": change_type,
+                "inputName": input_name,
+                "type": record_type,
+                "record": {
+                    "text": text
+                }
+            }
+        else:
+            json = {
+                "changeType": "DeleteRecordSet",
+                "inputName": input_name,
+                "type": record_type
+            }
     return json
 
 

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -117,7 +117,6 @@ object Boot extends App {
       val batchChangeValidations = new BatchChangeValidations(
         batchChangeLimit,
         batchAccessValidations,
-        VinylDNSConfig.multiRecordBatchUpdateEnabled,
         VinylDNSConfig.scheduledChangesEnabled
       )
       val membershipService = MembershipService(repositories)

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -129,9 +129,7 @@ object VinylDNSConfig {
     } else List()
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
-  lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]](s"default-ttl").getOrElse(7200L)
-  lazy val multiRecordBatchUpdateEnabled: Boolean =
-    vinyldnsConfig.as[Option[Boolean]]("enable-multi-record-batch-update").getOrElse(false)
+  lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]]("default-ttl").getOrElse(7200L)
   lazy val manualBatchReviewEnabled: Boolean = vinyldnsConfig
     .as[Option[Boolean]]("manual-batch-review-enabled")
     .getOrElse(false)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -90,8 +90,6 @@ final case class DeleteRRSetChangeInput(inputName: String, typ: RecordType) exte
     )
 }
 
-// TODO: Remove coverage on/off
-// $COVERAGE-OFF$
 final case class DeleteRecordChangeInput(inputName: String, typ: RecordType, record: RecordData)
     extends ChangeInput {
   def asNewStoredChange(errors: NonEmptyList[DomainValidationError]): SingleChange =
@@ -109,7 +107,6 @@ final case class DeleteRecordChangeInput(inputName: String, typ: RecordType, rec
       errors.toList.map(SingleChangeError(_))
     )
 }
-// $COVERAGE-ON$
 
 object AddChangeInput {
   def apply(

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -87,10 +87,8 @@ object BatchTransformations {
         case a: AddChangeInput => AddChangeForValidation(zone, recordName, a)
         case d: DeleteRRSetChangeInput =>
           DeleteRRSetChangeForValidation(zone, recordName, d)
-        // TODO: Support DeleteRecordChangeInput in ChangeForValidation
-        case _: DeleteRecordChangeInput =>
-          throw new UnsupportedOperationException(
-            "DeleteRecordChangeInput is not yet implemented/supported in VinylDNS.")
+        case d: DeleteRecordChangeInput =>
+          DeleteRecordChangeForValidation(zone, recordName, d)
       }
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -31,7 +31,6 @@ import vinyldns.core.domain.record._
 
 trait BatchChangeJsonProtocol extends JsonValidation {
 
-  // TODO: Add DeleteRecordChangeInputSerializer for DeleteRecord
   val batchChangeSerializers = Seq(
     JsonEnumV(ChangeInputType),
     JsonEnumV(SingleChangeStatus),
@@ -42,6 +41,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
     ChangeInputSerializer,
     AddChangeInputSerializer,
     DeleteRRSetChangeInputSerializer,
+    DeleteRecordChangeInputSerializer,
     SingleAddChangeSerializer,
     SingleDeleteRRSetChangeSerializer,
     SingleDeleteRecordChangeSerializer,
@@ -178,7 +178,7 @@ trait BatchChangeJsonProtocol extends JsonValidation {
   case object SingleDeleteRecordChangeSerializer
       extends ValidationSerializer[SingleDeleteRecordChange] {
     override def toJson(sdrc: SingleDeleteRecordChange): JValue =
-      ("changeType" -> "DeleteRecordSet") ~
+      ("changeType" -> "DeleteRecord") ~
         ("inputName" -> sdrc.inputName) ~
         ("type" -> Extraction.decompose(sdrc.typ)) ~
         ("status" -> sdrc.status.toString) ~

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -558,7 +558,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
           Add,
           NonEmptyList.fromListUnsafe(addSingleChangesGood),
           okZone,
-          singleAddChange.typ,
+          A,
           Set(singleAddChange.recordData),
           okUser.id,
           None,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -20,7 +20,12 @@ import cats.data.NonEmptyList
 import org.joda.time.DateTime
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.api.VinylDNSConfig
-import vinyldns.core.domain.{DomainValidationErrorType, SingleChangeError, ZoneDiscoveryError}
+import vinyldns.core.domain.{
+  DeleteRecordDataDoesNotExist,
+  DomainValidationErrorType,
+  SingleChangeError,
+  ZoneDiscoveryError
+}
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record.{AAAAData, AData, CNAMEData}
@@ -72,7 +77,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       asAdd.recordChangeId shouldBe None
       asAdd.recordSetId shouldBe None
     }
-    "Convert a DeleteChangeInput into SingleDeleteRRSetChange" in {
+    "Convert a DeleteRRSetChangeInput into SingleDeleteRRSetChange" in {
       val changeA = DeleteRRSetChangeInput("some.test.com", A)
       val converted = changeA.asNewStoredChange(NonEmptyList.of(ZoneDiscoveryError("test")))
 
@@ -84,6 +89,25 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       asDelete.recordName shouldBe None
       asDelete.inputName shouldBe "some.test.com."
       asDelete.typ shouldBe A
+      asDelete.status shouldBe SingleChangeStatus.NeedsReview
+      asDelete.systemMessage shouldBe None
+      asDelete.recordChangeId shouldBe None
+      asDelete.recordSetId shouldBe None
+    }
+    "Convert a DeleteRecordChangeInput into SingleDeleteRecordChange" in {
+      val changeA = DeleteRecordChangeInput("some.test.com.", A, AData("1.1.1.1"))
+      val converted = changeA.asNewStoredChange(
+        NonEmptyList.of(DeleteRecordDataDoesNotExist("some.test.com.", AData("1.1.1.1"))))
+
+      converted shouldBe a[SingleDeleteRecordChange]
+      val asDelete = converted.asInstanceOf[SingleDeleteRecordChange]
+
+      asDelete.zoneId shouldBe None
+      asDelete.zoneName shouldBe None
+      asDelete.recordName shouldBe None
+      asDelete.inputName shouldBe "some.test.com."
+      asDelete.typ shouldBe A
+      asDelete.recordData shouldBe AData("1.1.1.1")
       asDelete.status shouldBe SingleChangeStatus.NeedsReview
       asDelete.systemMessage shouldBe None
       asDelete.recordChangeId shouldBe None
@@ -110,7 +134,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       val expectedAddChange =
         AddChangeInput("testRname.testZoneName.", A, Some(1234), AData("1.2.3.4"))
 
-      val singleDelChange = SingleDeleteRRSetChange(
+      val singleDeleteRRSetChange = SingleDeleteRRSetChange(
         Some("testZoneId"),
         Some("testZoneName"),
         Some("testRname"),
@@ -123,15 +147,32 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
         List(SingleChangeError(DomainValidationErrorType.ZoneDiscoveryError, "test err"))
       )
 
-      val expectedDelChange =
+      val expectedDeleteRRSetChange =
         DeleteRRSetChangeInput("testRname.testZoneName.", A)
+
+      val singleDeleteRecordChange = SingleDeleteRecordChange(
+        Some("testZoneId"),
+        Some("testZoneName"),
+        Some("testRname"),
+        "testRname.testZoneName.",
+        A,
+        AData("1.1.1.1"),
+        SingleChangeStatus.NeedsReview,
+        Some("msg"),
+        None,
+        None,
+        List(SingleChangeError(DomainValidationErrorType.DeleteRecordDataDoesNotExist, "test err"))
+      )
+
+      val expectedDeleteRecordChange =
+        DeleteRecordChangeInput("testRname.testZoneName.", A, AData("1.1.1.1"))
 
       val change = BatchChange(
         "userId",
         "userName",
         Some("comments"),
         DateTime.now(),
-        List(singleAddChange, singleDelChange),
+        List(singleAddChange, singleDeleteRRSetChange, singleDeleteRecordChange),
         Some("owner"),
         BatchChangeApprovalStatus.PendingReview
       )
@@ -139,7 +180,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       val expectedInput =
         BatchChangeInput(
           Some("comments"),
-          List(expectedAddChange, expectedDelChange),
+          List(expectedAddChange, expectedDeleteRRSetChange, expectedDeleteRecordChange),
           Some("owner"))
 
       BatchChangeInput(change) shouldBe expectedInput

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1678,7 +1678,8 @@ class BatchChangeServiceSpec
     }
 
     "return a BatchChangeErrorList if all data inputs are valid/soft failures and manual review is disabled" in {
-      val delete = DeleteRRSetChangeInput("some.test.delete.", RecordType.TXT)
+      val delete =
+        DeleteRecordChangeInput("some.test.delete.", RecordType.TXT, TXTData("some test text"))
       val result = underTest
         .buildResponse(
           BatchChangeInput(None, List(apexAddA, onlyBaseAddAAAA, delete)),

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -51,9 +51,7 @@ class BatchChangeValidationsSpec
   private val maxChanges = 10
   private val accessValidations = new AccessValidations()
   private val underTest =
-    new BatchChangeValidations(maxChanges, accessValidations, multiRecordEnabled = true)
-  private val underTestMultiDisabled =
-    new BatchChangeValidations(maxChanges, accessValidations, multiRecordEnabled = false)
+    new BatchChangeValidations(maxChanges, accessValidations)
 
   import underTest._
 
@@ -299,11 +297,8 @@ class BatchChangeValidationsSpec
       None,
       List(AddChangeInput("private-create", RecordType.A, ttl, AData("1.1.1.1"))),
       scheduledTime = Some(DateTime.now))
-    val bcv = new BatchChangeValidations(
-      maxChanges,
-      accessValidations,
-      multiRecordEnabled = true,
-      scheduledChangesEnabled = false)
+    val bcv =
+      new BatchChangeValidations(maxChanges, accessValidations, scheduledChangesEnabled = false)
     bcv.validateBatchChangeInput(input, None, okAuth).value.unsafeRunSync() shouldBe Left(
       ScheduledChangesDisabled)
   }
@@ -314,11 +309,8 @@ class BatchChangeValidationsSpec
       None,
       List(AddChangeInput("private-create", RecordType.A, ttl, AData("1.1.1.1"))),
       scheduledTime = Some(DateTime.now.minusHours(1)))
-    val bcv = new BatchChangeValidations(
-      maxChanges,
-      accessValidations,
-      multiRecordEnabled = true,
-      scheduledChangesEnabled = true)
+    val bcv =
+      new BatchChangeValidations(maxChanges, accessValidations, scheduledChangesEnabled = true)
     bcv.validateBatchChangeInput(input, None, okAuth).value.unsafeRunSync() shouldBe Left(
       ScheduledTimeMustBeInFuture)
   }
@@ -442,14 +434,17 @@ class BatchChangeValidationsSpec
       AddChangeInput("invalidDomainName$", RecordType.A, ttl, AAAAData("1:2:3:4:5:6:7:8"))
     val invalidIpv6Input =
       AddChangeInput("testbad.example.com.", RecordType.AAAA, ttl, AAAAData("invalidIpv6:123"))
+    val goodDeleteRecord =
+      DeleteRecordChangeInput("good-delete-record.example.com.", RecordType.A, AData("1.1.1.1"))
     val result =
       validateInputChanges(
-        List(goodInput, goodAAAAInput, invalidDomainNameInput, invalidIpv6Input),
+        List(goodInput, goodAAAAInput, invalidDomainNameInput, invalidIpv6Input, goodDeleteRecord),
         false)
     result(0) shouldBe valid
     result(1) shouldBe valid
     result(2) should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
     result(3) should haveInvalid[DomainValidationError](InvalidIpv6Address("invalidIpv6:123"))
+    result(4) shouldBe valid
   }
 
   property("""validateInputName: should fail with a HighValueDomainError
@@ -1941,8 +1936,7 @@ class BatchChangeValidationsSpec
     result(0) shouldBe valid
   }
 
-  property(
-    "validateChangesWithContext: succeed update/delete to a multi record existing RecordSet if multi enabled") {
+  property("validateChangesWithContext: succeed update/delete to a multi record existing RecordSet") {
     val existing = List(
       sharedZoneRecord.copy(
         name = updateSharedAddChange.recordName,
@@ -1980,28 +1974,22 @@ class BatchChangeValidationsSpec
     result(5) shouldBe valid
   }
 
-  property(
-    "validateChangesWithContext: fail on update/delete to a multi record existing RecordSet if multi disabled") {
+  property("validateChangesWithContext: fail on add to a multi record existing RecordSet") {
     val existing = List(
-      sharedZoneRecord.copy(
-        name = updateSharedAddChange.recordName,
-        records = List(AAAAData("1::1"), AAAAData("2::2"))),
-      sharedZoneRecord.copy(
-        name = deleteSharedChange.recordName,
-        records = List(AAAAData("1::1"), AAAAData("2::2"))),
-      rsOk.copy(name = updatePrivateAddChange.recordName),
-      rsOk.copy(name = deletePrivateChange.recordName)
+      rsOk.copy(
+        zoneId = sharedZone.id,
+        name = createSharedAddChange.recordName,
+        records = List(AData("1.2.3.4"), AData("2.3.4.5")))
     )
 
-    val result = underTestMultiDisabled.validateChangesWithContext(
+    val createSharedAddChange2 = createSharedAddChange.copy(
+      inputChange = createSharedAddChange.inputChange.copy(record = AData("1.1.1.2")))
+
+    val result = underTest.validateChangesWithContext(
       ChangeForValidationMap(
         List(
-          updateSharedAddChange.validNel,
-          updateSharedDeleteChange.validNel,
-          deleteSharedChange.validNel,
-          updatePrivateAddChange.validNel,
-          updatePrivateDeleteChange.validNel,
-          deletePrivateChange.validNel
+          createSharedAddChange.validNel,
+          createSharedAddChange2.validNel
         ),
         ExistingRecordSets(existing)
       ),
@@ -2011,18 +1999,12 @@ class BatchChangeValidationsSpec
     )
 
     result(0) should haveInvalid[DomainValidationError](
-      ExistingMultiRecordError(updateSharedAddChange.inputChange.inputName, existing(0)))
+      RecordAlreadyExists(createSharedAddChange.inputChange.inputName))
     result(1) should haveInvalid[DomainValidationError](
-      ExistingMultiRecordError(updateSharedDeleteChange.inputChange.inputName, existing(0)))
-    result(2) should haveInvalid[DomainValidationError](
-      ExistingMultiRecordError(deleteSharedChange.inputChange.inputName, existing(1)))
-    // non duplicate
-    result(3) shouldBe valid
-    result(4) shouldBe valid
-    result(5) shouldBe valid
+      RecordAlreadyExists(createSharedAddChange2.inputChange.inputName))
   }
 
-  property("validateChangesWithContext: succeed on add/update to a multi record if multi enabled") {
+  property("validateChangesWithContext: succeed on add/update to a multi record") {
     val existing = List(
       sharedZoneRecord.copy(name = updateSharedAddChange.recordName)
     )
@@ -2049,7 +2031,7 @@ class BatchChangeValidationsSpec
           update2.validNel,
           add1.validNel,
           add2.validNel,
-          updatePrivateAddChange.validNel
+          updatePrivateAddChange.validNel // non-duplicate
         ),
         ExistingRecordSets(existing)
       ),
@@ -2058,65 +2040,7 @@ class BatchChangeValidationsSpec
       Some(okGroup.id)
     )
 
-    result(0) shouldBe valid
-    result(1) shouldBe valid
-    result(2) shouldBe valid
-    result(3) shouldBe valid
-    result(4) shouldBe valid
-    // non duplicate
-    result(5) shouldBe valid
-  }
-
-  property("validateChangesWithContext: fail on add/update to a multi record if multi disabled") {
-    val existing = List(
-      sharedZoneRecord.copy(
-        name = updateSharedAddChange.recordName,
-        records = List(AAAAData("1::1"))
-      )
-    )
-
-    val update1 = updateSharedAddChange.copy(
-      inputChange =
-        AddChangeInput("shared-update.shared", RecordType.AAAA, ttl, AAAAData("1:2:3:4:5:6:7:8"))
-    )
-    val update2 = updateSharedAddChange.copy(
-      inputChange = AddChangeInput("shared-update.shared", RecordType.AAAA, ttl, AAAAData("1::1"))
-    )
-    val add1 = createSharedAddChange.copy(
-      inputChange = AddChangeInput("shared-add.shared", RecordType.A, ttl, AData("1.2.3.4"))
-    )
-    val add2 = createSharedAddChange.copy(
-      inputChange = AddChangeInput("shared-add.shared", RecordType.A, ttl, AData("5.6.7.8"))
-    )
-
-    val result = underTestMultiDisabled.validateChangesWithContext(
-      ChangeForValidationMap(
-        List(
-          updateSharedDeleteChange.validNel,
-          update1.validNel,
-          update2.validNel,
-          add1.validNel,
-          add2.validNel,
-          updatePrivateAddChange.validNel
-        ),
-        ExistingRecordSets(existing)
-      ),
-      okAuth,
-      false,
-      Some(okGroup.id)
-    )
-
-    result(0) shouldBe valid
-    result(1) should haveInvalid[DomainValidationError](
-      NewMultiRecordError(update1.inputChange.inputName, update1.inputChange.typ))
-    result(2) should haveInvalid[DomainValidationError](
-      NewMultiRecordError(update2.inputChange.inputName, update2.inputChange.typ))
-    result(3) should haveInvalid[DomainValidationError](
-      NewMultiRecordError(add1.inputChange.inputName, add1.inputChange.typ))
-    result(4) should haveInvalid[DomainValidationError](
-      NewMultiRecordError(add2.inputChange.inputName, add2.inputChange.typ))
-    // non duplicate
-    result(5) shouldBe valid
+    result.foreach(_ shouldBe valid)
   }
 
   property("""validateChangesWithContext: should fail validateAddWithContext with

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -48,8 +48,7 @@ class BatchChangeJsonProtocolSpec
     with ValidatedValues
     with ValidatedMatchers {
 
-  // TODO: Remove DeleteRecordChangeInputSerializer
-  val serializers: Seq[Serializer[_]] = batchChangeSerializers :+ DeleteRecordChangeInputSerializer
+  val serializers: Seq[Serializer[_]] = batchChangeSerializers
 
   def buildAddChangeInputJson(
       inputName: Option[String] = None,
@@ -406,7 +405,7 @@ class BatchChangeJsonProtocolSpec
         ("recordSetId" -> decompose(None)) ~
         ("validationErrors" -> decompose(List(SingleChangeError(barDiscoveryError)))) ~
         ("id" -> "id") ~
-        ("changeType" -> "DeleteRecordSet")
+        ("changeType" -> "DeleteRecord")
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -129,7 +129,7 @@ class BatchChangeRoutingSpec()
           ttl.map("ttl" -> JInt(_)),
           record.map("record" -> Extraction.decompose(_))).flatten)
 
-    def buildDeleteChangeInput(
+    def buildDeleteRRSetChangeInput(
         inputName: Option[String] = None,
         typ: Option[RecordType] = None): JObject =
       JObject(List(
@@ -138,7 +138,7 @@ class BatchChangeRoutingSpec()
 
     val addAChangeInput: JObject =
       buildAddChangeInput(Some("bar."), Some(A), Some(3600), Some(AData("127.0.0.1")))
-    val deleteAChangeInput: JObject = buildDeleteChangeInput(Some("bar."), Some(A))
+    val deleteAChangeInput: JObject = buildDeleteRRSetChangeInput(Some("bar."), Some(A))
 
     val changeList: JObject = "changes" -> List(
       ("changeType" -> Extraction.decompose(Add)) ~~ addAChangeInput,

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -110,7 +110,7 @@ final case class ZoneDiscoveryError(name: String, fatal: Boolean = false)
 final case class RecordAlreadyExists(name: String) extends DomainValidationError {
   def message: String =
     s"""Record "$name" Already Exists: cannot add an existing record; to update it, """ +
-      "issue a DeleteRecordSet then an Add."
+      "issue a DeleteRecord or DeleteRecordSet then an Add."
 }
 
 final case class RecordDoesNotExist(name: String) extends DomainValidationError {
@@ -127,18 +127,6 @@ final case class CnameIsNotUniqueError(name: String, typ: RecordType)
 
 final case class UserIsNotAuthorized(userName: String) extends DomainValidationError {
   def message: String = s"""User "$userName" is not authorized."""
-}
-
-final case class RecordNameNotUniqueInBatch(name: String, typ: RecordType)
-    extends DomainValidationError {
-  def message: String =
-    s"""Record Name "$name" Not Unique In Batch Change: cannot have multiple "$typ" records with the same name."""
-}
-
-final case class RecordInReverseZoneError(name: String, typ: String) extends DomainValidationError {
-  def message: String =
-    "Invalid Record Type In Reverse Zone: record with name " +
-      s""""$name" and type "$typ" is not allowed in a reverse zone."""
 }
 
 final case class HighValueDomainError(name: String) extends DomainValidationError {
@@ -186,7 +174,20 @@ final case class UnsupportedOperation(operation: String) extends DomainValidatio
 
 final case class DeleteRecordDataDoesNotExist(inputName: String, recordData: RecordData)
     extends DomainValidationError {
-  def message: String = s"Record data $recordData does not exist for $inputName."
+  def message: String = s"""Record data $recordData does not exist for "$inputName"."""
+}
+
+// Deprecated errors
+final case class RecordNameNotUniqueInBatch(name: String, typ: RecordType)
+    extends DomainValidationError {
+  def message: String =
+    s"""Record Name "$name" Not Unique In Batch Change: cannot have multiple "$typ" records with the same name."""
+}
+
+final case class RecordInReverseZoneError(name: String, typ: String) extends DomainValidationError {
+  def message: String =
+    "Invalid Record Type In Reverse Zone: record with name " +
+      s""""$name" and type "$typ" is not allowed in a reverse zone."""
 }
 
 // $COVERAGE-ON$

--- a/modules/mysql/src/main/resources/db/migration/V3.20__SingleChangeExpandSingleChangeType.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.20__SingleChangeExpandSingleChangeType.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+ALTER TABLE single_change MODIFY change_type VARCHAR(25) NOT NULL;


### PR DESCRIPTION
Remove multi-record config and support DeleteRecord inputs.

Changes in this pull request:
- Remove multi-record configs and associated errors
- Enable `DeleteRecord` input
- Update existing tests

Outstanding:
- Add more exhaustive (functional and unit) testing for `DeleteRecord`

Note: This PR is dependent on both https://github.com/vinyldns/vinyldns/pull/833 and https://github.com/vinyldns/vinyldns/pull/834.