### PR TITLE
remove access validation from get zone by name service

### DIFF
--- a/modules/api/functional_test/live_tests/zones/get_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/get_zone_test.py
@@ -134,17 +134,24 @@ def test_get_zone_by_name_shared_zone_succeeds(shared_zone_test_context):
     """
     client = shared_zone_test_context.ok_vinyldns_client
 
-    client.get_zone_by_name(shared_zone_test_context.shared_zone['name'], status=403)
+    result = client.get_zone_by_name(shared_zone_test_context.shared_zone['name'], status=200)['zone']
+    assert_that(result['id'], is_(shared_zone_test_context.shared_zone['id']))
+    assert_that(result['name'], is_(shared_zone_test_context.shared_zone['name']))
+    assert_that(result['adminGroupName'], is_("testSharedZoneGroup"))
+    assert_that(result['accessLevel'], is_("NoAccess"))
 
 
-def test_get_zone_by_name_fails_without_access(shared_zone_test_context):
+def test_get_zone_by_name_succeeds_without_access(shared_zone_test_context):
     """
     Test get an existing zone by name without access
     """
     client = shared_zone_test_context.dummy_vinyldns_client
 
-    client.get_zone_by_name(shared_zone_test_context.ok_zone['name'], status=403)
-
+    result = client.get_zone_by_name("system-test", status=200)['zone']
+    assert_that(result['id'], is_(shared_zone_test_context.system_test_zone['id']))
+    assert_that(result['name'], is_(shared_zone_test_context.system_test_zone['name']))
+    assert_that(result['adminGroupName'], is_(shared_zone_test_context.ok_group['name']))
+    assert_that(result['accessLevel'], is_("NoAccess"))
 
 def test_get_zone_by_name_returns_404_when_not_found(shared_zone_test_context):
     """

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -126,7 +126,6 @@ class ZoneService(
   def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo] =
     for {
       zone <- getZoneByNameOrFail(ensureTrailingDot(zoneName))
-      _ <- canSeeZone(auth, zone).toResult
       aclInfo <- getZoneAclDisplay(zone.acl)
       groupName <- getGroupName(zone.adminGroupId)
       accessLevel = getZoneAccess(auth, zone)


### PR DESCRIPTION
The terraform provider doesn't support batch change so users need to make records in shared zones through the recordset API endpoint. The recordset endpoint requires a zone ID, so terraform clients need to be able to get a zone by name to find out the zone id. 

This is a read-only endpoint so there's not a need for access validations based on zone ownership or system administration. There's also already initial validations at the routing endpoint to ensure locked users and users without access to the system cannot make the request.
 
Changes in this pull request:
- remove access validation from getZoneByName method in the Zone Service
