### PR TITLE
Support non ActiveDirectory LDAP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - 2.7
 sudo: false
 jdk:
-- oraclejdk8
+- openjdk8
 services:
 - docker
 cache:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There exist several clients at <https://github.com/vinyldns> that can be used to
 
 ## Things to try in the portal
 1. View the portal at <http://localhost:9001> in a web browser
-1. Login with the credentials ***testuser*** and ***testpassword***
+1. Login with the credentials ***professor*** and ***professor***
 1. Navigate to the `groups` tab: <http://localhost:9001/groups>
 1. Click on the **New Group** button and create a new group, the group id is the uuid in the url after you view the group
 1. View zones you connected to in the `zones` tab: <http://localhost:9001/zones> (Note, see [Developer Guide](DEVELOPER_GUIDE.md#loading-test-data) for creating a zone)

--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -52,8 +52,8 @@ function usage {
 function clean_images {
 	if (( $CLEAN == 1 )); then
 		echo "cleaning docker images..."
-		docker rmi vinyldns/api:"$VINYLDNS_VERSION"
-		docker rmi vinyldns/portal:"$VINYLDNS_VERSION"
+		docker rmi vinyldns/api:$VINYLDNS_VERSION
+		docker rmi vinyldns/portal:$VINYLDNS_VERSION
 	fi
 }
 
@@ -93,7 +93,7 @@ while [ "$1" != "" ]; do
 		-t | --timeout  	) TIMEOUT="$2";  shift;;
 		-a | --api-only 	) SERVICE="api";;
 		-c | --clean    	) CLEAN=1;;
-		-v | --version		) export VINYLDNS_VERSION="$2"; shift;;
+		-v | --version		) export VINYLDNS_VERSION=$2; shift;;
 		* ) usage; exit;;
 	esac
 	shift
@@ -102,7 +102,7 @@ done
 clean_images
 
 echo "timeout is set to ${TIMEOUT}"
-echo "vinyldns version is set to ${VINYLDNS_VERSION}"
+echo "vinyldns version is set to '${VINYLDNS_VERSION}'"
 
 echo "Starting vinyldns and all dependencies in the background..."
 docker-compose -f "$DOCKER_COMPOSE_CONFIG" up -d ${SERVICE}

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -39,6 +39,12 @@ services:
     volumes:
       - ./elasticmq/custom.conf:/etc/elasticmq/elasticmq.conf
 
+  ldap:
+    image: rroemhild/test-openldap
+    container_name: "vinyldns-ldap"
+    ports:
+      - "19008:389"
+
   api:
     image: "vinyldns/api:${VINYLDNS_VERSION}"
     env_file:
@@ -61,5 +67,7 @@ services:
     container_name: "vinyldns-portal"
     volumes:
       - ./portal/application.ini:/opt/docker/conf/application.ini
+      - ./portal/application.conf:/opt/docker/conf/application.conf
     depends_on:
       - api
+      - ldap

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,3 +51,8 @@ services:
       - "19025:25"
     volumes:
       - ./email:/var/lib/mock-smtp
+
+  ldap:
+    image: rroemhild/test-openldap
+    ports:
+      - "19008:389"

--- a/docker/portal/application.conf
+++ b/docker/portal/application.conf
@@ -9,7 +9,7 @@ LDAP {
   domain = ""
 
   # This will be the name of the LDAP field that carries the user's login id (what they enter in the username in login form)
-  userNameField = "uid"
+  userNameAttribute = "uid"
 
   # For ogranization, leave empty for this demo, the domainName is what matters, and that is the LDAP structure
   # to search for users that require login

--- a/docker/portal/application.conf
+++ b/docker/portal/application.conf
@@ -1,0 +1,59 @@
+LDAP {
+  # For OpenLDAP, this would be a full DN to the admin for LDAP / user that can see all users
+  user = "cn=admin,dc=planetexpress,dc=com"
+
+  # Password for the admin account
+  password = "GoodNewsEveryone"
+
+  # Keep this as an empty string for OpenLDAP
+  domain = ""
+
+  # This will be the name of the LDAP field that carries the user's login id (what they enter in the username in login form)
+  userNameField = "uid"
+
+  # For ogranization, leave empty for this demo, the domainName is what matters, and that is the LDAP structure
+  # to search for users that require login
+  searchBase = [
+    {organization = "", domainName = "ou=people,dc=planetexpress,dc=com"},
+  ]
+  context {
+    initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory"
+    securityAuthentication = "simple"
+
+    # Note: The following assumes a purely docker setup, using container_name = vinyldns-ldap
+    providerUrl = "ldap://vinyldns-ldap:389"
+  }
+
+  # This is only needed if keeping vinyldns user store in sync with ldap (to auto lock out users who left your
+  # company for example)
+  user-sync {
+    enabled = false
+    hours-polling-interval = 1
+  }
+}
+
+# Note: This MUST match the API or strange errors will ensure, NoCrypto should not be used for production
+crypto {
+  type = "vinyldns.core.crypto.NoOpCrypto"
+}
+
+http.port = 9001
+
+data-stores = ["mysql"]
+
+# Note: The default mysql settings assume a local docker compose setup with mysql named vinyldns-mysql
+# follow the configuration guide to point to your mysql
+# Only 3 repositories are needed for portal: user, task, user-change
+mysql {
+  repositories {
+    user {
+    }
+    task {
+    }
+    user-change {
+    }
+  }
+}
+
+# You generate this yourself following https://www.playframework.com/documentation/2.7.x/ApplicationSecret
+play.http.secret.key = "rpkTGtoJvLIdIV?WU=0@yW^x:pcEGyAt`^p/P3G0fpbj9:uDnD@caSjCDqA0@tB="

--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -19,8 +19,10 @@ package vinyldns.core.notifier
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.slf4j.LoggerFactory
+import vinyldns.core.route.Monitored
 
-final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: ContextShift[IO]) {
+final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: ContextShift[IO])
+    extends Monitored {
 
   private val logger = LoggerFactory.getLogger("AllNotifiers")
 
@@ -30,7 +32,11 @@ final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: Contex
     } yield ()
 
   def notify(notifier: Notifier, notification: Notification[_]): IO[Unit] =
-    notifier.notify(notification).handleErrorWith { e =>
-      IO { logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e) }
+    monitor(notifier.getClass.getSimpleName) {
+      notifier.notify(notification).handleErrorWith { e =>
+        IO {
+          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e)
+        }
+      }
     }
 }

--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -119,15 +119,15 @@ object LdapAuthenticator {
         searchControls.setSearchScope(2)
 
         logger.info(
-          s"LDAP Search: org='${SEARCH_BASE(organization)}'; userName='$lookupUserName'; field='${settings.ldapUserNameField}'")
+          s"LDAP Search: org='${SEARCH_BASE(organization)}'; userName='$lookupUserName'; field='${settings.ldapUserNameAttribute}'")
 
         val result = dirContext.search(
           SEARCH_BASE(organization),
-          s"(${settings.ldapUserNameField}=$lookupUserName)",
+          s"(${settings.ldapUserNameAttribute}=$lookupUserName)",
           searchControls
         )
 
-        if (result.hasMore) Right(LdapUserDetails(result.next(), settings.ldapUserNameField))
+        if (result.hasMore) Right(LdapUserDetails(result.next(), settings.ldapUserNameAttribute))
         else Left(UserDoesNotExistException(s"[$lookupUserName] LDAP entity does not exist"))
       } catch {
         case unexpectedError: Throwable =>

--- a/modules/portal/app/controllers/Settings.scala
+++ b/modules/portal/app/controllers/Settings.scala
@@ -42,6 +42,8 @@ class Settings(private val config: Configuration) {
   val ldapCtxFactory: String = config.get[String]("LDAP.context.initialContextFactory")
   val ldapSecurityAuthentication: String = config.get[String]("LDAP.context.securityAuthentication")
   val ldapProviderUrl: URI = new URI(config.get[String]("LDAP.context.providerUrl"))
+  val ldapUserNameField: String =
+    config.getOptional[String]("LDAP.userNameField").getOrElse("sAMAccountName")
 
   val ldapSyncEnabled: Boolean =
     config.getOptional[Boolean]("LDAP.user-sync.enabled").getOrElse(false)

--- a/modules/portal/app/controllers/Settings.scala
+++ b/modules/portal/app/controllers/Settings.scala
@@ -42,8 +42,8 @@ class Settings(private val config: Configuration) {
   val ldapCtxFactory: String = config.get[String]("LDAP.context.initialContextFactory")
   val ldapSecurityAuthentication: String = config.get[String]("LDAP.context.securityAuthentication")
   val ldapProviderUrl: URI = new URI(config.get[String]("LDAP.context.providerUrl"))
-  val ldapUserNameField: String =
-    config.getOptional[String]("LDAP.userNameField").getOrElse("sAMAccountName")
+  val ldapUserNameAttribute: String =
+    config.getOptional[String]("LDAP.userNameAttribute").getOrElse("sAMAccountName")
 
   val ldapSyncEnabled: Boolean =
     config.getOptional[Boolean]("LDAP.user-sync.enabled").getOrElse(false)

--- a/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
@@ -393,7 +393,10 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
         }
 
         "call contextCreator.apply" in {
-          there.was(one(mocks.contextCreator).apply("someDomain\\foo", "bar"))
+          // We first authenticate to the service account, and then to the user
+          there.was(
+            one(mocks.contextCreator).apply("test\\test", "test"),
+            one(mocks.contextCreator).apply("", "bar"))
         }
 
         "call the correct search on context" in {


### PR DESCRIPTION
Support non ActiveDirectory LDAP

This PR has an optional local portal setup against this docker container - https://github.com/rroemhild/docker-test-openldap

The base modifications for LDAP was to change the actual authentication flow.  Before, we only attempted to bind (setting up a DirContext and relying on an exception).  We would test all of the search bases until we exhausted the list.

The new approach works differently:

1. First, login using the main service account
2. Second, do a lookup of the user
3. Finally, attempt to bind to that user's context directly using the password provided.

This works fine with both AD LDAP as well as the example docker container which uses OpenLDAP

Besides these changes, need to make configurable the userNameField, which is the ldap attribute that is used to search for the username sent in the login screen.  In AD, this is `sAMAccountName`, but in the example it is `uid`, the logon field is up to the way LDAP is setup

- `docker-up-vinyldns.sh` - fixed a quote issue with the startup script to properly send in the version of vinyldns
- `docker-compose-build.yml` - added the `ldap` container so the portal can connect as `vinyldns-ldap`
- `docker/portal/application.conf` - new config file so that we can connect to the new ldap container
- `docker-compose.yml` - added the `ldap` container here as well so we can play with it using `reStart` in sbt instead of `docker-up-vinyldns.sh` - simplifies local testing
- `LdapAuthenticator.scala` - this is where the main changes happen

### TO TEST DOCKER

**publish docker locally**
`> sbt docker:publish`

_This should publish 0.9.4-SNAPSHOT localy_

**start up the docker vinyldns including portal**
`> bin/docker-up-vinyldns.sh --version 0.9.4-SNAPSHOT`

**login to the portal once started up**
User is **professor** **professor**

### TO TEST LOCAL
To test this PR, check it out and do the following...

**Update your local.conf**

```
LDAP {
  user = "cn=admin,dc=planetexpress,dc=com"
  password = "GoodNewsEveryone"
  domain = ""
  userNameAttribute = "uid"
  searchBase = [
    {organization = "", domainName = "ou=people,dc=planetexpress,dc=com"},
  ]
  context {
    initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory"
    securityAuthentication = "simple"
    providerUrl = "ldap://localhost:19008"
  }

  user-sync {
    enabled = false
    hours-polling-interval = 1
  }
}
```

**Start up the API**

1. start `sbt`
2. go to api project `sbt> project api`
3. start up docker `sbt> dockerComposeUp`
4. start up api `sbt> reStart`
5. go to portal project `sbt> project portal`
6. run the portal `sbt> run`
7. Wait until ready, then go to http://localhost:9001
8. Login with **professor** **professor**

