### PR TITLE
Add logging around sent notifications in the API

### DIFF
--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -35,7 +35,7 @@ final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: Contex
     monitor(notifier.getClass.getSimpleName) {
       notifier.notify(notification).handleErrorWith { e =>
         IO {
-          logger.error(s"Notifi er ${notifier.getClass.getSimpleName} failed.", e)
+          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e)
         }
       }
     }

--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -19,8 +19,10 @@ package vinyldns.core.notifier
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.slf4j.LoggerFactory
+import vinyldns.core.route.Monitored
 
-final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: ContextShift[IO]) {
+final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: ContextShift[IO])
+    extends Monitored {
 
   private val logger = LoggerFactory.getLogger("AllNotifiers")
 
@@ -30,7 +32,11 @@ final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: Contex
     } yield ()
 
   def notify(notifier: Notifier, notification: Notification[_]): IO[Unit] =
-    notifier.notify(notification).handleErrorWith { e =>
-      IO { logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e) }
+    monitor(notifier.getClass.getSimpleName) {
+      notifier.notify(notification).handleErrorWith { e =>
+        IO {
+          logger.error(s"Notifi er ${notifier.getClass.getSimpleName} failed.", e)
+        }
+      }
     }
 }


### PR DESCRIPTION
Fixes #852 

Changes in this pull request:
- Adds logging to notification events by wrapping `notify.io` with a `monitor` class. 
