### PR TITLE
Feature flag multi record delete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - 2.7
 sudo: false
 jdk:
-- oraclejdk8
+- openjdk8
 services:
 - docker
 cache:

--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -228,6 +228,8 @@ vinyldns {
   # types of unowned records that users can access in shared zones
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 
+  enable-multi-record-batch-update = false
+
   manual-batch-review-enabled = true
 
   scheduled-changes-enabled = true

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -51,21 +51,21 @@ find . -name "__pycache__" -delete
 if [ "${PROD_ENV}" = "true" ]; then
     # -m plays havoc with -k, using variables is a headache, so doing this by hand
     # run parallel tests first (not serial)
-    echo "./run-tests.py live_tests -n2 -v -m \"not skip_production and not serial\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
-    ./run-tests.py live_tests -n2 -v -m "not skip_production and not serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
+    echo "./run-tests.py live_tests -n2 -v -m \"not skip_production and not serial and not multi_record_enabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
+    ./run-tests.py live_tests -n2 -v -m "not skip_production and not serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
     if [ $? -eq 0 ]; then
       # run serial tests second (serial marker)
-      echo "./run-tests.py live_tests -n0 -v -m \"not skip_production and serial\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
-      ./run-tests.py live_tests -n0 -v -m "not skip_production and serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
+      echo "./run-tests.py live_tests -n0 -v -m \"not skip_production and serial and not multi_record_enabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
+      ./run-tests.py live_tests -n0 -v -m "not skip_production and serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
     fi
 else
     # run parallel tests first (not serial)
-    echo "./run-tests.py live_tests -n2 -v -m \"not serial\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
-    ./run-tests.py live_tests -n2 -v -m "not serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
+    echo "./run-tests.py live_tests -n2 -v -m \"not serial and not multi_record_enabled\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
+    ./run-tests.py live_tests -n2 -v -m "not serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
 
     if [ $? -eq 0 ]; then
       # run serial tests second (serial marker)
-      echo "./run-tests.py live_tests -n0 -v -m \"serial\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
-      ./run-tests.py live_tests -n0 -v -m "serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
+      echo "./run-tests.py live_tests -n0 -v -m \"serial and not multi_record_enabled\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
+      ./run-tests.py live_tests -n0 -v -m "serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
     fi
 fi

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -55,15 +55,15 @@ def assert_change_success_response_values(changes_json, zone, index, record_name
     assert_that(changes_json[index]['id'], is_not(none()))
     assert_that(changes_json[index]['changeType'], is_(change_type))
     assert_that(record_type, is_in(['A', 'AAAA', 'CNAME', 'PTR', 'TXT', 'MX']))
-    if record_type in ["A", "AAAA"] and change_type == "Add":
+    if record_type in ["A", "AAAA"] and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['address'], is_(record_data))
-    elif record_type == "CNAME" and change_type == "Add":
+    elif record_type == "CNAME" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['cname'], is_(record_data))
-    elif record_type == "PTR" and change_type == "Add":
+    elif record_type == "PTR" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['ptrdname'], is_(record_data))
-    elif record_type == "TXT" and change_type == "Add":
+    elif record_type == "TXT" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['text'], is_(record_data))
-    elif record_type == "MX" and change_type == "Add":
+    elif record_type == "MX" and change_type != "DeleteRecordSet":
         assert_that(changes_json[index]['record']['preference'], is_(record_data['preference']))
         assert_that(changes_json[index]['record']['exchange'], is_(record_data['exchange']))
     return
@@ -1444,7 +1444,7 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
         # context validations: conflicting recordsets, unauthorized error
         assert_failed_change_in_error_response(response[7], input_name=existing_a_fqdn, record_data="1.2.3.4",
                                                error_messages=[
-                                                   "Record \"" + existing_a_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_a_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[8], input_name=existing_cname_fqdn,
                                                record_data="1.2.3.4",
                                                error_messages=[
@@ -1670,7 +1670,7 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[7], input_name=existing_aaaa_fqdn, record_type="AAAA",
                                                record_data="1::1",
                                                error_messages=[
-                                                   "Record \"" + existing_aaaa_fqdn+ "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_aaaa_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[8], input_name=existing_cname_fqdn, record_type="AAAA",
                                                record_data="1::1",
                                                error_messages=[
@@ -1955,7 +1955,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[14], input_name=existing_cname_fqdn,
                                                record_type="CNAME", record_data="test.com.",
                                                error_messages=[
-                                                   "Record \"" + existing_cname_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add.",
+                                                   'Record "' + existing_cname_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.',
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_cname_fqdn + "\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[15], input_name=existing_reverse_fqdn, record_type="CNAME",
                                                record_data="duplicate.in.db.",
@@ -2250,7 +2250,7 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
 
         # context validations: existing cname recordset
         assert_failed_change_in_error_response(response[11], input_name="192.0.2.193", record_type="PTR", record_data="existing-ptr.",
-                                               error_messages=['Record "192.0.2.193" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add.'])
+                                               error_messages=['Record "192.0.2.193" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[12], input_name="192.0.2.199", record_type="PTR", record_data="existing-cname.",
                                                error_messages=['CNAME Conflict: CNAME record names must be unique. Existing record with name "192.0.2.199" and type "CNAME" conflicts with this record.'])
 
@@ -2464,7 +2464,7 @@ def test_ipv6_ptr_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[5], input_name="fd69:27cc:fe91:1000::bbbb", record_type="PTR",
                                                record_data="existing.ptr.",
                                                error_messages=[
-                                                   "Record \"fd69:27cc:fe91:1000::bbbb\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "fd69:27cc:fe91:1000::bbbb" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -2635,7 +2635,7 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[5], input_name=existing_txt_fqdn, record_type="TXT",
                                                record_data="test",
                                                error_messages=[
-                                                   "Record \"" + existing_txt_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_txt_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[6], input_name=existing_cname_fqdn, record_type="TXT",
                                                record_data="test",
                                                error_messages=[
@@ -2858,7 +2858,7 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
         assert_failed_change_in_error_response(response[8], input_name=existing_mx_fqdn, record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=[
-                                                   "Record \"" + existing_mx_fqdn + "\" Already Exists: cannot add an existing record; to update it, issue a DeleteRecordSet then an Add."])
+                                                   'Record "' + existing_mx_fqdn + '" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'])
         assert_failed_change_in_error_response(response[9], input_name=existing_cname_fqdn, record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=[
@@ -3497,7 +3497,7 @@ def test_create_batch_change_validation_without_owner_group_id(shared_zone_test_
             shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
-def test_create_batch_delete_record_for_unassociated_user_in_owner_group_succeeds(shared_zone_test_context):
+def test_create_batch_delete_recordset_for_unassociated_user_in_owner_group_succeeds(shared_zone_test_context):
     """
     Test delete change in batch for a record in a shared zone for an unassociated user belonging to the record owner group succeeds
     """
@@ -3528,7 +3528,7 @@ def test_create_batch_delete_record_for_unassociated_user_in_owner_group_succeed
                                           change_type="DeleteRecordSet")
 
 
-def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fails(shared_zone_test_context):
+def test_create_batch_delete_recordset_for_unassociated_user_not_in_owner_group_fails(shared_zone_test_context):
     """
     Test delete change in batch for a record in a shared zone for an unassociated user not belonging to the record owner group fails
     """
@@ -3565,7 +3565,7 @@ def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fai
             shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
 
-def test_create_batch_delete_record_for_zone_admin_not_in_owner_group_succeeds(shared_zone_test_context):
+def test_create_batch_delete_recordset_for_zone_admin_not_in_owner_group_succeeds(shared_zone_test_context):
     """
     Test delete change in batch for a record in a shared zone for a zone admin not belonging to the record owner group succeeds
     """
@@ -3755,11 +3755,29 @@ def test_create_batch_with_irrelevant_global_acl_rule_applied_fails(shared_zone_
 
 @pytest.mark.serial
 @pytest.mark.skip_production
+@pytest.mark.multi_record_enabled
 def test_create_batch_duplicates_add_check(shared_zone_test_context):
     """
-    Test recordsets with multiple records cannot be added in batch (relies on config, skip-prod)
+    Test record sets with multiple records can be added in batch only if they are new creates (relies on skip-prod)
     """
     client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    classless_base_zone = shared_zone_test_context.classless_base_zone
+
+    # record sets to setup
+    a_name = generate_record_name()
+    a_fqdn = a_name + ".ok."
+    a_existing = get_recordset_json(ok_zone, a_name, "A", [{ "address": "1.1.1.1" }], 200)
+
+    ptr_existing = get_recordset_json(classless_base_zone, "45", "PTR", [{"ptrdname": "existing.ptr."}], 200)
+
+    txt_name = generate_record_name()
+    txt_fqdn = txt_name + ".ok."
+    txt_existing = get_recordset_json(ok_zone, txt_name, "TXT", [{ "text": "hello" }], 200)
+
+    mx_name = generate_record_name()
+    mx_fqdn = mx_name + ".ok."
+    mx_existing = get_recordset_json(ok_zone, mx_name, "MX", [{"preference": 1, "exchange": "foo.bar."}], 100)
 
     batch_change_input = {
         "comments": "this is optional",
@@ -3773,98 +3791,256 @@ def test_create_batch_duplicates_add_check(shared_zone_test_context):
             get_change_MX_json("multi-mx.ok.", preference=0),
             get_change_MX_json("multi-mx.ok.", preference=1000, exchange="bar.foo."),
 
-            # adding an HVD so this will fail if accidentally run against wrong config
-            get_change_A_AAAA_json("high-value-domain")
+            get_change_A_AAAA_json(a_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_fqdn, address="4.5.6.7"),
+            get_change_PTR_json("192.0.2.45", ptrdname="multi.test"),
+            get_change_PTR_json("192.0.2.45", ptrdname="multi2.test"),
+            get_change_TXT_json(txt_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_fqdn, text="more-multi-text"),
+            get_change_MX_json(mx_fqdn, preference=0),
+            get_change_MX_json(mx_fqdn, preference=1000, exchange="bar.foo.")
         ]
     }
 
-    response = client.create_batch_change(batch_change_input, status=400)
+    def err(name):
+        return 'Record "{}" Already Exists: cannot add an existing record; to update it, issue a DeleteRecord or DeleteRecordSet then an Add.'.format(name)
 
-    def err(name, type):
-        return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-               'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name, type)
+    to_delete = []
+    try:
+        for rs in [a_existing, ptr_existing, txt_existing, mx_existing]:
+            create_result = client.create_recordset(rs, status=202)
+            to_delete.append(client.wait_until_recordset_change_status(create_result, 'Complete'))
 
-    assert_error(response[0], error_messages=[err("multi.ok.", "A")])
-    assert_error(response[1], error_messages=[err("multi.ok.", "A")])
-    assert_error(response[2], error_messages=[err("192.0.2.44", "PTR")])
-    assert_error(response[3], error_messages=[err("192.0.2.44", "PTR")])
-    assert_error(response[4], error_messages=[err("multi-txt.ok.", "TXT")])
-    assert_error(response[5], error_messages=[err("multi-txt.ok.", "TXT")])
-    assert_error(response[6], error_messages=[err("multi-mx.ok.", "MX")])
-    assert_error(response[7], error_messages=[err("multi-mx.ok.", "MX")])
+        result = client.create_batch_change(batch_change_input, status=400)
+
+        assert_successful_change_in_error_response(result[0], input_name="multi.ok.", record_data="1.2.3.4")
+        assert_successful_change_in_error_response(result[1], input_name="multi.ok.", record_data="4.5.6.7")
+        assert_successful_change_in_error_response(result[2], input_name="192.0.2.44", record_type="PTR", record_data="multi.test.")
+        assert_successful_change_in_error_response(result[3], input_name="192.0.2.44", record_type="PTR", record_data="multi2.test.")
+        assert_successful_change_in_error_response(result[4], input_name="multi-txt.ok.", record_type="TXT", record_data="some-multi-text")
+        assert_successful_change_in_error_response(result[5], input_name="multi-txt.ok.", record_type="TXT", record_data="more-multi-text")
+        assert_successful_change_in_error_response(result[6], input_name="multi-mx.ok.", record_type="MX", record_data={"preference": 0, "exchange": "foo.bar."})
+        assert_successful_change_in_error_response(result[7], input_name="multi-mx.ok.", record_type="MX", record_data={"preference": 1000, "exchange": "bar.foo."})
+
+        assert_failed_change_in_error_response(result[8], input_name=a_fqdn, record_data="1.2.3.4", error_messages=[err(a_fqdn)])
+        assert_failed_change_in_error_response(result[9], input_name=a_fqdn, record_data="4.5.6.7", error_messages=[err(a_fqdn)])
+        assert_failed_change_in_error_response(result[10], input_name="192.0.2.45", record_type="PTR", record_data="multi.test.", error_messages=[err("192.0.2.45")])
+        assert_failed_change_in_error_response(result[11], input_name="192.0.2.45", record_type="PTR", record_data="multi2.test.", error_messages=[err("192.0.2.45")])
+        assert_failed_change_in_error_response(result[12], input_name=txt_fqdn,  record_type="TXT", record_data="some-multi-text", error_messages=[err(txt_fqdn)])
+        assert_failed_change_in_error_response(result[13], input_name=txt_fqdn, record_type="TXT", record_data="more-multi-text", error_messages=[err(txt_fqdn)])
+        assert_failed_change_in_error_response(result[14], input_name=mx_fqdn, record_type="MX", record_data={"preference":0, "exchange":"foo.bar."}, error_messages=[err(mx_fqdn)])
+        assert_failed_change_in_error_response(result[15], input_name=mx_fqdn, record_type="MX", record_data={"preference":1000, "exchange":"bar.foo."}, error_messages=[err(mx_fqdn)])
+
+    finally:
+        clear_recordset_list(to_delete, client)
 
 
 @pytest.mark.skip_production
+@pytest.mark.multi_record_enabled
 def test_create_batch_duplicates_update_check(shared_zone_test_context):
     """
-    Test recordsets with multiple records cannot be edited in batch (relies on config, skip-prod)
+    Test record sets with multiple records can be added, updated and deleted in batch (relies on skip-prod)
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone = shared_zone_test_context.ok_zone
 
     # record sets to setup
-    a_update_name = generate_record_name()
-    a_update_fqdn = a_update_name + ".ok."
-    a_update = get_recordset_json(ok_zone, a_update_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+    a_update_record_set_name = generate_record_name()
+    a_update_record_set_fqdn = a_update_record_set_name + ".ok."
+    a_update_record_set = get_recordset_json(ok_zone, a_update_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
 
-    txt_update_name = generate_record_name()
-    txt_update_fqdn = txt_update_name + ".ok."
-    txt_update = get_recordset_json(ok_zone, txt_update_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+    txt_update_record_set_name = generate_record_name()
+    txt_update_record_set_fqdn = txt_update_record_set_name + ".ok."
+    txt_update_record_set = get_recordset_json(ok_zone, txt_update_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
 
-    a_delete_name = generate_record_name()
-    a_delete_fqdn = a_delete_name + ".ok."
-    a_delete = get_recordset_json(ok_zone, a_delete_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+    a_update_record_full_name = generate_record_name()
+    a_update_record_full_fqdn = a_update_record_full_name + ".ok."
+    a_update_record_full = get_recordset_json(ok_zone, a_update_record_full_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
 
-    txt_delete_name = generate_record_name()
-    txt_delete_fqdn = txt_delete_name + ".ok."
-    txt_delete = get_recordset_json(ok_zone, txt_delete_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+    txt_update_record_full_name = generate_record_name()
+    txt_update_record_full_fqdn = txt_update_record_full_name + ".ok."
+    txt_update_record_full = get_recordset_json(ok_zone, txt_update_record_full_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_name = generate_record_name()
+    a_update_record_fqdn = a_update_record_name + ".ok."
+    a_update_record = get_recordset_json(ok_zone, a_update_record_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_name = generate_record_name()
+    txt_update_record_fqdn = txt_update_record_name + ".ok."
+    txt_update_record = get_recordset_json(ok_zone, txt_update_record_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_only_name = generate_record_name()
+    a_update_record_only_fqdn = a_update_record_only_name + ".ok."
+    a_update_record_only = get_recordset_json(ok_zone, a_update_record_only_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_only_name = generate_record_name()
+    txt_update_record_only_fqdn = txt_update_record_only_name + ".ok."
+    txt_update_record_only = get_recordset_json(ok_zone, txt_update_record_only_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_set_name = generate_record_name()
+    a_delete_record_set_fqdn = a_delete_record_set_name + ".ok."
+    a_delete_record_set = get_recordset_json(ok_zone, a_delete_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_set_name = generate_record_name()
+    txt_delete_record_set_fqdn = txt_delete_record_set_name + ".ok."
+    txt_delete_record_set = get_recordset_json(ok_zone, txt_delete_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_name = generate_record_name()
+    a_delete_record_fqdn = a_delete_record_name + ".ok."
+    a_delete_record = get_recordset_json(ok_zone, a_delete_record_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_name = generate_record_name()
+    txt_delete_record_fqdn = txt_delete_record_name + ".ok."
+    txt_delete_record = get_recordset_json(ok_zone, txt_delete_record_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_and_record_set_name = generate_record_name()
+    a_delete_record_and_record_set_fqdn = a_delete_record_and_record_set_name + ".ok."
+    a_delete_record_and_record_set = get_recordset_json(ok_zone, a_delete_record_and_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_and_record_set_name = generate_record_name()
+    txt_delete_record_and_record_set_fqdn = txt_delete_record_and_record_set_name + ".ok."
+    txt_delete_record_and_record_set = get_recordset_json(ok_zone, txt_delete_record_and_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
 
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_fqdn, address="1.2.3.4"),
-            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
+            ## Updates
+            # Add + DeleteRRSet
+            get_change_A_AAAA_json(a_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="4.5.6.7"),
 
-            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_fqdn, text="some-multi-text"),
-            get_change_TXT_json(txt_update_fqdn, text="more-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="more-multi-text"),
 
-            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecordSet"),
+            # Add + DeleteRecord (full delete)
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.2", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="4.5.6.7"),
 
-            # adding an HVD so this will fail if accidentally run against wrong config
-            get_change_A_AAAA_json("high-value-domain")
+            get_change_TXT_json(txt_update_record_full_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="again", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="more-multi-text"),
+
+            # Add + single DeleteRecord
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="4.5.6.7"),
+
+            get_change_TXT_json(txt_update_record_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_fqdn, text="more-multi-text"),
+
+            # Single DeleteRecord
+            get_change_A_AAAA_json(a_update_record_only_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_record_only_fqdn, text="hello", change_type="DeleteRecord"),
+
+            ## Full deletes
+            # Delete RRSet
+            get_change_A_AAAA_json(a_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+
+            # DeleteRecord (full delete)
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.2", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="again", change_type="DeleteRecord"),
+
+            # DeleteRecord + DeleteRRSet
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, address="1.1.1.1", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, text="hello", change_type="DeleteRecord"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet")
         ]
     }
 
     to_delete = []
     try:
-        for rs in [a_update, txt_update, a_delete, txt_delete]:
+        for rs in [a_update_record_set, txt_update_record_set, a_update_record_full, txt_update_record_full, a_update_record, txt_update_record, a_update_record_only, txt_update_record_only,
+                   a_delete_record_set, txt_delete_record_set, a_delete_record, txt_delete_record, a_delete_record_and_record_set, txt_delete_record_and_record_set]:
             create_rs = client.create_recordset(rs, status=202)
             to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
 
-        response = client.create_batch_change(batch_change_input, status=400)
+        result = client.create_batch_change(batch_change_input, status=202)
+        client.wait_until_batch_change_completed(result)
 
-        def existing_err(name, type):
-            return 'RecordSet with name {} and type {} cannot be updated in a single '.format(name, type) + \
-                   'Batch Change because it contains multiple DNS records (2).'
+        # Check batch change response
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=0, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=2, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=3, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=4, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=5, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="more-multi-text")
 
-        def new_err(name, type):
-            return 'Multi-record recordsets are not enabled for this instance of VinylDNS. ' \
-                   'Cannot create a new record set with multiple records for inputName {} and type {}.'.format(name,
-                                                                                                               type)
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=6, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=7, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.2", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=8, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=9, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=10, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="again", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=12, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="more-multi-text")
 
-        assert_error(response[0], error_messages=[existing_err(a_update_fqdn, "A")])
-        assert_error(response[1], error_messages=[existing_err(a_update_fqdn, "A"), new_err(a_update_fqdn, "A")])
-        assert_error(response[2], error_messages=[existing_err(a_update_fqdn, "A"), new_err(a_update_fqdn, "A")])
-        assert_error(response[3], error_messages=[existing_err(txt_update_fqdn, "TXT")])
-        assert_error(response[4],
-                     error_messages=[existing_err(txt_update_fqdn, "TXT"), new_err(txt_update_fqdn, "TXT")])
-        assert_error(response[5],
-                     error_messages=[existing_err(txt_update_fqdn, "TXT"), new_err(txt_update_fqdn, "TXT")])
-        assert_error(response[6], error_messages=[existing_err(a_delete_fqdn, "A")])
-        assert_error(response[7], error_messages=[existing_err(txt_delete_fqdn, "TXT")])
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=14, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=15, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=16, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=17, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=18, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=19, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=20, input_name=a_update_record_only_fqdn, record_name=a_update_record_only_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=21, input_name=txt_update_record_only_fqdn, record_name=txt_update_record_only_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=22, input_name=a_delete_record_set_fqdn, record_name=a_delete_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=23, input_name=txt_delete_record_set_fqdn, record_name=txt_delete_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=24, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=25, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.2", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=26, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=27, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="again", change_type="DeleteRecord")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=28, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=29, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=30, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data="hello", change_type="DeleteRecord")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=31, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+
+        # Perform look up to verify record set data
+        for rs in to_delete:
+            rs_name = rs['recordSet']['name']
+            rs_id = rs['recordSet']['id']
+            zone_id = rs['zone']['id']
+
+            # deletes should not exist
+            if rs_name in [a_delete_record_set_name, txt_delete_record_set_name, a_delete_record_name,
+                           txt_delete_record_name, a_delete_record_and_record_set_name, txt_delete_record_and_record_set_name]:
+                client.get_recordset(zone_id, rs_id, status=404)
+            else:
+                result_rs = client.get_recordset(zone_id, rs_id, status=200)
+                records = result_rs['recordSet']['records']
+
+                # full deletes with updates
+                if rs_name in [a_update_record_set_name, a_update_record_full_name]:
+                    assert_that(records, contains({"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"}, {"address": "1.1.1.2"})))
+                elif rs_name in [txt_update_record_set_name, txt_update_record_full_name]:
+                    assert_that(records, contains({"text": "some-multi-text"}, {"text": "more-multi-text"}))
+                    assert_that(records, is_not(contains({"text": "hello"}, {"text": "again"})))
+                # single entry delete with adds
+                elif rs_name == a_update_record_name:
+                    assert_that(records, contains({"address": "1.1.1.2"}, {"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
+                elif rs_name == txt_update_record_name:
+                    assert_that(records, contains({"text": "again"}, {"text": "some-multi-text"}, {"text": "more-multi-text"}))
+                    assert_that(records, is_not(contains({"text": "hello"})))
+                elif rs_name == a_update_record_only_name:
+                    assert_that(records, contains({"address": "1.1.1.2"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
+                elif rs_name == txt_update_record_only_name:
+                    assert_that(records, contains({"text": "again"}))
+                    assert_that(records, is_not(contains({"text": "hello"})))
+
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -3903,6 +4079,139 @@ def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_co
             rejecter.reject_batch_change(response['id'], status=200)
 
 
+@pytest.mark.multi_record_enabled
+def test_create_batch_delete_record_succeeds(shared_zone_test_context):
+    """
+    Test creating batch change with DeleteRecord change input type is recognized
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    ok_group = shared_zone_test_context.ok_group
+
+    rs_name = generate_record_name()
+    rs_fqdn = rs_name + ".ok."
+    rs_to_create = get_recordset_json(ok_zone, rs_name, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
+
+    batch_change_input = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecord")
+        ]
+    }
+
+    to_delete = []
+
+    create_rs = client.create_recordset(rs_to_create, status=202)
+    to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+    result = client.create_batch_change(batch_change_input, status=202)
+    client.wait_until_batch_change_completed(result)
+
+    client.get_recordset(create_rs['zone']['id'], create_rs['recordSet']['id'], status=404)
+
+
+@pytest.mark.serial
+@pytest.mark.multi_record_enabled
+def test_create_batch_delete_record_access_checks(shared_zone_test_context):
+    """
+    Test access for full-delete DeleteRecord (delete) and non-full-delete DeleteRecord (update)
+    """
+    ok_client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    dummy_client = shared_zone_test_context.dummy_vinyldns_client
+    dummy_group_id = shared_zone_test_context.dummy_group['id']
+
+    a_delete_acl = generate_acl_rule('Delete', groupId=dummy_group_id, recordMask='.*', recordTypes=['A'])
+    txt_write_acl = generate_acl_rule('Write', groupId=dummy_group_id, recordMask='.*', recordTypes=['TXT'])
+
+    a_update_name = generate_record_name()
+    a_update_fqdn = a_update_name + ".ok."
+    a_update = get_recordset_json(ok_zone, a_update_name, "A", [{"address": "1.1.1.1"}])
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(ok_zone, a_delete_name, "A", [{"address": "1.1.1.1"}])
+
+    txt_update_name = generate_record_name()
+    txt_update_fqdn = txt_update_name + ".ok."
+    txt_update = get_recordset_json(ok_zone, txt_update_name, "TXT", [{"text": "test"}])
+
+    txt_delete_name = generate_record_name()
+    txt_delete_fqdn = txt_delete_name + ".ok."
+    txt_delete = get_recordset_json(ok_zone, txt_delete_name, "TXT", [{"text": "test"}])
+
+    batch_change_input = {
+        "comments": "Testing DeleteRecord access levels",
+        "changes": [
+            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
+            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecord"),
+            get_change_TXT_json(txt_update_fqdn, text="updated text"),
+            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecord")
+        ]
+    }
+
+    to_delete = []
+    try:
+        add_ok_acl_rules(shared_zone_test_context, [a_delete_acl, txt_write_acl])
+
+        for create_json in [a_update, a_delete, txt_update, txt_delete]:
+            create_result = ok_client.create_recordset(create_json, status=202)
+            to_delete.append(ok_client.wait_until_recordset_change_status(create_result, 'Complete'))
+
+        response = dummy_client.create_batch_change(batch_change_input, status=400)
+
+        assert_successful_change_in_error_response(response[0], input_name=a_update_fqdn, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_successful_change_in_error_response(response[1], input_name=a_update_fqdn, record_data="4.5.6.7")
+        assert_successful_change_in_error_response(response[2], input_name=a_delete_fqdn, record_data="1.1.1.1", change_type="DeleteRecord")
+        assert_successful_change_in_error_response(response[3], input_name=txt_update_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecord")
+        assert_successful_change_in_error_response(response[4], input_name=txt_update_fqdn, record_type="TXT", record_data="updated text")
+        assert_failed_change_in_error_response(response[5], input_name=txt_delete_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecord",
+                                               error_messages=['User "dummy" is not authorized.'])
+
+    finally:
+        clear_ok_acl_rules(shared_zone_test_context)
+        clear_recordset_list(to_delete, ok_client)
+
+
+@pytest.mark.multi_record_enabled
+def test_create_batch_delete_record_for_invalid_record_data_fails(shared_zone_test_context):
+    """
+    Test delete record failure for non-existent record and non-existent record data
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(shared_zone_test_context.ok_zone, a_delete_fqdn, "A", [{"address": "1.1.1.1"}])
+
+    batch_change_input = {
+        "comments": "test delete record failures",
+        "changes": [
+            get_change_A_AAAA_json("delete-non-existent-record.ok.", change_type="DeleteRecord"),
+            get_change_A_AAAA_json(a_delete_fqdn, address="4.5.6.7", change_type="DeleteRecord")
+        ]
+    }
+
+    to_delete = []
+    try:
+        create_rs = client.create_recordset(a_delete, status=202)
+        to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+        errors = client.create_batch_change(batch_change_input, status=400)
+        assert_failed_change_in_error_response(errors[0], input_name="delete-non-existent-record.ok.", record_data="1.1.1.1", change_type="DeleteRecord",
+                                               error_messages=['Record "delete-non-existent-record.ok." Does Not Exist: cannot delete a record that does not exist.'])
+        assert_failed_change_in_error_response(errors[1], input_name=a_delete_fqdn, record_data="4.5.6.7", change_type="DeleteRecord",
+                                               error_messages=['Record data AData(4.5.6.7) does not exist for "' + a_delete_fqdn + '".'])
+
+    finally:
+        clear_recordset_list(to_delete, client)
+
+
+@pytest.mark.serial
+@pytest.mark.skip_production
+@pytest.mark.multi_record_disabled
 def test_create_batch_delete_record_fails(shared_zone_test_context):
     """
     Test creating batch change with DeleteRecord change input type is not recognized
@@ -3926,8 +4235,6 @@ def test_create_batch_delete_record_fails(shared_zone_test_context):
     try:
         create_rs = client.create_recordset(rs_to_create, status=202)
         client.wait_until_recordset_change_status(create_rs, 'Complete')
-
-        # TODO: Update this when DeleteRecord is supported
         client.create_batch_change(batch_change_input, status=400)
 
     finally:

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -152,6 +152,8 @@ vinyldns {
     }
   ]
 
+  enable-multi-record-batch-update = false
+
   # feature flag for manual batch review
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -132,7 +132,6 @@ vinyldns {
     }
   }
 
-  scheduled-changes-enabled = false
   v6-discovery-nibble-boundaries {
     min = 5
     max = 20

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -129,7 +129,7 @@ object VinylDNSConfig {
     } else List()
 
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
-  lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]](s"default-ttl").getOrElse(7200L)
+  lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]]("default-ttl").getOrElse(7200L)
   lazy val multiRecordBatchUpdateEnabled: Boolean =
     vinyldnsConfig.as[Option[Boolean]]("enable-multi-record-batch-update").getOrElse(false)
   lazy val manualBatchReviewEnabled: Boolean = vinyldnsConfig

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -33,53 +33,53 @@ import vinyldns.core.domain.membership.Group
 trait BatchChangeValidationsAlgebra {
 
   def validateBatchChangeInput(
-                                input: BatchChangeInput,
-                                existingGroup: Option[Group],
-                                authPrincipal: AuthPrincipal): BatchResult[Unit]
+      input: BatchChangeInput,
+      existingGroup: Option[Group],
+      authPrincipal: AuthPrincipal): BatchResult[Unit]
 
   def validateInputChanges(
-                            input: List[ChangeInput],
-                            isApproved: Boolean): ValidatedBatch[ChangeInput]
+      input: List[ChangeInput],
+      isApproved: Boolean): ValidatedBatch[ChangeInput]
 
   def validateChangesWithContext(
-                                  groupedChanges: ChangeForValidationMap,
-                                  auth: AuthPrincipal,
-                                  isApproved: Boolean,
-                                  batchOwnerGroupId: Option[String]): ValidatedBatch[ChangeForValidation]
+      groupedChanges: ChangeForValidationMap,
+      auth: AuthPrincipal,
+      isApproved: Boolean,
+      batchOwnerGroupId: Option[String]): ValidatedBatch[ChangeForValidation]
 
   def canGetBatchChange(
-                         batchChange: BatchChange,
-                         auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit]
+      batchChange: BatchChange,
+      auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit]
 
   def validateBatchChangeRejection(
-                                    batchChange: BatchChange,
-                                    authPrincipal: AuthPrincipal,
-                                    bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit]
+      batchChange: BatchChange,
+      authPrincipal: AuthPrincipal,
+      bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit]
 
   def validateBatchChangeApproval(
-                                   batchChange: BatchChange,
-                                   authPrincipal: AuthPrincipal,
-                                   isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit]
+      batchChange: BatchChange,
+      authPrincipal: AuthPrincipal,
+      isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit]
 
   def validateBatchChangeCancellation(
-                                       batchChange: BatchChange,
-                                       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit]
+      batchChange: BatchChange,
+      authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit]
 }
 
 class BatchChangeValidations(
-                              changeLimit: Int,
-                              accessValidation: AccessValidationsAlgebra,
-                              multiRecordBatchUpdateEnabled: Boolean = false,
-                              scheduledChangesEnabled: Boolean = false)
-  extends BatchChangeValidationsAlgebra {
+    changeLimit: Int,
+    accessValidation: AccessValidationsAlgebra,
+    multiRecordBatchUpdateEnabled: Boolean = false,
+    scheduledChangesEnabled: Boolean = false)
+    extends BatchChangeValidationsAlgebra {
 
   import RecordType._
   import accessValidation._
 
   def validateBatchChangeInput(
-                                input: BatchChangeInput,
-                                existingGroup: Option[Group],
-                                authPrincipal: AuthPrincipal): BatchResult[Unit] = {
+      input: BatchChangeInput,
+      existingGroup: Option[Group],
+      authPrincipal: AuthPrincipal): BatchResult[Unit] = {
     val validations = validateBatchChangeInputSize(input) |+| validateOwnerGroupId(
       input.ownerGroupId,
       existingGroup,
@@ -104,9 +104,9 @@ class BatchChangeValidations(
     }
 
   def validateOwnerGroupId(
-                            ownerGroupId: Option[String],
-                            existingGroup: Option[Group],
-                            authPrincipal: AuthPrincipal): SingleValidation[Unit] =
+      ownerGroupId: Option[String],
+      existingGroup: Option[Group],
+      authPrincipal: AuthPrincipal): SingleValidation[Unit] =
     (ownerGroupId, existingGroup) match {
       case (None, _) => ().validNel
       case (Some(groupId), None) => GroupDoesNotExist(groupId).invalidNel
@@ -116,37 +116,37 @@ class BatchChangeValidations(
     }
 
   def validateBatchChangeRejection(
-                                    batchChange: BatchChange,
-                                    authPrincipal: AuthPrincipal,
-                                    bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit] =
+      batchChange: BatchChange,
+      authPrincipal: AuthPrincipal,
+      bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit] =
     validateAuthorizedReviewer(authPrincipal, batchChange, bypassTestValidation) |+| validateBatchChangePendingReview(
       batchChange)
 
   def validateBatchChangeApproval(
-                                   batchChange: BatchChange,
-                                   authPrincipal: AuthPrincipal,
-                                   isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit] =
+      batchChange: BatchChange,
+      authPrincipal: AuthPrincipal,
+      isTestChange: Boolean): Either[BatchChangeErrorResponse, Unit] =
     validateAuthorizedReviewer(authPrincipal, batchChange, isTestChange) |+| validateBatchChangePendingReview(
       batchChange) |+| validateScheduledApproval(batchChange)
 
   def validateBatchChangeCancellation(
-                                       batchChange: BatchChange,
-                                       authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
+      batchChange: BatchChange,
+      authPrincipal: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
     validateBatchChangePendingReview(batchChange) |+| validateCreatorCancellation(
       batchChange,
       authPrincipal)
 
   def validateBatchChangePendingReview(
-                                        batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
+      batchChange: BatchChange): Either[BatchChangeErrorResponse, Unit] =
     batchChange.approvalStatus match {
       case BatchChangeApprovalStatus.PendingReview => ().asRight
       case _ => BatchChangeNotPendingReview(batchChange.id).asLeft
     }
 
   def validateAuthorizedReviewer(
-                                  auth: AuthPrincipal,
-                                  batchChange: BatchChange,
-                                  bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit] =
+      auth: AuthPrincipal,
+      batchChange: BatchChange,
+      bypassTestValidation: Boolean): Either[BatchChangeErrorResponse, Unit] =
     if (auth.isSystemAdmin && (bypassTestValidation || !auth.isTestUser)) {
       // bypassTestValidation = true for a test change
       ().asRight
@@ -161,8 +161,8 @@ class BatchChangeValidations(
     }
 
   def validateCreatorCancellation(
-                                   batchChange: BatchChange,
-                                   auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
+      batchChange: BatchChange,
+      auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
     if (batchChange.userId == auth.userId) {
       ().asRight
     } else {
@@ -171,8 +171,8 @@ class BatchChangeValidations(
   /* input validations */
 
   def validateInputChanges(
-                            input: List[ChangeInput],
-                            isApproved: Boolean): ValidatedBatch[ChangeInput] =
+      input: List[ChangeInput],
+      isApproved: Boolean): ValidatedBatch[ChangeInput] =
     input.map {
       case a: AddChangeInput => validateAddChangeInput(a, isApproved).map(_ => a)
       case d: DeleteRRSetChangeInput => validateInputName(d, isApproved).map(_ => d)
@@ -182,8 +182,8 @@ class BatchChangeValidations(
     }
 
   def validateAddChangeInput(
-                              addChangeInput: AddChangeInput,
-                              isApproved: Boolean): SingleValidation[Unit] = {
+      addChangeInput: AddChangeInput,
+      isApproved: Boolean): SingleValidation[Unit] = {
     val validTTL = addChangeInput.ttl.map(validateTTL(_).asUnit).getOrElse(().valid)
     val validRecord = validateRecordData(addChangeInput.record)
     val validInput = validateInputName(addChangeInput, isApproved)
@@ -233,16 +233,16 @@ class BatchChangeValidations(
   /* context validations */
 
   def validateChangesWithContext(
-                                  groupedChanges: ChangeForValidationMap,
-                                  auth: AuthPrincipal,
-                                  isApproved: Boolean,
-                                  batchOwnerGroupId: Option[String]): ValidatedBatch[ChangeForValidation] =
-  // Updates are a combination of an add and delete for a record with the same name and type in a zone.
+      groupedChanges: ChangeForValidationMap,
+      auth: AuthPrincipal,
+      isApproved: Boolean,
+      batchOwnerGroupId: Option[String]): ValidatedBatch[ChangeForValidation] =
+    // Updates are a combination of an add and delete for a record with the same name and type in a zone.
     groupedChanges.changes.mapValid {
       case add: AddChangeForValidation
-        if groupedChanges
-          .getLogicalChangeType(add.recordKey)
-          .contains(LogicalChangeType.Add) =>
+          if groupedChanges
+            .getLogicalChangeType(add.recordKey)
+            .contains(LogicalChangeType.Add) =>
         validateAddWithContext(add, groupedChanges, auth, isApproved, batchOwnerGroupId)
       case addUpdate: AddChangeForValidation =>
         validateAddUpdateWithContext(addUpdate, groupedChanges, auth, isApproved, batchOwnerGroupId)
@@ -250,24 +250,24 @@ class BatchChangeValidations(
       // - order matters
       // - all AddChangeForValidations are covered by this point
       case delete
-        if groupedChanges
-          .getLogicalChangeType(delete.recordKey)
-          .contains(LogicalChangeType.FullDelete) =>
+          if groupedChanges
+            .getLogicalChangeType(delete.recordKey)
+            .contains(LogicalChangeType.FullDelete) =>
         validateDeleteWithContext(delete, groupedChanges, auth, isApproved)
       case deleteUpdate =>
         validateDeleteUpdateWithContext(deleteUpdate, groupedChanges, auth, isApproved)
     }
 
   def existingRecordSetIsNotMulti(
-                                   change: ChangeForValidation,
-                                   recordSet: RecordSet): SingleValidation[Unit] =
+      change: ChangeForValidation,
+      recordSet: RecordSet): SingleValidation[Unit] =
     if (!multiRecordBatchUpdateEnabled & recordSet.records.length > 1) {
       ExistingMultiRecordError(change.inputChange.inputName, recordSet).invalidNel
     } else ().validNel
 
   def newRecordSetIsNotMulti(
-                              change: AddChangeForValidation,
-                              groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
+      change: AddChangeForValidation,
+      groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
     lazy val matchingAddRecords = groupedChanges
       .getProposedAdds(change.recordKey)
     if (!multiRecordBatchUpdateEnabled && matchingAddRecords.size > 1)
@@ -282,14 +282,14 @@ class BatchChangeValidations(
       ().validNel
 
   def ensureRecordExists(
-                          change: ChangeForValidation,
-                          groupedChanges: ChangeForValidationMap): SingleValidation[Unit] =
+      change: ChangeForValidation,
+      groupedChanges: ChangeForValidationMap): SingleValidation[Unit] =
     change match {
       // For DeleteRecord inputs, need to verify that the record data actually exists
       case deleteRecord: DeleteRecordChangeForValidation
-        if !groupedChanges
-          .getExistingRecordSet(change.recordKey)
-          .exists(_.records.contains(deleteRecord.inputChange.record)) =>
+          if !groupedChanges
+            .getExistingRecordSet(change.recordKey)
+            .exists(_.records.contains(deleteRecord.inputChange.record)) =>
         DeleteRecordDataDoesNotExist(
           deleteRecord.inputChange.inputName,
           deleteRecord.inputChange.record).invalidNel
@@ -298,10 +298,10 @@ class BatchChangeValidations(
     }
 
   def validateDeleteWithContext(
-                                 change: ChangeForValidation,
-                                 groupedChanges: ChangeForValidationMap,
-                                 auth: AuthPrincipal,
-                                 isApproved: Boolean): SingleValidation[ChangeForValidation] = {
+      change: ChangeForValidation,
+      groupedChanges: ChangeForValidationMap,
+      auth: AuthPrincipal,
+      isApproved: Boolean): SingleValidation[ChangeForValidation] = {
 
     val validations =
       groupedChanges.getExistingRecordSet(change.recordKey) match {
@@ -316,11 +316,11 @@ class BatchChangeValidations(
   }
 
   def validateAddUpdateWithContext(
-                                    change: AddChangeForValidation,
-                                    groupedChanges: ChangeForValidationMap,
-                                    auth: AuthPrincipal,
-                                    isApproved: Boolean,
-                                    batchOwnerGroupId: Option[String]): SingleValidation[ChangeForValidation] = {
+      change: AddChangeForValidation,
+      groupedChanges: ChangeForValidationMap,
+      auth: AuthPrincipal,
+      isApproved: Boolean,
+      batchOwnerGroupId: Option[String]): SingleValidation[ChangeForValidation] = {
     // Updates require checking against other batch changes since multiple adds
     // could potentially be grouped with a single delete
     val typedValidations = change.inputChange.typ match {
@@ -351,10 +351,10 @@ class BatchChangeValidations(
   }
 
   def validateDeleteUpdateWithContext(
-                                       change: ChangeForValidation,
-                                       groupedChanges: ChangeForValidationMap,
-                                       auth: AuthPrincipal,
-                                       isApproved: Boolean): SingleValidation[ChangeForValidation] = {
+      change: ChangeForValidation,
+      groupedChanges: ChangeForValidationMap,
+      auth: AuthPrincipal,
+      isApproved: Boolean): SingleValidation[ChangeForValidation] = {
     val validations =
       groupedChanges.getExistingRecordSet(change.recordKey) match {
         case Some(rs) =>
@@ -371,11 +371,11 @@ class BatchChangeValidations(
   }
 
   def validateAddWithContext(
-                              change: AddChangeForValidation,
-                              groupedChanges: ChangeForValidationMap,
-                              auth: AuthPrincipal,
-                              isApproved: Boolean,
-                              ownerGroupId: Option[String]): SingleValidation[ChangeForValidation] = {
+      change: AddChangeForValidation,
+      groupedChanges: ChangeForValidationMap,
+      auth: AuthPrincipal,
+      isApproved: Boolean,
+      ownerGroupId: Option[String]): SingleValidation[ChangeForValidation] = {
     val typedValidations = change.inputChange.typ match {
       case A | AAAA | MX if multiRecordBatchUpdateEnabled =>
         newRecordSetIsNotDotted(change)
@@ -410,8 +410,8 @@ class BatchChangeValidations(
   }
 
   def cnameHasUniqueNameInBatch(
-                                 cnameChange: AddChangeForValidation,
-                                 groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
+      cnameChange: AddChangeForValidation,
+      groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
 
     val duplicateNameChangeInBatch = RecordType.values.toList.exists { recordType =>
       val recordKey = RecordKey(cnameChange.zone.id, cnameChange.recordName, recordType)
@@ -426,8 +426,8 @@ class BatchChangeValidations(
   }
 
   def recordIsUniqueInBatch(
-                             change: AddChangeForValidation,
-                             groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
+      change: AddChangeForValidation,
+      groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
     // Ignore true duplicates, but identify multi-records
     val proposedAdds = groupedChanges.getProposedAdds(change.recordKey)
 
@@ -437,19 +437,19 @@ class BatchChangeValidations(
   }
 
   def recordDoesNotExist(
-                          zoneId: String,
-                          recordName: String,
-                          inputName: String,
-                          typ: RecordType,
-                          groupedChanges: ChangeForValidationMap): SingleValidation[Unit] =
+      zoneId: String,
+      recordName: String,
+      inputName: String,
+      typ: RecordType,
+      groupedChanges: ChangeForValidationMap): SingleValidation[Unit] =
     groupedChanges.getExistingRecordSet(RecordKey(zoneId, recordName, typ)) match {
       case Some(_) => RecordAlreadyExists(inputName).invalidNel
       case None => ().validNel
     }
 
   def noIncompatibleRecordExists(
-                                  change: AddChangeForValidation,
-                                  groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
+      change: AddChangeForValidation,
+      groupedChanges: ChangeForValidationMap): SingleValidation[Unit] = {
     // find conflicting types in existing records
     val conflictingExistingTypes = change.inputChange.typ match {
       case CNAME =>
@@ -478,8 +478,8 @@ class BatchChangeValidations(
   }
 
   def userCanAddRecordSet(
-                           input: AddChangeForValidation,
-                           authPrincipal: AuthPrincipal): SingleValidation[Unit] = {
+      input: AddChangeForValidation,
+      authPrincipal: AuthPrincipal): SingleValidation[Unit] = {
     val result = canAddRecordSet(
       authPrincipal,
       input.recordName,
@@ -490,10 +490,10 @@ class BatchChangeValidations(
   }
 
   def userCanUpdateRecordSet(
-                              input: ChangeForValidation,
-                              authPrincipal: AuthPrincipal,
-                              ownerGroupId: Option[String],
-                              addRecords: List[RecordData]): SingleValidation[Unit] = {
+      input: ChangeForValidation,
+      authPrincipal: AuthPrincipal,
+      ownerGroupId: Option[String],
+      addRecords: List[RecordData]): SingleValidation[Unit] = {
     val result =
       canUpdateRecordSet(
         authPrincipal,
@@ -507,10 +507,10 @@ class BatchChangeValidations(
   }
 
   def userCanDeleteRecordSet(
-                              input: ChangeForValidation,
-                              authPrincipal: AuthPrincipal,
-                              ownerGroupId: Option[String],
-                              existingRecords: List[RecordData]): SingleValidation[Unit] = {
+      input: ChangeForValidation,
+      authPrincipal: AuthPrincipal,
+      ownerGroupId: Option[String],
+      existingRecords: List[RecordData]): SingleValidation[Unit] = {
     val result =
       canDeleteRecordSet(
         authPrincipal,
@@ -524,8 +524,8 @@ class BatchChangeValidations(
   }
 
   def canGetBatchChange(
-                         batchChange: BatchChange,
-                         auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
+      batchChange: BatchChange,
+      auth: AuthPrincipal): Either[BatchChangeErrorResponse, Unit] =
     if (auth.isSystemAdmin || auth.userId == batchChange.userId) {
       ().asRight
     } else {
@@ -560,9 +560,9 @@ class BatchChangeValidations(
     }
 
   def ownerGroupProvidedIfNeeded(
-                                  change: AddChangeForValidation,
-                                  existingRecord: Option[RecordSet],
-                                  ownerGroupId: Option[String]): SingleValidation[Unit] =
+      change: AddChangeForValidation,
+      existingRecord: Option[RecordSet],
+      ownerGroupId: Option[String]): SingleValidation[Unit] =
     if (!change.zone.shared || ownerGroupId.isDefined) {
       ().validNel
     } else {
@@ -575,8 +575,8 @@ class BatchChangeValidations(
     }
 
   def validateScheduledChange(
-                               input: BatchChangeInput,
-                               scheduledChangesEnabled: Boolean): Either[BatchChangeErrorResponse, Unit] =
+      input: BatchChangeInput,
+      scheduledChangesEnabled: Boolean): Either[BatchChangeErrorResponse, Unit] =
     (scheduledChangesEnabled, input.scheduledTime) match {
       case (_, None) => Right(())
       case (true, Some(scheduledTime)) if scheduledTime.isAfterNow => Right(())
@@ -585,8 +585,8 @@ class BatchChangeValidations(
     }
 
   def zoneDoesNotRequireManualReview(
-                                      change: ChangeForValidation,
-                                      isApproved: Boolean): SingleValidation[Unit] =
+      change: ChangeForValidation,
+      isApproved: Boolean): SingleValidation[Unit] =
     if (isApproved) {
       ().validNel
     } else {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -87,7 +87,8 @@ object BatchTransformations {
         case a: AddChangeInput => AddChangeForValidation(zone, recordName, a)
         case d: DeleteRRSetChangeInput =>
           DeleteRRSetChangeForValidation(zone, recordName, d)
-        // TODO: Support DeleteRecordChangeInput in ChangeForValidation
+        case d: DeleteRecordChangeInput if VinylDNSConfig.multiRecordBatchUpdateEnabled =>
+          DeleteRecordChangeForValidation(zone, recordName, d)
         case _: DeleteRecordChangeInput =>
           throw new UnsupportedOperationException(
             "DeleteRecordChangeInput is not yet implemented/supported in VinylDNS.")

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -135,6 +135,7 @@ vinyldns {
     }
   ]
 
+  enable-multi-record-batch-update = true
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -37,7 +37,7 @@ import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone, ZoneStatus}
 import scala.util.Random
 
 class BatchChangeValidationsSpec
-  extends PropSpec
+    extends PropSpec
     with Matchers
     with GeneratorDrivenPropertyChecks
     with EitherMatchers
@@ -161,8 +161,8 @@ class BatchChangeValidationsSpec
     approvalStatus = BatchChangeApprovalStatus.AutoApproved)
 
   private def makeAddUpdateRecord(
-                                   recordName: String,
-                                   aData: AData = AData("1.2.3.4")): AddChangeForValidation =
+      recordName: String,
+      aData: AData = AData("1.2.3.4")): AddChangeForValidation =
     AddChangeForValidation(
       okZone,
       s"$recordName",
@@ -175,8 +175,8 @@ class BatchChangeValidationsSpec
       DeleteRRSetChangeInput(s"$recordName.ok.", RecordType.A))
 
   private def makeDeleteUpdateDeleteRecord(
-                                            recordName: String,
-                                            aData: AData = AData("1.1.1.1")): DeleteRecordChangeForValidation =
+      recordName: String,
+      aData: AData = AData("1.1.1.1")): DeleteRecordChangeForValidation =
     DeleteRecordChangeForValidation(
       okZone,
       s"$recordName",

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -520,6 +520,14 @@ sns {
   }
 }
 
+### Multi-Record Batch Update Enabled
+Configuration setting that determines if users are able to make Batch Changes that include changes to mult-record recordsets.
+If enabled, users can create and delete multi-record recordsets through Batch Change. They can also delete individual records in a multi-record recordset.
+
+```yaml
+enable-multi-record-batch-update = false
+```
+
 ### Batch Manual Review Enabled <a id="manual-review" />
 Configuration setting that determines whether batch changes with non-fatal errors can be reviewed rather than failing immediately.
 When enabling manual review, the expectation is that a DNS technician is actively querying and addressing batch change
@@ -528,6 +536,14 @@ manual review.
 
 ```yaml
 manual-batch-review-enabled = true
+```
+
+### Scheduled Batch Changes Enabled
+Configuration setting that determines if users are able to make Batch Changes with a scheduled time. `manual-batch-review-enabled` must be enabled as well.
+If enabled, a VinylDNS administrator cannot approve the Batch Change until after the scheduled time. An administrator could also reject the Batch Change.
+
+```yaml
+scheduled-changes-enabled = true
 ```
 
 ### Manual Review Domains
@@ -549,14 +565,6 @@ manual-review-domains = {
     "zone.requires.review."
   ]
 }
-```
-
-### Scheduled Batch Changes Enabled
-Configuration setting that determines if users are able to make Batch Changes with a scheduled time. `manual-batch-review-enabled` must be enabled as well.
-If enabled, a VinylDNS administrator cannot approve the Batch Change until after the scheduled time. An administrator could also reject the Batch Change.
-
-```yaml
-scheduled-changes-enabled = true
 ```
 
 ### IPv6 Zone Discovery Boundaries
@@ -724,7 +732,7 @@ vinyldns {
   batch-change-limit = 1000
   
   # true if you want to allow batch changes to update/delete multi-record recordsets, false if not.
-  enable-multi-record-batch-update = true
+  enable-multi-record-batch-update = false
   
   # notifier configuration
   notifiers = ["email", "sns"]

--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -23,7 +23,8 @@ case class Meta(
     batchChangeLimit: Int,
     defaultTtl: Long,
     manualBatchChangeReviewEnabled: Boolean,
-    scheduledBatchChangesEnabled: Boolean)
+    scheduledBatchChangesEnabled: Boolean,
+    multiRecordBatchUpdateEnabled: Boolean)
 object Meta {
   def apply(config: Configuration): Meta =
     Meta(
@@ -32,6 +33,7 @@ object Meta {
       config.getOptional[Int]("batch-change-limit").getOrElse(1000),
       config.getOptional[Long]("default-ttl").getOrElse(7200L),
       config.getOptional[Boolean]("manual-batch-review-enabled").getOrElse(false),
-      config.getOptional[Boolean]("scheduled-changes-enabled").getOrElse(false)
+      config.getOptional[Boolean]("scheduled-changes-enabled").getOrElse(false),
+      config.getOptional[Boolean]("enable-multi-record-batch-update").getOrElse(false)
     )
 }

--- a/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
+++ b/modules/portal/app/views/batchChanges/batchChangeNew.scala.html
@@ -100,6 +100,7 @@
                                     <td>
                                         <select class="form-control changeType" ng-model="change.changeType">
                                             <option value="Add">Add</option>
+                                            <option value="DeleteRecord" ng-if="@meta.multiRecordBatchUpdateEnabled">DeleteRecord</option>
                                             <option value="DeleteRecordSet">DeleteRecordSet</option>
                                         </select>
                                     </td>

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -65,5 +65,13 @@ class MetaSpec extends Specification with Mockito {
       val config = Map("scheduled-changes-enabled" -> true)
       Meta(Configuration.from(config)).scheduledBatchChangesEnabled must beTrue
     }
+    "default to false if enable-multi-record-batch-update is not found" in {
+      val config = Map("vinyldns.version" -> "foo-bar")
+      Meta(Configuration.from(config)).multiRecordBatchUpdateEnabled must beFalse
+    }
+    "set to true if enable-multi-record-batch-update is true in config" in {
+      val config = Map("enable-multi-record-batch-update" -> true)
+      Meta(Configuration.from(config)).multiRecordBatchUpdateEnabled must beTrue
+    }
   }
 }


### PR DESCRIPTION
fixes #860

Changes in this pull request:
- reimplement reverted commits related to multi-record batch change support (except docs commit)
- add feature flags to the API and portal `enable-multi-record-batch-update`, default to false.
- add markers to the func tests that depend on the `enable-multi-record-batch-update` config value. One marker is `multi_record_enabled`, the other is `multi_record_disabled`. Right now I've set the tests to not run `multi_record_enabled` tests for all environments.
