### PR TITLE
Fix update group

### DIFF
--- a/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBMembershipRepositoryIntegrationSpec.scala
+++ b/modules/dynamodb/src/it/scala/vinyldns/dynamodb/repository/DynamoDBMembershipRepositoryIntegrationSpec.scala
@@ -54,7 +54,18 @@ class DynamoDBMembershipRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
     val user1 = genString
     val user2 = genString
     "add members successfully" in {
-      repo.addMembers(groupId, Set(user1, user2)).unsafeRunSync() should contain theSameElementsAs Set(user1, user2)
+      repo
+        .addMembers(groupId, Set(user1, user2))
+        .unsafeRunSync() should contain theSameElementsAs Set(user1, user2)
+    }
+
+    "add members with no member ids invokes no change" in {
+      val user1 = genString
+      repo.addMembers(groupId, Set(user1)).unsafeRunSync()
+
+      val originalResult = repo.getGroupsForUser(user1).unsafeRunSync()
+      repo.addMembers(groupId, Set()).unsafeRunSync()
+      repo.getGroupsForUser(user1).unsafeRunSync() should contain theSameElementsAs originalResult
     }
 
     "add a group to an existing user" in {
@@ -102,6 +113,15 @@ class DynamoDBMembershipRepositoryIntegrationSpec extends DynamoDBIntegrationSpe
         } yield userGroups
 
       f.unsafeRunSync() shouldBe empty
+    }
+
+    "remove members with no member ids invokes no change" in {
+      val user1 = genString
+      repo.addMembers(groupId, Set(user1)).unsafeRunSync()
+
+      val originalResult = repo.getGroupsForUser(user1).unsafeRunSync()
+      repo.removeMembers(groupId, Set()).unsafeRunSync()
+      repo.getGroupsForUser(user1).unsafeRunSync() should contain theSameElementsAs originalResult
     }
 
     "remove all groups for user" in {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlMembershipRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlMembershipRepositoryIntegrationSpec.scala
@@ -57,6 +57,17 @@ class MySqlMembershipRepositoryIntegrationSpec
     }
 
   "MySqlMembershipRepo.addMembers" should {
+    "do nothing if member ids is empty" in {
+      val originalResult = getAllRecords
+      val groupId = "group-id-1"
+      val userIds: Set[String] = Set()
+      val addResult = repo.addMembers(groupId, userIds).unsafeRunSync()
+      addResult shouldBe empty
+
+      // records remain the same as original
+      getAllRecords should contain theSameElementsAs originalResult
+    }
+
     "add a member successfully" in {
       val groupId = "group-id-1"
       val userIds = Set("user-id-1")
@@ -128,6 +139,18 @@ class MySqlMembershipRepositoryIntegrationSpec
       repo.removeMembers(groupId, toBeRemoved).unsafeRunSync() should contain theSameElementsAs toBeRemoved
       val expectedUserIds = userIds -- toBeRemoved
       getAllRecords should contain theSameElementsAs expectedUserIds.map(Tuple2(_, groupId))
+    }
+
+    "do nothing if the member set is empty" in {
+      val groupId = "group-id-1"
+      val userIds = Set("user-id-1")
+
+      repo.addMembers(groupId, userIds).unsafeRunSync()
+      val originalResult = getAllRecords
+      val result = repo.removeMembers(groupId, Set()).unsafeRunSync()
+      result shouldBe empty
+
+      getAllRecords should contain theSameElementsAs originalResult
     }
   }
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlMembershipRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlMembershipRepositoryIntegrationSpec.scala
@@ -17,13 +17,12 @@
 package vinyldns.mysql.repository
 
 import org.scalatest._
-import scalikejdbc.DB
+import scalikejdbc.{DB, _}
 import vinyldns.core.domain.membership.MembershipRepository
 import vinyldns.mysql.TestMySqlInstance
-import scalikejdbc._
 
 class MySqlMembershipRepositoryIntegrationSpec
-  extends WordSpec
+    extends WordSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with Matchers {
@@ -112,7 +111,9 @@ class MySqlMembershipRepositoryIntegrationSpec
       repo.addMembers(groupIdTwo, userIds).unsafeRunSync() shouldBe userIds
 
       val expectedGroups = Set(groupIdOne, groupIdTwo)
-      repo.getGroupsForUser(userIds.head).unsafeRunSync() should contain theSameElementsAs expectedGroups
+      repo
+        .getGroupsForUser(userIds.head)
+        .unsafeRunSync() should contain theSameElementsAs expectedGroups
     }
   }
 
@@ -136,7 +137,9 @@ class MySqlMembershipRepositoryIntegrationSpec
       getAllRecords should contain theSameElementsAs userIds.map(Tuple2(_, groupId))
 
       val toBeRemoved = userIds.take(5)
-      repo.removeMembers(groupId, toBeRemoved).unsafeRunSync() should contain theSameElementsAs toBeRemoved
+      repo
+        .removeMembers(groupId, toBeRemoved)
+        .unsafeRunSync() should contain theSameElementsAs toBeRemoved
       val expectedUserIds = userIds -- toBeRemoved
       getAllRecords should contain theSameElementsAs expectedUserIds.map(Tuple2(_, groupId))
     }
@@ -172,7 +175,9 @@ class MySqlMembershipRepositoryIntegrationSpec
       // not adding to group three
 
       val expectedGroups = Set(groupIdOne, groupIdTwo)
-      repo.getGroupsForUser(underTest.head).unsafeRunSync() should contain theSameElementsAs expectedGroups
+      repo
+        .getGroupsForUser(underTest.head)
+        .unsafeRunSync() should contain theSameElementsAs expectedGroups
     }
 
     "return empty when no groups for user" in {


### PR DESCRIPTION
Fixes #868 

In `MySqlMembershipRepo` we unfortunately throw an exception if someone passes in an empty `Set` when trying to add or remove members in a group.  The effect should really be nothing instead of blowing up.

- `MySqlMembershipRepository` - added checks, if an empty set just return; otherwise process normally.  Added corresponding integration tests
- `DynamoDBMembershipRepository` - no changes, but just added some additional integration specs that work properly.
