### PR TITLE
feature flag portal multi-record batch change support

### DIFF
--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -23,7 +23,8 @@ case class Meta(
     batchChangeLimit: Int,
     defaultTtl: Long,
     manualBatchChangeReviewEnabled: Boolean,
-    scheduledBatchChangesEnabled: Boolean)
+    scheduledBatchChangesEnabled: Boolean,
+    multiRecordBatchChangeEnabled: Boolean)
 object Meta {
   def apply(config: Configuration): Meta =
     Meta(
@@ -32,6 +33,7 @@ object Meta {
       config.getOptional[Int]("batch-change-limit").getOrElse(1000),
       config.getOptional[Long]("default-ttl").getOrElse(7200L),
       config.getOptional[Boolean]("manual-batch-review-enabled").getOrElse(false),
-      config.getOptional[Boolean]("scheduled-changes-enabled").getOrElse(false)
+      config.getOptional[Boolean]("scheduled-changes-enabled").getOrElse(false),
+      config.getOptional[Boolean]("multi-record-batch-change-enabled").getOrElse(false)
     )
 }

--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -134,9 +134,6 @@
                                     </td>
                                     <!--TTL based on change type-->
                                     <!--record data name based on record type and change type-->
-                                    <td ng-if="change.changeType=='DeleteRecordSet' && change.type!='A+PTR' && change.type!='AAAA+PTR'">
-                                        <input class="form-control" placeholder="" disabled/>
-                                    </td>
                                     <td ng-if="change.type=='A+PTR'">
                                         <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" required="string" class="form-control" placeholder="e.g. 1.1.1.1" ipv4>
                                         <p ng-show="createBatchChangeForm.$submitted">
@@ -151,42 +148,46 @@
                                             <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.ipv6" class="batch-change-error-help">must be a valid IPv6 Address!</span>
                                         </p>
                                     </td>
-                                    <td ng-if="change.type=='A' && change.changeType=='Add'">
-                                        <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. 1.1.1.1" ng-disabled="change.changeType=='DeleteRecordSet'" ipv4>
+                                    <td ng-if="change.type=='A'">
+                                        <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. 1.1.1.1" ng-disabled="change.changeType=='DeleteRecordSet' && !@meta.multiRecordBatchChangeEnabled" ipv4>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                             <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.ipv4" class="batch-change-error-help">must be a valid IPv4 Address!</span>
                                         </p>
+                                        <p class="help-block" ng-if="change.changeType=='DeleteRecordSet' && @meta.multiRecordBatchChangeEnabled">Record Data is optional.</p>
                                     </td>
-                                    <td ng-if="change.type=='AAAA' && change.changeType=='Add'">
-                                        <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. fd69:27cc:fe91::60" ng-disabled="change.changeType=='DeleteRecordSet'" ipv6>
+                                    <td ng-if="change.type=='AAAA'">
+                                        <input name="record_address_{{$index}}" type="text" ng-model="change.record.address" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. fd69:27cc:fe91::60" ng-disabled="change.changeType=='DeleteRecordSet' && !@meta.multiRecordBatchChangeEnabled" ipv6>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                             <span ng-show="createBatchChangeForm.record_address_{{$index}}.$error.ipv6" class="batch-change-error-help">must be a valid IPv6 Address!</span>
                                         </p>
+                                        <p class="help-block" ng-if="change.changeType=='DeleteRecordSet' && @meta.multiRecordBatchChangeEnabled">Record Data is optional.</p>
                                     </td>
-                                    <td ng-if="change.type=='CNAME' && change.changeType=='Add'">
+                                    <td ng-if="change.type=='CNAME'">
                                         <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be absolute!</span>
                                         </p>
                                     </td>
-                                    <td ng-if="change.type=='PTR' && change.changeType=='Add'">
-                                        <input name="record_ptr_{{$index}}" type="text" ng-model="change.record.ptrdname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.com." ng-disabled="change.changeType=='DeleteRecordSet'">
+                                    <td ng-if="change.type=='PTR'">
+                                        <input name="record_ptr_{{$index}}" type="text" ng-model="change.record.ptrdname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.com." ng-disabled="change.changeType=='DeleteRecordSet' && !@meta.multiRecordBatchChangeEnabled">
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_ptr_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                         </p>
+                                        <p class="help-block" ng-if="change.changeType=='DeleteRecordSet' && @meta.multiRecordBatchChangeEnabled">Record Data is optional.</p>
                                     </td>
-                                    <td ng-if="change.type=='TXT' && change.changeType=='Add'">
-                                        <textarea name="record_txt_{{$index}}" type="text" ng-model="change.record.text" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. attr=val" ng-disabled="change.changeType=='DeleteRecordSet'"></textarea>
+                                    <td ng-if="change.type=='TXT'">
+                                        <textarea name="record_txt_{{$index}}" type="text" ng-model="change.record.text" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. attr=val" ng-disabled="change.changeType=='DeleteRecordSet' && !@meta.multiRecordBatchChangeEnabled"></textarea>
+                                        <p class="help-block" ng-if="change.changeType=='DeleteRecordSet' && @meta.multiRecordBatchChangeEnabled">Record Data is optional.</p>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_txt_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                         </p>
                                     </td>
-                                    <td ng-if="change.type=='MX' && change.changeType=='Add'">
+                                    <td ng-if="change.type=='MX'">
                                         <label class="batch-label">Preference</label>
-                                        <input name="record_mx_preference_{{$index}}" type="number" ng-model="change.record.preference" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. 1" ng-min="0" ng-max="65535" ng-disabled="change.changeType=='DeleteRecordSet'">
+                                        <input name="record_mx_preference_{{$index}}" type="number" ng-model="change.record.preference" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. 1" ng-min="0" ng-max="65535" ng-disabled="change.changeType=='DeleteRecordSet' && !@meta.multiRecordBatchChangeEnabled">
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_mx_preference_{{$index}}.$error.required" class="batch-change-error-help">Preference is required!</span>
                                             <span ng-show="createBatchChangeForm.record_mx_preference_{{$index}}.$error.min" class="batch-change-error-help">Must be between 0 and 65535!</span>
@@ -197,11 +198,12 @@
                                         <br />
 
                                         <label class="batch-label">Exchange</label>
-                                        <input name="record_mx_exchange_{{$index}}" type="text" ng-model="change.record.exchange" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn>
+                                        <input name="record_mx_exchange_{{$index}}" type="text" ng-model="change.record.exchange" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet' && !@meta.multiRecordBatchChangeEnabled" fqdn>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_mx_exchange_{{$index}}.$error.required" class="batch-change-error-help">Exchange data is required!</span>
                                             <span ng-show="createBatchChangeForm.record_mx_exchange_{{$index}}.$error.fqdn" class="batch-change-error-help">Exchange data must be absolute!</span>
                                         </p>
+                                        <p class="help-block" ng-if="change.changeType=='DeleteRecordSet' && @meta.multiRecordBatchChangeEnabled">Record Data is optional.</p>
                                     </td>
                                     <!--end record data name based on record type and change type-->
                                     <td class="col-md-3" ng-if="batchChangeErrors">

--- a/modules/portal/app/views/main.scala.html
+++ b/modules/portal/app/views/main.scala.html
@@ -153,12 +153,7 @@
             <script src="/public/gentelella/vendors/bootstrap/dist/js/bootstrap.min.js"></script>
             <script src="/public/gentelella/vendors/bootstrap-daterangepicker/daterangepicker.js"></script>
             <script src="/public/javascripts/angular.min.js"></script>
-            <script src="/public/lib/batch-change/batch-change.module.js"></script>
-            <script src="/public/lib/batch-change/batch-change-detail.controller.js"></script>
-            <script src="/public/lib/batch-change/batch-change-new.controller.js"></script>
-            <script src="/public/lib/batch-change/batch-change.directive.js"></script>
-            <script src="/public/lib/batch-change/batch-change.service.js"></script>
-            <script src="/public/lib/batch-change/batch-changes.controller.js"></script>
+            <script src="/public/lib/dns-change/dns-change.module.js"></script>
             <script src="/public/lib/controllers/controller.groups.js"></script>
             <script src="/public/lib/controllers/controller.manageZones.js"></script>
             <script src="/public/lib/controllers/controller.membership.js"></script>
@@ -177,6 +172,11 @@
             <script src="/public/lib/directives/directives.notifications.js"></script>
             <script src="/public/lib/directives/directives.validations.js"></script>
             <script src="/public/lib/directives/directives.validations.zones.js"></script>
+            <script src="/public/lib/dns-change/dns-change-detail.controller.js"></script>
+            <script src="/public/lib/dns-change/dns-change-new.controller.js"></script>
+            <script src="/public/lib/dns-change/dns-change.directive.js"></script>
+            <script src="/public/lib/dns-change/dns-change.service.js"></script>
+            <script src="/public/lib/dns-change/dns-changes.controller.js"></script>
             <script src="/public/lib/oidc-finish.js"></script>
             <script src="/public/lib/services/groups/service.groups.js"></script>
             <script src="/public/lib/services/paging/service.paging.js"></script>

--- a/modules/portal/public/lib/dns-change/dns-change.directive.js
+++ b/modules/portal/public/lib/dns-change/dns-change.directive.js
@@ -72,7 +72,7 @@
             link: function(scope, elm, attrs, ctrl) {
                 ctrl.$validators.ipv6 = function (modelValue, viewValue) {
                     if (attrs.required || (viewValue !== undefined && viewValue.length > 0)) {
-                        return IPV4_REGEX.test(viewValue);
+                        return IPV6_REGEX.test(viewValue);
                     }
                     return true;
                 };

--- a/modules/portal/public/lib/dns-change/dns-change.directive.js
+++ b/modules/portal/public/lib/dns-change/dns-change.directive.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-(function(){
-
+(function () {
     var app = angular.module('batch-change');
     var FQDN_REGEX = /\./;
     var IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
@@ -39,50 +38,58 @@
                                 ')$'
     ].join(''));
 
-    app.directive('fqdn', function() {
+    app.directive('fqdn', function () {
         return {
             require: 'ngModel',
-            link: function(scope, elm, attrs, ctrl) {
-                ctrl.$validators.fqdn = function(modelValue, viewValue) {
-                    return FQDN_REGEX.test(viewValue);
-                }
-            }
-        };
-    });
-
-    app.directive('ipv4', function() {
-        return {
-            require: 'ngModel',
-            link: function(scope, elm, attrs, ctrl) {
-                ctrl.$validators.ipv4 = function(modelValue, viewValue) {
-                    return IPV4_REGEX.test(viewValue);
-                }
-            }
-        };
-    });
-
-    app.directive('ipv6', function() {
-        return {
-            require: 'ngModel',
-            link: function(scope, elm, attrs, ctrl) {
-                ctrl.$validators.ipv6 = function(modelValue, viewValue) {
-                    return IPV6_REGEX.test(viewValue);
-                }
-            }
-        };
-    });
-
-    app.directive('batchChangeFile', function() {
-        return {
-            require: 'ngModel',
-            link: function(scope, elm, attrs, ctrl) {
-                elm.on('change', function(e){
-                    if (e.target.files.length > 0) {
-                        ctrl.$setViewValue(e.target.files[0]);
-                    } else {
-                        ctrl.$setViewValue();
+            link: function (scope, elm, attrs, ctrl) {
+                ctrl.$validators.fqdn = function (modelValue, viewValue) {
+                    if (attrs.required || (viewValue !== undefined && viewValue.length > 0)) {
+                        return FQDN_REGEX.test(viewValue);
                     }
-                })
+                    return true;
+                };
+            }
+        };
+    });
+
+    app.directive('ipv4', function () {
+        return {
+            require: 'ngModel',
+            link: function (scope, elm, attrs, ctrl) {
+                ctrl.$validators.ipv4 = function (modelValue, viewValue) {
+                    if (attrs.required || (viewValue !== undefined && viewValue.length > 0)) {
+                        return IPV4_REGEX.test(viewValue);
+                    }
+                    return true;
+                }
+            }
+        };
+    });
+
+    app.directive('ipv6', function () {
+        return {
+            require: 'ngModel',
+            link: function(scope, elm, attrs, ctrl) {
+                ctrl.$validators.ipv6 = function (modelValue, viewValue) {
+                    if (attrs.required || (viewValue !== undefined && viewValue.length > 0)) {
+                        return IPV4_REGEX.test(viewValue);
+                    }
+                    return true;
+                };
+            }
+        };
+    });
+
+    app.directive('batchChangeFile', function () {
+        return {
+            require: 'ngModel',
+            link: function (scope, elm, attrs, ctrl) {
+                elm.on('change', function (e) {
+                    if (e.target.files.length > 0) {
+                        return ctrl.$setViewValue(e.target.files[0]);
+                    }
+                    return ctrl.$setViewValue();
+                });
             }
         };
     });

--- a/modules/portal/public/lib/dns-change/dns-change.directive.js
+++ b/modules/portal/public/lib/dns-change/dns-change.directive.js
@@ -86,9 +86,9 @@
             link: function (scope, elm, attrs, ctrl) {
                 elm.on('change', function (e) {
                     if (e.target.files.length > 0) {
-                        return ctrl.$setViewValue(e.target.files[0]);
+                        ctrl.$setViewValue(e.target.files[0]);
                     }
-                    return ctrl.$setViewValue();
+                    ctrl.$setViewValue();
                 });
             }
         };

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -65,5 +65,13 @@ class MetaSpec extends Specification with Mockito {
       val config = Map("scheduled-changes-enabled" -> true)
       Meta(Configuration.from(config)).scheduledBatchChangesEnabled must beTrue
     }
+    "default to false if multi-record-batch-change-enabled is not found" in {
+      val config = Map("vinyldns.version" -> "foo-bar")
+      Meta(Configuration.from(config)).multiRecordBatchChangeEnabled must beFalse
+    }
+    "set to true if multi-record-batch-change-enabled is true in config" in {
+      val config = Map("multi-record-batch-change-enabled" -> true)
+      Meta(Configuration.from(config)).multiRecordBatchChangeEnabled must beTrue
+    }
   }
 }


### PR DESCRIPTION
portal flag for #867

Changes in this pull request:
- feature flag for the New DNS Change form that determines if the Record Data field shows for a change if the is a DeleteRecordSet type. 
- `multi-record-batch-change-enabled` config value defaults to false if not set. We use the term "DNS Change" in the portal but the config values for the API and portal should match hence the use of "batch-change".
- Include help text when the feature is enabled to let the user know when Record Data is not a required field.

Screenshot of portal with `multi-record-batch-change-enabled` set to true:
<img width="1102" alt="Screen Shot 2019-10-10 at 3 14 58 AM" src="https://user-images.githubusercontent.com/4439228/66568501-93fbeb80-eb37-11e9-8eb9-92e396a859e1.png">
