### PR TITLE
Enable multi-record functionality in batch change

### DIFF
--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -55,8 +55,8 @@ if [ "${PROD_ENV}" = "true" ]; then
     ./run-tests.py live_tests -n2 -v -m "not skip_production and not serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
     if [ $? -eq 0 ]; then
       # run serial tests second (serial marker)
-      echo "./run-tests.py live_tests -n0 -v -m \"not skip_production and serial and not multi_record_disabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
-      ./run-tests.py live_tests -n0 -v -m "not skip_production and serial and not multi_record_disabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
+      echo "./run-tests.py live_tests -n0 -v -m \"not skip_production and serial and not multi_record_enabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
+      ./run-tests.py live_tests -n0 -v -m "not skip_production and serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
     fi
 else
     # run parallel tests first (not serial)

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -51,21 +51,21 @@ find . -name "__pycache__" -delete
 if [ "${PROD_ENV}" = "true" ]; then
     # -m plays havoc with -k, using variables is a headache, so doing this by hand
     # run parallel tests first (not serial)
-    echo "./run-tests.py live_tests -n2 -v -m \"not skip_production and not serial\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
-    ./run-tests.py live_tests -n2 -v -m "not skip_production and not serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
+    echo "./run-tests.py live_tests -n2 -v -m \"not skip_production and not serial and not multi_record_enabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
+    ./run-tests.py live_tests -n2 -v -m "not skip_production and not serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
     if [ $? -eq 0 ]; then
       # run serial tests second (serial marker)
-      echo "./run-tests.py live_tests -n0 -v -m \"not skip_production and serial\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
-      ./run-tests.py live_tests -n0 -v -m "not skip_production and serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
+      echo "./run-tests.py live_tests -n0 -v -m \"not skip_production and serial and not multi_record_disabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
+      ./run-tests.py live_tests -n0 -v -m "not skip_production and serial and not multi_record_disabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
     fi
 else
     # run parallel tests first (not serial)
-    echo "./run-tests.py live_tests -n2 -v -m \"not serial\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
-    ./run-tests.py live_tests -n2 -v -m "not serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
+    echo "./run-tests.py live_tests -n2 -v -m \"not serial and not multi_record_disabled\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
+    ./run-tests.py live_tests -n2 -v -m "not serial and not multi_record_disabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
 
     if [ $? -eq 0 ]; then
       # run serial tests second (serial marker)
-      echo "./run-tests.py live_tests -n0 -v -m \"serial\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
-      ./run-tests.py live_tests -n0 -v -m "serial" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
+      echo "./run-tests.py live_tests -n0 -v -m \"serial and not multi_record_disabled\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True"
+      ./run-tests.py live_tests -n0 -v -m "serial and not multi_record_disabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=True
     fi
 fi

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -92,7 +92,7 @@ def test_create_batch_change_with_adds_success(shared_zone_test_context):
         "changes": [
             get_change_A_AAAA_json("parent.com.", address="4.5.6.7"),
             get_change_A_AAAA_json("ok.", record_type="AAAA", address="fd69:27cc:fe91::60"),
-            get_change_A_AAAA_json("relative.parent.com.", address="1.1.1.1"),
+            get_change_A_AAAA_json("relative.parent.com."),
             get_change_CNAME_json("CNAME.PARENT.COM", cname="nice.parent.com"),
             get_change_CNAME_json("_2cname.parent.com", cname="nice.parent.com"),
             get_change_CNAME_json("4.2.0.192.in-addr.arpa.", cname="4.4/30.2.0.192.in-addr.arpa."),
@@ -420,7 +420,7 @@ def test_create_batch_change_with_zone_discovery_error_without_owner_group_fails
 
     batch_change_input = {
         "changes": [
-            get_change_A_AAAA_json("some.non-existent.zone.", address="1.1.1.1")
+            get_change_A_AAAA_json("some.non-existent.zone.")
         ]
     }
 
@@ -926,7 +926,7 @@ def test_create_batch_change_with_high_value_domain_fails(shared_zone_test_conte
             get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:0"),
             get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:0", change_type="DeleteRecordSet"),
 
-            get_change_A_AAAA_json("i-can-be-touched.ok.", address="1.1.1.1")
+            get_change_A_AAAA_json("i-can-be-touched.ok.")
         ]
     }
 
@@ -985,7 +985,7 @@ def test_create_batch_change_with_domains_requiring_review_succeeds(shared_zone_
             get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:2"),
             get_change_PTR_json("fd69:27cc:fe91:0:0:0:ffff:2", change_type="DeleteRecordSet"),
 
-            get_change_A_AAAA_json("i-can-be-touched.ok.", address="1.1.1.1")
+            get_change_A_AAAA_json("i-can-be-touched.ok.")
         ]
     }
     response = None
@@ -3012,14 +3012,14 @@ def test_user_validation_ownership(shared_zone_test_context):
     client = shared_zone_test_context.shared_zone_vinyldns_client
     batch_change_input = {
         "changes": [
-            get_change_A_AAAA_json("add-test-batch.non.test.shared.", address="1.1.1.1"),
+            get_change_A_AAAA_json("add-test-batch.non.test.shared."),
             get_change_A_AAAA_json("update-test-batch.non.test.shared.", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json("update-test-batch.non.test.shared.", address="1.1.1.1"),
+            get_change_A_AAAA_json("update-test-batch.non.test.shared."),
             get_change_A_AAAA_json("delete-test-batch.non.test.shared.", change_type="DeleteRecordSet"),
 
-            get_change_A_AAAA_json("add-test-batch.shared.", address="1.1.1.1"),
+            get_change_A_AAAA_json("add-test-batch.shared."),
             get_change_A_AAAA_json("update-test-batch.shared.", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json("update-test-batch.shared.", address="1.1.1.1"),
+            get_change_A_AAAA_json("update-test-batch.shared."),
             get_change_A_AAAA_json("delete-test-batch.shared.", change_type="DeleteRecordSet"),
         ],
         "ownerGroupId": "shared-zone-group"
@@ -3054,9 +3054,9 @@ def test_user_validation_shared(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
     batch_change_input = {
         "changes": [
-            get_change_A_AAAA_json("add-test-batch.non.test.shared.", address="1.1.1.1"),
+            get_change_A_AAAA_json("add-test-batch.non.test.shared."),
             get_change_A_AAAA_json("update-test-batch.non.test.shared.", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json("update-test-batch.non.test.shared.", address="1.1.1.1"),
+            get_change_A_AAAA_json("update-test-batch.non.test.shared."),
             get_change_A_AAAA_json("delete-test-batch.non.test.shared.", change_type="DeleteRecordSet")
         ],
         "ownerGroupId": shared_zone_test_context.ok_group['id']
@@ -3664,7 +3664,7 @@ def test_create_batch_with_global_acl_rule_applied_succeeds(shared_zone_test_con
         "changes": [
             get_change_A_AAAA_json(a_fqdn, record_type="A", ttl=200, address="192.0.2.44"),
             get_change_PTR_json("192.0.2.44", ptrdname=a_fqdn),
-            get_change_A_AAAA_json(a_fqdn, record_type="A", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_fqdn, record_type="A", address="1.1.1.1", change_type="DeleteRecordSet"),
             get_change_PTR_json("192.0.2.44", change_type="DeleteRecordSet")
         ]
     }
@@ -3753,6 +3753,7 @@ def test_create_batch_with_irrelevant_global_acl_rule_applied_fails(shared_zone_
             shared_client.wait_until_recordset_change_status(delete_a_rs, 'Complete')
 
 
+@pytest.mark.multi_record_disabled
 @pytest.mark.serial
 @pytest.mark.skip_production
 def test_create_batch_duplicates_add_check(shared_zone_test_context):
@@ -3794,8 +3795,106 @@ def test_create_batch_duplicates_add_check(shared_zone_test_context):
     assert_error(response[7], error_messages=[err("multi-mx.ok.", "MX")])
 
 
+@pytest.mark.manual_batch_review
+def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_context):
+    """
+    Confirm that individual changes matching zone names requiring review get correctly flagged for manual review
+    """
+    rejecter = shared_zone_test_context.support_user_client
+    client = shared_zone_test_context.ok_vinyldns_client
+    batch_change_input = {
+        "changes": [
+            get_change_A_AAAA_json("add-test-batch.zone.requires.review."),
+            get_change_A_AAAA_json("update-test-batch.zone.requires.review.", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json("update-test-batch.zone.requires.review."),
+            get_change_A_AAAA_json("delete-test-batch.zone.requires.review.", change_type="DeleteRecordSet")
+        ],
+        "ownerGroupId": shared_zone_test_context.ok_group['id']
+    }
+
+    response = None
+
+    try:
+        response = client.create_batch_change(batch_change_input, status=202)
+        get_batch = client.get_batch_change(response['id'])
+        assert_that(get_batch['status'], is_('PendingReview'))
+        assert_that(get_batch['approvalStatus'], is_('PendingReview'))
+        for i in xrange(0, 3):
+            assert_that(get_batch['changes'][i]['status'], is_('NeedsReview'))
+            assert_that(get_batch['changes'][i]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
+
+    finally:
+        # Clean up so data doesn't change
+        if response:
+            rejecter.reject_batch_change(response['id'], status=200)
+
+def test_create_batch_delete_record_for_invalid_record_data_fails(shared_zone_test_context):
+    """
+    Test delete record set fails for non-existent record and non-existent record data
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(shared_zone_test_context.ok_zone, a_delete_fqdn, "A", [{"address": "1.1.1.1"}])
+
+    batch_change_input = {
+        "comments": "test delete record failures",
+        "changes": [
+            get_change_A_AAAA_json("delete-non-existent-record.ok.", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_delete_fqdn, address="4.5.6.7", change_type="DeleteRecordSet")
+        ]
+    }
+
+    to_delete = []
+
+    try:
+        create_rs = client.create_recordset(a_delete, status=202)
+        to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+        errors = client.create_batch_change(batch_change_input, status=400)
+
+        assert_failed_change_in_error_response(errors[0], input_name="delete-non-existent-record.ok.", record_data="1.1.1.1", change_type="DeleteRecordSet",
+                                               error_messages=['Record "delete-non-existent-record.ok." Does Not Exist: cannot delete a record that does not exist.'])
+        assert_failed_change_in_error_response(errors[1], input_name=a_delete_fqdn, record_data="4.5.6.7", change_type="DeleteRecordSet",
+                                               error_messages=['Record data AData(4.5.6.7) does not exist for "' + a_delete_fqdn + '".'])
+
+    finally:
+        clear_recordset_list(to_delete, client)
+
+# def test_create_batch_delete_recordset_fails(shared_zone_test_context):
+#     """
+#     Test creating batch change with record data in DeleteRecord change input type is not recognized
+#     """
+#     client = shared_zone_test_context.ok_vinyldns_client
+#     ok_zone = shared_zone_test_context.ok_zone
+#     ok_group = shared_zone_test_context.ok_group
+#
+#     rs_name = generate_record_name()
+#     rs_fqdn = rs_name + ".ok."
+#     rs_to_create = get_recordset_json(ok_zone, rs_name, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
+#
+#     batch_change_input = {
+#         "comments": "this is optional",
+#         "changes": [
+#             get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet")
+#         ]
+#     }
+#
+#     to_delete = []
+#
+#     create_rs = client.create_recordset(rs_to_create, status=202)
+#     to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+#
+#     result = client.create_batch_change(batch_change_input, status=202)
+#     client.wait_until_batch_change_completed(result)
+#
+#     client.get_recordset(create_rs['zone']['id'], create_rs['recordSet']['id'], status=404)
+
+
+@pytest.mark.multi_record_disabled
 @pytest.mark.skip_production
-def test_create_batch_duplicates_update_check(shared_zone_test_context):
+def test_create_batch_multi_record_update_fails(shared_zone_test_context):
     """
     Test recordsets with multiple records cannot be edited in batch (relies on config, skip-prod)
     """
@@ -3822,56 +3921,19 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            ## Updates
-            # Add + DeleteRRSet
-            get_change_A_AAAA_json(a_update_record_set_fqdn, change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_record_set_fqdn, address="1.2.3.4"),
-            get_change_A_AAAA_json(a_update_record_set_fqdn, address="4.5.6.7"),
+            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
 
-            get_change_TXT_json(txt_update_record_set_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_record_set_fqdn, text="some-multi-text"),
-            get_change_TXT_json(txt_update_record_set_fqdn, text="more-multi-text"),
+            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_fqdn, text="more-multi-text"),
 
-            # Add + DeleteRRSet (full delete)
-            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.2", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.2.3.4"),
-            get_change_A_AAAA_json(a_update_record_full_fqdn, address="4.5.6.7"),
+            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecordSet"),
 
-            get_change_TXT_json(txt_update_record_full_fqdn, text="hello", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_record_full_fqdn, text="again", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_record_full_fqdn, text="some-multi-text"),
-            get_change_TXT_json(txt_update_record_full_fqdn, text="more-multi-text"),
-
-            # Add + single DeleteRRSet with record data
-            get_change_A_AAAA_json(a_update_record_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_record_fqdn, address="1.2.3.4"),
-            get_change_A_AAAA_json(a_update_record_fqdn, address="4.5.6.7"),
-
-            get_change_TXT_json(txt_update_record_fqdn, text="hello", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_record_fqdn, text="some-multi-text"),
-            get_change_TXT_json(txt_update_record_fqdn, text="more-multi-text"),
-
-            # Single DeleteRRSet
-            get_change_A_AAAA_json(a_update_record_only_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_record_only_fqdn, text="hello", change_type="DeleteRecordSet"),
-
-            ## Full deletes
-            # DeleteRRSet (without record data)
-            get_change_A_AAAA_json(a_delete_record_set_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_record_set_fqdn, change_type="DeleteRecordSet"),
-
-            # DeleteRRSet (with record data)
-            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.2", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_record_fqdn, text="hello", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_record_fqdn, text="again", change_type="DeleteRecordSet"),
-
-            # single DeleteRRSet (with record data) + DeleteRRSet (without record data)
-            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, text="hello", change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet")
+            # adding an HVD so this will fail if accidentally run against wrong config
+            get_change_A_AAAA_json("high-value-domain")
         ]
     }
 
@@ -3881,82 +3943,7 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
             create_rs = client.create_recordset(rs, status=202)
             to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
 
-        result = client.create_batch_change(batch_change_input, status=202)
-        client.wait_until_batch_change_completed(result)
-
-        # Check batch change response
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=0, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data=None, change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="1.2.3.4")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=2, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="4.5.6.7")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=3, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=4, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="some-multi-text")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=5, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="more-multi-text")
-
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=6, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=7, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.2", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=8, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.2.3.4")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=9, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="4.5.6.7")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=10, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="again", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=12, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="some-multi-text")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="more-multi-text")
-
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=14, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=15, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.2.3.4")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=16, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="4.5.6.7")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=17, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=18, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="some-multi-text")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=19, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="more-multi-text")
-
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=20, input_name=a_update_record_only_fqdn, record_name=a_update_record_only_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=21, input_name=txt_update_record_only_fqdn, record_name=txt_update_record_only_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
-
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=22, input_name=a_delete_record_set_fqdn, record_name=a_delete_record_set_name, record_data=None, change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=23, input_name=txt_delete_record_set_fqdn, record_name=txt_delete_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=24, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=25, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.2", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=26, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=27, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="again", change_type="DeleteRecordSet")
-
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=28, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=29, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data=None, change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=30, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=31, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
-
-        # Perform look up to verify record set data
-        for rs in to_delete:
-            rs_name = rs['recordSet']['name']
-            rs_id = rs['recordSet']['id']
-            zone_id = rs['zone']['id']
-
-            # deletes should not exist
-            if rs_name in [a_delete_record_set_name, txt_delete_record_set_name, a_delete_record_name,
-               txt_delete_record_name, a_delete_record_and_record_set_name, txt_delete_record_and_record_set_name]:
-                client.get_recordset(zone_id, rs_id, status=404)
-            else:
-                result_rs = client.get_recordset(zone_id, rs_id, status=200)
-                records = result_rs['recordSet']['records']
-
-                # full deletes with updates
-                if rs_name in [a_update_record_set_name, a_update_record_full_name]:
-                    assert_that(records, contains({"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
-                    assert_that(records, is_not(contains({"address": "1.1.1.1"}, {"address": "1.1.1.2"})))
-                elif rs_name in [txt_update_record_set_name, txt_update_record_full_name]:
-                    assert_that(records, contains({"text": "some-multi-text"}, {"text": "more-multi-text"}))
-                    assert_that(records, is_not(contains({"text": "hello"}, {"text": "again"})))
-                # single entry delete with adds
-                elif rs_name == a_update_record_name:
-                    assert_that(records, contains({"address": "1.1.1.2"}, {"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
-                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
-                elif rs_name == txt_update_record_name:
-                    assert_that(records, contains({"text": "again"}, {"text": "some-multi-text"}, {"text": "more-multi-text"}))
-                    assert_that(records, is_not(contains({"text": "hello"})))
-                elif rs_name == a_update_record_only_name:
-                    assert_that(records, contains({"address": "1.1.1.2"}))
-                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
-                elif rs_name == txt_update_record_only_name:
-                    assert_that(records, contains({"text": "again"}))
-                    assert_that(records, is_not(contains({"text": "hello"})))
+        response = client.create_batch_change(batch_change_input, status=400)
 
         def existing_err(name, type):
             return 'RecordSet with name {} and type {} cannot be updated in a single '.format(name, type) + \
@@ -3981,70 +3968,63 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
         clear_recordset_list(to_delete, client)
 
 
-@pytest.mark.manual_batch_review
-def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_context):
+@pytest.mark.multi_record_disabled
+def test_create_batch_deletes_fails(shared_zone_test_context):
     """
-    Confirm that individual changes matching zone names requiring review get correctly flagged for manual review
-    """
-    rejecter = shared_zone_test_context.support_user_client
-    client = shared_zone_test_context.ok_vinyldns_client
-    batch_change_input = {
-        "changes": [
-            get_change_A_AAAA_json("add-test-batch.zone.requires.review.", address="1.1.1.1"),
-            get_change_A_AAAA_json("update-test-batch.zone.requires.review.", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json("update-test-batch.zone.requires.review.", address="1.1.1.1"),
-            get_change_A_AAAA_json("delete-test-batch.zone.requires.review.", change_type="DeleteRecordSet")
-        ],
-        "ownerGroupId": shared_zone_test_context.ok_group['id']
-    }
-
-    response = None
-
-    try:
-        response = client.create_batch_change(batch_change_input, status=202)
-        get_batch = client.get_batch_change(response['id'])
-        assert_that(get_batch['status'], is_('PendingReview'))
-        assert_that(get_batch['approvalStatus'], is_('PendingReview'))
-        for i in xrange(0, 3):
-            assert_that(get_batch['changes'][i]['status'], is_('NeedsReview'))
-            assert_that(get_batch['changes'][i]['validationErrors'][0]['errorType'], is_('RecordRequiresManualReview'))
-
-    finally:
-        # Clean up so data doesn't change
-        if response:
-            rejecter.reject_batch_change(response['id'], status=200)
-
-
-def test_create_batch_delete_record_fails(shared_zone_test_context):
-    """
-    Test creating batch change with DeleteRecord change input type is not recognized
+    Test creating batch change with DeleteRecordSets when multi-record support is disabled
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone = shared_zone_test_context.ok_zone
     ok_group = shared_zone_test_context.ok_group
 
     rs_name = generate_record_name()
+    rs_name_2 = generate_record_name()
+    multi_rs_name = generate_record_name()
+    multi_rs_name_2 = generate_record_name()
     rs_fqdn = rs_name + ".ok."
+    rs_fqdn_2 = rs_name + ".ok."
+    multi_rs_fqdn = multi_rs_name + ".ok."
+    multi_rs_fqdn_2 = multi_rs_name_2 + ".ok."
     rs_to_create = get_recordset_json(ok_zone, rs_name, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
+    rs_to_create_2 = get_recordset_json(ok_zone, rs_name_2, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
+    multi_record_rs_to_create = get_recordset_json(ok_zone, multi_rs_name, "A", [{"address": "1.2.3.4"}, {"address": "1.1.1.1"}], 200, ok_group['id'])
+    multi_record_rs_to_create_2 = get_recordset_json(ok_zone, multi_rs_name_2, "A", [{"address": "1.2.3.4"}, {"address": "1.1.1.1"}], 200, ok_group['id'])
 
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet")
+            get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(rs_fqdn_2, address="1.2.3.4", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(multi_rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(multi_rs_fqdn_2, change_type="DeleteRecordSet")
         ]
     }
 
     to_delete = []
 
-    create_rs = client.create_recordset(rs_to_create, status=202)
-    to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+    try:
+        create_rs = client.create_recordset(rs_to_create, status=202)
+        create_rs_2 = client.create_recordset(rs_to_create_2, status=202)
+        create_multi_rs = client.create_recordset(multi_record_rs_to_create, status=202)
+        create_multi_rs_2 = client.create_recordset(multi_record_rs_to_create_2, status=202)
+        to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+        to_delete.append(client.wait_until_recordset_change_status(create_rs_2, 'Complete'))
+        to_delete.append(client.wait_until_recordset_change_status(create_multi_rs, 'Complete'))
+        to_delete.append(client.wait_until_recordset_change_status(create_multi_rs_2, 'Complete'))
 
-    result = client.create_batch_change(batch_change_input, status=202)
-    client.wait_until_batch_change_completed(result)
+        response = client.create_batch_change(batch_change_input, status=400)
 
-    client.get_recordset(create_rs['zone']['id'], create_rs['recordSet']['id'], status=404)
+        assert_successful_change_in_error_response(response[0], input_name=rs_fqdn, record_type="A", record_data="1.2.3.4", change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[1], input_name=rs_fqdn_2, record_type="A", change_type="DeleteRecordSet")
+        assert_failed_change_in_error_response(response[2], input_name=multi_rs_fqdn, record_type="A", record_data="1.2.3.4", change_type="DeleteRecordSet",
+                                               error_messages=['RecordSet with name ' + multi_rs_fqdn + ' and type A cannot be updated in a single Batch Change because it contains multiple DNS records (2).'])
+        assert_failed_change_in_error_response(response[3], input_name=multi_rs_fqdn_2, record_type="A", change_type="DeleteRecordSet",
+                                               error_messages=['RecordSet with name ' + multi_rs_fqdn_2 + ' and type A cannot be updated in a single Batch Change because it contains multiple DNS records (2).'])
 
+    finally:
+        clear_recordset_list(to_delete, client)
 
+@pytest.mark.multi_record_enabled
 @pytest.mark.serial
 def test_create_batch_delete_record_access_checks(shared_zone_test_context):
     """
@@ -4109,62 +4089,244 @@ def test_create_batch_delete_record_access_checks(shared_zone_test_context):
         clear_recordset_list(to_delete, ok_client)
 
 
-@pytest.mark.multi_record_disabled
-def test_create_batch_delete_record_for_invalid_record_data_fails(shared_zone_test_context):
+@pytest.mark.multi_record_enabled
+@pytest.mark.skip_production
+def test_create_batch_multi_record_update_succeeds(shared_zone_test_context):
     """
-    Test delete record set fails for non-existent record and non-existent record data
+    Test record sets with multiple records can be added, updated and deleted in batch (relies on skip-prod)
     """
     client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
 
-    a_delete_name = generate_record_name()
-    a_delete_fqdn = a_delete_name + ".ok."
-    a_delete = get_recordset_json(shared_zone_test_context.ok_zone, a_delete_fqdn, "A", [{"address": "1.1.1.1"}])
+    # record sets to setup
+    a_update_record_set_name = generate_record_name()
+    a_update_record_set_fqdn = a_update_record_set_name + ".ok."
+    a_update_record_set = get_recordset_json(ok_zone, a_update_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_set_name = generate_record_name()
+    txt_update_record_set_fqdn = txt_update_record_set_name + ".ok."
+    txt_update_record_set = get_recordset_json(ok_zone, txt_update_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_full_name = generate_record_name()
+    a_update_record_full_fqdn = a_update_record_full_name + ".ok."
+    a_update_record_full = get_recordset_json(ok_zone, a_update_record_full_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_full_name = generate_record_name()
+    txt_update_record_full_fqdn = txt_update_record_full_name + ".ok."
+    txt_update_record_full = get_recordset_json(ok_zone, txt_update_record_full_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_name = generate_record_name()
+    a_update_record_fqdn = a_update_record_name + ".ok."
+    a_update_record = get_recordset_json(ok_zone, a_update_record_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_name = generate_record_name()
+    txt_update_record_fqdn = txt_update_record_name + ".ok."
+    txt_update_record = get_recordset_json(ok_zone, txt_update_record_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_update_record_only_name = generate_record_name()
+    a_update_record_only_fqdn = a_update_record_only_name + ".ok."
+    a_update_record_only = get_recordset_json(ok_zone, a_update_record_only_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_update_record_only_name = generate_record_name()
+    txt_update_record_only_fqdn = txt_update_record_only_name + ".ok."
+    txt_update_record_only = get_recordset_json(ok_zone, txt_update_record_only_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_set_name = generate_record_name()
+    a_delete_record_set_fqdn = a_delete_record_set_name + ".ok."
+    a_delete_record_set = get_recordset_json(ok_zone, a_delete_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_set_name = generate_record_name()
+    txt_delete_record_set_fqdn = txt_delete_record_set_name + ".ok."
+    txt_delete_record_set = get_recordset_json(ok_zone, txt_delete_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_name = generate_record_name()
+    a_delete_record_fqdn = a_delete_record_name + ".ok."
+    a_delete_record = get_recordset_json(ok_zone, a_delete_record_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_name = generate_record_name()
+    txt_delete_record_fqdn = txt_delete_record_name + ".ok."
+    txt_delete_record = get_recordset_json(ok_zone, txt_delete_record_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
+
+    a_delete_record_and_record_set_name = generate_record_name()
+    a_delete_record_and_record_set_fqdn = a_delete_record_and_record_set_name + ".ok."
+    a_delete_record_and_record_set = get_recordset_json(ok_zone, a_delete_record_and_record_set_name, "A", [{"address": "1.1.1.1"}, {"address": "1.1.1.2"}], 200)
+
+    txt_delete_record_and_record_set_name = generate_record_name()
+    txt_delete_record_and_record_set_fqdn = txt_delete_record_and_record_set_name + ".ok."
+    txt_delete_record_and_record_set = get_recordset_json(ok_zone, txt_delete_record_and_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
 
     batch_change_input = {
-        "comments": "test delete record failures",
+        "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json("delete-non-existent-record.ok.", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_delete_fqdn, address="4.5.6.7", change_type="DeleteRecordSet")
+            ## Updates
+            # Add + DeleteRRSet
+            get_change_A_AAAA_json(a_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="4.5.6.7"),
+
+            get_change_TXT_json(txt_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="more-multi-text"),
+
+            # Add + DeleteRecord (full delete)
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.2", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="4.5.6.7"),
+
+            get_change_TXT_json(txt_update_record_full_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="again", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="more-multi-text"),
+
+            # Add + single DeleteRecord
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="4.5.6.7"),
+
+            get_change_TXT_json(txt_update_record_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_fqdn, text="more-multi-text"),
+
+            # Single DeleteRecord
+            get_change_A_AAAA_json(a_update_record_only_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_only_fqdn, text="hello", change_type="DeleteRecordSet"),
+
+            ## Full deletes
+            # Delete RRSet
+            get_change_A_AAAA_json(a_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+
+            # DeleteRecord (full delete)
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.2", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="again", change_type="DeleteRecordSet"),
+
+            # DeleteRecord + DeleteRRSet
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet")
         ]
     }
 
-    create_rs = None
+    to_delete = []
     try:
-        create_rs = client.create_recordset(rs_to_create, status=202)
-        client.wait_until_recordset_change_status(create_rs, 'Complete')
+        for rs in [a_update_record_set, txt_update_record_set, a_update_record_full, txt_update_record_full, a_update_record, txt_update_record, a_update_record_only, txt_update_record_only,
+                   a_delete_record_set, txt_delete_record_set, a_delete_record, txt_delete_record, a_delete_record_and_record_set, txt_delete_record_and_record_set]:
+            create_rs = client.create_recordset(rs, status=202)
+            to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
 
-        errors = client.create_batch_change(batch_change_input, status=400)
+        result = client.create_batch_change(batch_change_input, status=202)
+        client.wait_until_batch_change_completed(result)
 
-        assert_failed_change_in_error_response(errors[0], input_name="delete-non-existent-record.ok.", record_data="1.1.1.1", change_type="DeleteRecordSet",
-                                               error_messages=['Record "delete-non-existent-record.ok." Does Not Exist: cannot delete a record that does not exist.'])
-        assert_failed_change_in_error_response(errors[1], input_name=a_delete_fqdn, record_data="4.5.6.7", change_type="DeleteRecordSet",
-                                               error_messages=['Record data AData(4.5.6.7) does not exist for "' + a_delete_fqdn + '".'])
+        # Check batch change response
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=0, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=2, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=3, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=4, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=5, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=6, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=7, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.2", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=8, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=9, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=10, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="again", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=12, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=14, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=15, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=16, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=17, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=18, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=19, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=20, input_name=a_update_record_only_fqdn, record_name=a_update_record_only_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=21, input_name=txt_update_record_only_fqdn, record_name=txt_update_record_only_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=22, input_name=a_delete_record_set_fqdn, record_name=a_delete_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=23, input_name=txt_delete_record_set_fqdn, record_name=txt_delete_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=24, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=25, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.2", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=26, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=27, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="again", change_type="DeleteRecordSet")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=28, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=29, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=30, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=31, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+
+        # Perform look up to verify record set data
+        for rs in to_delete:
+            rs_name = rs['recordSet']['name']
+            rs_id = rs['recordSet']['id']
+            zone_id = rs['zone']['id']
+
+            # deletes should not exist
+            if rs_name in [a_delete_record_set_name, txt_delete_record_set_name, a_delete_record_name,
+                           txt_delete_record_name, a_delete_record_and_record_set_name, txt_delete_record_and_record_set_name]:
+                client.get_recordset(zone_id, rs_id, status=404)
+            else:
+                result_rs = client.get_recordset(zone_id, rs_id, status=200)
+                records = result_rs['recordSet']['records']
+
+                # full deletes with updates
+                if rs_name in [a_update_record_set_name, a_update_record_full_name]:
+                    assert_that(records, contains({"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"}, {"address": "1.1.1.2"})))
+                elif rs_name in [txt_update_record_set_name, txt_update_record_full_name]:
+                    assert_that(records, contains({"text": "some-multi-text"}, {"text": "more-multi-text"}))
+                    assert_that(records, is_not(contains({"text": "hello"}, {"text": "again"})))
+                # single entry delete with adds
+                elif rs_name == a_update_record_name:
+                    assert_that(records, contains({"address": "1.1.1.2"}, {"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
+                elif rs_name == txt_update_record_name:
+                    assert_that(records, contains({"text": "again"}, {"text": "some-multi-text"}, {"text": "more-multi-text"}))
+                    assert_that(records, is_not(contains({"text": "hello"})))
+                elif rs_name == a_update_record_only_name:
+                    assert_that(records, contains({"address": "1.1.1.2"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
+                elif rs_name == txt_update_record_only_name:
+                    assert_that(records, contains({"text": "again"}))
+                    assert_that(records, is_not(contains({"text": "hello"})))
 
     finally:
         clear_recordset_list(to_delete, client)
 
-
 @pytest.mark.multi_record_enabled
-def test_create_batch_delete_record_succeeds(shared_zone_test_context):
+def test_create_batch_deletes_succeeds(shared_zone_test_context):
     """
-    Test creating batch change with DeleteRecord change input type is recognized
+    Test creating batch change with DeleteRecordSet with valid record data succeeds
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone = shared_zone_test_context.ok_zone
     ok_group = shared_zone_test_context.ok_group
 
     rs_name = generate_record_name()
+    rs_name_2 = generate_record_name()
     multi_rs_name = generate_record_name()
+    multi_rs_name_2 = generate_record_name()
     rs_fqdn = rs_name + ".ok."
-    multi_rs_fqdn = rs_name + ".ok."
+    rs_fqdn_2 = rs_name_2 + ".ok."
+    multi_rs_fqdn = multi_rs_name + ".ok."
+    multi_rs_fqdn_2 = multi_rs_name_2 + ".ok."
     rs_to_create = get_recordset_json(ok_zone, rs_name, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
-    multi_record_rs_to_create = get_recordset_json(ok_zone, multi_rs_name, "A", [{"address": "1.2.3.4", "address": "1.1.1.1"}], 200, ok_group['id'])
+    rs_to_create_2 = get_recordset_json(ok_zone, rs_name_2, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
+    multi_record_rs_to_create = get_recordset_json(ok_zone, multi_rs_name, "A", [{"address": "1.2.3.4"}, {"address": "1.1.1.1"}], 200, ok_group['id'])
+    multi_record_rs_to_create_2 = get_recordset_json(ok_zone, multi_rs_name_2, "A", [{"address": "1.2.3.4"}, {"address": "1.1.1.1"}], 200, ok_group['id'])
 
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
             get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(multi_rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet")
+            get_change_A_AAAA_json(rs_fqdn_2, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(multi_rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(multi_rs_fqdn_2, change_type="DeleteRecordSet")
         ]
     }
 
@@ -4172,15 +4334,22 @@ def test_create_batch_delete_record_succeeds(shared_zone_test_context):
 
     try:
         create_rs = client.create_recordset(rs_to_create, status=202)
+        create_rs_2 = client.create_recordset(rs_to_create_2, status=202)
         create_multi_rs = client.create_recordset(multi_record_rs_to_create, status=202)
+        create_multi_rs_2 = client.create_recordset(multi_record_rs_to_create_2, status=202)
         to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+        to_delete.append(client.wait_until_recordset_change_status(create_rs_2, 'Complete'))
         to_delete.append(client.wait_until_recordset_change_status(create_multi_rs, 'Complete'))
+        to_delete.append(client.wait_until_recordset_change_status(create_multi_rs_2, 'Complete'))
 
         result = client.create_batch_change(batch_change_input, status=202)
         client.wait_until_batch_change_completed(result)
 
         client.get_recordset(create_rs['zone']['id'], create_rs['recordSet']['id'], status=404)
-        client.get_recordset(create_multi_rs['zone']['id'], create_multi_rs['recordSet']['id'], status=200)
+        client.get_recordset(create_rs_2['zone']['id'], create_rs_2['recordSet']['id'], status=404)
+        updated_rs = client.get_recordset(create_multi_rs['zone']['id'], create_multi_rs['recordSet']['id'], status=200)['recordSet']
+        assert_that(updated_rs['records'], is_([{'address': '1.1.1.1'}]))
+        client.get_recordset(create_multi_rs_2['zone']['id'], create_multi_rs_2['recordSet']['id'], status=404)
 
     finally:
         clear_recordset_list(to_delete, client)

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1093,15 +1093,24 @@ def test_create_batch_change_with_bad_A_record_data_fails(shared_zone_test_conte
     Test creating a batch change with malformed A record address fails
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    bad_A_data_request = {
+    bad_A_data_request_add = {
         "comments": "this is optional",
         "changes": [
             get_change_A_AAAA_json("thing.thing.com.", address="bad address")
         ]
     }
-    errors = client.create_batch_change(bad_A_data_request, status=400)
 
-    assert_error(errors, error_messages=["A must be a valid IPv4 Address"])
+    bad_A_data_request_delete_record_set = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_A_AAAA_json("thing.thing.com.", address="bad address", change_type="DeleteRecordSet")
+        ]
+    }
+    error1 = client.create_batch_change(bad_A_data_request_add, status=400)
+    error2 = client.create_batch_change(bad_A_data_request_delete_record_set, status=400)
+
+    assert_error(error1, error_messages=["A must be a valid IPv4 Address"])
+    assert_error(error2, error_messages=["A must be a valid IPv4 Address"])
 
 
 def test_create_batch_change_with_bad_AAAA_record_data_fails(shared_zone_test_context):
@@ -1109,15 +1118,24 @@ def test_create_batch_change_with_bad_AAAA_record_data_fails(shared_zone_test_co
     Test creating a batch change with malformed AAAA record address fails
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    bad_AAAA_data_request = {
+    bad_AAAA_data_request_add = {
         "comments": "this is optional",
         "changes": [
             get_change_A_AAAA_json("thing.thing.com.", record_type="AAAA", address="bad address")
         ]
     }
-    errors = client.create_batch_change(bad_AAAA_data_request, status=400)
 
-    assert_error(errors, error_messages=["AAAA must be a valid IPv6 Address"])
+    bad_AAAA_data_request_delete_record_set = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_A_AAAA_json("thing.thing.com.", record_type="AAAA", address="bad address", change_type="DeleteRecordSet")
+        ]
+    }
+    error1 = client.create_batch_change(bad_AAAA_data_request_add, status=400)
+    error2 = client.create_batch_change(bad_AAAA_data_request_delete_record_set, status=400)
+
+    assert_error(error1, error_messages=["AAAA must be a valid IPv6 Address"])
+    assert_error(error2, error_messages=["AAAA must be a valid IPv6 Address"])
 
 
 def test_create_batch_change_with_incorrect_CNAME_record_attribute_fails(shared_zone_test_context):
@@ -1173,15 +1191,24 @@ def test_create_batch_change_with_bad_CNAME_record_attribute_fails(shared_zone_t
     Test creating a batch change with malformed CNAME record fails
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    bad_CNAME_data_request = {
+    bad_CNAME_data_request_add = {
         "comments": "this is optional",
         "changes": [
             get_change_CNAME_json(input_name="bizz.baz.", cname="s." + "s" * 256)
         ]
     }
-    errors = client.create_batch_change(bad_CNAME_data_request, status=400)
 
-    assert_error(errors, error_messages=["CNAME domain name must not exceed 255 characters"])
+    bad_CNAME_data_request_delete_record_set = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_CNAME_json(input_name="bizz.baz.", cname="s." + "s" * 256, change_type="DeleteRecordSet")
+        ]
+    }
+    error1 = client.create_batch_change(bad_CNAME_data_request_add, status=400)
+    error2 = client.create_batch_change(bad_CNAME_data_request_delete_record_set, status=400)
+
+    assert_error(error1, error_messages=["CNAME domain name must not exceed 255 characters"])
+    assert_error(error2, error_messages=["CNAME domain name must not exceed 255 characters"])
 
 
 def test_create_batch_change_with_bad_PTR_record_attribute_fails(shared_zone_test_context):
@@ -1189,16 +1216,24 @@ def test_create_batch_change_with_bad_PTR_record_attribute_fails(shared_zone_tes
     Test creating a batch change with malformed PTR record fails
     """
     client = shared_zone_test_context.ok_vinyldns_client
-    bad_PTR_data_request = {
+    bad_PTR_data_request_add = {
         "comments": "this is optional",
         "changes": [
-            get_change_PTR_json("4.5.6.7", ptrdname="s" * 256)
+            get_change_PTR_json("4.5.6.7", ptrdname="s" * 256),
         ]
     }
-    errors = client.create_batch_change(bad_PTR_data_request, status=400)
 
-    assert_error(errors, error_messages=["PTR must be less than 255 characters"])
+    bad_PTR_data_request_delete_record_set = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_PTR_json("4.5.6.7", ptrdname="s" * 256),
+        ]
+    }
+    error1 = client.create_batch_change(bad_PTR_data_request_add, status=400)
+    error2 = client.create_batch_change(bad_PTR_data_request_delete_record_set, status=400)
 
+    assert_error(error1, error_messages=["PTR must be less than 255 characters"])
+    assert_error(error2, error_messages=["PTR must be less than 255 characters"])
 
 def test_create_batch_change_with_missing_input_name_for_delete_fails(shared_zone_test_context):
     """
@@ -1244,25 +1279,43 @@ def test_mx_recordtype_cannot_have_invalid_preference(shared_zone_test_context):
     """
     ok_client = shared_zone_test_context.ok_vinyldns_client
 
-    batch_change_input_low = {
+    batch_change_input_low_add = {
         "comments": "this is optional",
         "changes": [
             get_change_MX_json("too-small.ok.", preference=-1)
         ]
     }
 
-    batch_change_input_high = {
+    batch_change_input_high_add = {
         "comments": "this is optional",
         "changes": [
             get_change_MX_json("too-big.ok.", preference=65536)
         ]
     }
 
-    error_low = ok_client.create_batch_change(batch_change_input_low, status=400)
-    error_high = ok_client.create_batch_change(batch_change_input_high, status=400)
+    batch_change_input_low_delete_record_set = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_MX_json("too-small.ok.", preference=-1, change_type="DeleteRecordSet")
+        ]
+    }
 
-    assert_error(error_low, error_messages=["MX.preference must be a 16 bit integer"])
-    assert_error(error_high, error_messages=["MX.preference must be a 16 bit integer"])
+    batch_change_input_high_delete_record_set = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_MX_json("too-big.ok.", preference=65536, change_type="DeleteRecordSet")
+        ]
+    }
+
+    error_low_add = ok_client.create_batch_change(batch_change_input_low_add, status=400)
+    error_high_add = ok_client.create_batch_change(batch_change_input_high_add, status=400)
+    error_low_delete_record_set = ok_client.create_batch_change(batch_change_input_low_delete_record_set, status=400)
+    error_high_delete_record_set = ok_client.create_batch_change(batch_change_input_high_delete_record_set, status=400)
+
+    assert_error(error_low_add, error_messages=["MX.preference must be a 16 bit integer"])
+    assert_error(error_high_add, error_messages=["MX.preference must be a 16 bit integer"])
+    assert_error(error_low_delete_record_set, error_messages=["MX.preference must be a 16 bit integer"])
+    assert_error(error_high_delete_record_set, error_messages=["MX.preference must be a 16 bit integer"])
 
 
 def test_create_batch_change_with_invalid_duplicate_record_names_fails(shared_zone_test_context):

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -3497,7 +3497,7 @@ def test_create_batch_change_validation_without_owner_group_id(shared_zone_test_
             shared_client.wait_until_recordset_change_status(delete_result, 'Complete')
 
 
-def test_create_batch_delete_record_for_unassociated_user_in_owner_group_succeeds(shared_zone_test_context):
+def test_create_batch_delete_recordset_for_unassociated_user_in_owner_group_succeeds(shared_zone_test_context):
     """
     Test delete change in batch for a record in a shared zone for an unassociated user belonging to the record owner group succeeds
     """
@@ -3528,7 +3528,7 @@ def test_create_batch_delete_record_for_unassociated_user_in_owner_group_succeed
                                           change_type="DeleteRecordSet")
 
 
-def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fails(shared_zone_test_context):
+def test_create_batch_delete_recordset_for_unassociated_user_not_in_owner_group_fails(shared_zone_test_context):
     """
     Test delete change in batch for a record in a shared zone for an unassociated user not belonging to the record owner group fails
     """
@@ -3565,7 +3565,7 @@ def test_create_batch_delete_record_for_unassociated_user_not_in_owner_group_fai
             shared_client.wait_until_recordset_change_status(delete_rs, 'Complete')
 
 
-def test_create_batch_delete_record_for_zone_admin_not_in_owner_group_succeeds(shared_zone_test_context):
+def test_create_batch_delete_recordset_for_zone_admin_not_in_owner_group_succeeds(shared_zone_test_context):
     """
     Test delete change in batch for a record in a shared zone for a zone admin not belonging to the record owner group succeeds
     """
@@ -3822,19 +3822,56 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_update_fqdn, address="1.2.3.4"),
-            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
+            ## Updates
+            # Add + DeleteRRSet
+            get_change_A_AAAA_json(a_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_set_fqdn, address="4.5.6.7"),
 
-            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_update_fqdn, text="some-multi-text"),
-            get_change_TXT_json(txt_update_fqdn, text="more-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_set_fqdn, text="more-multi-text"),
 
-            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecordSet"),
-            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecordSet"),
+            # Add + DeleteRRSet (full delete)
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.1.1.2", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_full_fqdn, address="4.5.6.7"),
 
-            # adding an HVD so this will fail if accidentally run against wrong config
-            get_change_A_AAAA_json("high-value-domain")
+            get_change_TXT_json(txt_update_record_full_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="again", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_full_fqdn, text="more-multi-text"),
+
+            # Add + single DeleteRRSet with record data
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="1.2.3.4"),
+            get_change_A_AAAA_json(a_update_record_fqdn, address="4.5.6.7"),
+
+            get_change_TXT_json(txt_update_record_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_fqdn, text="some-multi-text"),
+            get_change_TXT_json(txt_update_record_fqdn, text="more-multi-text"),
+
+            # Single DeleteRRSet
+            get_change_A_AAAA_json(a_update_record_only_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_record_only_fqdn, text="hello", change_type="DeleteRecordSet"),
+
+            ## Full deletes
+            # DeleteRRSet (without record data)
+            get_change_A_AAAA_json(a_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_set_fqdn, change_type="DeleteRecordSet"),
+
+            # DeleteRRSet (with record data)
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_delete_record_fqdn, address="1.1.1.2", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_fqdn, text="again", change_type="DeleteRecordSet"),
+
+            # single DeleteRRSet (with record data) + DeleteRRSet (without record data)
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, address="1.1.1.1", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, text="hello", change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet")
         ]
     }
 
@@ -3844,7 +3881,82 @@ def test_create_batch_duplicates_update_check(shared_zone_test_context):
             create_rs = client.create_recordset(rs, status=202)
             to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
 
-        response = client.create_batch_change(batch_change_input, status=400)
+        result = client.create_batch_change(batch_change_input, status=202)
+        client.wait_until_batch_change_completed(result)
+
+        # Check batch change response
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=0, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=2, input_name=a_update_record_set_fqdn, record_name=a_update_record_set_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=3, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=4, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=5, input_name=txt_update_record_set_fqdn, record_name=txt_update_record_set_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=6, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=7, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.1.1.2", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=8, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=9, input_name=a_update_record_full_fqdn, record_name=a_update_record_full_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=10, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=11, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="again", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=12, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=13, input_name=txt_update_record_full_fqdn, record_name=txt_update_record_full_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=14, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=15, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="1.2.3.4")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=16, input_name=a_update_record_fqdn, record_name=a_update_record_name, record_data="4.5.6.7")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=17, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=18, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="some-multi-text")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=19, input_name=txt_update_record_fqdn, record_name=txt_update_record_name, record_type="TXT", record_data="more-multi-text")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=20, input_name=a_update_record_only_fqdn, record_name=a_update_record_only_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=21, input_name=txt_update_record_only_fqdn, record_name=txt_update_record_only_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=22, input_name=a_delete_record_set_fqdn, record_name=a_delete_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=23, input_name=txt_delete_record_set_fqdn, record_name=txt_delete_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=24, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=25, input_name=a_delete_record_fqdn, record_name=a_delete_record_name, record_data="1.1.1.2", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=26, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=27, input_name=txt_delete_record_fqdn, record_name=txt_delete_record_name, record_type="TXT", record_data="again", change_type="DeleteRecordSet")
+
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=28, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=29, input_name=a_delete_record_and_record_set_fqdn, record_name=a_delete_record_and_record_set_name, record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=30, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=31, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+
+        # Perform look up to verify record set data
+        for rs in to_delete:
+            rs_name = rs['recordSet']['name']
+            rs_id = rs['recordSet']['id']
+            zone_id = rs['zone']['id']
+
+            # deletes should not exist
+            if rs_name in [a_delete_record_set_name, txt_delete_record_set_name, a_delete_record_name,
+               txt_delete_record_name, a_delete_record_and_record_set_name, txt_delete_record_and_record_set_name]:
+                client.get_recordset(zone_id, rs_id, status=404)
+            else:
+                result_rs = client.get_recordset(zone_id, rs_id, status=200)
+                records = result_rs['recordSet']['records']
+
+                # full deletes with updates
+                if rs_name in [a_update_record_set_name, a_update_record_full_name]:
+                    assert_that(records, contains({"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"}, {"address": "1.1.1.2"})))
+                elif rs_name in [txt_update_record_set_name, txt_update_record_full_name]:
+                    assert_that(records, contains({"text": "some-multi-text"}, {"text": "more-multi-text"}))
+                    assert_that(records, is_not(contains({"text": "hello"}, {"text": "again"})))
+                # single entry delete with adds
+                elif rs_name == a_update_record_name:
+                    assert_that(records, contains({"address": "1.1.1.2"}, {"address": "1.2.3.4"}, {"address": "4.5.6.7"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
+                elif rs_name == txt_update_record_name:
+                    assert_that(records, contains({"text": "again"}, {"text": "some-multi-text"}, {"text": "more-multi-text"}))
+                    assert_that(records, is_not(contains({"text": "hello"})))
+                elif rs_name == a_update_record_only_name:
+                    assert_that(records, contains({"address": "1.1.1.2"}))
+                    assert_that(records, is_not(contains({"address": "1.1.1.1"})))
+                elif rs_name == txt_update_record_only_name:
+                    assert_that(records, contains({"text": "again"}))
+                    assert_that(records, is_not(contains({"text": "hello"})))
 
         def existing_err(name, type):
             return 'RecordSet with name {} and type {} cannot be updated in a single '.format(name, type) + \
@@ -3918,7 +4030,101 @@ def test_create_batch_delete_record_fails(shared_zone_test_context):
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
-            get_change_A_AAAA_json(rs_fqdn, change_type="DeleteRecord")
+            get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet")
+        ]
+    }
+
+    to_delete = []
+
+    create_rs = client.create_recordset(rs_to_create, status=202)
+    to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+    result = client.create_batch_change(batch_change_input, status=202)
+    client.wait_until_batch_change_completed(result)
+
+    client.get_recordset(create_rs['zone']['id'], create_rs['recordSet']['id'], status=404)
+
+
+@pytest.mark.serial
+def test_create_batch_delete_record_access_checks(shared_zone_test_context):
+    """
+    Test access for full-delete DeleteRecord (delete) and non-full-delete DeleteRecord (update)
+    """
+    ok_client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    dummy_client = shared_zone_test_context.dummy_vinyldns_client
+    dummy_group_id = shared_zone_test_context.dummy_group['id']
+
+    a_delete_acl = generate_acl_rule('Delete', groupId=dummy_group_id, recordMask='.*', recordTypes=['A'])
+    txt_write_acl = generate_acl_rule('Write', groupId=dummy_group_id, recordMask='.*', recordTypes=['TXT'])
+
+    a_update_name = generate_record_name()
+    a_update_fqdn = a_update_name + ".ok."
+    a_update = get_recordset_json(ok_zone, a_update_name, "A", [{"address": "1.1.1.1"}])
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(ok_zone, a_delete_name, "A", [{"address": "1.1.1.1"}])
+
+    txt_update_name = generate_record_name()
+    txt_update_fqdn = txt_update_name + ".ok."
+    txt_update = get_recordset_json(ok_zone, txt_update_name, "TXT", [{"text": "test"}])
+
+    txt_delete_name = generate_record_name()
+    txt_delete_fqdn = txt_delete_name + ".ok."
+    txt_delete = get_recordset_json(ok_zone, txt_delete_name, "TXT", [{"text": "test"}])
+
+    batch_change_input = {
+        "comments": "Testing DeleteRecord access levels",
+        "changes": [
+            get_change_A_AAAA_json(a_update_fqdn, change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_update_fqdn, address="4.5.6.7"),
+            get_change_A_AAAA_json(a_delete_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_fqdn, change_type="DeleteRecordSet"),
+            get_change_TXT_json(txt_update_fqdn, text="updated text"),
+            get_change_TXT_json(txt_delete_fqdn, change_type="DeleteRecordSet")
+        ]
+    }
+
+    to_delete = []
+    try:
+        add_ok_acl_rules(shared_zone_test_context, [a_delete_acl, txt_write_acl])
+
+        for create_json in [a_update, a_delete, txt_update, txt_delete]:
+            create_result = ok_client.create_recordset(create_json, status=202)
+            to_delete.append(ok_client.wait_until_recordset_change_status(create_result, 'Complete'))
+
+        response = dummy_client.create_batch_change(batch_change_input, status=400)
+
+        assert_successful_change_in_error_response(response[0], input_name=a_update_fqdn, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[1], input_name=a_update_fqdn, record_data="4.5.6.7")
+        assert_successful_change_in_error_response(response[2], input_name=a_delete_fqdn, record_data="1.1.1.1", change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[3], input_name=txt_update_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=txt_update_fqdn, record_type="TXT", record_data="updated text")
+        assert_failed_change_in_error_response(response[5], input_name=txt_delete_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecordSet",
+                                               error_messages=['User "dummy" is not authorized.'])
+
+    finally:
+        clear_ok_acl_rules(shared_zone_test_context)
+        clear_recordset_list(to_delete, ok_client)
+
+
+@pytest.mark.multi_record_disabled
+def test_create_batch_delete_record_for_invalid_record_data_fails(shared_zone_test_context):
+    """
+    Test delete record set fails for non-existent record and non-existent record data
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    a_delete_name = generate_record_name()
+    a_delete_fqdn = a_delete_name + ".ok."
+    a_delete = get_recordset_json(shared_zone_test_context.ok_zone, a_delete_fqdn, "A", [{"address": "1.1.1.1"}])
+
+    batch_change_input = {
+        "comments": "test delete record failures",
+        "changes": [
+            get_change_A_AAAA_json("delete-non-existent-record.ok.", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(a_delete_fqdn, address="4.5.6.7", change_type="DeleteRecordSet")
         ]
     }
 
@@ -3927,10 +4133,54 @@ def test_create_batch_delete_record_fails(shared_zone_test_context):
         create_rs = client.create_recordset(rs_to_create, status=202)
         client.wait_until_recordset_change_status(create_rs, 'Complete')
 
-        # TODO: Update this when DeleteRecord is supported
-        client.create_batch_change(batch_change_input, status=400)
+        errors = client.create_batch_change(batch_change_input, status=400)
+
+        assert_failed_change_in_error_response(errors[0], input_name="delete-non-existent-record.ok.", record_data="1.1.1.1", change_type="DeleteRecordSet",
+                                               error_messages=['Record "delete-non-existent-record.ok." Does Not Exist: cannot delete a record that does not exist.'])
+        assert_failed_change_in_error_response(errors[1], input_name=a_delete_fqdn, record_data="4.5.6.7", change_type="DeleteRecordSet",
+                                               error_messages=['Record data AData(4.5.6.7) does not exist for "' + a_delete_fqdn + '".'])
 
     finally:
-        if create_rs:
-            delete_rs = client.delete_recordset(ok_zone['id'], create_rs['recordSet']['id'], status=202)
-            client.wait_until_recordset_change_status(delete_rs, 'Complete')
+        clear_recordset_list(to_delete, client)
+
+
+@pytest.mark.multi_record_enabled
+def test_create_batch_delete_record_succeeds(shared_zone_test_context):
+    """
+    Test creating batch change with DeleteRecord change input type is recognized
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    ok_group = shared_zone_test_context.ok_group
+
+    rs_name = generate_record_name()
+    multi_rs_name = generate_record_name()
+    rs_fqdn = rs_name + ".ok."
+    multi_rs_fqdn = rs_name + ".ok."
+    rs_to_create = get_recordset_json(ok_zone, rs_name, "A", [{"address": "1.2.3.4"}], 200, ok_group['id'])
+    multi_record_rs_to_create = get_recordset_json(ok_zone, multi_rs_name, "A", [{"address": "1.2.3.4", "address": "1.1.1.1"}], 200, ok_group['id'])
+
+    batch_change_input = {
+        "comments": "this is optional",
+        "changes": [
+            get_change_A_AAAA_json(rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(multi_rs_fqdn, address="1.2.3.4", change_type="DeleteRecordSet")
+        ]
+    }
+
+    to_delete = []
+
+    try:
+        create_rs = client.create_recordset(rs_to_create, status=202)
+        create_multi_rs = client.create_recordset(multi_record_rs_to_create, status=202)
+        to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+        to_delete.append(client.wait_until_recordset_change_status(create_multi_rs, 'Complete'))
+
+        result = client.create_batch_change(batch_change_input, status=202)
+        client.wait_until_batch_change_completed(result)
+
+        client.get_recordset(create_rs['zone']['id'], create_rs['recordSet']['id'], status=404)
+        client.get_recordset(create_multi_rs['zone']['id'], create_multi_rs['recordSet']['id'], status=200)
+
+    finally:
+        clear_recordset_list(to_delete, client)

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -413,7 +413,7 @@ def clear_groups(client, exclude=[]):
             client.delete_group(group_id, status=200)
 
 
-def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address="1.1.1.1", change_type="Add"):
+def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address=None, change_type="Add"):
     if change_type == "Add":
         json = {
             "changeType": change_type,
@@ -421,77 +421,7 @@ def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address="1.1.1.
             "type": record_type,
             "ttl": ttl,
             "record": {
-                "address": address
-            }
-        }
-    else:
-        if change_type == "DeleteRecord":
-            json = {
-                "changeType": "DeleteRecord",
-                "inputName": input_name,
-                "type": record_type,
-                "record": {
-                    "address": address
-                }
-            }
-        else:
-            json = {
-                "changeType": "DeleteRecordSet",
-                "inputName": input_name,
-                "type": record_type
-            }
-    return json
-
-
-def get_change_CNAME_json(input_name, ttl=200, cname="test.com", change_type="Add"):
-    if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": input_name,
-            "type": "CNAME",
-            "ttl": ttl,
-            "record": {
-                "cname": cname
-            }
-        }
-    else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": "CNAME"
-        }
-    return json
-
-
-def get_change_PTR_json(ip, ttl=200, ptrdname="test.com", change_type="Add"):
-    if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": ip,
-            "type": "PTR",
-            "ttl": ttl,
-            "record": {
-                "ptrdname": ptrdname
-            }
-        }
-    else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": ip,
-            "type": "PTR"
-        }
-    return json
-
-
-def get_change_TXT_json(input_name, record_type="TXT", ttl=200, text="test", change_type="Add"):
-    if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": input_name,
-            "type": record_type,
-            "ttl": ttl,
-            "record": {
-                "text": text
+                "address": address or "1.1.1.1"
             }
         }
     else:
@@ -500,10 +430,86 @@ def get_change_TXT_json(input_name, record_type="TXT", ttl=200, text="test", cha
             "inputName": input_name,
             "type": record_type
         }
+        if address is not None:
+            json["record"] = {
+                "address": address
+            }
     return json
 
 
-def get_change_MX_json(input_name, ttl=200, preference=1, exchange="foo.bar.", change_type="Add"):
+def get_change_CNAME_json(input_name, ttl=200, cname=None, change_type="Add"):
+    if change_type == "Add":
+        json = {
+            "changeType": change_type,
+            "inputName": input_name,
+            "type": "CNAME",
+            "ttl": ttl,
+            "record": {
+                "cname": cname or "test.com"
+            }
+        }
+    else:
+        json = {
+            "changeType": "DeleteRecordSet",
+            "inputName": input_name,
+            "type": "CNAME"
+        }
+        if cname is not None:
+            json["record"] = {
+                "cname": cname
+            }
+    return json
+
+
+def get_change_PTR_json(ip, ttl=200, ptrdname=None, change_type="Add"):
+    if change_type == "Add":
+        json = {
+            "changeType": change_type,
+            "inputName": ip,
+            "type": "PTR",
+            "ttl": ttl,
+            "record": {
+                "ptrdname": ptrdname or "test.com"
+            }
+        }
+    else:
+        json = {
+            "changeType": "DeleteRecordSet",
+            "inputName": ip,
+            "type": "PTR"
+        }
+        if ptrdname is not None:
+            json["record"] = {
+                "ptrdname": ptrdname
+            }
+    return json
+
+
+def get_change_TXT_json(input_name, record_type="TXT", ttl=200, text=None, change_type="Add"):
+    if change_type == "Add":
+        json = {
+            "changeType": change_type,
+            "inputName": input_name,
+            "type": record_type,
+            "ttl": ttl,
+            "record": {
+                "text": text or "test"
+            }
+        }
+    else:
+        json = {
+            "changeType": "DeleteRecordSet",
+            "inputName": input_name,
+            "type": record_type
+        }
+        if text is not None:
+            json["record"] = {
+                "text": text
+            }
+    return json
+
+
+def get_change_MX_json(input_name, ttl=200, preference=None, exchange=None, change_type="Add"):
     if change_type == "Add":
         json = {
             "changeType": change_type,
@@ -512,15 +518,25 @@ def get_change_MX_json(input_name, ttl=200, preference=1, exchange="foo.bar.", c
             "ttl": ttl,
             "record": {
                 "preference": preference,
-                "exchange": exchange
+                "exchange": exchange or "foo.bar."
             }
         }
+        if preference is None:
+            json["record"]["preference"] = 1
     else:
         json = {
             "changeType": "DeleteRecordSet",
             "inputName": input_name,
-            "type": "MX"
+            "type": "MX",
         }
+        if preference is not None or exchange is not None:
+            json["record"] = {
+                "preference": preference,
+                "exchange": exchange or "foo.bar."
+            }
+            if preference is None:
+                json["record"]["preference"] = 1
+
     return json
 
 

--- a/modules/api/functional_test/utils.py
+++ b/modules/api/functional_test/utils.py
@@ -414,22 +414,18 @@ def clear_groups(client, exclude=[]):
 
 
 def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address=None, change_type="Add"):
+    json = {
+        "changeType": change_type,
+        "inputName": input_name,
+        "type": record_type,
+
+    }
     if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": input_name,
-            "type": record_type,
-            "ttl": ttl,
-            "record": {
-                "address": address or "1.1.1.1"
-            }
+        json["ttl"] = ttl
+        json["record"] = {
+            "address": address or "1.1.1.1"
         }
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": record_type
-        }
         if address is not None:
             json["record"] = {
                 "address": address
@@ -438,22 +434,18 @@ def get_change_A_AAAA_json(input_name, record_type="A", ttl=200, address=None, c
 
 
 def get_change_CNAME_json(input_name, ttl=200, cname=None, change_type="Add"):
+    json = {
+        "changeType": change_type,
+        "inputName": input_name,
+        "type": "CNAME",
+
+    }
     if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": input_name,
-            "type": "CNAME",
-            "ttl": ttl,
-            "record": {
-                "cname": cname or "test.com"
-            }
+        json["ttl"] = ttl
+        json["record"] = {
+            "cname": cname or "test.com"
         }
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": "CNAME"
-        }
         if cname is not None:
             json["record"] = {
                 "cname": cname
@@ -462,22 +454,17 @@ def get_change_CNAME_json(input_name, ttl=200, cname=None, change_type="Add"):
 
 
 def get_change_PTR_json(ip, ttl=200, ptrdname=None, change_type="Add"):
+    json = {
+        "changeType": change_type,
+        "inputName": ip,
+        "type": "PTR"
+    }
     if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": ip,
-            "type": "PTR",
-            "ttl": ttl,
-            "record": {
-                "ptrdname": ptrdname or "test.com"
-            }
+        json["ttl"] = ttl
+        json["record"] = {
+            "ptrdname": ptrdname or "test.com"
         }
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": ip,
-            "type": "PTR"
-        }
         if ptrdname is not None:
             json["record"] = {
                 "ptrdname": ptrdname
@@ -486,22 +473,18 @@ def get_change_PTR_json(ip, ttl=200, ptrdname=None, change_type="Add"):
 
 
 def get_change_TXT_json(input_name, record_type="TXT", ttl=200, text=None, change_type="Add"):
+    json = {
+        "changeType": change_type,
+        "inputName": input_name,
+        "type": "TXT",
+
+    }
     if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": input_name,
-            "type": record_type,
-            "ttl": ttl,
-            "record": {
-                "text": text or "test"
-            }
+        json["ttl"] = ttl
+        json["record"] = {
+            "text": text or "test"
         }
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": record_type
-        }
         if text is not None:
             json["record"] = {
                 "text": text
@@ -510,25 +493,21 @@ def get_change_TXT_json(input_name, record_type="TXT", ttl=200, text=None, chang
 
 
 def get_change_MX_json(input_name, ttl=200, preference=None, exchange=None, change_type="Add"):
+    json = {
+        "changeType": change_type,
+        "inputName": input_name,
+        "type": "MX",
+
+    }
     if change_type == "Add":
-        json = {
-            "changeType": change_type,
-            "inputName": input_name,
-            "type": "MX",
-            "ttl": ttl,
-            "record": {
-                "preference": preference,
-                "exchange": exchange or "foo.bar."
-            }
+        json["ttl"] = ttl
+        json["record"] = {
+            "preference": preference,
+            "exchange": exchange or "foo.bar."
         }
         if preference is None:
             json["record"]["preference"] = 1
     else:
-        json = {
-            "changeType": "DeleteRecordSet",
-            "inputName": input_name,
-            "type": "MX",
-        }
         if preference is not None or exchange is not None:
             json["record"] = {
                 "preference": preference,

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -152,6 +152,8 @@ vinyldns {
     }
   ]
 
+  multi-record-batch-change-enabled = true
+
   # feature flag for manual batch review
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -131,7 +131,7 @@ object VinylDNSConfig {
   lazy val maxZoneSize: Int = vinyldnsConfig.as[Option[Int]]("max-zone-size").getOrElse(60000)
   lazy val defaultTtl: Long = vinyldnsConfig.as[Option[Long]](s"default-ttl").getOrElse(7200L)
   lazy val multiRecordBatchUpdateEnabled: Boolean =
-    vinyldnsConfig.as[Option[Boolean]]("enable-multi-record-batch-update").getOrElse(false)
+    vinyldnsConfig.as[Option[Boolean]]("multi-record-batch-change-enabled").getOrElse(false)
   lazy val manualBatchReviewEnabled: Boolean = vinyldnsConfig
     .as[Option[Boolean]]("manual-batch-review-enabled")
     .getOrElse(false)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeProtocol.scala
@@ -115,7 +115,7 @@ object DeleteRRSetChangeInput {
   def apply(
       inputName: String,
       typ: RecordType,
-      record: Option[RecordData]): DeleteRRSetChangeInput = {
+      record: Option[RecordData] = None): DeleteRRSetChangeInput = {
     val transformName = typ match {
       case PTR => inputName
       case _ => ensureTrailingDot(inputName)

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -268,7 +268,6 @@ class BatchChangeService(
           .getOrElse(add)
           .validNel
       case del: DeleteRRSetChangeForValidation => del.validNel
-      case del: DeleteRecordChangeForValidation => del.validNel
     }
 
   def getOwnerGroup(ownerGroupId: Option[String]): BatchResult[Option[Group]] = {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -175,7 +175,7 @@ class BatchChangeValidations(
       isApproved: Boolean): ValidatedBatch[ChangeInput] =
     input.map {
       case a: AddChangeInput => validateAddChangeInput(a, isApproved).map(_ => a)
-      case d: DeleteRRSetChangeInput => validateInputName(d, isApproved).map(_ => d)
+      case d: DeleteRRSetChangeInput => validateDeleteRRSetChangeInput(d, isApproved).map(_ => d)
     }
 
   def validateAddChangeInput(
@@ -186,6 +186,18 @@ class BatchChangeValidations(
     val validInput = validateInputName(addChangeInput, isApproved)
 
     validTTL |+| validRecord |+| validInput
+  }
+
+  def validateDeleteRRSetChangeInput(
+      deleteRRSetChangeInput: DeleteRRSetChangeInput,
+      isApproved: Boolean): SingleValidation[Unit] = {
+    val validRecord = deleteRRSetChangeInput.record match {
+      case Some(recordData) => validateRecordData(recordData)
+      case None => ().validNel
+    }
+    val validInput = validateInputName(deleteRRSetChangeInput, isApproved)
+
+    validRecord |+| validInput
   }
 
   def validateRecordData(record: RecordData): SingleValidation[Unit] =

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -23,7 +23,7 @@ import vinyldns.core.domain.batch.{
   BatchChangeApprovalStatus,
   SingleAddChange,
   SingleChange,
-  SingleDeleteRRSetChange,
+  SingleDeleteRRSetChange
 }
 import vinyldns.core.domain.membership.UserRepository
 import vinyldns.core.domain.membership.User

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -24,7 +24,6 @@ import vinyldns.core.domain.batch.{
   SingleAddChange,
   SingleChange,
   SingleDeleteRRSetChange,
-  SingleDeleteRecordChange
 }
 import vinyldns.core.domain.membership.UserRepository
 import vinyldns.core.domain.membership.User
@@ -143,10 +142,7 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
       s"""<tr><td>${index + 1}</td><td>Add</td><td>$typ</td><td>$inputName</td>
         |     <td>$ttl</td><td>${formatRecordData(recordData)}</td><td>$status</td>
         |     <td>${systemMessage.getOrElse("")}</td></tr>"""
-    case SingleDeleteRRSetChange(_, _, _, inputName, typ, status, systemMessage, _, _, _, _) =>
-      s"""<tr><td>${index + 1}</td><td>Delete</td><td>$typ</td><td>$inputName</td>
-        |     <td></td><td></td><td>$status</td><td>${systemMessage.getOrElse("")}</td></tr>"""
-    case SingleDeleteRecordChange(
+    case SingleDeleteRRSetChange(
         _,
         _,
         _,
@@ -159,8 +155,9 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
         _,
         _,
         _) =>
+      val recordDataValue = recordData.map(_.toString).getOrElse("")
       s"""<tr><td>${index + 1}</td><td>Delete</td><td>$typ</td><td>$inputName</td>
-         |     <td></td><td>$recordData</td><td>$status</td><td>${systemMessage
+        |     <td></td><td>$recordDataValue</td><td>$status</td><td>${systemMessage
         .getOrElse("")}</td></tr>"""
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -64,6 +64,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
       Some(name),
       fqdn,
       typ,
+      None,
       SingleChangeStatus.Pending,
       None,
       None,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -116,6 +116,7 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
         Some("testRname"),
         "testRname.testZoneName.",
         A,
+        None,
         SingleChangeStatus.NeedsReview,
         Some("msg"),
         None,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -1608,6 +1608,7 @@ class BatchChangeServiceSpec
         None,
         "some.test.delete.",
         TXT,
+        None,
         SingleChangeStatus.NeedsReview,
         None,
         None,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1764,6 +1764,24 @@ class BatchChangeValidationsSpec
     result should haveInvalid[DomainValidationError](InvalidDomainName("foo$.bar."))
   }
 
+  property(
+    "validateDeleteChangeInput: should succeed for valid data when no record data is passed in") {
+    val input = DeleteRRSetChangeInput("a.ok.", RecordType.A, None)
+    validateDeleteRRSetChangeInput(input, false) shouldBe valid
+  }
+
+  property("validateDeleteChangeInput: should succeed for valid data when record data is passed in") {
+    val input = DeleteRRSetChangeInput("a.ok.", RecordType.A, Some(AData("1.1.1.1")))
+    validateDeleteRRSetChangeInput(input, false) shouldBe valid
+  }
+
+  property("validateDeleteChangeInput: should fail when invalid record data is passed in") {
+    val invalidIp = "invalid IP address"
+    val input = DeleteRRSetChangeInput("a.ok.", RecordType.A, Some(AData(invalidIp)))
+    val result = validateDeleteRRSetChangeInput(input, false)
+    result should haveInvalid[DomainValidationError](InvalidIpv4Address(invalidIp))
+  }
+
   property("validateChangesWithContext: should fail if MX record in batch already exists") {
     val existingMX = rsOk.copy(
       zoneId = okZone.id,

--- a/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
@@ -183,6 +183,7 @@ class EmailNotifierSpec
           Some(""),
           "deleteme.test.com",
           RecordType.A,
+          None,
           SingleChangeStatus.Failed,
           Some("message for you"),
           None,
@@ -222,9 +223,6 @@ class EmailNotifierSpec
             row.contains(ac.ttl.toString) should be(true)
           case _: SingleDeleteRRSetChange =>
             row.contains("Delete") should be(true)
-          case dc: SingleDeleteRecordChange =>
-            row.contains("Delete") should be(true)
-            row.contains(dc.recordData) should be(true)
         }
       }
 

--- a/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
@@ -41,7 +41,7 @@ import scala.collection.JavaConverters._
 import vinyldns.core.notifier.NotifierConfig
 
 object MockTransport extends MockitoSugar {
-  val mockTransport = mock[Transport]
+  val mockTransport: Transport = mock[Transport]
 }
 
 class MockTransport(session: Session, urlname: URLName) extends Transport(session, urlname) {
@@ -64,8 +64,8 @@ class EmailNotifierSpec
 
   import MockTransport._
 
-  val mockUserRepository = mock[UserRepository]
-  val session = Session.getInstance(new Properties())
+  val mockUserRepository: UserRepository = mock[UserRepository]
+  val session: Session = Session.getInstance(new Properties())
   session.setProvider(
     new Provider(
       Provider.Type.TRANSPORT,
@@ -194,13 +194,13 @@ class EmailNotifierSpec
 
       notifier.notify(Notification(change)).unsafeRunSync()
 
-      val message = messageArgument.getValue()
+      val message = messageArgument.getValue
 
-      message.getFrom() should be(Array(fromAddress))
-      message.getContentType() should be("text/html; charset=us-ascii")
-      message.getAllRecipients() should be(expectedAddresses)
-      message.getSubject() should be("VinylDNS Batch change testBatch results")
-      val content = message.getContent().asInstanceOf[String]
+      message.getFrom should be(Array(fromAddress))
+      message.getContentType should be("text/html; charset=us-ascii")
+      message.getAllRecipients should be(expectedAddresses)
+      message.getSubject should be("VinylDNS Batch change testBatch results")
+      val content = message.getContent.asInstanceOf[String]
 
       content.contains(change.id) should be(true)
       content.contains(description) should be(true)
@@ -221,8 +221,13 @@ class EmailNotifierSpec
               case _ => row.contains(ac.recordData) should be(true)
             }
             row.contains(ac.ttl.toString) should be(true)
-          case _: SingleDeleteRRSetChange =>
+          case dc: SingleDeleteRRSetChange =>
             row.contains("Delete") should be(true)
+            dc.recordData match {
+              case Some(AData(address)) => row.contains(address) should be(true)
+              case Some(recordData) => row.contains(recordData) should be(true)
+              case None => row.contains(dc.recordData) should be(false)
+            }
         }
       }
 

--- a/modules/api/src/test/scala/vinyldns/api/notifier/sns/SnsNotifierSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/notifier/sns/SnsNotifierSpec.scala
@@ -118,6 +118,7 @@ class SnsNotifierSpec
           Some(""),
           "deleteme.test.com",
           RecordType.A,
+          None,
           SingleChangeStatus.Failed,
           Some("message for you"),
           None,
@@ -128,15 +129,14 @@ class SnsNotifierSpec
 
       notifier.notify(Notification(change)).unsafeRunSync()
 
-      val request = requestArgument.getValue()
+      val request = requestArgument.getValue
 
-      request.getTopicArn() should be("batches")
-      val userNameAttribute = request.getMessageAttributes().get("userName")
-      userNameAttribute.getDataType() should be("String")
-      userNameAttribute.getStringValue() should be("testUser")
+      request.getTopicArn should be("batches")
+      val userNameAttribute = request.getMessageAttributes.get("userName")
+      userNameAttribute.getDataType should be("String")
+      userNameAttribute.getStringValue should be("testUser")
 
-      request
-        .getMessage() should be(
+      request.getMessage should be(
         """{"userId":"test","userName":"testUser","comments":"notes",""" +
           """"createdTimestamp":"2019-07-22T17:01:19Z","status":"PartialFailure","approvalStatus":"AutoApproved",""" +
           """"id":"testBatch"}""")

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -324,7 +324,7 @@ class BatchChangeJsonProtocolSpec
   }
 
   "Serializing SingleDeleteRRSetChange to JSON" should {
-    "successfully serialize" in {
+    "successfully serialize when record data is not provided" in {
       val toJson = SingleDeleteRRSetChange(
         Some("zoneId"),
         Some("zoneName"),
@@ -347,6 +347,38 @@ class BatchChangeJsonProtocolSpec
         ("inputName" -> "fqdn") ~
         ("type" -> decompose(A)) ~
         ("record" -> decompose(None)) ~
+        ("status" -> decompose(Pending)) ~
+        ("systemMessage" -> "systemMessage") ~
+        ("recordChangeId" -> decompose(None)) ~
+        ("recordSetId" -> decompose(None)) ~
+        ("validationErrors" -> decompose(List(SingleChangeError(barDiscoveryError)))) ~
+        ("id" -> "id") ~
+        ("changeType" -> "DeleteRecordSet")
+    }
+
+    "successfully serialize when record data is provided" in {
+      val toJson = SingleDeleteRRSetChange(
+        Some("zoneId"),
+        Some("zoneName"),
+        Some("recordName"),
+        "fqdn",
+        A,
+        Some(AData("1.2.3.4")),
+        Pending,
+        Some("systemMessage"),
+        None,
+        None,
+        List(SingleChangeError(barDiscoveryError)),
+        id = "id"
+      )
+      val result = SingleDeleteRRSetChangeSerializer.toJson(toJson)
+
+      result shouldBe ("zoneId" -> "zoneId") ~
+        ("zoneName" -> "zoneName") ~
+        ("recordName" -> "recordName") ~
+        ("inputName" -> "fqdn") ~
+        ("type" -> decompose(A)) ~
+        ("record" -> decompose(Some(AData("1.2.3.4")))) ~
         ("status" -> decompose(Pending)) ~
         ("systemMessage" -> "systemMessage") ~
         ("recordChangeId" -> decompose(None)) ~

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -96,6 +96,7 @@ class BatchChangeRoutingSpec()
             Some("recordName"),
             "fqdn",
             A,
+            None,
             Pending,
             Some("systemMessage"),
             None,
@@ -182,6 +183,7 @@ class BatchChangeRoutingSpec()
       None,
       "fqdn.two",
       A,
+      None,
       Pending,
       Some("systemMessage"),
       None,
@@ -193,6 +195,7 @@ class BatchChangeRoutingSpec()
       None,
       "fqdn.two",
       A,
+      None,
       Pending,
       Some("systemMessage"),
       None,
@@ -694,8 +697,7 @@ class BatchChangeRoutingSpec()
         resp.startFrom shouldBe None
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
-        resp.approvalStatus.toString() shouldBe Some(BatchChangeApprovalStatus.PendingReview)
-          .toString()
+        resp.approvalStatus.toString shouldBe Some(BatchChangeApprovalStatus.PendingReview).toString
       }
     }
   }

--- a/modules/core/src/main/protobuf/VinylDNSProto.proto
+++ b/modules/core/src/main/protobuf/VinylDNSProto.proto
@@ -180,8 +180,8 @@ message SingleAddChange {
   required RecordData recordData = 2;
 }
 
-message SingleDeleteRecordChange {
-  required RecordData recordData = 1;
+message SingleDeleteRecordSetChange {
+  optional RecordData recordData = 1;
 }
 
 message SingleChangeData {

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -186,7 +186,7 @@ final case class UnsupportedOperation(operation: String) extends DomainValidatio
 
 final case class DeleteRecordDataDoesNotExist(inputName: String, recordData: RecordData)
     extends DomainValidationError {
-  def message: String = s"Record data $recordData does not exist for $inputName."
+  def message: String = s"""Record data $recordData does not exist for "$inputName"."""
 }
 
 // $COVERAGE-ON$

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/BatchChangeProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/BatchChangeProtobufConversions.scala
@@ -24,26 +24,19 @@ import vinyldns.core.domain.batch.{
   SingleChangeStatus,
   SingleDeleteRRSetChange
 }
-import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordType
-import vinyldns.core.protobuf.SingleChangeType.{
-  SingleAddType,
-  SingleChangeType,
-  SingleDeleteRecordType,
-  SingleDeleteType
-}
+import vinyldns.core.protobuf.SingleChangeType.{SingleAddType, SingleChangeType, SingleDeleteType}
 import vinyldns.proto.VinylDNSProto
 
 import scala.collection.JavaConverters._
 
 object SingleChangeType extends Enumeration {
   type SingleChangeType = Value
-  val SingleAddType, SingleDeleteType, SingleDeleteRecordType = Value
+  val SingleAddType, SingleDeleteType = Value
 
   def from(singleChange: SingleChange): SingleChangeType = singleChange match {
     case _: SingleAddChange => SingleChangeType.SingleAddType
     case _: SingleDeleteRRSetChange => SingleChangeType.SingleDeleteType
-    case _: SingleDeleteRecordChange => SingleChangeType.SingleDeleteRecordType
   }
 }
 
@@ -75,25 +68,15 @@ trait BatchChangeProtobufConversions extends ProtobufConversions {
             change.getId
           )
         case SingleDeleteType =>
-          SingleDeleteRRSetChange(
-            if (change.hasZoneId) Some(change.getZoneId) else None,
-            if (change.hasZoneName) Some(change.getZoneName) else None,
-            if (change.hasRecordName) Some(change.getRecordName) else None,
-            change.getInputName,
-            RecordType.withName(change.getRecordType),
-            SingleChangeStatus.withName(change.getStatus),
-            if (change.hasSystemMessage) Some(change.getSystemMessage) else None,
-            if (change.hasRecordChangeId) Some(change.getRecordChangeId) else None,
-            if (change.hasRecordSetId) Some(change.getRecordSetId) else None,
-            errors,
-            change.getId
-          )
-        case SingleDeleteRecordType =>
           val changeData =
-            VinylDNSProto.SingleDeleteRecordChange.parseFrom(change.getChangeData.getData)
+            VinylDNSProto.SingleDeleteRecordSetChange.parseFrom(change.getChangeData.getData)
+
           val recordData =
-            fromPB(changeData.getRecordData, RecordType.withName(change.getRecordType))
-          SingleDeleteRecordChange(
+            if (changeData.hasRecordData)
+              Some(fromPB(changeData.getRecordData, RecordType.withName(change.getRecordType)))
+            else None
+
+          SingleDeleteRRSetChange(
             if (change.hasZoneId) Some(change.getZoneId) else None,
             if (change.hasZoneName) Some(change.getZoneName) else None,
             if (change.hasRecordName) Some(change.getRecordName) else None,
@@ -146,25 +129,18 @@ trait BatchChangeProtobufConversions extends ProtobufConversions {
 
   def toPB(change: SingleDeleteRRSetChange): Either[Throwable, VinylDNSProto.SingleChange] =
     Either.catchNonFatal {
-      val sc = VinylDNSProto.SingleChange
-        .newBuilder()
-        .setChangeType(SingleDeleteType.toString)
-
-      addCommonSingleChangeFields(sc, change)
-      sc.build()
-    }
-
-  def toPB(change: SingleDeleteRecordChange): Either[Throwable, VinylDNSProto.SingleChange] =
-    Either.catchNonFatal {
-      val rd = toRecordData(change.recordData)
-      val sdrc =
-        VinylDNSProto.SingleDeleteRecordChange.newBuilder().setRecordData(rd).build()
-      val scd = VinylDNSProto.SingleChangeData.newBuilder().setData(sdrc.toByteString)
+      val rd = change.recordData.map(toRecordData)
+      val sdd = {
+        val builder = VinylDNSProto.SingleDeleteRecordSetChange.newBuilder()
+        rd.map(builder.setRecordData)
+        builder.build()
+      }
+      val scd = VinylDNSProto.SingleChangeData.newBuilder().setData(sdd.toByteString)
 
       val sc = VinylDNSProto.SingleChange
         .newBuilder()
         .setChangeData(scd)
-        .setChangeType(SingleDeleteRecordType.toString)
+        .setChangeType(SingleDeleteType.toString)
 
       addCommonSingleChangeFields(sc, change)
       sc.build()
@@ -200,6 +176,5 @@ trait BatchChangeProtobufConversions extends ProtobufConversions {
     change match {
       case sac: SingleAddChange => toPB(sac)
       case sdc: SingleDeleteRRSetChange => toPB(sdc)
-      case sdrc: SingleDeleteRecordChange => toPB(sdrc)
     }
 }

--- a/modules/core/src/test/scala/vinyldns/core/protobuf/BatchChangeProtobufConversionsSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/protobuf/BatchChangeProtobufConversionsSpec.scala
@@ -19,12 +19,7 @@ package vinyldns.core.protobuf
 import cats.scalatest.EitherMatchers
 import org.scalatest.{EitherValues, Matchers, WordSpec}
 import vinyldns.core.domain.{HighValueDomainError, SingleChangeError, ZoneDiscoveryError}
-import vinyldns.core.domain.batch.{
-  SingleAddChange,
-  SingleChangeStatus,
-  SingleDeleteRRSetChange,
-  SingleDeleteRecordChange
-}
+import vinyldns.core.domain.batch.{SingleAddChange, SingleChangeStatus, SingleDeleteRRSetChange}
 import vinyldns.core.domain.record.{AData, RecordType}
 
 class BatchChangeProtobufConversionsSpec
@@ -51,12 +46,13 @@ class BatchChangeProtobufConversionsSpec
     List(testDVError),
     "id"
   )
-  private val testDeleteRRSetChange = SingleDeleteRRSetChange(
+  private val testDeleteRRSetChangeWithoutRecordData = SingleDeleteRRSetChange(
     Some("zoneId"),
     Some("zoneName"),
     Some("recordName"),
     "inputName",
     RecordType.A,
+    None,
     SingleChangeStatus.Pending,
     Some("systemMessage"),
     Some("recordChangeId"),
@@ -64,13 +60,13 @@ class BatchChangeProtobufConversionsSpec
     List(testDVError, SingleChangeError(HighValueDomainError("hvd"))),
     "id"
   )
-  private val testDeleteRecordChange = SingleDeleteRecordChange(
+  private val testDeleteRRSetChangeWithRecordData = SingleDeleteRRSetChange(
     Some("zoneId"),
     Some("zoneName"),
     Some("recordName"),
     "inputName",
     RecordType.A,
-    AData("1.1.1.1"),
+    Some(AData("1.1.1.1")),
     SingleChangeStatus.Pending,
     Some("systemMessage"),
     Some("recordChangeId"),
@@ -88,13 +84,13 @@ class BatchChangeProtobufConversionsSpec
     }
 
     "round trip single delete changes with all values provided" in {
-      val rrSetPb = toPB(testDeleteRRSetChange)
-      val recordPb = toPB(testDeleteRecordChange)
-      val rrSetRoundTrip = fromPB(rrSetPb.toOption.get)
-      val recordRoundTrip = fromPB(recordPb.toOption.get)
+      val rrSetWithoutDataPb = toPB(testDeleteRRSetChangeWithoutRecordData)
+      val rrSetWithDataPb = toPB(testDeleteRRSetChangeWithRecordData)
+      val rrSetWithoutDataRoundTrip = fromPB(rrSetWithoutDataPb.toOption.get)
+      val rrSetWithDataRoundTrip = fromPB(rrSetWithDataPb.toOption.get)
 
-      rrSetRoundTrip shouldBe Right(testDeleteRRSetChange)
-      recordRoundTrip shouldBe Right(testDeleteRecordChange)
+      rrSetWithoutDataRoundTrip shouldBe Right(testDeleteRRSetChangeWithoutRecordData)
+      rrSetWithDataRoundTrip shouldBe Right(testDeleteRRSetChangeWithRecordData)
     }
 
     "round trip single add changes when optional values are not present" in {
@@ -127,6 +123,7 @@ class BatchChangeProtobufConversionsSpec
         None,
         "testInputName",
         RecordType.A,
+        None,
         SingleChangeStatus.Pending,
         None,
         None,
@@ -148,6 +145,7 @@ class BatchChangeProtobufConversionsSpec
         None,
         "testInputName",
         RecordType.A,
+        None,
         SingleChangeStatus.NeedsReview,
         None,
         None,
@@ -169,6 +167,7 @@ class BatchChangeProtobufConversionsSpec
         None,
         "testInputName",
         RecordType.A,
+        None,
         SingleChangeStatus.Rejected,
         None,
         None,

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -69,6 +69,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
         Some("delete"),
         "delete.somezone.com.",
         A,
+        None,
         Pending,
         None,
         None,
@@ -213,8 +214,6 @@ class MySqlBatchChangeRepositoryIntegrationSpec
         case sad: SingleAddChange =>
           sad.copy(recordName = sad.recordName.map(name => s"updated-$name"))
         case sdc: SingleDeleteRRSetChange =>
-          sdc.copy(recordName = sdc.recordName.map(name => s"updated-$name"))
-        case sdc: SingleDeleteRecordChange =>
           sdc.copy(recordName = sdc.recordName.map(name => s"updated-$name"))
       }
       val updatedBatch = batchChange.copy(


### PR DESCRIPTION
Prototype for multi-record enabled.

Changes in this PR:
- Allow optional `record` data with `DeleteRecordSet` requests (controlled by configuration value of `multi-record-batch-change-enabled`)
- Update unit tests

Outstanding issues:
- Update functional tests (with testing behavior dependent on multi-record enabled)