### PR TITLE
Restore SQL migration

### DIFF
--- a/modules/mysql/src/main/resources/db/migration/V3.20__SingleChangeExpandSingleChangeType.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.20__SingleChangeExpandSingleChangeType.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+ALTER TABLE single_change MODIFY change_type VARCHAR(25) NOT NULL;


### PR DESCRIPTION
When multi-record support was initially reverted (https://github.com/vinyldns/vinyldns/pull/854), it included a SQL migration that was also migrated. Restoring that now.