### PR TITLE
[ci skip] Temp fix for docker up until release

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -18,4 +18,4 @@ USER_CHANGE_TABLE_NAME=userChange
 TEST_LOGIN=true
 
 # api and portal docker tag
-VINYLDNS_VERSION=latest
+VINYLDNS_VERSION=0.9.4-SNAPSHOT

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -30,6 +30,7 @@ services:
     environment:
       - SERVICES=dynamodb:19000,sns:19006,sqs:19007
       - START_WEB=0
+      - HOSTNAME_EXTERNAL=vinyldns-localstack
 
   ldap:
     image: rroemhild/test-openldap


### PR DESCRIPTION
There is an issue with the current docker-up script that does not work with `latest` but does work with snapshot.  Changes here are necessary to get docker-up script working again.
