### PR TITLE
add license badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Travis build](https://api.travis-ci.org/vinyldns/vinyldns.svg?branch=master)](https://travis-ci.org/vinyldns/vinyldns)
 [![CodeCov ](https://codecov.io/gh/vinyldns/vinyldns/branch/master/graph/badge.svg)](https://codecov.io/gh/vinyldns/vinyldns)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2682/badge)](https://bestpractices.coreinfrastructure.org/projects/2682)
+![License](https://img.shields.io/github/license/vinyldns/vinyldns)
 
 <p align="left">
   <a href="http://www.vinyldns.io/">


### PR DESCRIPTION
Changes in this pull request:
-Added license-badge to Readme

Screen Shot from Atom Markdown Preview:
![image](https://user-images.githubusercontent.com/56047579/67018599-77c4f500-f0c9-11e9-825c-dd9b6bd24a58.png)

