### PR TITLE
update DeleteRRSetChangeInputSerializer toJson method

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeJsonProtocol.scala
@@ -118,7 +118,8 @@ trait BatchChangeJsonProtocol extends JsonValidation {
     override def toJson(drsci: DeleteRRSetChangeInput): JValue =
       ("changeType" -> Extraction.decompose(DeleteRecordSet)) ~
         ("inputName" -> drsci.inputName) ~
-        ("type" -> Extraction.decompose(drsci.typ))
+        ("type" -> Extraction.decompose(drsci.typ)) ~
+        ("record" -> Extraction.decompose(drsci.record))
   }
 
   // recordName, zoneName, zoneId used to be required; getOrElse to maintain backwards compatibility with clients

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -209,6 +209,16 @@ class BatchChangeJsonProtocolSpec
     }
   }
 
+  "serializing ChangeInputSerializer to JSON" should {
+    "successfully serialize valid data for delete" in {
+      val deleteChangeInput = DeleteRRSetChangeInput("foo.", A, Some(AData("1.1.1.1")))
+      val json: JObject = buildDeleteRRSetInputJson(Some("foo."), Some(A), Some(AData("1.1.1.1")))
+      val result = ChangeInputSerializer.toJson(deleteChangeInput)
+
+      result shouldBe json
+    }
+  }
+
   "De-serializing BatchChangeInput from JSON" should {
     "successfully serialize valid add change data with comment and without owner group ID" in {
       val result = BatchChangeInputSerializer.fromJson(addBatchChangeInputWithComment).value


### PR DESCRIPTION
Changes in this pull request:
- add record data to the DeleteRRSetChangeInputSerializer `toJson` method so record data is returned in responses if it was included in requests.
