### PR TITLE
Allow overriding parallelism for func tests

### DIFF
--- a/bin/func-test-api-travis.sh
+++ b/bin/func-test-api-travis.sh
@@ -35,8 +35,9 @@ cp -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar $WORK_DIR/docker/api
 echo "Starting docker environment and running func tests..."
 
 if [ -z "${PAR_CPU}" ]; then
-  PAR_CPU=2
+  export PAR_CPU=2
 fi
+
 docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker up --build --exit-code-from functest
 test_result=$?
 

--- a/bin/func-test-api-travis.sh
+++ b/bin/func-test-api-travis.sh
@@ -33,6 +33,10 @@ fi
 cp -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar $WORK_DIR/docker/api
 
 echo "Starting docker environment and running func tests..."
+
+if [ -z "${PAR_CPU}" ]; then
+  PAR_CPU=2
+fi
 docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker up --build --exit-code-from functest
 test_result=$?
 

--- a/bin/func-test-api.sh
+++ b/bin/func-test-api.sh
@@ -33,6 +33,12 @@ fi
 cp -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar $WORK_DIR/docker/api
 
 echo "Starting docker environment and running func tests..."
+
+# If PAR_CPU is unset; default to auto
+if [ -z "${PAR_CPU}" ]; then
+  PAR_CPU=auto
+fi
+
 docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker --log-level ERROR up --build --exit-code-from functest
 test_result=$?
 

--- a/bin/func-test-api.sh
+++ b/bin/func-test-api.sh
@@ -36,7 +36,7 @@ echo "Starting docker environment and running func tests..."
 
 # If PAR_CPU is unset; default to auto
 if [ -z "${PAR_CPU}" ]; then
-  PAR_CPU=auto
+  export PAR_CPU=auto
 fi
 
 docker-compose -f $WORK_DIR/docker/docker-compose-func-test.yml --project-directory $WORK_DIR/docker --log-level ERROR up --build --exit-code-from functest

--- a/docker/docker-compose-func-test.yml
+++ b/docker/docker-compose-func-test.yml
@@ -67,6 +67,8 @@ services:
       context: functest
     env_file:
       .env
+    environment:
+      - PAR_CPU=${PAR_CPU}
     container_name: "vinyldns-functest"
     depends_on:
       - api

--- a/docker/functest/Dockerfile
+++ b/docker/functest/Dockerfile
@@ -16,5 +16,8 @@ ADD functional_test /app
 # Install our func test requirements
 RUN pip install --index-url https://pypi.python.org/simple/ -r /app/requirements.txt
 
+# Specifies how many CPUs to use for func tests; the more the better or specifiy "auto" for optimal results
+ENV PAR_CPU=2
+
 # set the entry point for the container to start vinyl, specify the config resource
 ENTRYPOINT ["/app/run.sh"]

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -15,10 +15,6 @@ else
   TEST_PATTERN="-k ${TEST_PATTERN}"
 fi
 
-if [ -z "${PAR_CPU}" ]; then
-  PAR_CPU=2
-fi
-
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=60

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -15,6 +15,10 @@ else
   TEST_PATTERN="-k ${TEST_PATTERN}"
 fi
 
+if [ -z "${PAR_CPU}" ]; then
+  export PAR_CPU=2
+fi
+
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=60

--- a/docker/functest/run.sh
+++ b/docker/functest/run.sh
@@ -15,6 +15,10 @@ else
   TEST_PATTERN="-k ${TEST_PATTERN}"
 fi
 
+if [ -z "${PAR_CPU}" ]; then
+  PAR_CPU=2
+fi
+
 echo "Waiting for API to be ready at ${VINYLDNS_URL} ..."
 DATA=""
 RETRY=60
@@ -52,8 +56,8 @@ result=0
 if [ "${PROD_ENV}" = "true" ]; then
     # -m plays havoc with -k, using variables is a headache, so doing this by hand
     # run parallel tests first (not serial)
-    echo "./run-tests.py live_tests -n2 -v -m \"not skip_production and not serial and not multi_record_enabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
-    ./run-tests.py live_tests -n2 -v -m "not skip_production and not serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
+    echo "./run-tests.py live_tests -n${PAR_CPU} -v -m \"not skip_production and not serial and not multi_record_enabled\" -v --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
+    ./run-tests.py live_tests -n${PAR_CPU} -v -m "not skip_production and not serial and not multi_record_enabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
     result=$?
     if [ $result -eq 0 ]; then
       # run serial tests second (serial marker)
@@ -63,8 +67,8 @@ if [ "${PROD_ENV}" = "true" ]; then
     fi
 else
     # run parallel tests first (not serial)
-    echo "./run-tests.py live_tests -n2 -v -m \"not serial and not multi_record_disabled\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
-    ./run-tests.py live_tests -n2 -v -m "not serial and not multi_record_disabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
+    echo "./run-tests.py live_tests -n${PAR_CPU} -v -m \"not serial and not multi_record_disabled\" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False"
+    ./run-tests.py live_tests -n${PAR_CPU} -v -m "not serial and not multi_record_disabled" --url=${VINYLDNS_URL} --dns-ip=${DNS_IP} ${TEST_PATTERN} --teardown=False
     result=$?
     if [ $result -eq 0 ]; then
       # run serial tests second (serial marker)


### PR DESCRIPTION
Allow overriding of the number of CPUs to use for running func tests.  Leaving this as an override as `auto` is not always optimal and will depend on the machine performing the func tests.