### PR TITLE
Use a separate environment configuration for running locally.

### DIFF
--- a/docker/.env.build
+++ b/docker/.env.build
@@ -1,0 +1,21 @@
+REST_PORT=9000
+# Do not use quotes around the environment variables.
+MYSQL_ROOT_PASSWORD=pass
+# This is required as mysql is currently locked down to localhost
+MYSQL_ROOT_HOST=%
+# Host URL for queue
+QUEUE_HOST=vinyldns-elasticmq
+
+# portal settings
+PORTAL_PORT=9001
+PLAY_HTTP_SECRET_KEY=change-this-for-prod
+VINYLDNS_BACKEND_URL=http://vinyldns-api:9000
+SQS_ENDPOINT=http://vinyldns-localstack:19007
+DYNAMODB_ENDPOINT=http://vinyldns-localstack:19000
+MYSQL_ENDPOINT=vinyldns-mysql:3306
+USER_TABLE_NAME=users
+USER_CHANGE_TABLE_NAME=userChange
+TEST_LOGIN=true
+
+# api and portal docker tag
+VINYLDNS_VERSION=0.9.4-SNAPSHOT

--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -3,7 +3,7 @@ services:
   mysql:
     image: "mysql:5.7"
     env_file:
-      .env
+      .env.build
     container_name: "vinyldns-mysql"
     ports:
       - "19002:3306"
@@ -11,7 +11,7 @@ services:
   bind9:
     image: "vinyldns/bind9:0.0.4"
     env_file:
-      .env
+      .env.build
     container_name: "vinyldns-bind9"
     ports:
       - "19001:53/udp"
@@ -41,7 +41,7 @@ services:
   api:
     image: "vinyldns/api:${VINYLDNS_VERSION}"
     env_file:
-      .env
+      .env.build
     container_name: "vinyldns-api"
     ports:
       - "${REST_PORT}:${REST_PORT}"
@@ -55,7 +55,7 @@ services:
   portal:
     image: "vinyldns/portal:${VINYLDNS_VERSION}"
     env_file:
-      .env
+      .env.build
     ports:
       - "${PORTAL_PORT}:${PORTAL_PORT}"
     container_name: "vinyldns-portal"


### PR DESCRIPTION
Right now, the `.env` configuration file is shared between
multiple `docker-compose` configurations. However, these
configurations actually need different environments; for example,
`docker-compose-build.yml` runs a local DynamoDB via `localstack`,
whereas `docker-compose-func-test.yml` runs it via `dynamodb-local`.
(Incidentally, this leads to the [quickstart](https://github.com/vinyldns/vinyldns/blob/master/README.md#quickstart) not working properly, as
documented in #887).

This changes creates a separate `.env.build` file for use by the
`docker-compose-build.yml` and updates it to point to the correct
location of the local DynamoDB.

Fixes #887.

Changes in this pull request:
- create new environment variable file for running locally
