### PR TITLE
Update Release

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,6 +26,8 @@ the [vinyldns organization](https://hub.docker.com/u/vinyldns/dashboard/). Namel
 * vinyldns/api: images for vinyldns core api engine 
 * vinyldns/portal: images for vinyldns web client
 * vinyldns/bind9: images for local DNS server used for testing 
+* vinyldns/test-bind9: contains the setup to run functional tests 
+* vinyldns/test: has the actual functional tests pinned to a version of VinylDNS 
 
 The offline root key and repository keys are managed by the core maintainer team. The keys managed are:
 
@@ -33,6 +35,8 @@ The offline root key and repository keys are managed by the core maintainer team
 * api key: used to sign tagged images in vinyldns/api
 * portal key: used to sign tagged images in vinyldns/portal
 * bind9 key: used to sign tagged images in the vinyldns/bind9
+* test-bind9 key: used to sign tagged images in the vinyldns/test-bind9
+* test key: used to sign tagged images in the vinyldns/test
 
 These keys are named in a <hash>.key format, e.g. 5526ecd15bd413e08718e66c440d17a28968d5cd2922b59a17510da802ca6572.key,
 do not change the names of the keys. 
@@ -156,11 +160,11 @@ running the release
 1. Follow [Docker Content Trust](#docker-content-trust) to setup a notary delegation for yourself
 1. Follow [Sonatype Credentials](#sonatype-credentials) to setup the sonatype pgp signing key on your local
 1. Make sure you're logged in to Docker with `docker login`
-1. Export `DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE` in your env with your notary key passphrase 
 1. Run `bin/release.sh` _Note: the arg "skip-tests" will skip unit, integration and functional testing before a release_
 1. You will be asked to confirm the version which originally comes from `version.sbt`. _NOTE: if the version ends with 
 `SNAPSHOT`, then the docker latest tag won't be applied and the core module will only be published to the sonatype
-staging repo._
+staging repo.
 1. When it comes to the sonatype stage, you will need the passphrase handy for the signing key, [Sonatype Credentials](#sonatype-credentials)
 1. Assuming things were successful, make a pr since sbt release auto-bumped `version.sbt` and made a commit for you
-
+1. Run `./build/docker-release.sh --branch [TAG CREATED FROM PREVIOUS STEP, e.g. v0.9.3] --clean --push`
+1. You will need to have your keys ready so you can sign each image as it is published.

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,49 +1,6 @@
 #!/usr/bin/env bash
 
-function usage() {
-  printf "usage: release.sh [OPTIONS]\n\n"
-  printf "builds and releases vinyldns artifacts\n\n"
-  printf "options:\n"
-  printf "\t-b, --bump [BUMP]: what to bump: major | minor | patch; default is patch\n"
-}
-
-BUMP="patch"
-while [ "$1" != "" ]; do
-  case "$1" in
-  -b | --bump)
-    BUMP="$2"
-    shift 2
-    ;;
-  *)
-    usage
-    exit
-    ;;
-  esac
-done
-
-if [[ "$BUMP" == "major" ]]; then
-  BUMP="sbtrelease.Version.Bump.Major"
-elif [[ "$BUMP" == "minor" ]]; then
-  BUMP="sbtrelease.Version.Bump.Minor"
-else
-  BUMP="sbtrelease.Version.Bump.Bugfix"
-fi
-
 printf "\nnote: follow the guides in MAINTAINERS.md to setup notary delegation (Docker) and get sonatype key (Maven) \n"
-
-# If we are not in the main repository then fail fast
-REMOTE_REPO=$(git config --get remote.origin.url)
-#echo "REMOTE REPO IS $REMOTE_REPO"
-#if [[ "$REMOTE_REPO" != *-vinyldns/vinyldns.git ]]; then
-#  printf "\nCannot run a release from this repository as it is not the main repository: $REMOTE_REPO \n"
-#  exit 1
-#fi
-
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-#if [[ "$BRANCH" != "master" ]]; then
-#  printf "\nCannot run a release from this branch: $BRANCH is not master \n"
-#  exit 1;
-#fi
 
 DIR=$( cd $(dirname $0) ; pwd -P )
 
@@ -51,49 +8,58 @@ DIR=$( cd $(dirname $0) ; pwd -P )
 export GPG_TTY=$(tty)
 
 ##
-# Checking for uncommitted changes
-##
-#printf "\nchecking for uncommitted changes... \n"
-#if ! (cd "$DIR" && git add . && git diff-index --quiet HEAD --)
-#then
-#    printf "\nerror: attempting to release with uncommitted changes\n"
-#    exit 1
-#fi
-
-##
 # running tests
 ##
-#printf "\nrunning api func tests... \n"
-#"$DIR"/remove-vinyl-containers.sh
-#if ! "$DIR"/func-test-api.sh
-#then
-#    printf "\nerror: bin/func-test-api.sh failed \n"
-#    exit 1
-#fi
-#"$DIR"/remove-vinyl-containers.sh
-#
-#printf "\nrunning portal func tests... \n"
-#if ! "$DIR"/func-test-portal.sh
-#then
-#    printf "\nerror: bin/func-test-portal.sh failed \n"
-#    exit 1
-#fi
-#
-#printf "\nrunning verify... \n"
-#if ! "$DIR"/verify.sh
-#then
-#    printf "\nerror: bin/verify.sh failed \n"
-#    exit 1
-#fi
+if [ "$1" != "skip-tests" ]; then
+  # Checking for uncommitted changes
+  printf "\nchecking for uncommitted changes... \n"
+  if ! (cd "$DIR" && git add . && git diff-index --quiet HEAD --)
+  then
+      printf "\nerror: attempting to release with uncommitted changes\n"
+      exit 1
+  fi
+  # If we are not in the main repository then fail fast
+  REMOTE_REPO=$(git config --get remote.origin.url)
+  echo "REMOTE REPO IS $REMOTE_REPO"
+  if [[ "$REMOTE_REPO" != *-vinyldns/vinyldns.git ]]; then
+    printf "\nCannot run a release from this repository as it is not the main repository: $REMOTE_REPO \n"
+    exit 1
+  fi
+
+  # If we are not on the master branch,then fail fast
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$BRANCH" != "master" ]]; then
+    printf "\nCannot run a release from this branch: $BRANCH is not master \n"
+    exit 1;
+  fi
+
+  printf "\nrunning api func tests... \n"
+  "$DIR"/remove-vinyl-containers.sh
+  if ! "$DIR"/func-test-api.sh
+  then
+      printf "\nerror: bin/func-test-api.sh failed \n"
+      exit 1
+  fi
+  "$DIR"/remove-vinyl-containers.sh
+
+  printf "\nrunning portal func tests... \n"
+  if ! "$DIR"/func-test-portal.sh
+  then
+      printf "\nerror: bin/func-test-portal.sh failed \n"
+      exit 1
+  fi
+
+  printf "\nrunning verify... \n"
+  if ! "$DIR"/verify.sh
+  then
+      printf "\nerror: bin/verify.sh failed \n"
+      exit 1
+  fi
+fi
 
 ##
 # run release
 ##
-# Calculate the version to be released
-VERSION=$(sbt "set releaseVersionBump := $BUMP" "showNextVersion")
-printf "VERSION TO BE RELEASED IS $VERSION"
-
-printf "\nrunning sbt release bumping $BUMP... \n"
-#cd "$DIR"/../ && sbt "set releaseVersionBump := sbtrelease.Version.Bump.Major" "release with-defaults"
+cd "$DIR"/../ && sbt release && cd $DIR
 
 printf "\nrelease finished \n"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -53,12 +53,12 @@ export GPG_TTY=$(tty)
 ##
 # Checking for uncommitted changes
 ##
-printf "\nchecking for uncommitted changes... \n"
-if ! (cd "$DIR" && git add . && git diff-index --quiet HEAD --)
-then
-    printf "\nerror: attempting to release with uncommitted changes\n"
-    exit 1
-fi
+#printf "\nchecking for uncommitted changes... \n"
+#if ! (cd "$DIR" && git add . && git diff-index --quiet HEAD --)
+#then
+#    printf "\nerror: attempting to release with uncommitted changes\n"
+#    exit 1
+#fi
 
 ##
 # running tests
@@ -89,14 +89,11 @@ fi
 ##
 # run release
 ##
-# First, run the docker image release as those need to be out before running SBT as SBT bumps version
-V=$(find $CURDIR/target -name "version.sbt" | head -n1 | xargs grep "[ \\t]*version in ThisBuild :=" | head -n1 | sed 's/.*"\(.*\)".*/\1/')
-VERSION="$V"
-if [[ "$V" == *-SNAPSHOT ]]; then
-  VERSION="${V%?????????}"
-fi
+# Calculate the version to be released
+VERSION=$(sbt "set releaseVersionBump := $BUMP" "showNextVersion")
+printf "VERSION TO BE RELEASED IS $VERSION"
 
 printf "\nrunning sbt release bumping $BUMP... \n"
-cd "$DIR"/../ && sbt "set releaseVersionBump := sbtrelease.Version.Bump.Major" "release with-defaults"
+#cd "$DIR"/../ && sbt "set releaseVersionBump := sbtrelease.Version.Bump.Major" "release with-defaults"
 
 printf "\nrelease finished \n"

--- a/build.sbt
+++ b/build.sbt
@@ -452,39 +452,13 @@ lazy val setSonatypeReleaseSettings = ReleaseStep(action = oldState => {
   }
 })
 
-lazy val createSetDockerUpdateLatestCommand = ReleaseStep(action = state => {
-  // dockerUpdateLatest is set to true if the version is not a SNAPSHOT
-  val snap = Project.extract(state).get(Keys.version).endsWith("SNAPSHOT")
-
-  val setDockerUpdateLatest = if (!snap)
-    Command.command("setDockerUpdateLatest") {
-      "set every dockerUpdateLatest := true" ::
-      _
-    }
-  else
-    Command.command("setDockerUpdateLatest") {
-      "" ::
-      _
-    }
-
-  state.copy(definedCommands = state.definedCommands :+ setDockerUpdateLatest)
-})
-
 lazy val sonatypePublishStage = Seq[ReleaseStep](
   releaseStepCommandAndRemaining(";sonatypeReleaseCommand")
 )
 
-lazy val dockerPublishStage = Seq[ReleaseStep](
-  releaseStepCommandAndRemaining(";project api;docker:publish"),
-  releaseStepCommandAndRemaining(";project portal;docker:publish")
-)
-
-
 lazy val initReleaseStage = Seq[ReleaseStep](
   inquireVersions, // have a developer confirm versions
   setReleaseVersion,
-  createSetDockerUpdateLatestCommand,
-  releaseStepCommandAndRemaining(";setDockerUpdateLatest"),
   setSonatypeReleaseSettings
 )
 
@@ -497,7 +471,6 @@ lazy val finalReleaseStage = Seq[ReleaseStep] (
 
 releaseProcess :=
   initReleaseStage ++
-  dockerPublishStage ++
   sonatypePublishStage ++
   finalReleaseStage
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ import scoverage.ScoverageKeys.{coverageFailOnMinimum, coverageMinimum}
 import org.scalafmt.sbt.ScalafmtPlugin._
 import microsites._
 import ReleaseTransformations._
+import sbtrelease.Version
 
 resolvers ++= additionalResolvers
 
@@ -241,6 +242,11 @@ lazy val root = (project in file(".")).enablePlugins(DockerComposePlugin, Automa
       import scala.sys.process._
       "./bin/remove-vinyl-containers.sh" !
     },
+    showNextVersion := {
+      val x = Version(version.value).map(_.bump(releaseVersionBump.value).withoutQualifier.string).getOrElse("Cannot calculate next version")
+      val y = Version(version.value).map(_.withoutQualifier.string).getOrElse("Cannot calculate next version")
+      println(s"NEXT VERSION = $y; BUMP = $x")
+    }
   )
   .aggregate(core, api, portal, dynamodb, mysql, sqs)
 
@@ -341,6 +347,7 @@ lazy val sqs = (project in file("modules/sqs"))
 val preparePortal = TaskKey[Unit]("preparePortal", "Runs NPM to prepare portal for start")
 val checkJsHeaders = TaskKey[Unit]("checkJsHeaders", "Runs script to check for APL 2.0 license headers")
 val createJsHeaders = TaskKey[Unit]("createJsHeaders", "Runs script to prepend APL 2.0 license headers to files")
+val showNextVersion = TaskKey[Unit]("showNextVersion", "Show the next version calculated based on current release settings")
 
 lazy val portal = (project in file("modules/portal")).enablePlugins(PlayScala, AutomateHeaderPlugin)
   .settings(sharedSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -242,16 +242,6 @@ lazy val root = (project in file(".")).enablePlugins(DockerComposePlugin, Automa
       import scala.sys.process._
       "./bin/remove-vinyl-containers.sh" !
     },
-    showNextVersion := {
-      if (releaseVersionBump.value == sbtrelease.Version.Bump.Bugfix) {
-        val nextV = Version(version.value).map(_.withoutQualifier.string).getOrElse("Cannot calculate next version")
-        println(s"NEXT VERSION=$nextV")
-      } else {
-        // We are set to bump to a Minor or Major, so we need to actually bump
-        val bumpV = Version(version.value).map(_.bump(releaseVersionBump.value).withoutQualifier.string).getOrElse("Cannot calculate next version")
-        println(s"NEXT VERSION=$bumpV")
-      }
-    }
   )
   .aggregate(core, api, portal, dynamodb, mysql, sqs)
 
@@ -352,7 +342,6 @@ lazy val sqs = (project in file("modules/sqs"))
 val preparePortal = TaskKey[Unit]("preparePortal", "Runs NPM to prepare portal for start")
 val checkJsHeaders = TaskKey[Unit]("checkJsHeaders", "Runs script to check for APL 2.0 license headers")
 val createJsHeaders = TaskKey[Unit]("createJsHeaders", "Runs script to prepend APL 2.0 license headers to files")
-val showNextVersion = TaskKey[Unit]("showNextVersion", "Show the next version calculated based on current release settings")
 
 lazy val portal = (project in file("modules/portal")).enablePlugins(PlayScala, AutomateHeaderPlugin)
   .settings(sharedSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -243,9 +243,14 @@ lazy val root = (project in file(".")).enablePlugins(DockerComposePlugin, Automa
       "./bin/remove-vinyl-containers.sh" !
     },
     showNextVersion := {
-      val x = Version(version.value).map(_.bump(releaseVersionBump.value).withoutQualifier.string).getOrElse("Cannot calculate next version")
-      val y = Version(version.value).map(_.withoutQualifier.string).getOrElse("Cannot calculate next version")
-      println(s"NEXT VERSION = $y; BUMP = $x")
+      if (releaseVersionBump.value == sbtrelease.Version.Bump.Bugfix) {
+        val nextV = Version(version.value).map(_.withoutQualifier.string).getOrElse("Cannot calculate next version")
+        println(s"NEXT VERSION=$nextV")
+      } else {
+        // We are set to bump to a Minor or Major, so we need to actually bump
+        val bumpV = Version(version.value).map(_.bump(releaseVersionBump.value).withoutQualifier.string).getOrElse("Cannot calculate next version")
+        println(s"NEXT VERSION=$bumpV")
+      }
     }
   )
   .aggregate(core, api, portal, dynamodb, mysql, sqs)

--- a/build/README.md
+++ b/build/README.md
@@ -42,6 +42,7 @@ is `docker.io`
 - `-r | --repository [REPOSITORY]` - a URL to your docker registry, defaults to `docker.io`
 - `-t | --tag [TAG]` - a build qualifer for this build.  For example, pass in the build number for your 
 continuous integration tool
+- `-v | --version [VERSION]` - overrides the version calculation and forces the version passed in.  Used primarily for official releases
 
 ## Docker Images
 

--- a/build/README.md
+++ b/build/README.md
@@ -8,7 +8,7 @@ This folder contains scripts and everything you need to build and test VinylDNS 
 
 ## Local Build and Test
 
-1. `./release.sh --clean`
+1. `./docker-release.sh --clean`
 1. Open up `version.sbt` in the root to know the directory (or capture in the script output)
 1. Once complete, run a test `./start.sh --version 0.9.4-SNAPSHOT` (replace 0.9.4 with the value in version.sbt).
 1. Login to the portal at http://localhost:9001 to verify everything looks good
@@ -20,7 +20,7 @@ This folder contains scripts and everything you need to build and test VinylDNS 
 Whether you sign or not is up to your organization.  You need to have notary setup to be able to sign properly.
 1. Be sure to login to your docker registry, typically done by `docker login` in the terminal you will release from.
 1. The actual version number is pulled from the local `version.sbt` based on the branch specified (defaults to master)
-1. Run `./release.sh --push --clean --tag [your tag here] --branch [your branch here]`
+1. Run `./docker-release.sh --push --clean --tag [your tag here] --branch [your branch here]`
     1. typically the `tag` is a build number that you maintain, for example a build number in Jenkins.  Using this field is recommended.  This value will be appended to the generated version as `-b[TAG]`; for example `0.9.4-b123` if using `123` for the tag.
     1. the `branch` defaults to `master` if not specified, you can choose any branch or tag from https://github.com/vinyldns/vinyldns
 1. The version generated will be whatever the version is in the `version.sbt` on the `branch` specified (defaults to master)
@@ -30,7 +30,7 @@ Whether you sign or not is up to your organization.  You need to have notary set
 
 ### Release Script
 Does a clean build off of remote master and tags it with 
-`./release.sh --clean --push --tag 123`
+`./docker-release.sh --clean --push --tag 123`
 
 The release script is used for doing a release.  It takes the following parameters:
 

--- a/build/docker-release.sh
+++ b/build/docker-release.sh
@@ -3,7 +3,7 @@
 CURDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function usage() {
-  printf "usage: release.sh [OPTIONS]\n\n"
+  printf "usage: docker-release.sh [OPTIONS]\n\n"
   printf "builds and releases vinyldns artifacts\n\n"
   printf "options:\n"
   printf "\t-b, --branch: the branch of tag to use for the build; default is master\n"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -40,3 +40,4 @@ addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
+addSbtPlugin("org.scala-sbt" % "sbt-autoversion" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -39,5 +39,3 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
-
-addSbtPlugin("org.scala-sbt" % "sbt-autoversion" % "1.0.0")


### PR DESCRIPTION
Updated release process:

- `bin/release.sh` - added checks so we can only release from master, and can only release from upstream
- `build.sbt` - removed sbt publishing of docker images, we will now use `build/docker-release.sh` for that release
- `build/release.sh` -- renamed --> `build/docker-release.sh`
- `build/docker-release.sh` - added a version override to make it simple to force a version
