### PR TITLE
set help text for DNS Change form input name and record data

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -85,12 +85,16 @@
                                     <th class="col-md-2">Change Type</th>
                                     <th>Record Type</th>
                                     <th>Input Name
-                                        <span data-toggle="tooltip" data-placement="top" title="Fully qualified domain name or IP address, depending on the record type.">
+                                        <span data-toggle="tooltip" data-placement="top" title="The name of the record set. Fully qualified domain name or IP address, depending on the record type.">
                                             <span class="fa fa-question-circle"></span>
                                         </span>
                                     </th>
                                     <th class="col-md-1">TTL (optional)</th>
-                                    <th>Record Data</th>
+                                    <th>Record Data
+                                        <span data-toggle="tooltip" data-placement="top" title="Where the record should point.">
+                                            <span class="fa fa-question-circle"></span>
+                                        </span>
+                                    </th>
                                     <th></th>
                                 </tr>
                                 </thead>


### PR DESCRIPTION
Fixes #879.

Changes in this pull request:

- Update the Input Name help text and add Record Data help text in the DNS Change form. 
  - Input Name help text: The name of the record set. Fully qualified domain name or IP address, depending on the record type.
  - Record data help text: Where the record should point.

![Screen Shot 2019-10-29 at 11 05 58 AM](https://user-images.githubusercontent.com/4439228/67780852-0d9f3f00-fa3d-11e9-9032-62bed3f8d204.png)

![Screen Shot 2019-10-29 at 11 14 10 AM](https://user-images.githubusercontent.com/4439228/67781022-450deb80-fa3d-11e9-8863-0facf474e1b2.png)

