### PR TITLE
Fix - Adding access logging

### DIFF
--- a/docker/api/logback.xml
+++ b/docker/api/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <!-- Test configuration, log to console so we can get the docker logs -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d [test] %-5p | \(%logger{4}:%line\) | %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/docker/docker-compose-quick-start.yml
+++ b/docker/docker-compose-quick-start.yml
@@ -46,7 +46,8 @@ services:
     ports:
       - "${REST_PORT}:${REST_PORT}"
     volumes:
-      - ./api/docker.conf:/opt/docker/conf/application.conf      
+      - ./api/docker.conf:/opt/docker/conf/application.conf
+      - ./api/logback.xml:/opt/docker/conf/logback.xml
     depends_on:
       - mysql
       - bind9

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
@@ -180,6 +180,6 @@ class VinylDNSService(
   val vinyldnsRoutes: Route =
     logRequestResult(VinylDNSService.buildLogEntry(unloggedUris))(allRoutes)
   val routes: Route =
-    handleRejections(validationRejectionHandler)(allRoutes)
+    handleRejections(validationRejectionHandler)(vinyldnsRoutes)
 }
 // $COVERAGE-ON$


### PR DESCRIPTION
Seems like we had a PR that took away access logs.

- `VinylDNSService.scala` - make sure to use the correct routes with logging, before we were not using the logged routes
- `logback.xml` - added this as an example so others can follow on more overrides for logging

