### PR TITLE
DNS Change detail notices

### DIFF
--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import actions.SecuritySupport
 import javax.inject.{Inject, Singleton}
-import models.{CustomLinks, Meta}
+import models.{CustomLinks, DnsChangeNotices, Meta}
 import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.mvc._
@@ -87,10 +87,11 @@ class FrontendController @Inject() (
   def viewBatchChange(batchId: String): Action[AnyContent] = userAction.async { implicit request =>
     logger.info(s"View Batch Change for $batchId")
     val canReview = request.user.isSuper || request.user.isSupport
+    val dnsChangeNotices = configuration.get[DnsChangeNotices]("dnsChangeNotices")
     Future(
       Ok(
         views.html.dnsChanges
-          .dnsChangeDetail(request.user.userName, canReview)
+          .dnsChangeDetail(request.user.userName, canReview, dnsChangeNotices)
       )
     )
   }

--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -87,7 +87,7 @@ class FrontendController @Inject() (
   def viewBatchChange(batchId: String): Action[AnyContent] = userAction.async { implicit request =>
     logger.info(s"View Batch Change for $batchId")
     val canReview = request.user.isSuper || request.user.isSupport
-    val dnsChangeNotices = configuration.get[DnsChangeNotices]("dnsChangeNotices")
+    val dnsChangeNotices = configuration.get[DnsChangeNotices]("dns-change-notices")
     Future(
       Ok(
         views.html.dnsChanges

--- a/modules/portal/app/models/DnsChangeNotices.scala
+++ b/modules/portal/app/models/DnsChangeNotices.scala
@@ -55,12 +55,12 @@ case class DnsChangeNotice(
     alertType: DnsChangeNoticeType,
     text: String,
     hrefText: String,
-    href: String)
+    href: String
+)
 
 object DnsChangeStatus extends Enumeration {
   type DnsChangeStatus = Value
-  val Cancelled, Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected,
-  Scheduled = Value
+  val Cancelled, Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected, Scheduled = Value
 }
 
 object DnsChangeNoticeType extends Enumeration {

--- a/modules/portal/app/models/DnsChangeNotices.scala
+++ b/modules/portal/app/models/DnsChangeNotices.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import com.typesafe.config.Config
+import models.DnsChangeNoticeType.DnsChangeNoticeType
+import models.DnsChangeStatus.DnsChangeStatus
+import play.api.libs.json.{JsValue, Json}
+import play.api.{ConfigLoader}
+
+import scala.collection.JavaConverters._
+
+case class DnsChangeNotices(notices: JsValue)
+
+object DnsChangeNotices {
+  implicit val configLoader: ConfigLoader[DnsChangeNotices] =
+    new ConfigLoader[DnsChangeNotices] {
+      def load(config: Config, path: String): DnsChangeNotices = {
+        val notices = config.getConfigList(path).asScala.map { noticeConfig =>
+          formatDnsChangeNotice(noticeConfig)
+        }
+        DnsChangeNotices(noticesToJson(notices.toList))
+      }
+    }
+
+  def noticesToJson(notices: List[DnsChangeNotice]): JsValue =
+    Json.toJson(
+      notices.map { n =>
+        Map(
+          "status" -> n.status.toString,
+          "alertType" -> n.alertType.toString,
+          "text" -> n.text,
+          "href" -> n.href.getOrElse(""),
+          "hrefText" -> n.hrefText.getOrElse("")
+        )
+      }
+    )
+
+  def formatDnsChangeNotice(config: Config): DnsChangeNotice = {
+    val status = DnsChangeStatus.find(config.getString("status"))
+    val alertType = DnsChangeNoticeType.find(config.getString("alertType"))
+    val text = config.getString("text")
+    if (config.hasPath("hrefText") && config.hasPath("href")) {
+      DnsChangeNotice(
+        status,
+        alertType,
+        text,
+        Some(config.getString("hrefText")),
+        Some(config.getString("href")))
+    } else {
+      DnsChangeNotice(status, alertType, text, None, None)
+    }
+  }
+}
+case class DnsChangeNotice(
+    status: DnsChangeStatus,
+    alertType: DnsChangeNoticeType,
+    text: String,
+    hrefText: Option[String],
+    href: Option[String])
+
+object DnsChangeStatus extends Enumeration {
+  type DnsChangeStatus = Value
+  val Cancelled, Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected,
+  Scheduled, Unknown = Value
+
+  private val valueMap = DnsChangeStatus.values.map(v => v.toString -> v).toMap
+
+  def find(status: String): DnsChangeStatus = valueMap.getOrElse(status, Unknown)
+}
+
+object DnsChangeNoticeType extends Enumeration {
+  type DnsChangeNoticeType = Value
+  val info, success, warning, danger = Value
+
+  private val valueMap = DnsChangeNoticeType.values.map(v => v.toString -> v).toMap
+
+  def find(status: String): DnsChangeNoticeType = valueMap.getOrElse(status, info)
+}

--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -36,6 +36,14 @@
                 <notification ng-model="alert"></notification>
             </div>
         </div>
+        @for(link <- customLinks.links) {
+            @if(link.displayOnSidebar) {
+
+            }
+        }
+        <div ng-if="batch.status == 'Complete'" class="alert alert-info" role="alert">Your changes are fully implemented. Keep in mind it may take a few hours for the changes to fully propogate out. <a href="http://docs.vinyldns.comcast.net/getting-started/faq/#how-long-changes-vinyldns">See the docs for more information.</a></div>
+        <div ng-if="batch.approvalStatus == 'PendingReview' && !batch.scheduledTime" class="alert alert-info" role="alert">Your DNS Change requires further review. It will be approved and processed or rejected within 24 hours.</div>
+        <div ng-if="batch.status == 'Scheduled'" class="alert alert-info" role="alert">If there are any changes in your scheduled DNS Change with a status of Needs Review they will be addressed prior to the scheduled date and time.</div>
         <div class="row">
             <div class="col-md-12">
                 <p><strong>ID:</strong> {{batch.id}}</p>

--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -1,8 +1,8 @@
-@(rootAccountName: String, rootAccountCanReview: Boolean)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
+@(rootAccountName: String, rootAccountCanReview: Boolean, dnsChangeNotices: DnsChangeNotices)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
 
 @content = {
 <!-- PAGE CONTENT -->
-<div class="right_col" role="main">
+<div class="right_col" role="main" ng-init="notices = @dnsChangeNotices.notices;">
 
     <!-- BREADCRUMB -->
     <ul class="breadcrumb">
@@ -36,14 +36,9 @@
                 <notification ng-model="alert"></notification>
             </div>
         </div>
-        @for(link <- customLinks.links) {
-            @if(link.displayOnSidebar) {
 
-            }
-        }
-        <div ng-if="batch.status == 'Complete'" class="alert alert-info" role="alert">Your changes are fully implemented. Keep in mind it may take a few hours for the changes to fully propogate out. <a href="http://docs.vinyldns.comcast.net/getting-started/faq/#how-long-changes-vinyldns">See the docs for more information.</a></div>
-        <div ng-if="batch.approvalStatus == 'PendingReview' && !batch.scheduledTime" class="alert alert-info" role="alert">Your DNS Change requires further review. It will be approved and processed or rejected within 24 hours.</div>
-        <div ng-if="batch.status == 'Scheduled'" class="alert alert-info" role="alert">If there are any changes in your scheduled DNS Change with a status of Needs Review they will be addressed prior to the scheduled date and time.</div>
+        <notice ng-model="notice" ng-if="notice"></notice>
+
         <div class="row">
             <div class="col-md-12">
                 <p><strong>ID:</strong> {{batch.id}}</p>

--- a/modules/portal/app/views/main.scala.html
+++ b/modules/portal/app/views/main.scala.html
@@ -169,6 +169,7 @@
             <script src="/public/lib/directives/directives.modals.modal.js"></script>
             <script src="/public/lib/directives/directives.modals.record.js"></script>
             <script src="/public/lib/directives/directives.modals.zoneconnection.js"></script>
+            <script src="/public/lib/directives/directives.notices.js"></script>
             <script src="/public/lib/directives/directives.notifications.js"></script>
             <script src="/public/lib/directives/directives.validations.js"></script>
             <script src="/public/lib/directives/directives.validations.zones.js"></script>

--- a/modules/portal/conf/reference.conf
+++ b/modules/portal/conf/reference.conf
@@ -151,6 +151,26 @@ links = [
   }
 ]
 
+dnsChangeNotices = [
+  {
+    status = "Complete"
+    alertType = "info"
+    text = "Your changes are fully implemented. Keep in mind it may take a few hours for the changes to fully propogate out."
+  }
+  {
+    status = "PendingReview"
+    alertType = "info"
+    text = "Your DNS Change requires further review. It will be approved and processed following the review."
+    hrefText = "See the docs for more information."
+    href = "https://www.vinyldns.io/portal/manual-review-scheduling"
+  }
+  {
+    status = "Scheduled"
+    alertType = "info"
+    text = "If there are any changes in your scheduled DNS Change with a status of Needs Review they will be addressed prior to the scheduled date and time."
+  }
+]
+
 play.modules.enabled += "modules.VinylDNSModule"
 
 # base version this image is built on

--- a/modules/portal/conf/reference.conf
+++ b/modules/portal/conf/reference.conf
@@ -151,19 +151,19 @@ links = [
   }
 ]
 
-dnsChangeNotices = [
+dns-change-notices = [
   {
     status = "Complete"
     alertType = "info"
     text = "Your changes are fully implemented. Keep in mind it may take a few hours for the changes to fully propogate out."
-  }
+  },
   {
     status = "PendingReview"
     alertType = "info"
     text = "Your DNS Change requires further review. It will be approved and processed following the review."
     hrefText = "See the docs for more information."
     href = "https://www.vinyldns.io/portal/manual-review-scheduling"
-  }
+  },
   {
     status = "Scheduled"
     alertType = "info"

--- a/modules/portal/public/css/theme-overrides.css
+++ b/modules/portal/public/css/theme-overrides.css
@@ -167,8 +167,15 @@ ul.bar_tabs>li a {
   border: 1px solid #adadad!important;
 }
 
-.alert-info {
-    color: #31708f!important;
-    background-color: #d9edf7!important;
-    border-color: #bce8f1!important;
+.alert-danger a, .alert-warning a, .alert-info a, .alert-success a {
+    font-weight: 600;
+    text-decoration: underline;
+}
+
+.alert-danger a, .alert-warning a, .alert-info a {
+    color: #E9EDEF!important;
+}
+
+.alert-success a {
+    color: #fff!important;
 }

--- a/modules/portal/public/css/theme-overrides.css
+++ b/modules/portal/public/css/theme-overrides.css
@@ -166,3 +166,9 @@ ul.bar_tabs>li a {
   background-color: #e6e6e6!important;
   border: 1px solid #adadad!important;
 }
+
+.alert-info {
+    color: #31708f!important;
+    background-color: #d9edf7!important;
+    border-color: #bce8f1!important;
+}

--- a/modules/portal/public/lib/directives/directives.notices.js
+++ b/modules/portal/public/lib/directives/directives.notices.js
@@ -22,11 +22,6 @@ angular.module('directives.notices.module', [])
         scope: {
           ngModel: '='
         },
-        templateUrl: "/public/templates/notice.html",
-//        link: function(scope, element, attrs) {
-//          $timeout(function() {
-//            element.fadeOut(50);
-//          }, 6000)
-//        }
+        templateUrl: "/public/templates/notice.html"
       }
     });

--- a/modules/portal/public/lib/directives/directives.notices.js
+++ b/modules/portal/public/lib/directives/directives.notices.js
@@ -14,4 +14,19 @@
  * limitations under the License.
  */
 
-angular.module('directives.module', ['directives.validations.module', 'directives.modals.module', 'directives.notifications.module', 'directives.notices.module']);
+angular.module('directives.notices.module', [])
+    .directive('notice', function($timeout) {
+      return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+          ngModel: '='
+        },
+        templateUrl: "/public/templates/notice.html",
+//        link: function(scope, element, attrs) {
+//          $timeout(function() {
+//            element.fadeOut(50);
+//          }, 6000)
+//        }
+      }
+    });

--- a/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
@@ -36,6 +36,7 @@
                     if (response.data.reviewTimestamp) {
                         $scope.batch.reviewTimestamp = utilityService.formatDateTime(response.data.reviewTimestamp);
                     }
+                    $scope.notice = $scope.notices.find(notice => notice['status'] == $scope.batch.status)
                 }
 
                 return dnsChangeService

--- a/modules/portal/public/templates/notice.html
+++ b/modules/portal/public/templates/notice.html
@@ -1,0 +1,4 @@
+<div class="alert" ng-class="'alert-'+ngModel.alertType" role="alert">
+    {{ngModel.text}}
+    <a ng-if="ngModel.href" href="{{ngModel.href}}" target="_blank">{{ngModel.hrefText}}</a>
+</div>

--- a/modules/portal/public/templates/notice.html
+++ b/modules/portal/public/templates/notice.html
@@ -1,4 +1,4 @@
 <div class="alert" ng-class="'alert-'+ngModel.alertType" role="alert">
     {{ngModel.text}}
-    <a ng-if="ngModel.href" href="{{ngModel.href}}" target="_blank">{{ngModel.hrefText}}</a>
+    <a ng-if="ngModel.href && ngModel.hrefText" href="{{ngModel.href}}" target="_blank">{{ngModel.hrefText}}</a>
 </div>

--- a/modules/portal/test/models/DnsChangeNoticesSpec.scala
+++ b/modules/portal/test/models/DnsChangeNoticesSpec.scala
@@ -95,14 +95,47 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
       Configuration
         .from(Map("dnsChangeNotices" -> "invalid"))
         .get[DnsChangeNotices]("dnsChangeNotices") must
-        throwA[ConfigException]("dnsChangeNotices has type STRING rather than LIST")
+        throwA[ConfigException.WrongType]("dnsChangeNotices has type STRING rather than LIST")
     }
 
-    "error if no dnsChangeNotices is in the config" in {
+    "error if no dnsChangeNotices key is in the config" in {
       Configuration
         .from(Map())
         .get[DnsChangeNotices]("dnsChangeNotices") must
-        throwA[ConfigException]("No configuration setting found for key 'dnsChangeNotices'")
+        throwA[ConfigException.Missing]("No configuration setting found for key 'dnsChangeNotices'")
+    }
+
+    "error if no text value is given" in {
+      val config = Map(
+        "dnsChangeNotices" -> List(
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "info"
+          )
+        )
+      )
+
+      Configuration
+        .from(config)
+        .get[DnsChangeNotices]("dnsChangeNotices") must
+        throwA[ConfigException.Missing]("No configuration setting found for key 'text'")
+    }
+
+    "error if incorrect text type is given" in {
+      val config = Map(
+        "dnsChangeNotices" -> List(
+          Map(
+            "text" -> List("all done."),
+            "status" -> "Cancelled",
+            "alertType" -> "info"
+          )
+        )
+      )
+
+      Configuration
+        .from(config)
+        .get[DnsChangeNotices]("dnsChangeNotices") must
+        throwA[ConfigException.WrongType]("text has type LIST rather than STRING")
     }
   }
 }

--- a/modules/portal/test/models/DnsChangeNoticesSpec.scala
+++ b/modules/portal/test/models/DnsChangeNoticesSpec.scala
@@ -95,7 +95,7 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
         "dnsChangeNotices" -> List()
       )
 
-      val configFormatted = Json.toJson(List())
+      val configFormatted = Json.arr()
       val dnsChangeNotices = Configuration.from(config).get[DnsChangeNotices]("dnsChangeNotices")
       dnsChangeNotices.notices must beEqualTo(configFormatted)
     }

--- a/modules/portal/test/models/DnsChangeNoticesSpec.scala
+++ b/modules/portal/test/models/DnsChangeNoticesSpec.scala
@@ -26,7 +26,7 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
   "DnsChangeNotices" should {
     "load valid notices from config" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "status" -> "Cancelled",
             "alertType" -> "info",
@@ -84,39 +84,42 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
             "href" -> "",
             "hrefText" -> "See more."
           )
-        ))
+        )
+      )
 
-      val dnsChangeNotices = Configuration.from(config).get[DnsChangeNotices]("dnsChangeNotices")
+      val dnsChangeNotices = Configuration.from(config).get[DnsChangeNotices]("dns-change-notices")
       dnsChangeNotices.notices must beEqualTo(configFormatted)
     }
 
     "load valid notices from config" in {
       val config = Map(
-        "dnsChangeNotices" -> List()
+        "dns-change-notices" -> List()
       )
 
       val configFormatted = Json.arr()
-      val dnsChangeNotices = Configuration.from(config).get[DnsChangeNotices]("dnsChangeNotices")
+      val dnsChangeNotices = Configuration.from(config).get[DnsChangeNotices]("dns-change-notices")
       dnsChangeNotices.notices must beEqualTo(configFormatted)
     }
 
-    "error if no dnsChangeNotices key is in the config" in {
+    "error if no dns-change-notices key is in the config" in {
       Configuration
         .from(Map())
-        .get[DnsChangeNotices]("dnsChangeNotices") must
-        throwA[ConfigException.Missing]("No configuration setting found for key 'dnsChangeNotices'")
+        .get[DnsChangeNotices]("dns-change-notices") must
+        throwA[ConfigException.Missing](
+          "No configuration setting found for key 'dns-change-notices'"
+        )
     }
 
-    "error if the dnsChangeNotices value is not a list" in {
+    "error if the dns-change-notices value is not a list" in {
       Configuration
-        .from(Map("dnsChangeNotices" -> "invalid"))
-        .get[DnsChangeNotices]("dnsChangeNotices") must
-        throwA[ConfigException.WrongType]("dnsChangeNotices has type STRING rather than LIST")
+        .from(Map("dns-change-notices" -> "invalid"))
+        .get[DnsChangeNotices]("dns-change-notices") must
+        throwA[ConfigException.WrongType]("dns-change-notices has type STRING rather than LIST")
     }
 
     "error if no text value is given" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "status" -> "Cancelled",
             "alertType" -> "info"
@@ -126,13 +129,13 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
 
       Configuration
         .from(config)
-        .get[DnsChangeNotices]("dnsChangeNotices") must
+        .get[DnsChangeNotices]("dns-change-notices") must
         throwA[ConfigException.Missing]("No configuration setting found for key 'text'")
     }
 
     "error if the given text value is not a string" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "text" -> List("all done."),
             "status" -> "Cancelled",
@@ -143,13 +146,13 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
 
       Configuration
         .from(config)
-        .get[DnsChangeNotices]("dnsChangeNotices") must
+        .get[DnsChangeNotices]("dns-change-notices") must
         throwA[ConfigException.WrongType]("text has type LIST rather than STRING")
     }
 
     "error if no status is given" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "alertType" -> "info",
             "text" -> "Invalid status value"
@@ -159,13 +162,13 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
 
       Configuration
         .from(config)
-        .get[DnsChangeNotices]("dnsChangeNotices") must
+        .get[DnsChangeNotices]("dns-change-notices") must
         throwA[ConfigException.Missing]("No configuration setting found for key 'status'")
     }
 
     "error if an invalid status is given" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "status" -> "Invalid",
             "alertType" -> "info",
@@ -176,13 +179,13 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
 
       Configuration
         .from(config)
-        .get[DnsChangeNotices]("dnsChangeNotices") must
+        .get[DnsChangeNotices]("dns-change-notices") must
         throwA[ConfigException.BadValue]
     }
 
     "error if no alertType is given" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "status" -> "Complete",
             "text" -> "Invalid alertType value"
@@ -192,13 +195,13 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
 
       Configuration
         .from(config)
-        .get[DnsChangeNotices]("dnsChangeNotices") must
+        .get[DnsChangeNotices]("dns-change-notices") must
         throwA[ConfigException.Missing]("No configuration setting found for key 'alertType'")
     }
 
     "error if an invalid status is given" in {
       val config = Map(
-        "dnsChangeNotices" -> List(
+        "dns-change-notices" -> List(
           Map(
             "status" -> "Invalid",
             "alertType" -> "veryBad",
@@ -209,7 +212,7 @@ class DnsChangeNoticesSpec extends Specification with Mockito {
 
       Configuration
         .from(config)
-        .get[DnsChangeNotices]("dnsChangeNotices") must
+        .get[DnsChangeNotices]("dns-change-notices") must
         throwA[ConfigException.BadValue]
     }
   }

--- a/modules/portal/test/models/DnsChangeNoticesSpec.scala
+++ b/modules/portal/test/models/DnsChangeNoticesSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import com.typesafe.config.ConfigException
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.Configuration
+import play.api.libs.json.Json
+
+class DnsChangeNoticesSpec extends Specification with Mockito {
+  "DnsChangeNotices" should {
+    "load notices from config" in {
+      val config = Map(
+        "dnsChangeNotices" -> List(
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "info",
+            "text" -> "All done"
+          ),
+          Map(
+            "status" -> "Invalid",
+            "alertType" -> "info",
+            "text" -> "All done",
+            "href" -> "http://example.com",
+            "hrefText" -> "See more."
+          ),
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "info",
+            "text" -> "All done",
+            "href" -> "http://example.com"
+          ),
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "bad",
+            "text" -> "All done",
+            "href" -> "http://example.com",
+            "hrefText" -> "See more."
+          )
+        )
+      )
+
+      val configFormatted = Json.toJson(
+        List(
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "info",
+            "text" -> "All done",
+            "href" -> "",
+            "hrefText" -> ""
+          ),
+          Map(
+            "status" -> "Unknown",
+            "alertType" -> "info",
+            "text" -> "All done",
+            "href" -> "http://example.com",
+            "hrefText" -> "See more."
+          ),
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "info",
+            "text" -> "All done",
+            "href" -> "",
+            "hrefText" -> ""
+          ),
+          Map(
+            "status" -> "Cancelled",
+            "alertType" -> "info",
+            "text" -> "All done",
+            "href" -> "http://example.com",
+            "hrefText" -> "See more."
+          )
+        ))
+
+      val dnsChangeNotices = Configuration.from(config).get[DnsChangeNotices]("dnsChangeNotices")
+      dnsChangeNotices.notices must beEqualTo(configFormatted)
+    }
+
+    "error if an invalid dnsChangeNotices value is in the config" in {
+      Configuration
+        .from(Map("dnsChangeNotices" -> "invalid"))
+        .get[DnsChangeNotices]("dnsChangeNotices") must
+        throwA[ConfigException]("dnsChangeNotices has type STRING rather than LIST")
+    }
+
+    "error if no dnsChangeNotices is in the config" in {
+      Configuration
+        .from(Map())
+        .get[DnsChangeNotices]("dnsChangeNotices") must
+        throwA[ConfigException]("No configuration setting found for key 'dnsChangeNotices'")
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   lazy val jaxbV = "2.3.0"
   lazy val ip4sV = "1.1.1"
   lazy val fs2V = "2.0.1"
+  lazy val ficusV = "1.4.3"
 
   lazy val apiDependencies = Seq(
     "com.typesafe.akka"         %% "akka-http"                      % akkaHttpV,
@@ -50,7 +51,7 @@ object Dependencies {
     "com.47deg"                 %% "github4s"                       % "0.18.6",
     "com.comcast"               %% "ip4s-core"                      % ip4sV,
     "com.comcast"               %% "ip4s-cats"                      % ip4sV,
-    "com.iheart"                %% "ficus"                          % "1.4.3",
+    "com.iheart"                %% "ficus"                          % ficusV,
     "com.sun.mail"              %  "javax.mail"                     % "1.6.2",
     "javax.mail"                %  "javax.mail-api"                 % "1.6.2",
     "com.amazonaws"             %  "aws-java-sdk-sns"               % awsV withSources()
@@ -118,6 +119,7 @@ object Dependencies {
     "com.nimbusds"              % "oauth2-oidc-sdk"                 % "6.5",
     "com.nimbusds"              % "nimbus-jose-jwt"                 % "7.0",
     "co.fs2"                    %% "fs2-core"                       % fs2V,
-    "de.leanovate.play-mockws"  %% "play-mockws" % "2.7.1"          % "test"
+    "de.leanovate.play-mockws"  %% "play-mockws" % "2.7.1"          % "test",
+    "com.iheart"                %% "ficus"                          % ficusV
   )
 }


### PR DESCRIPTION
Changes in this pull request:
- Add configurable notices to the DNS Change detail page based on the DNS Change status. The notices are intended to give users additional context about the state of their DNS Change.
- Config key is "dnsChangeNotices" and requires a list. The list can be empty or contain objects with the attributes: "status", "text", "alertType", "href" (optional), "hrefText" (optional).
- status is matched against our current list of valid batch change statuses: Cancelled, Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected, Scheduled. If the given status doesn't match we set the status to "Unknown". This determines which notice appears on which DNS Change.
- alertType is matched against a list of valid Bootstrap 3 alert types: info, success, danger, warning. If the given alertType doesn't match we set the alertType to "info". This sets the styling of the notice.
- If included, the "href" and "hrefText" will appear after the given "text" value in the notice message.


**Documentation Note**: will include documentation updates in this PR, but will wait for feedback to confirm the configuration.

Screenshots of the different style notices based on "alertType":

info alertType:
![Screen Shot of alert-info style notice](https://user-images.githubusercontent.com/4439228/68486034-52ca2a80-020e-11ea-88fc-d327e6c345a8.png)

success alertType:
![Screen Shot of alert-info style notice](https://user-images.githubusercontent.com/4439228/68486198-a177c480-020e-11ea-8f3e-ed5973914184.png)

warning alertType:
![Screen Shot of alert-info style notice](https://user-images.githubusercontent.com/4439228/68486223-ab012c80-020e-11ea-9a43-afcf19225bfc.png)

danger alertType:
![Screen Shot of alert-info style notice](https://user-images.githubusercontent.com/4439228/68486248-b3f1fe00-020e-11ea-9395-02f0fc27948a.png)

