### PR TITLE
Use test bind9 image

### DIFF
--- a/docker/docker-compose-func-test.yml
+++ b/docker/docker-compose-func-test.yml
@@ -11,13 +11,8 @@ services:
       driver: none
 
   bind9:
-    image: "vinyldns/bind9:0.0.4"
-    env_file:
-      .env
+    image: "vinyldns/test-bind9:0.9.4"
     container_name: "vinyldns-bind9"
-    volumes:
-      - ./bind9/etc:/var/cache/bind/config
-      - ./bind9/zones:/var/cache/bind/zones
     ports:
       - "19001:53/tcp"
       - "19001:53/udp"


### PR DESCRIPTION
Currently we use a BIND9 image which mounts the zone files on spin up, but we can use the `vinyldns/test-bind9` image which to circumvent issues with mounting.

Also corrected an issue where the docker func scripts were only running parallel tests.