### PR TITLE
Convert batch change notification to command

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/engine/BatchChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/BatchChangeHandler.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.engine
+
+import cats.effect._
+import cats.implicits._
+import org.slf4j.LoggerFactory
+import vinyldns.core.domain.batch.{
+  BatchChange,
+  BatchChangeCommand,
+  BatchChangeRepository,
+  BatchChangeStatus
+}
+import vinyldns.core.notifier.{AllNotifiers, Notification}
+
+object BatchChangeHandler {
+  private val logger = LoggerFactory.getLogger("vinyldns.api.engine.BatchChangeHandler")
+
+  def apply(
+      batchChangeRepository: BatchChangeRepository,
+      notifiers: AllNotifiers): BatchChangeCommand => IO[Option[BatchChange]] =
+    batchChangeId => {
+      process(
+        batchChangeRepository: BatchChangeRepository,
+        notifiers,
+        batchChangeId
+      )
+    }
+
+  def process(
+      batchChangeRepository: BatchChangeRepository,
+      notifiers: AllNotifiers,
+      batchChangeCommand: BatchChangeCommand): IO[Option[BatchChange]] =
+    for {
+      batchChange <- batchChangeRepository.getBatchChange(batchChangeCommand.id)
+      completedState <- fsm(notifiers, Pending(batchChange, batchChangeCommand))
+    } yield completedState.change
+
+  private sealed trait BatchChangeProcessorState {
+    def change: Option[BatchChange]
+  }
+
+  private final case class Pending(
+      change: Option[BatchChange],
+      batchChangeCommand: BatchChangeCommand)
+      extends BatchChangeProcessorState
+
+  private final case class PendingBatchNotificationError(change: BatchChange) extends Throwable
+
+  private final case class Completed(change: Option[BatchChange]) extends BatchChangeProcessorState
+
+  private def fsm(
+      notifiers: AllNotifiers,
+      state: BatchChangeProcessorState): IO[BatchChangeProcessorState] =
+    state match {
+      case Pending(batchChange, batchChangeCommand) =>
+        notify(notifiers, batchChange, batchChangeCommand).as(Completed(batchChange))
+      case completed => IO.pure(completed)
+    }
+
+  private def notify(
+      notifiers: AllNotifiers,
+      change: Option[BatchChange],
+      batchChangeCommand: BatchChangeCommand): IO[Unit] =
+    change match {
+      case Some(pendingBatch)
+          if pendingBatch.status == BatchChangeStatus.PendingProcessing ||
+            pendingBatch.status == BatchChangeStatus.PendingReview =>
+        logger.info(s"Notification not sent for pending batch: ${getChangeLog(pendingBatch)}.")
+        IO.raiseError(PendingBatchNotificationError(pendingBatch))
+      case Some(completedBatch) =>
+        logger.info(s"Sending notification for batch: ${getChangeLog(completedBatch)}.")
+        notifiers.notify(Notification(completedBatch))
+      case None =>
+        logger.error(
+          s"Notification not sent since batch change with ID ${batchChangeCommand.id} not found.")
+        IO.unit
+    }
+
+  private def getChangeLog(change: BatchChange): String = {
+    val sb = new StringBuilder
+    sb.append("changeId='").append(change.id).append("'")
+    sb.append(" status='").append(change.status).append("'")
+    sb.toString
+  }
+}

--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.{BeforeAndAfterEach, EitherValues, Matchers, WordSpec}
 import vinyldns.api.VinylDNSTestHelpers
 import vinyldns.api.backend.CommandHandler.{DeleteMessage, RetryMessage}
 import vinyldns.api.domain.dns.DnsConnection
-import vinyldns.core.domain.batch.BatchChangeRepository
+import vinyldns.core.domain.batch.{BatchChange, BatchChangeCommand, BatchChangeRepository}
 import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetChange, RecordSetRepository}
 import vinyldns.core.domain.zone.{ZoneChange, ZoneChangeType, ZoneCommand, _}
 import vinyldns.core.queue.{CommandMessage, MessageCount, MessageId, MessageQueue}
@@ -64,6 +64,7 @@ class CommandHandlerSpec
   private val mockRecordChangeProcessor =
     mock[(DnsConnection, RecordSetChange) => IO[RecordSetChange]]
   private val mockZoneSyncProcessor = mock[ZoneChange => IO[ZoneChange]]
+  private val mockBatchChangeProcessor = mock[BatchChangeCommand => IO[Option[BatchChange]]]
   private val defaultConn =
     ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
   private val connections = ConfiguredDnsConnections(defaultConn, defaultConn, List())
@@ -72,6 +73,7 @@ class CommandHandlerSpec
       mockZoneChangeProcessor,
       mockRecordChangeProcessor,
       mockZoneSyncProcessor,
+      mockBatchChangeProcessor,
       connections
     )
 
@@ -216,6 +218,7 @@ class CommandHandlerSpec
           mockZoneChangeProcessor,
           mockRecordChangeProcessor,
           mockZoneSyncProcessor,
+          mockBatchChangeProcessor,
           ConfiguredDnsConnections(default, default, List())
         )
       val change = TestCommandMessage(noConnChange, "foo")
@@ -282,6 +285,7 @@ class CommandHandlerSpec
             mockZoneChangeProcessor,
             mockRecordChangeProcessor,
             mockZoneSyncProcessor,
+            mockBatchChangeProcessor,
             mq,
             count,
             100.millis,
@@ -324,6 +328,7 @@ class CommandHandlerSpec
             mockZoneChangeProcessor,
             mockRecordChangeProcessor,
             mockZoneSyncProcessor,
+            mockBatchChangeProcessor,
             mq,
             count,
             100.millis,

--- a/modules/api/src/test/scala/vinyldns/api/engine/BatchChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/BatchChangeHandlerSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.engine
+
+import cats.effect._
+import org.joda.time.DateTime
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{doReturn, verify}
+import org.scalatest.{BeforeAndAfterEach, WordSpec}
+import org.scalatest.mockito.MockitoSugar
+import vinyldns.api.CatsHelpers
+import vinyldns.api.repository.InMemoryBatchChangeRepository
+import vinyldns.core.domain.batch._
+import vinyldns.core.domain.record._
+import vinyldns.core.notifier.{AllNotifiers, Notification, Notifier}
+
+import scala.concurrent.ExecutionContext
+
+class BatchChangeHandlerSpec
+    extends WordSpec
+    with MockitoSugar
+    with BeforeAndAfterEach
+    with CatsHelpers {
+
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(ec)
+
+  private val batchRepo = new InMemoryBatchChangeRepository
+  private val mockNotifier = mock[Notifier]
+  private val notifiers = AllNotifiers(List(mockNotifier))
+
+  private val addChange = SingleAddChange(
+    Some("zoneId"),
+    Some("zoneName"),
+    Some("recordName"),
+    "recordName.zoneName",
+    RecordType.A,
+    300,
+    AData("1.1.1.1"),
+    SingleChangeStatus.Complete,
+    None,
+    Some("recordChangeId"),
+    Some("recordSetId"),
+    List(),
+    "changeId"
+  )
+
+  private val completedBatchChange = BatchChange(
+    "userId",
+    "userName",
+    Some("comments"),
+    DateTime.now,
+    List(addChange),
+    Some("ownerGroupId"),
+    BatchChangeApprovalStatus.AutoApproved)
+
+  override protected def beforeEach(): Unit =
+    batchRepo.clear()
+
+  "notify on batch change complete" in {
+    doReturn(IO.unit).when(mockNotifier).notify(any[Notification[_]])
+
+    await(batchRepo.save(completedBatchChange))
+
+    BatchChangeHandler
+      .process(batchRepo, notifiers, BatchChangeCommand(completedBatchChange.id))
+      .unsafeRunSync()
+
+    verify(mockNotifier).notify(Notification(completedBatchChange))
+  }
+
+  "notify on failure" in {
+    doReturn(IO.unit).when(mockNotifier).notify(any[Notification[_]])
+
+    val partiallyFailedBatchChange =
+      completedBatchChange.copy(changes = List(addChange.copy(status = SingleChangeStatus.Failed)))
+
+    await(batchRepo.save(partiallyFailedBatchChange))
+
+    BatchChangeHandler
+      .process(batchRepo, notifiers, BatchChangeCommand(partiallyFailedBatchChange.id))
+      .unsafeRunSync()
+
+    verify(mockNotifier).notify(Notification(partiallyFailedBatchChange))
+  }
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChange.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import org.joda.time.DateTime
 import vinyldns.core.domain.batch.BatchChangeStatus.BatchChangeStatus
 import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
+import vinyldns.core.domain.zone.{ZoneCommand, ZoneCommandResult}
 
 case class BatchChange(
     userId: String,
@@ -52,6 +53,8 @@ case class BatchChange(
       isScheduled)
   }
 }
+
+case class BatchChangeCommand(id: String) extends ZoneCommand with ZoneCommandResult
 
 /*
  - Complete means all changes are in complete state

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneCommand.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneCommand.scala
@@ -17,7 +17,6 @@
 package vinyldns.core.domain.zone
 
 trait ZoneCommand {
-  val zoneId: String
   val id: String
 }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/queue/MessageType.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/queue/MessageType.scala
@@ -15,6 +15,7 @@
  */
 
 package vinyldns.mysql.queue
+import vinyldns.core.domain.batch.BatchChangeCommand
 import vinyldns.core.domain.record.RecordSetChange
 import vinyldns.core.domain.zone.{ZoneChange, ZoneCommand}
 
@@ -22,17 +23,20 @@ sealed abstract class MessageType(val value: Int)
 object MessageType {
   case object RecordChangeMessageType extends MessageType(1)
   case object ZoneChangeMessageType extends MessageType(2)
+  case object BatchChangeMessageType extends MessageType(3)
   final case class InvalidMessageType(value: Int)
       extends Throwable(s"$value is not a valid message type value")
 
   def fromCommand(cmd: ZoneCommand): MessageType = cmd match {
     case _: ZoneChange => ZoneChangeMessageType
     case _: RecordSetChange => RecordChangeMessageType
+    case _: BatchChangeCommand => BatchChangeMessageType
   }
 
   def fromInt(i: Int): Either[InvalidMessageType, MessageType] = i match {
     case 1 => Right(RecordChangeMessageType)
     case 2 => Right(ZoneChangeMessageType)
+    case 3 => Right(BatchChangeMessageType)
     case _ => Left(InvalidMessageType(i))
   }
 }

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessage.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessage.scala
@@ -19,11 +19,16 @@ import java.util.Base64
 
 import cats.implicits._
 import com.amazonaws.services.sqs.model.Message
+import vinyldns.core.domain.batch.BatchChangeCommand
 import vinyldns.core.domain.zone.ZoneCommand
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.queue.{CommandMessage, MessageId}
 import vinyldns.proto.VinylDNSProto
-import vinyldns.sqs.queue.SqsMessageType.{SqsRecordSetChangeMessage, SqsZoneChangeMessage}
+import vinyldns.sqs.queue.SqsMessageType.{
+  SqsBatchChangeMessage,
+  SqsRecordSetChangeMessage,
+  SqsZoneChangeMessage
+}
 
 final case class SqsMessage(id: MessageId, command: ZoneCommand) extends CommandMessage
 object SqsMessage extends ProtobufConversions {
@@ -49,6 +54,8 @@ object SqsMessage extends ProtobufConversions {
             case SqsRecordSetChangeMessage =>
               fromPB(VinylDNSProto.RecordSetChange.parseFrom(contents))
             case SqsZoneChangeMessage => fromPB(VinylDNSProto.ZoneChange.parseFrom(contents))
+            case SqsBatchChangeMessage =>
+              BatchChangeCommand(new String(contents))
           }
         }
     } yield SqsMessage(MessageId(message.getReceiptHandle), cmd)

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageType.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageType.scala
@@ -17,6 +17,7 @@
 package vinyldns.sqs.queue
 import cats.implicits._
 import com.amazonaws.services.sqs.model.{Message, MessageAttributeValue}
+import vinyldns.core.domain.batch.BatchChangeCommand
 import vinyldns.core.domain.record.RecordSetChange
 import vinyldns.core.domain.zone.{ZoneChange, ZoneCommand}
 
@@ -30,6 +31,7 @@ sealed abstract class SqsMessageType(val name: String) {
 object SqsMessageType {
   case object SqsRecordSetChangeMessage extends SqsMessageType("SqsRecordSetChangeMessage")
   case object SqsZoneChangeMessage extends SqsMessageType("SqsZoneChangeMessage")
+  case object SqsBatchChangeMessage extends SqsMessageType("SqsBatchChangeMessage")
   sealed abstract class SqsMessageTypeError(message: String) extends Throwable(message)
 
   final case class InvalidMessageTypeValue(value: String)
@@ -40,12 +42,14 @@ object SqsMessageType {
   def fromCommand[A <: ZoneCommand](cmd: A): SqsMessageType = cmd match {
     case _: RecordSetChange => SqsRecordSetChangeMessage
     case _: ZoneChange => SqsZoneChangeMessage
+    case _: BatchChangeCommand => SqsBatchChangeMessage
   }
 
   def fromString(messageType: String): Either[InvalidMessageTypeValue, SqsMessageType] =
     messageType match {
       case SqsRecordSetChangeMessage.name => Right(SqsRecordSetChangeMessage)
       case SqsZoneChangeMessage.name => Right(SqsZoneChangeMessage)
+      case SqsBatchChangeMessage.name => Right(SqsBatchChangeMessage)
       case invalid => Left(InvalidMessageTypeValue(invalid))
     }
 

--- a/modules/sqs/src/test/scala/vinyldns/sqs/queue/SqsMessageTypeSpec.scala
+++ b/modules/sqs/src/test/scala/vinyldns/sqs/queue/SqsMessageTypeSpec.scala
@@ -30,6 +30,10 @@ class SqsMessageTypeSpec extends WordSpec with Matchers {
       fromString(SqsZoneChangeMessage.name) shouldBe Right(SqsZoneChangeMessage)
     }
 
+    "parse a SqsBatchChangeMessage" in {
+      fromString(SqsBatchChangeMessage.name) shouldBe Right(SqsBatchChangeMessage)
+    }
+
     "return InvalidMessageTypeValue for invalid string" in {
       val invalidString = "invalid-message-type-string"
       fromString(invalidString) shouldBe Left(InvalidMessageTypeValue(invalidString))


### PR DESCRIPTION
Currently the notifications for batch changes are fired during the record set change processing stage, but there is an edge case where the notification doesn't trigger despite processing completion. Queueing a new batch change command allows us the following:
- Retries on the processing notification
- Middle ground before batch processing is supported by the `CommandHandler`.
