### PR TITLE
validate CNAME record data is not an IP address in DNS Change form

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -168,8 +168,8 @@
                                         <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn invalidip>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
-                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be a full domain name!</span>
-                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.invalidip" class="batch-change-error-help">CNAME data must be a domain name, not an IP address!</span>
+                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be a fully qualified domain name!</span>
+                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.invalidip" class="batch-change-error-help">CNAME data must be a fully qualified domain name, not an IP address!<br>Or you mean to create an A record, not a CNAME.</span>
                                         </p>
                                     </td>
                                     <td ng-if="change.type=='PTR'">

--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -165,10 +165,11 @@
                                         <p class="help-block" ng-if="change.changeType=='DeleteRecordSet'">Record Data is optional.</p>
                                     </td>
                                     <td ng-if="change.type=='CNAME'">
-                                        <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn>
+                                        <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn invalidip>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
-                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be absolute!</span>
+                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be a full domain name!</span>
+                                            <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.invalidip" class="batch-change-error-help">CNAME data must be a domain name, not an IP address!</span>
                                         </p>
                                     </td>
                                     <td ng-if="change.type=='PTR'">

--- a/modules/portal/public/lib/dns-change/dns-change.directive.js
+++ b/modules/portal/public/lib/dns-change/dns-change.directive.js
@@ -17,6 +17,7 @@
 (function () {
     var app = angular.module('dns-change');
     var FQDN_REGEX = /\./;
+    var INVALID_FQDN_REGEX = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}\.?$/;
     var IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
     var IPV6_REGEX = new RegExp(['^(',
                                 '([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|',
@@ -44,7 +45,21 @@
             link: function (scope, elm, attrs, ctrl) {
                 ctrl.$validators.fqdn = function (modelValue, viewValue) {
                     if (attrs.required || (viewValue !== undefined && viewValue.length > 0)) {
-                        return FQDN_REGEX.test(viewValue);
+                       return FQDN_REGEX.test(viewValue);
+                    }
+                    return true;
+                };
+            }
+        };
+    });
+
+    app.directive('invalidip', function () {
+        return {
+            require: 'ngModel',
+            link: function (scope, elm, attrs, ctrl) {
+                ctrl.$validators.invalidip = function (modelValue, viewValue) {
+                    if (attrs.required || (viewValue !== undefined && viewValue.length > 0)) {
+                       return !INVALID_FQDN_REGEX.test(viewValue)
                     }
                     return true;
                 };

--- a/modules/portal/public/lib/dns-change/dns-change.directive.js
+++ b/modules/portal/public/lib/dns-change/dns-change.directive.js
@@ -17,8 +17,8 @@
 (function () {
     var app = angular.module('dns-change');
     var FQDN_REGEX = /\./;
-    var INVALID_FQDN_REGEX = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}\.?$/;
     var IPV4_REGEX = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+    var INVALID_FQDN_REGEX = new RegExp(IPV4_REGEX.source.replace("$", "\\.?$"))
     var IPV6_REGEX = new RegExp(['^(',
                                 '([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|',
                                 '([0-9a-fA-F]{1,4}:){1,7}:|',

--- a/modules/portal/public/lib/dns-change/dns-change.spec.js
+++ b/modules/portal/public/lib/dns-change/dns-change.spec.js
@@ -477,6 +477,80 @@ describe('BatchChange', function(){
         });
     });
 
+    describe('Directive: Invalid IPv4 validation for CNAME record data', function(){
+        var form;
+        beforeEach(inject(function($compile, $rootScope) {
+            this.rootScope = $rootScope;
+            this.scope = $rootScope.$new();
+            var element = angular.element(
+                '<form name="form">' +
+                    '<input ng-model="change.cname" name="cname" invalidip />' +
+                '</form>'
+            );
+            this.scope.change = { fqdn: null };
+            $compile(element)(this.scope);
+            form = this.scope.form;
+        }));
+
+        it('fails with an IPV4 address', function(){
+            form.cname.$setViewValue('1.1.1.1');
+            this.scope.$digest();
+            expect(this.scope.change.cname).toBeUndefined();
+            expect(form.cname.$valid).toBe(false);
+        });
+
+        it('fails with an IPV4 address and a trailing dot', function(){
+            form.cname.$setViewValue('test.');
+            this.scope.$digest();
+            expect(this.scope.change.cname).toBeUndefined();
+            expect(form.cname.$valid).toBe(false);
+        });
+
+        it('passes if not given an IPV4 address', function(){
+            form.cname.$setViewValue('notanIP');
+            this.scope.$digest();
+            expect(this.scope.change.cname).toEqual('notanIP');
+            expect(form.cname.$valid).toBe(true);
+        });
+    });
+
+        describe('Directive: combined CNAME record data validations', function(){
+            var form;
+            beforeEach(inject(function($compile, $rootScope) {
+                this.rootScope = $rootScope;
+                this.scope = $rootScope.$new();
+                var element = angular.element(
+                    '<form name="form">' +
+                        '<input ng-model="change.cname" name="cname" fqdn invalidip />' +
+                    '</form>'
+                );
+                this.scope.change = { fqdn: null };
+                $compile(element)(this.scope);
+                form = this.scope.form;
+            }));
+
+            it('passes with at least one dot and not an IP Address', function(){
+                form.cname.$setViewValue('test.com');
+                this.scope.$digest();
+                expect(this.scope.change.cname).toEqual('test.com');
+                expect(form.cname.$valid).toBe(false);
+            });
+
+            it('fails with an IP Address', function(){
+                form.cname.$setViewValue('1.1.1.1');
+                this.scope.$digest();
+                expect(this.scope.change.cname).toBeUndefined();
+                expect(form.cname.$valid).toBe(false);
+            });
+
+            it('fails without at least one dot', function(){
+                form.cname.$setViewValue('testcom');
+                this.scope.$digest();
+                expect(this.scope.change.cname).toBeUndefined();
+                expect(form.cname.$valid).toBe(false);
+            });
+        }
+
     describe('Directive: IPv4 validation', function(){
         var form;
         beforeEach(inject(function($compile, $rootScope) {


### PR DESCRIPTION
<img width="1182" alt="Screen Shot 2019-11-14 at 11 19 47 AM" src="https://user-images.githubusercontent.com/4439228/68877203-b1424d80-06d3-11ea-92c2-bd2fcac4b9a2.png">

Changes in this pull request:
- add an invalid IP check to the CNAME record data field in the DNS Change form. If the record data is an IPV4 address (with or without a trailing dot) return an error that states "CNAME data must be a domain name, not an IP address!" Opted for this new message as opposed to tying it into the existing FQDN validation in order to provide users with more context about why the data they provided is invalid, and help them understand that CNAMES are for FQDNS not IP addresses. 

Intentionally kept the scope of this PR small, but we should make additional changes to the FQDN regex in the portal and the API to not allow IP addresses to be considered valid FQDNs. It's a little tricky right now between the regex and the way we handle adding trailing dots. I believe we add or ensure there's a trailing dot before we do the FQDN regex validation in the API. So `1.1.1.1` would normally fail but by the time it gets to the validation it's `1.1.1.1.` which passes.