### PR TITLE
retry some failed record changes

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -4028,13 +4028,6 @@ def test_create_batch_multi_record_update_succeeds(shared_zone_test_context):
     txt_delete_record_and_record_set_fqdn = txt_delete_record_and_record_set_name + ".ok."
     txt_delete_record_and_record_set = get_recordset_json(ok_zone, txt_delete_record_and_record_set_name, "TXT", [{"text": "hello"}, {"text": "again"}], 200)
 
-    a_update_to_cname_and_record_set_name = generate_record_name()
-    a_update_to_cname_and_record_set_fqdn = a_update_to_cname_and_record_set_name + ".ok."
-    a_update_to_cname_and_record_set = get_recordset_json(ok_zone, a_update_to_cname_and_record_set_name, "A", [{"address": "1.1.1.1"}], 200)
-
-    cname_update_from_a_and_record_set_fqdn = a_update_to_cname_and_record_set_name + ".ok."
-    cname_update_from_a_and_record_set = get_recordset_json(ok_zone, a_update_to_cname_and_record_set_name, "CNAME", [{"cname": "example.com."}], 200)
-
     batch_change_input = {
         "comments": "this is optional",
         "changes": [
@@ -4088,17 +4081,13 @@ def test_create_batch_multi_record_update_succeeds(shared_zone_test_context):
             get_change_A_AAAA_json(a_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
             get_change_TXT_json(txt_delete_record_and_record_set_fqdn, text="hello", change_type="DeleteRecordSet"),
             get_change_TXT_json(txt_delete_record_and_record_set_fqdn, change_type="DeleteRecordSet"),
-
-            # Update A record to CNAME
-            get_change_A_AAAA_json(a_update_to_cname_and_record_set_fqdn, change_type="DeleteRecordSet"),
-            get_change_CNAME_json(cname_update_from_a_and_record_set_fqdn, cname="example.com.")
         ]
     }
 
     to_delete = []
     try:
         for rs in [a_update_record_set, txt_update_record_set, a_update_record_full, txt_update_record_full, a_update_record, txt_update_record, a_update_record_only, txt_update_record_only,
-                   a_delete_record_set, txt_delete_record_set, a_delete_record, txt_delete_record, a_delete_record_and_record_set, txt_delete_record_and_record_set, a_update_to_cname_and_record_set]:
+                   a_delete_record_set, txt_delete_record_set, a_delete_record, txt_delete_record, a_delete_record_and_record_set, txt_delete_record_and_record_set]:
             create_rs = client.create_recordset(rs, status=202)
             to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
 
@@ -4146,9 +4135,6 @@ def test_create_batch_multi_record_update_succeeds(shared_zone_test_context):
         assert_change_success_response_values(result['changes'], zone=ok_zone, index=30, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data="hello", change_type="DeleteRecordSet")
         assert_change_success_response_values(result['changes'], zone=ok_zone, index=31, input_name=txt_delete_record_and_record_set_fqdn, record_name=txt_delete_record_and_record_set_name, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
 
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=32, input_name=a_update_to_cname_and_record_set_fqdn, record_name=a_update_to_cname_and_record_set_name, record_type="A", record_data=None, change_type="DeleteRecordSet")
-        assert_change_success_response_values(result['changes'], zone=ok_zone, index=33, input_name=cname_update_from_a_and_record_set_fqdn, record_name=a_update_to_cname_and_record_set_name, record_type="CNAME", record_data="example.com.")
-
         # Perform look up to verify record set data
         for rs in to_delete:
             rs_name = rs['recordSet']['name']
@@ -4157,8 +4143,7 @@ def test_create_batch_multi_record_update_succeeds(shared_zone_test_context):
 
             # deletes should not exist
             if rs_name in [a_delete_record_set_name, txt_delete_record_set_name, a_delete_record_name,
-                           txt_delete_record_name, a_delete_record_and_record_set_name, txt_delete_record_and_record_set_name,
-                           a_update_to_cname_and_record_set_name]:
+                           txt_delete_record_name, a_delete_record_and_record_set_name, txt_delete_record_and_record_set_name]:
                 client.get_recordset(zone_id, rs_id, status=404)
             else:
                 result_rs = client.get_recordset(zone_id, rs_id, status=200)
@@ -4185,7 +4170,55 @@ def test_create_batch_multi_record_update_succeeds(shared_zone_test_context):
                     assert_that(records, contains({"text": "again"}))
                     assert_that(records, is_not(contains({"text": "hello"})))
 
-        new_cname_result_rs = result['changes'][33]
+    finally:
+        clear_recordset_list(to_delete, client)
+
+@pytest.mark.skip_production
+def test_create_batch_update_record_type_succeeds(shared_zone_test_context):
+    """
+    Test existing record sets can be updated to a different type in batch (relies on skip-prod)
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+
+    # record sets to setup
+    a_update_to_cname_and_record_set_name = generate_record_name()
+    a_update_to_cname_and_record_set_fqdn = a_update_to_cname_and_record_set_name + ".ok."
+    a_update_to_cname_and_record_set = get_recordset_json(ok_zone, a_update_to_cname_and_record_set_name, "A", [{"address": "1.1.1.1"}], 200)
+
+    cname_update_from_a_and_record_set_fqdn = a_update_to_cname_and_record_set_name + ".ok."
+
+    batch_change_input = {
+        "comments": "this is optional",
+        "changes": [
+            # Update A record to CNAME
+            get_change_A_AAAA_json(a_update_to_cname_and_record_set_fqdn, change_type="DeleteRecordSet"),
+            get_change_CNAME_json(cname_update_from_a_and_record_set_fqdn, cname="example.com.")
+        ]
+    }
+
+    to_delete = []
+    try:
+        create_rs = client.create_recordset(a_update_to_cname_and_record_set, status=202)
+        to_delete.append(client.wait_until_recordset_change_status(create_rs, 'Complete'))
+
+        initial_result = client.create_batch_change(batch_change_input, status=202)
+        result = client.wait_until_batch_change_completed(initial_result)
+
+        assert_that(result['status'], is_('Complete'))
+
+        # Check batch change response
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=0, input_name=a_update_to_cname_and_record_set_fqdn, record_name=a_update_to_cname_and_record_set_name, record_type="A", record_data=None, change_type="DeleteRecordSet")
+        assert_change_success_response_values(result['changes'], zone=ok_zone, index=1, input_name=cname_update_from_a_and_record_set_fqdn, record_name=a_update_to_cname_and_record_set_name, record_type="CNAME", record_data="example.com.")
+
+        # Perform look up to verify record set data
+        for rs in to_delete:
+            rs_id = rs['recordSet']['id']
+            zone_id = rs['zone']['id']
+
+            client.get_recordset(zone_id, rs_id, status=404)
+
+        new_cname_result_rs = result['changes'][1]
         new_cname_rs = client.get_recordset(new_cname_result_rs['zoneId'], new_cname_result_rs['recordSetId'], status=200)['recordSet']
         new_cname_rdata = new_cname_rs['records']
         assert_that(new_cname_rdata, contains({"cname": "example.com."}))

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [u'VinylDNSClient', u'MAX_RETRIES', u'RETRY_WAIT']
 
-MAX_RETRIES = 60
+MAX_RETRIES = 75
 RETRY_WAIT = 0.05
 
 class VinylDNSClient(object):

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [u'VinylDNSClient', u'MAX_RETRIES', u'RETRY_WAIT']
 
-MAX_RETRIES = 40
+MAX_RETRIES = 100
 RETRY_WAIT = 0.05
 
 class VinylDNSClient(object):

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [u'VinylDNSClient', u'MAX_RETRIES', u'RETRY_WAIT']
 
-MAX_RETRIES = 100
+MAX_RETRIES = 40
 RETRY_WAIT = 0.05
 
 class VinylDNSClient(object):

--- a/modules/api/functional_test/vinyldns_python.py
+++ b/modules/api/functional_test/vinyldns_python.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [u'VinylDNSClient', u'MAX_RETRIES', u'RETRY_WAIT']
 
-MAX_RETRIES = 40
+MAX_RETRIES = 60
 RETRY_WAIT = 0.05
 
 class VinylDNSClient(object):

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -31,7 +31,7 @@ object RecordSetChangeHandler {
   private implicit val cs: ContextShift[IO] =
     IO.contextShift(scala.concurrent.ExecutionContext.global)
 
-  private final case class Requeue(change: RecordSetChange) extends Throwable
+  final case class Requeue(change: RecordSetChange) extends Throwable
 
   def apply(
       recordSetRepository: RecordSetRepository,


### PR DESCRIPTION
close #842 

Retry failed record changes if the record change error is Refused during the apply step of the finite state machine, or if the record change error is Try Again during the verify step of the finiite state machine in the RecordSetChangeHandler. Raising an error in the RecordSetChangeHandler causes the change to go back on the MySqlMessageQueue.

Tested against a commonly failing scenario, changing an A record to a CNAME through a batch change. Currently the A record deletes successfully but the CNAME fails in the backend. With the re-queue the CNAME add appears to succeed.

record statuses based on current flow:
<img width="1009" alt="Screen Shot 2019-11-20 at 9 12 29 PM" src="https://user-images.githubusercontent.com/4439228/69345166-b016a080-0c3e-11ea-91ba-73dd3456c9ba.png">

record statuses based on updated flow:
<img width="1005" alt="Screen Shot 2019-11-20 at 9 12 46 PM" src="https://user-images.githubusercontent.com/4439228/69345178-b4db5480-0c3e-11ea-9c6f-eb9d79f7cf02.png">



Need to add/update more tests.