### PR TITLE
make Batch Change AAAA record data flexible

### DIFF
--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1773,7 +1773,7 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
 
     rs_delete_name = generate_record_name()
     rs_delete_fqdn = rs_delete_name + ".ok."
-    rs_delete_ok = get_recordset_json(ok_zone, rs_delete_name, "AAAA", [{"address": "1:2:3:4:5:6:7:8"}], 200)
+    rs_delete_ok = get_recordset_json(ok_zone, rs_delete_name, "AAAA", [{"address": "1::4:5:6:7:8"}], 200)
 
     rs_update_name = generate_record_name()
     rs_update_fqdn = rs_update_name + ".ok."
@@ -1792,7 +1792,7 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
         "comments": "this is optional",
         "changes": [
             # valid changes
-            get_change_A_AAAA_json(rs_delete_fqdn, record_type="AAAA", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(rs_delete_fqdn, record_type="AAAA", change_type="DeleteRecordSet", address="1:0::4:5:6:7:8"),
             get_change_A_AAAA_json(rs_update_fqdn, record_type="AAAA", ttl=300, address="1:2:3:4:5:6:7:8"),
             get_change_A_AAAA_json(rs_update_fqdn, record_type="AAAA", change_type="DeleteRecordSet"),
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -183,6 +183,14 @@ object BatchTransformations {
   }
 
   object ValidationChanges {
+    def matchRecordData(existingRecord: RecordData, recordData: String): Boolean =
+      existingRecord match {
+        case AAAAData(address) =>
+          InetAddress.getByName(address).getHostName ==
+            InetAddress.getByName(recordData).getHostName
+        case _ => false
+      }
+
     def apply(
         changes: List[ChangeForValidation],
         existingRecordSet: Option[RecordSet]
@@ -203,11 +211,7 @@ object BatchTransformations {
               _,
               DeleteRRSetChangeInput(_, AAAA, Some(AAAAData(address)))
               ) =>
-            existingRecords.filter { r =>
-              InetAddress.getByName(address).getHostName ==
-                InetAddress.getByName(r.asInstanceOf[AAAAData].address).getHostName
-
-            }
+            existingRecords.filter(r => matchRecordData(r, address))
           case DeleteRRSetChangeForValidation(
               _,
               _,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -138,6 +138,12 @@ class BatchChangeValidationsSpec
     DeleteRRSetChangeInput("shared-update", RecordType.AAAA)
   )
 
+  private val deleteSingleRecordChange = DeleteRRSetChangeForValidation(
+    sharedZone,
+    "shared-update",
+    DeleteRRSetChangeInput("shared-update", RecordType.AAAA, Some(AAAAData("1:0::1")))
+  )
+
   private val deletePrivateChange = DeleteRRSetChangeForValidation(
     okZone,
     "private-delete",
@@ -2279,7 +2285,7 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(
         List(
           updateSharedAddChange.validNel,
-          updateSharedDeleteChange.validNel,
+          deleteSingleRecordChange.validNel,
           deleteSharedChange.validNel,
           updatePrivateAddChange.validNel,
           updatePrivateDeleteChange.validNel,


### PR DESCRIPTION
For Batch Changes we now accept record data for DeleteRecordSet to delete only specific records in a recordset rather than the entire recordset. We do an exact match on the existing records in the recordset which is fine for most record data types, except IPv6 address for AAAA records. They can be written in many forms and we should match our existing records across any given format.

Changes in this pull request:
- try to match the given IPv6 address with existing record data in `BatchChangeValidations`
- choose the existing record data that is the equivalent of the given record data in `BatchTransformations`