### PR TITLE
Add max retries to MySQL queue configuration

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -15,6 +15,7 @@ vinyldns {
 
     messages-per-poll = 10
     polling-interval = 250.millis
+    max-retries = 100 # Max retries for message on queue; currently only applies to MySqlMessageQueue
 
     settings {
       # AWS access key and secret.

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -240,11 +240,12 @@ object RecordSetChangeHandler {
   private def verify(change: RecordSetChange, dnsConn: DnsConnection): IO[ProcessorState] =
     getProcessingStatus(change, dnsConn).map {
       case AlreadyApplied(_) => Completed(change.successful)
-      case Failure(_, message) => Completed(
-            change.failed(
-              s"Failed verifying update to DNS for change ${change.id}:${change.recordSet.name}: $message"
-            )
+      case Failure(_, message) =>
+        Completed(
+          change.failed(
+            s"Failed verifying update to DNS for change ${change.id}:${change.recordSet.name}: $message"
           )
+        )
       case _ => Retrying(change)
     }
 

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSDirectives.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSDirectives.scala
@@ -44,11 +44,11 @@ trait VinylDNSDirectives[E] extends Directives {
       onSuccess(
         vinylDNSAuthenticator.authenticate(ctx, strictEntity.data.utf8String).unsafeToFuture()
       ).flatMap {
-          case Right(authPrincipal) ⇒
-            provide(authPrincipal)
-          case Left(e) ⇒
-            complete(handleAuthenticateError(e))
-        }
+        case Right(authPrincipal) ⇒
+          provide(authPrincipal)
+        case Left(e) ⇒
+          complete(handleAuthenticateError(e))
+      }
     }
   }
 

--- a/modules/core/src/main/scala/vinyldns/core/queue/MessageQueueConfig.scala
+++ b/modules/core/src/main/scala/vinyldns/core/queue/MessageQueueConfig.scala
@@ -25,5 +25,5 @@ final case class MessageQueueConfig(
     pollingInterval: FiniteDuration,
     messagesPerPoll: Int,
     settings: Config,
-    maxRetries: Option[Int]
+    maxRetries: Int
 )

--- a/modules/core/src/main/scala/vinyldns/core/queue/MessageQueueConfig.scala
+++ b/modules/core/src/main/scala/vinyldns/core/queue/MessageQueueConfig.scala
@@ -24,5 +24,6 @@ final case class MessageQueueConfig(
     className: String,
     pollingInterval: FiniteDuration,
     messagesPerPoll: Int,
-    settings: Config
+    settings: Config,
+    maxRetries: Option[Int]
 )

--- a/modules/core/src/test/scala/vinyldns/core/queue/MessageQueueLoaderSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/queue/MessageQueueLoaderSpec.scala
@@ -56,7 +56,8 @@ class MessageQueueLoaderSpec extends WordSpec with Matchers {
           "vinyldns.core.queue.MockMessageQueueProvider",
           pollingInterval,
           messagesPerPoll,
-          placeholderConfig
+          placeholderConfig,
+          100
         )
 
       val loadCall = MessageQueueLoader.load(config)
@@ -64,7 +65,7 @@ class MessageQueueLoaderSpec extends WordSpec with Matchers {
     }
     "Error if the configured provider cannot be found" in {
       val config =
-        MessageQueueConfig("bad.class", pollingInterval, messagesPerPoll, placeholderConfig)
+        MessageQueueConfig("bad.class", pollingInterval, messagesPerPoll, placeholderConfig, 100)
 
       val loadCall = MessageQueueLoader.load(config)
 
@@ -76,7 +77,8 @@ class MessageQueueLoaderSpec extends WordSpec with Matchers {
           "vinyldns.core.queue.FailMessageQueueProvider",
           pollingInterval,
           messagesPerPoll,
-          placeholderConfig
+          placeholderConfig,
+          100
         )
 
       val loadCall = MessageQueueLoader.load(config)

--- a/modules/docs/src/main/tut/operator/config-api.md
+++ b/modules/docs/src/main/tut/operator/config-api.md
@@ -119,6 +119,7 @@ queue {
   
   polling-interval = 250.millis
   messages-per-poll = 10
+  max-retries = 50 # Override max retries; default = 100
 
   settings = {
     name = "vinyldns"

--- a/modules/mysql/src/it/resources/application.conf
+++ b/modules/mysql/src/it/resources/application.conf
@@ -38,6 +38,7 @@ queue {
   class-name = "vinyldns.mysql.queue.MySqlMessageQueueProvider"
   polling-interval = 250.millis
   messages-per-poll = 10
+  max-retries = 100 # Max retries for message on queue
 
   settings = {
     name = "vinyldns2"

--- a/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueueProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueueProvider.scala
@@ -38,7 +38,7 @@ class MySqlMessageQueueProvider extends MessageQueueProvider {
       connectionSettings <- loadConfigF[IO, MySqlConnectionConfig](config.settings)
       _ <- runDBMigrations(connectionSettings)
       _ <- setupQueueConnection(connectionSettings)
-    } yield new MySqlMessageQueue()
+    } yield new MySqlMessageQueue(config.maxRetries)
 
   def setupQueueConnection(config: MySqlConnectionConfig): IO[Unit] = {
     val queueConnectionSettings = MySqlDataSourceSettings(config, "mysqlQueuePool")

--- a/modules/mysql/src/test/scala/vinyldns/mysql/queue/MySqlMessageQueueProviderSpec.scala
+++ b/modules/mysql/src/test/scala/vinyldns/mysql/queue/MySqlMessageQueueProviderSpec.scala
@@ -32,6 +32,7 @@ class MySqlMessageQueueProviderSpec extends WordSpec with Matchers {
             |  class-name = "vinyldns.mysql.queue.MySqlMessageQueueProvider"
             |    polling-interval = 250.millis
             |    messages-per-poll = 10
+            |    max-retries = 100
             |
             |  settings = {
             |    name = "vinyldns"

--- a/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlDataStoreProviderSpec.scala
+++ b/modules/mysql/src/test/scala/vinyldns/mysql/repository/MySqlDataStoreProviderSpec.scala
@@ -19,7 +19,7 @@ package vinyldns.mysql.repository
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
-import vinyldns.core.repository.{DataStoreConfig}
+import vinyldns.core.repository.DataStoreConfig
 import vinyldns.mysql.MySqlConnectionConfig
 
 class MySqlDataStoreProviderSpec extends WordSpec with Matchers {

--- a/modules/portal/app/models/DnsChangeNotices.scala
+++ b/modules/portal/app/models/DnsChangeNotices.scala
@@ -60,7 +60,8 @@ case class DnsChangeNotice(
 
 object DnsChangeStatus extends Enumeration {
   type DnsChangeStatus = Value
-  val Cancelled, Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected, Scheduled = Value
+  val Cancelled, Complete, Failed, PartialFailure, PendingProcessing, PendingReview, Rejected,
+      Scheduled = Value
 }
 
 object DnsChangeNoticeType extends Enumeration {

--- a/modules/sqs/src/it/resources/application.conf
+++ b/modules/sqs/src/it/resources/application.conf
@@ -2,6 +2,7 @@ sqs {
   class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
   polling-interval = 250.millis
   messages-per-poll = 10
+  max-retries = 100
   settings = {
     access-key = "x"
     secret-key = "x"

--- a/modules/sqs/src/it/scala/vinyldns/sqs/queue/SqsMessageQueueProviderIntegrationSpec.scala
+++ b/modules/sqs/src/it/scala/vinyldns/sqs/queue/SqsMessageQueueProviderIntegrationSpec.scala
@@ -30,6 +30,7 @@ class SqsMessageQueueProviderIntegrationSpec extends WordSpec with Matchers {
           |    class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
           |    polling-interval = 250.millis
           |    messages-per-poll = 10
+          |    max-retries = 100
           |
           |    settings {
           |      access-key = "x"
@@ -52,6 +53,7 @@ class SqsMessageQueueProviderIntegrationSpec extends WordSpec with Matchers {
           |    class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
           |    polling-interval = 250.millis
           |    messages-per-poll = 10
+          |    max-retries = 100
           |
           |    settings {
           |      access-key = "x"
@@ -77,6 +79,7 @@ class SqsMessageQueueProviderIntegrationSpec extends WordSpec with Matchers {
           |    class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
           |    polling-interval = 250.millis
           |    messages-per-poll = 10
+          |    max-retries = 100
           |
           |    settings {
           |      access-key = "x"
@@ -97,6 +100,7 @@ class SqsMessageQueueProviderIntegrationSpec extends WordSpec with Matchers {
           |    class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
           |    polling-interval = 250.millis
           |    messages-per-poll = 10
+          |    max-retries = 100
           |
           |    settings {
           |      access-key = "x"
@@ -119,6 +123,7 @@ class SqsMessageQueueProviderIntegrationSpec extends WordSpec with Matchers {
           |    class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
           |    polling-interval = 250.millis
           |    messages-per-poll = 10
+          |    max-retries = 100
           |
           |    settings {
           |      access-key = "x"


### PR DESCRIPTION
Changes in this PR:
- Add new optional `maxRetries` config value for `MySqlMessageQueue` with default value of 100
- Update example config in documentation

----
Note: If encountering a config error during API boot, try doing a clean (`sbt ";project api ;clean ;run"`).