### PR TITLE
fix user lock status in group response

### DIFF
--- a/modules/api/functional_test/live_tests/membership/list_group_members_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_group_members_test.py
@@ -96,7 +96,7 @@ def test_list_group_members_start_from(shared_zone_test_context):
 
         # members has one more because admins are added as members
         assert_that(result['members'], has_length(len(members) + 1))
-        assert_that(result['members'], has_item({'lockStatus': 'Unlocked', 'id': 'ok'}))
+        assert_that(result['members'], has_item({'id': 'ok'}))
         result_member_ids = map(lambda member: member['id'], result['members'])
         for user in members:
             assert_that(result_member_ids, has_item(user['id']))

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -43,8 +43,8 @@ object GroupInfo {
     description = group.description,
     created = group.created,
     status = group.status,
-    members = group.memberIds.map(UserId(_)),
-    admins = group.adminUserIds.map(UserId(_))
+    members = group.memberIds.map(UserId),
+    admins = group.adminUserIds.map(UserId)
   )
 }
 
@@ -68,15 +68,7 @@ object GroupChangeInfo {
   )
 }
 
-case class UserId(
-    id: String
-)
-object UserId {
-  def apply(user: User): UserId =
-    UserId(
-      id = user.id
-    )
-}
+case class UserId(id: String)
 
 case class UserInfo(
     id: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -32,8 +32,8 @@ final case class GroupInfo(
     description: Option[String] = None,
     created: DateTime = DateTime.now,
     status: GroupStatus = GroupStatus.Active,
-    members: Set[UserInfo] = Set.empty,
-    admins: Set[UserInfo] = Set.empty
+    members: Set[UserId] = Set.empty,
+    admins: Set[UserId] = Set.empty
 )
 object GroupInfo {
   def apply(group: Group): GroupInfo = GroupInfo(
@@ -43,8 +43,8 @@ object GroupInfo {
     description = group.description,
     created = group.created,
     status = group.status,
-    members = group.memberIds.map(UserInfo(_)),
-    admins = group.adminUserIds.map(UserInfo(_))
+    members = group.memberIds.map(UserId(_)),
+    admins = group.adminUserIds.map(UserId(_))
   )
 }
 
@@ -68,6 +68,16 @@ object GroupChangeInfo {
   )
 }
 
+case class UserId(
+    id: String
+)
+object UserId {
+  def apply(user: User): UserId =
+    UserId(
+      id = user.id
+    )
+}
+
 case class UserInfo(
     id: String,
     userName: Option[String] = None,
@@ -75,7 +85,7 @@ case class UserInfo(
     lastName: Option[String] = None,
     email: Option[String] = None,
     created: Option[DateTime] = None,
-    lockStatus: LockStatus = LockStatus.Unlocked
+    lockStatus: LockStatus
 )
 object UserInfo {
   def apply(user: User): UserInfo =

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -30,16 +30,16 @@ object MembershipJsonProtocol {
       name: String,
       email: String,
       description: Option[String],
-      members: Set[UserInfo],
-      admins: Set[UserInfo]
+      members: Set[UserId],
+      admins: Set[UserId]
   )
   final case class UpdateGroupInput(
       id: String,
       name: String,
       email: String,
       description: Option[String],
-      members: Set[UserInfo],
-      admins: Set[UserInfo]
+      members: Set[UserId],
+      admins: Set[UserId]
   )
 }
 
@@ -65,8 +65,8 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "name").required[String]("Missing Group.name"),
         (js \ "email").required[String]("Missing Group.email"),
         (js \ "description").optional[String],
-        (js \ "members").required[Set[UserInfo]]("Missing Group.members"),
-        (js \ "admins").required[Set[UserInfo]]("Missing Group.admins")
+        (js \ "members").required[Set[UserId]]("Missing Group.members"),
+        (js \ "admins").required[Set[UserId]]("Missing Group.admins")
       ).mapN(CreateGroupInput.apply)
   }
   case object UpdateGroupInputSerializer extends ValidationSerializer[UpdateGroupInput] {
@@ -76,8 +76,8 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "name").required[String]("Missing Group.name"),
         (js \ "email").required[String]("Missing Group.email"),
         (js \ "description").optional[String],
-        (js \ "members").required[Set[UserInfo]]("Missing Group.members"),
-        (js \ "admins").required[Set[UserInfo]]("Missing Group.admins")
+        (js \ "members").required[Set[UserId]]("Missing Group.members"),
+        (js \ "admins").required[Set[UserId]]("Missing Group.admins")
       ).mapN(UpdateGroupInput.apply)
   }
 
@@ -108,8 +108,8 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "description").optional[String],
         (js \ "created").default[DateTime](DateTime.now),
         (js \ "status").default(GroupStatus, GroupStatus.Active),
-        (js \ "members").default[Set[UserInfo]](Set.empty),
-        (js \ "admins").default[Set[UserInfo]](Set.empty)
+        (js \ "members").default[Set[UserId]](Set.empty),
+        (js \ "admins").default[Set[UserId]](Set.empty)
       ).mapN(GroupInfo.apply)
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/CreateGroupInputSerializerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/CreateGroupInputSerializerSpec.scala
@@ -21,7 +21,7 @@ import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.{Matchers, WordSpec}
-import vinyldns.api.domain.membership.UserInfo
+import vinyldns.api.domain.membership.UserId
 
 class CreateGroupInputSerializerSpec
     extends WordSpec
@@ -35,8 +35,8 @@ class CreateGroupInputSerializerSpec
       name: String,
       email: String,
       description: Option[String],
-      members: Set[UserInfo] = Set.empty,
-      admins: Set[UserInfo] = Set.empty
+      members: Set[UserId] = Set.empty,
+      admins: Set[UserId] = Set.empty
   ): JValue =
     ("name" -> name) ~~
       ("email" -> email) ~~
@@ -49,8 +49,8 @@ class CreateGroupInputSerializerSpec
       val expectedName = "foo"
       val expectedEmail = "test@test.com"
       val expectedDesc = Some("this is a test")
-      val members = Set(UserInfo("foo"))
-      val admins = Set(UserInfo("bar"))
+      val members = Set(UserId("foo"))
+      val admins = Set(UserId("bar"))
 
       val json = testJson(expectedName, expectedEmail, expectedDesc, members, admins)
 

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -370,8 +370,8 @@ class MembershipRoutingSpec
         result.name shouldBe okGroup.name
         result.email shouldBe okGroup.email
         result.description shouldBe okGroup.description
-        result.members shouldBe okGroup.memberIds.map(UserInfo(_))
-        result.admins shouldBe okGroup.memberIds.map(UserInfo(_))
+        result.members shouldBe okGroup.memberIds.map(UserId(_))
+        result.admins shouldBe okGroup.memberIds.map(UserId(_))
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -64,7 +64,7 @@ class MembershipRoutingSpec
   // this is avoided since were working with 0s there anyway
   val baseTime = new DateTime(0)
   val okUserInfo: UserInfo = UserInfo(okUser).copy(created = Some(baseTime))
-  val okUserId: UserId = UserId(okUser)
+  val okUserId: UserId = UserId(okUser.id)
   val dummyUserInfo: UserInfo = UserInfo(dummyUser).copy(created = Some(baseTime))
   val okGroupInfo: GroupInfo = GroupInfo(okGroup).copy(created = baseTime)
   val okMemberInfo: MemberInfo = MemberInfo(okUser, okGroup).copy(created = Some(baseTime))

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -64,6 +64,7 @@ class MembershipRoutingSpec
   // this is avoided since were working with 0s there anyway
   val baseTime = new DateTime(0)
   val okUserInfo: UserInfo = UserInfo(okUser).copy(created = Some(baseTime))
+  val okUserId: UserId = UserId(okUser)
   val dummyUserInfo: UserInfo = UserInfo(dummyUser).copy(created = Some(baseTime))
   val okGroupInfo: GroupInfo = GroupInfo(okGroup).copy(created = baseTime)
   val okMemberInfo: MemberInfo = MemberInfo(okUser, okGroup).copy(created = Some(baseTime))
@@ -79,8 +80,8 @@ class MembershipRoutingSpec
         "good",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
       val expected = GroupInfo(okGroup)
 
@@ -105,8 +106,8 @@ class MembershipRoutingSpec
         "duplicate",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
       doReturn(result(GroupAlreadyExistsError("fail")))
         .when(membershipService)
@@ -156,8 +157,8 @@ class MembershipRoutingSpec
         "not found",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
       doReturn(result(UserNotFoundError("not found")))
         .when(membershipService)
@@ -174,8 +175,8 @@ class MembershipRoutingSpec
         "bad",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
       doReturn(result(new IllegalArgumentException("fail")))
         .when(membershipService)
@@ -345,8 +346,8 @@ class MembershipRoutingSpec
         "good",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
 
       doReturn(result(okGroup))
@@ -381,8 +382,8 @@ class MembershipRoutingSpec
         "duplicate",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
       doReturn(result(GroupAlreadyExistsError("fail")))
         .when(membershipService)
@@ -436,8 +437,8 @@ class MembershipRoutingSpec
         "forbidden",
         "test@test.com",
         Some("describe me"),
-        Set(okUserInfo),
-        Set(okUserInfo)
+        Set(okUserId),
+        Set(okUserId)
       )
 
       doReturn(result(NotAuthorizedError("fail")))
@@ -643,6 +644,7 @@ class MembershipRoutingSpec
       }
     }
   }
+
   "GET GroupActivity" should {
     "return a 200 response with the group changes" in {
       val expected = ListGroupChangesResponse(
@@ -720,6 +722,7 @@ class MembershipRoutingSpec
       }
     }
   }
+
   "PUT update user lock status" should {
     "return a 200 response with the user locked" in {
       membershipRoute = superUserRoute

--- a/modules/api/src/test/scala/vinyldns/api/route/UpdateGroupInputSerializerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/UpdateGroupInputSerializerSpec.scala
@@ -21,7 +21,7 @@ import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.{Matchers, WordSpec}
-import vinyldns.api.domain.membership.UserInfo
+import vinyldns.api.domain.membership.UserId
 
 class UpdateGroupInputSerializerSpec
     extends WordSpec
@@ -36,8 +36,8 @@ class UpdateGroupInputSerializerSpec
       name: String,
       email: String,
       description: Option[String],
-      members: Set[UserInfo] = Set.empty,
-      admins: Set[UserInfo] = Set.empty
+      members: Set[UserId] = Set.empty,
+      admins: Set[UserId] = Set.empty
   ): JValue =
     ("id" -> id) ~~
       ("name" -> name) ~~
@@ -52,8 +52,8 @@ class UpdateGroupInputSerializerSpec
       val expectedName = "foo"
       val expectedEmail = "test@test.com"
       val expectedDesc = Some("this is a test")
-      val members = Set(UserInfo("foo"))
-      val admins = Set(UserInfo("bar"))
+      val members = Set(UserId("foo"))
+      val admins = Set(UserId("bar"))
 
       val json = testJson(expectedId, expectedName, expectedEmail, expectedDesc, members, admins)
 


### PR DESCRIPTION
Noticed our get group endpoint was returning all user lock statuses with the value of Unlocked even if the user is Locked. Looked into this more closely and realized we're using the UserInfo class as part of the response. In the UserInfo class all fields are optional except ID and LockStatus, but when retrieving a group we only have the member IDs so I set a default LockStatus of Unlocked on initial implementation. 

In reality if we're only handling user IDs in certain instances we should just be using a type that only includes the user ID as an attribute. I added UserID that is used in the get, create and update group endpoints. And updated UserInfo to not have a default LockStatus. This also removes LockStatus from the get group endpoint which matches what our documentation currently states the response is.