### PR TITLE
update CNAME placeholders in DNS Change form

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -116,7 +116,8 @@
                                         </select>
                                     </td>
                                     <td>
-                                        <input ng-if="change.type!=='PTR'" name="inputName_{{$index}}" type="text" ng-model="change.inputName" required="string" class="form-control" placeholder="e.g. test.example.com.">
+                                        <input ng-if="change.type!=='PTR' && change.type!=='CNAME'" name="inputName_{{$index}}" type="text" ng-model="change.inputName" required="string" class="form-control" placeholder="e.g. test.example.com.">
+                                        <input ng-if="change.type=='CNAME'" name="inputName_{{$index}}" type="text" ng-model="change.inputName" required="string" class="form-control" placeholder="e.g. alias.example.com.">
                                         <input ng-if="change.type=='PTR'" name="inputName_{{$index}}" type="text" ng-model="change.inputName" required="string" class="form-control" placeholder="e.g. 192.0.2.193">
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.inputName_{{$index}}.$error.required" class="batch-change-error-help">Input name is required!</span>
@@ -165,7 +166,7 @@
                                         <p class="help-block" ng-if="change.changeType=='DeleteRecordSet'">Record Data is optional.</p>
                                     </td>
                                     <td ng-if="change.type=='CNAME'">
-                                        <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. test.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn invalidip>
+                                        <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. answer.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn invalidip>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be a fully qualified domain name!</span>

--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -166,7 +166,7 @@
                                         <p class="help-block" ng-if="change.changeType=='DeleteRecordSet'">Record Data is optional.</p>
                                     </td>
                                     <td ng-if="change.type=='CNAME'">
-                                        <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. answer.example.com." ng-disabled="change.changeType=='DeleteRecordSet'" fqdn invalidip>
+                                        <input name="record_cname_{{$index}}" type="text" ng-model="change.record.cname" ng-required="change.changeType=='Add'" class="form-control" placeholder="e.g. target.example.com" ng-disabled="change.changeType=='DeleteRecordSet'" fqdn invalidip>
                                         <p ng-show="createBatchChangeForm.$submitted">
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.required" class="batch-change-error-help">Record data is required!</span>
                                             <span ng-show="createBatchChangeForm.record_cname_{{$index}}.$error.fqdn" class="batch-change-error-help">CNAME data must be a fully qualified domain name!</span>


### PR DESCRIPTION
There's confusion over which domains go in which DNS Change form fields for CNAME records. Both of the placeholder values are currently "test.example.com". We can change the placeholder values to be more helpful.

Changes in this pull request:
- change the Input Name placeholder to "alias.example.com"
- change the Record Data placeholder to "answer.example.com"
