### PR TITLE
link group and zone names to detail pages

### DIFF
--- a/modules/portal/app/views/groups/groups.scala.html
+++ b/modules/portal/app/views/groups/groups.scala.html
@@ -68,7 +68,10 @@
                             </thead>
                             <tbody>
                                 <tr ng-repeat="group in groups.items | orderBy:'+name'">
-                                    <td class="wrap-long-text">{{group.name}}</td>
+                                    <td class="wrap-long-text">
+                                        <a ng-if="canSeeGroup(group)" ng-href="/groups/{{group.id}}">{{group.name}}</a>
+                                        <span ng-if="!canSeeGroup(group)">{{group.name}}</span>
+                                    </td>
                                     <td class="wrap-long-text">{{group.email}}</td>
                                     <td class="wrap-long-text">{{group.description}}</td>
                                     <td>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -100,7 +100,7 @@
                                         </thead>
                                         <tbody>
                                         <tr ng-repeat="zone in zones">
-                                            <td class="wrap-long-text" ng-bind="zone.name"></td>
+                                            <td class="wrap-long-text"><a ng-href="/zones/{{ zone.id }}" ng-bind="zone.name"></a></td>
                                             <td class="wrap-long-text" ng-bind="zone.email"></td>
                                             <td>
                                                 <a ng-if="canAccessGroup(zone.adminGroupId)" ng-bind="zone.adminGroupName" href="/groups/{{zone.adminGroupId}}"></a>
@@ -205,7 +205,10 @@
                                         </thead>
                                         <tbody>
                                         <tr ng-repeat="zone in allZones">
-                                            <td class="wrap-long-text" ng-bind="zone.name"></td>
+                                            <td class="wrap-long-text">
+                                                <a ng-if="canAccessZone(zone.accessLevel)" ng-bind="zone.name" href="/zones/{{zone.id}}"></a>
+                                                <span ng-if="!canAccessZone(zone.accessLevel)" ng-bind="zone.name"></span>
+                                            </td>
                                             <td class="wrap-long-text" ng-bind="zone.email"></td>
                                             <td>
                                                 <a ng-if="canAccessGroup(zone.adminGroupId)" ng-bind="zone.adminGroupName" href="/groups/{{zone.adminGroupId}}"></a>


### PR DESCRIPTION
<img width="1194" alt="Screen Shot 2019-12-10 at 9 22 31 AM" src="https://user-images.githubusercontent.com/4439228/70537731-f28d1800-1b2e-11ea-8a86-4096c8b021e7.png">

We have view buttons in the Groups and Zones list pages that link to groups and zones users have access too, but we could also help by linking the names in the tables to the detail pages.

Changes in this pull request:
- If a user has access to view a zone or group link the name to the detail page.

