### PR TITLE
Use vinyldns/bind9 image for func test

### DIFF
--- a/bin/func-test-api-testbind9.sh
+++ b/bin/func-test-api-testbind9.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+######################################################################
+# Copies the contents of `docker` into target/scala-2.12
+# to start up dependent services via docker compose.  Once
+# dependent services are started up, the fat jar built by sbt assembly
+# is loaded into a docker container.  Finally, the func tests run inside
+# another docker container
+# At the end, we grab all the logs and place them in the target
+# directory
+######################################################################
+
+DIR=$( cd $(dirname $0) ; pwd -P )
+WORK_DIR=$DIR/../target/scala-2.12
+mkdir -p $WORK_DIR
+
+echo "Cleaning up unused networks..."
+docker network prune -f
+
+echo "Copy all docker to the target directory so we can start up properly and the docker context is small..."
+cp -af $DIR/../docker $WORK_DIR/
+
+echo "Copy over the functional tests as well as those that are run in a container..."
+mkdir -p $WORK_DIR/functest
+rsync -av --exclude='.virtualenv' $DIR/../modules/api/functional_test $WORK_DIR/docker/functest
+
+echo "Copy the vinyldns.jar to the api docker folder so it is in context..."
+if [[ ! -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar ]]; then
+    echo "vinyldns jar not found, building..."
+    cd $DIR/../
+    sbt api/clean api/assembly
+    cd $DIR
+fi
+cp -f $DIR/../modules/api/target/scala-2.12/vinyldns.jar $WORK_DIR/docker/api
+
+echo "Starting docker environment and running func tests..."
+
+# If PAR_CPU is unset; default to auto
+if [ -z "${PAR_CPU}" ]; then
+  export PAR_CPU=auto
+fi
+
+docker-compose -f $WORK_DIR/docker/docker-compose-func-test-testbind9.yml --project-directory $WORK_DIR/docker --log-level ERROR up --build --exit-code-from functest
+test_result=$?
+
+echo "Grabbing the logs..."
+
+docker logs vinyldns-api > $DIR/../target/vinyldns-api.log 2>/dev/null
+docker logs vinyldns-bind9 > $DIR/../target/vinyldns-bind9.log 2>/dev/null
+docker logs vinyldns-mysql > $DIR/../target/vinyldns-mysql.log 2>/dev/null
+docker logs vinyldns-elasticmq > $DIR/../target/vinyldns-elasticmq.log 2>/dev/null
+docker logs vinyldns-dynamodb > $DIR/../target/vinyldns-dynamodb.log 2>/dev/null
+docker logs vinyldns-functest > $DIR/../target/vinyldns-functest.log 2>/dev/null
+
+echo "Cleaning up docker containers..."
+$DIR/./remove-vinyl-containers.sh
+
+echo "Func tests returned result: ${test_result}"
+exit ${test_result}

--- a/docker/docker-compose-func-test-testbind9.yml
+++ b/docker/docker-compose-func-test-testbind9.yml
@@ -6,21 +6,16 @@ services:
       .env
     container_name: "vinyldns-mysql"
     ports:
-      - "19002:3306"
+    - "19002:3306"
     logging:
       driver: none
 
   bind9:
-    image: "vinyldns/bind9:0.0.4"
-    env_file:
-      .env
+    image: "vinyldns/test-bind9:0.9.4"
     container_name: "vinyldns-bind9"
-    volumes:
-      - ./bind9/etc:/var/cache/bind/config
-      - ./bind9/zones:/var/cache/bind/zones
     ports:
-      - "19001:53/tcp"
-      - "19001:53/udp"
+    - "19001:53/tcp"
+    - "19001:53/udp"
     logging:
       driver: none
 
@@ -32,19 +27,19 @@ services:
     logging:
       driver: none
     ports:
-      - "19000:8000"
+    - "19000:8000"
     command: "--sharedDb --inMemory"
 
   localstack:
     image: localstack/localstack:0.10.4
     container_name: "vinyldns-localstack"
     ports:
-      - "19006:19006"
-      - "19007:19007"
+    - "19006:19006"
+    - "19007:19007"
     environment:
-      - SERVICES=sns:19006,sqs:19007
-      - START_WEB=0
-      - HOSTNAME_EXTERNAL=vinyldns-localstack
+    - SERVICES=sns:19006,sqs:19007
+    - START_WEB=0
+    - HOSTNAME_EXTERNAL=vinyldns-localstack
 
   # this file is copied into the target directory to get the jar!  won't run in place as is!
   api:
@@ -54,11 +49,11 @@ services:
       .env
     container_name: "vinyldns-api"
     ports:
-      - "9000:9000"
+    - "9000:9000"
     depends_on:
-      - mysql
-      - bind9
-      - localstack
+    - mysql
+    - bind9
+    - localstack
     logging:
       driver: none
 
@@ -68,7 +63,7 @@ services:
     env_file:
       .env
     environment:
-      - PAR_CPU=${PAR_CPU}
+    - PAR_CPU=${PAR_CPU}
     container_name: "vinyldns-functest"
     depends_on:
-      - api
+    - api


### PR DESCRIPTION
Changes in this pull request:
- Revert `bin/func-test-api.sh` to use `vinyldns/bind9` image for default func tests (to pull local BIND9 files)
- Clone a copy of func test and docker to use `vinyldns/testbind9`
