### PR TITLE
Implement record set sync against DNS backend in RecordSetChangeHandler process flow

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetChangeGenerator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetChangeGenerator.scala
@@ -123,7 +123,11 @@ object RecordSetChangeGenerator extends DnsConversions {
   def forDelete(recordSet: RecordSet, zone: Zone, auth: AuthPrincipal): RecordSetChange =
     forDelete(recordSet, zone, auth.userId, List())
 
-  def forSyncAdd(recordSet: RecordSet, zone: Zone): RecordSetChange =
+  private def forSyncAdd(
+      recordSet: RecordSet,
+      zone: Zone,
+      systemMessage: Option[String]
+  ): RecordSetChange =
     RecordSetChange(
       zone = zone,
       recordSet = recordSet
@@ -131,10 +135,15 @@ object RecordSetChangeGenerator extends DnsConversions {
       userId = "system",
       changeType = RecordSetChangeType.Create,
       status = RecordSetChangeStatus.Complete,
-      systemMessage = Some("Change applied via zone sync")
+      systemMessage = systemMessage
     )
 
-  def forSyncUpdate(replacing: RecordSet, newRecordSet: RecordSet, zone: Zone): RecordSetChange =
+  private def forSyncUpdate(
+      replacing: RecordSet,
+      newRecordSet: RecordSet,
+      zone: Zone,
+      systemMessage: Option[String]
+  ): RecordSetChange =
     RecordSetChange(
       zone = zone,
       recordSet = newRecordSet.copy(
@@ -148,10 +157,14 @@ object RecordSetChangeGenerator extends DnsConversions {
       changeType = RecordSetChangeType.Update,
       status = RecordSetChangeStatus.Complete,
       updates = Some(replacing),
-      systemMessage = Some("Change applied via zone sync")
+      systemMessage = systemMessage
     )
 
-  def forSyncDelete(recordSet: RecordSet, zone: Zone): RecordSetChange =
+  private def forSyncDelete(
+      recordSet: RecordSet,
+      zone: Zone,
+      systemMessage: Option[String]
+  ): RecordSetChange =
     RecordSetChange(
       zone = zone,
       recordSet = recordSet.copy(name = relativize(recordSet.name, zone.name)),
@@ -159,6 +172,32 @@ object RecordSetChangeGenerator extends DnsConversions {
       changeType = RecordSetChangeType.Delete,
       status = RecordSetChangeStatus.Complete,
       updates = Some(recordSet),
-      systemMessage = Some("Change applied via zone sync")
+      systemMessage = systemMessage
     )
+
+  def forZoneSyncAdd(recordSet: RecordSet, zone: Zone): RecordSetChange =
+    forSyncAdd(recordSet, zone, Some("Change applied via zone sync"))
+
+  def forZoneSyncUpdate(
+      replacing: RecordSet,
+      newRecordSet: RecordSet,
+      zone: Zone
+  ): RecordSetChange =
+    forSyncUpdate(replacing, newRecordSet, zone, Some("Change applied via zone sync"))
+
+  def forZoneSyncDelete(recordSet: RecordSet, zone: Zone): RecordSetChange =
+    forSyncDelete(recordSet, zone, Some("Change applied via zone sync"))
+
+  def forRecordSyncAdd(recordSet: RecordSet, zone: Zone): RecordSetChange =
+    forSyncAdd(recordSet, zone, Some("Change applied via record sync"))
+
+  def forRecordSyncUpdate(
+      replacing: RecordSet,
+      newRecordSet: RecordSet,
+      zone: Zone
+  ): RecordSetChange =
+    forSyncUpdate(replacing, newRecordSet, zone, Some("Change applied via record sync"))
+
+  def forRecordSyncDelete(recordSet: RecordSet, zone: Zone): RecordSetChange =
+    forSyncAdd(recordSet, zone, Some("Change applied via record sync"))
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetChangeGenerator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetChangeGenerator.scala
@@ -189,15 +189,15 @@ object RecordSetChangeGenerator extends DnsConversions {
     forSyncDelete(recordSet, zone, Some("Change applied via zone sync"))
 
   def forRecordSyncAdd(recordSet: RecordSet, zone: Zone): RecordSetChange =
-    forSyncAdd(recordSet, zone, Some("Change applied via record sync"))
+    forSyncAdd(recordSet, zone, Some("Change applied via record set sync"))
 
   def forRecordSyncUpdate(
       replacing: RecordSet,
       newRecordSet: RecordSet,
       zone: Zone
   ): RecordSetChange =
-    forSyncUpdate(replacing, newRecordSet, zone, Some("Change applied via record sync"))
+    forSyncUpdate(replacing, newRecordSet, zone, Some("Change applied via record set sync"))
 
   def forRecordSyncDelete(recordSet: RecordSet, zone: Zone): RecordSetChange =
-    forSyncAdd(recordSet, zone, Some("Change applied via record sync"))
+    forSyncAdd(recordSet, zone, Some("Change applied via record set sync"))
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneView.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneView.scala
@@ -48,13 +48,13 @@ case class ZoneView(zone: Zone, recordSetsMap: Map[(String, RecordType), RecordS
   def diff(otherView: ZoneView): Seq[RecordSetChange] = {
 
     def toAddRecordSetChange(recordSet: RecordSet): RecordSetChange =
-      RecordSetChangeGenerator.forSyncAdd(recordSet, zone)
+      RecordSetChangeGenerator.forZoneSyncAdd(recordSet, zone)
 
     def toDeleteRecordSetChange(recordSet: RecordSet): RecordSetChange =
-      RecordSetChangeGenerator.forSyncDelete(recordSet, zone)
+      RecordSetChangeGenerator.forZoneSyncDelete(recordSet, zone)
 
     def toUpdateRecordSetChange(newRecordSet: RecordSet, oldRecordSet: RecordSet): RecordSetChange =
-      RecordSetChangeGenerator.forSyncUpdate(oldRecordSet, newRecordSet, zone)
+      RecordSetChangeGenerator.forZoneSyncUpdate(oldRecordSet, newRecordSet, zone)
 
     def areDifferent(left: RecordSet, right: RecordSet): Boolean = !matches(left, right, zone.name)
 

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -21,9 +21,11 @@ import cats.implicits._
 import org.slf4j.LoggerFactory
 import vinyldns.api.domain.dns.DnsConnection
 import vinyldns.api.domain.dns.DnsProtocol.{NoError, Refused, TryAgain}
+import vinyldns.api.domain.record.RecordSetChangeGenerator
 import vinyldns.api.domain.record.RecordSetHelpers._
 import vinyldns.core.domain.batch.{BatchChangeRepository, SingleChange}
 import vinyldns.core.domain.record._
+import vinyldns.core.domain.zone.Zone
 
 object RecordSetChangeHandler {
 
@@ -57,7 +59,13 @@ object RecordSetChangeHandler {
   )(implicit timer: Timer[IO]): IO[RecordSetChange] =
     for {
       wildCardExists <- wildCardExistsForRecord(recordSetChange.recordSet, recordSetRepository)
-      completedState <- fsm(Pending(recordSetChange), conn, wildCardExists)
+      completedState <- fsm(
+        Pending(recordSetChange),
+        conn,
+        wildCardExists,
+        recordSetRepository,
+        recordChangeRepository
+      )
       changeSet = ChangeSet(completedState.change).complete(completedState.change)
       _ <- recordSetRepository.apply(changeSet)
       _ <- recordChangeRepository.save(changeSet)
@@ -114,46 +122,78 @@ object RecordSetChangeHandler {
   // Failure to process change. Permitted to retry.
   final case class Retry(change: RecordSetChange) extends ProcessingStatus
 
-  def getProcessingStatus(change: RecordSetChange, dnsConn: DnsConnection): IO[ProcessingStatus] = {
+  def syncAndGetProcessingStatusFromDnsBackend(
+      change: RecordSetChange,
+      dnsConn: DnsConnection,
+      recordSetRepository: RecordSetRepository,
+      recordChangeRepository: RecordChangeRepository,
+      performSync: Boolean = false
+  ): IO[ProcessingStatus] = {
     def isDnsMatch(dnsResult: List[RecordSet], recordSet: RecordSet, zoneName: String): Boolean =
       dnsResult.exists(matches(_, recordSet, zoneName))
 
-    dnsConn.resolve(change.recordSet.name, change.zone.name, change.recordSet.typ).value.map {
+    // Determine processing status by comparing request against disposition of DNS backend
+    def getProcessingStatus(
+        change: RecordSetChange,
+        existingRecords: List[RecordSet]
+    ): IO[ProcessingStatus] = IO {
+      change.changeType match {
+        case RecordSetChangeType.Create =>
+          if (existingRecords.isEmpty) ReadyToApply(change)
+          else if (isDnsMatch(existingRecords, change.recordSet, change.zone.name))
+            AlreadyApplied(change)
+          else Failure(change, "Incompatible record already exists in DNS.")
+
+        case RecordSetChangeType.Update =>
+          if (isDnsMatch(existingRecords, change.recordSet, change.zone.name))
+            AlreadyApplied(change)
+          else {
+            // record must not exist in the DNS backend, or be synced if it exists
+            val canApply = existingRecords.isEmpty ||
+              change.updates.exists(oldRs => isDnsMatch(existingRecords, oldRs, change.zone.name))
+
+            if (canApply) ReadyToApply(change)
+            else
+              Failure(
+                change,
+                "This record set is out of sync with the DNS backend; " +
+                  "sync this zone before attempting to update this record set."
+              )
+          }
+
+        case RecordSetChangeType.Delete =>
+          if (existingRecords.nonEmpty) ReadyToApply(change) // we have a record set, move forward
+          else AlreadyApplied(change) // we did not find the record set, so already applied
+      }
+    }
+
+    dnsConn.resolve(change.recordSet.name, change.zone.name, change.recordSet.typ).value.flatMap {
       case Right(existingRecords) =>
-        change.changeType match {
-          case RecordSetChangeType.Create =>
-            if (existingRecords.isEmpty) ReadyToApply(change)
-            else if (isDnsMatch(existingRecords, change.recordSet, change.zone.name))
-              AlreadyApplied(change)
-            else Failure(change, "Incompatible record already exists in DNS.")
-
-          case RecordSetChangeType.Update =>
-            if (isDnsMatch(existingRecords, change.recordSet, change.zone.name))
-              AlreadyApplied(change)
-            else {
-              // record must not exist in the DNS backend, or be synced if it exists
-              val canApply = existingRecords.isEmpty ||
-                change.updates.exists(oldRs => isDnsMatch(existingRecords, oldRs, change.zone.name))
-
-              if (canApply) ReadyToApply(change)
-              else
-                Failure(
-                  change,
-                  "This record set is out of sync with the DNS backend; " +
-                    "sync this zone before attempting to update this record set."
-                )
-            }
-
-          case RecordSetChangeType.Delete =>
-            if (existingRecords.nonEmpty) ReadyToApply(change) // we have a record set, move forward
-            else AlreadyApplied(change) // we did not find the record set, so already applied
+        if (performSync) {
+          for {
+            dnsBackendRRSet <- syncAgainstDnsBackend(
+              change,
+              existingRecords,
+              recordSetRepository,
+              recordChangeRepository
+            )
+            processingStatus <- getProcessingStatus(change, dnsBackendRRSet)
+          } yield processingStatus
+        } else {
+          getProcessingStatus(change, existingRecords)
         }
-      case Left(_: TryAgain) => Retry(change)
-      case Left(error) => Failure(change, error.getMessage)
+      case Left(_: TryAgain) => IO(Retry(change))
+      case Left(error) => IO(Failure(change, error.getMessage))
     }
   }
 
-  private def fsm(state: ProcessorState, conn: DnsConnection, wildcardExists: Boolean)(
+  private def fsm(
+      state: ProcessorState,
+      conn: DnsConnection,
+      wildcardExists: Boolean,
+      recordSetRepository: RecordSetRepository,
+      recordChangeRepository: RecordChangeRepository
+  )(
       implicit timer: Timer[IO]
   ): IO[ProcessorState] = {
 
@@ -176,21 +216,27 @@ object RecordSetChangeHandler {
       val toRun =
         if (wildcardExists || state.change.recordSet.typ == RecordType.NS) IO.pure(skip) else orElse
 
-      toRun.flatMap(fsm(_, conn, wildcardExists))
+      toRun.flatMap(fsm(_, conn, wildcardExists, recordSetRepository, recordChangeRepository))
     }
 
     state match {
       case Pending(change) =>
         logger.info(s"CHANGE PENDING; ${getChangeLog(change)}")
-        bypassValidation(Validated(change))(orElse = validate(change, conn))
+        bypassValidation(Validated(change))(
+          orElse = validate(change, conn, recordSetRepository, recordChangeRepository)
+        )
 
       case Validated(change) =>
         logger.info(s"CHANGE VALIDATED; ${getChangeLog(change)}")
-        apply(change, conn).flatMap(fsm(_, conn, wildcardExists))
+        apply(change, conn).flatMap(
+          fsm(_, conn, wildcardExists, recordSetRepository, recordChangeRepository)
+        )
 
       case Applied(change) =>
         logger.info(s"CHANGE APPLIED; ${getChangeLog(change)}")
-        bypassValidation(Verified(change.successful))(orElse = verify(change, conn))
+        bypassValidation(Verified(change.successful))(
+          orElse = verify(change, conn, recordSetRepository, recordChangeRepository)
+        )
 
       case Verified(change) =>
         logger.info(s"CHANGE VERIFIED; ${getChangeLog(change)}")
@@ -207,9 +253,74 @@ object RecordSetChangeHandler {
     }
   }
 
+  private def syncAgainstDnsBackend(
+      change: RecordSetChange,
+      dnsBackendRRSet: List[RecordSet],
+      recordSetRepository: RecordSetRepository,
+      recordChangeRepository: RecordChangeRepository
+  ): IO[List[RecordSet]] = {
+
+    /*
+     * Sync current VinylDNS disposition of DNS records against DNS backend for the following conditions:
+     * - Create record from database for DELETE or UPDATE request if missing in database but exists in DNS backend
+     * - Delete record from database for ADD request if exists in database but does not exist in DNS backend
+     */
+    def syncDnsBackendRRSet(
+        storedRRSet: Option[RecordSet],
+        dnsBackendRRSet: Option[RecordSet],
+        zone: Zone,
+        recordSetRepository: RecordSetRepository,
+        recordChangeRepository: RecordChangeRepository
+    ): IO[Unit] = {
+      val recordSetToSync = (storedRRSet, dnsBackendRRSet) match {
+        case (Some(savedRs), None) if change.changeType == RecordSetChangeType.Create =>
+          Some(RecordSetChangeGenerator.forRecordSyncDelete(savedRs, zone))
+        case (None, Some(existingRs))
+            if change.changeType == RecordSetChangeType.Delete ||
+              change.changeType == RecordSetChangeType.Update =>
+          Some(RecordSetChangeGenerator.forRecordSyncAdd(existingRs, zone))
+        case _ => None
+      }
+
+      // Generate record set and record set change to store
+      recordSetToSync
+        .map { rsc =>
+          val changeSet = ChangeSet(rsc)
+          for {
+            _ <- recordChangeRepository.save(changeSet)
+            _ <- recordSetRepository.apply(changeSet)
+          } yield ()
+        }
+        .getOrElse(IO.unit)
+    }
+
+    for {
+      storedRRSet <- recordSetRepository
+        .getRecordSetsByName(change.zoneId, change.recordSet.name)
+      _ <- syncDnsBackendRRSet(
+        storedRRSet.headOption,
+        dnsBackendRRSet.headOption,
+        change.zone,
+        recordSetRepository,
+        recordChangeRepository
+      )
+    } yield dnsBackendRRSet
+  }
+
   /* Step 1: Validate the change hasn't already been applied */
-  private def validate(change: RecordSetChange, dnsConn: DnsConnection): IO[ProcessorState] =
-    getProcessingStatus(change, dnsConn).map {
+  private def validate(
+      change: RecordSetChange,
+      dnsConn: DnsConnection,
+      recordSetRepository: RecordSetRepository,
+      recordChangeRepository: RecordChangeRepository
+  ): IO[ProcessorState] =
+    syncAndGetProcessingStatusFromDnsBackend(
+      change,
+      dnsConn,
+      recordSetRepository,
+      recordChangeRepository,
+      true
+    ).map {
       case AlreadyApplied(_) => Completed(change.successful)
       case ReadyToApply(_) => Validated(change)
       case Failure(_, message) =>
@@ -237,8 +348,18 @@ object RecordSetChangeHandler {
     }
 
   /* Step 3: Verify the record was created. If the ProcessorState is applied or failed we requeue the record.*/
-  private def verify(change: RecordSetChange, dnsConn: DnsConnection): IO[ProcessorState] =
-    getProcessingStatus(change, dnsConn).map {
+  private def verify(
+      change: RecordSetChange,
+      dnsConn: DnsConnection,
+      recordSetRepository: RecordSetRepository,
+      recordChangeRepository: RecordChangeRepository
+  ): IO[ProcessorState] =
+    syncAndGetProcessingStatusFromDnsBackend(
+      change,
+      dnsConn,
+      recordSetRepository,
+      recordChangeRepository
+    ).map {
       case AlreadyApplied(_) => Completed(change.successful)
       case Failure(_, message) =>
         Completed(

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -298,7 +298,7 @@ object RecordSetChangeHandler {
       storedRRSet <- recordSetRepository
         .getRecordSetsByName(change.zoneId, change.recordSet.name)
       _ <- syncDnsBackendRRSet(
-        storedRRSet.headOption,
+        storedRRSet.find(_.typ == change.recordSet.typ),
         dnsBackendRRSet.headOption,
         change.zone,
         recordSetRepository,

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewSpec.scala
@@ -143,8 +143,8 @@ class ZoneViewSpec extends WordSpec with Matchers with VinylDNSTestHelpers {
         val diff = vinyldnsView.diff(dnsView)
 
         val expectedRecordSetChanges = Seq(
-          RecordSetChangeGenerator.forSyncAdd(dnsRecords(1), testZone),
-          RecordSetChangeGenerator.forSyncAdd(dnsRecords(2), testZone)
+          RecordSetChangeGenerator.forZoneSyncAdd(dnsRecords(1), testZone),
+          RecordSetChangeGenerator.forZoneSyncAdd(dnsRecords(2), testZone)
         )
         val anonymizedDiffRecordSetChanges = diff.map(anonymize)
         val anonymizedExpectedRecordSetChanges = expectedRecordSetChanges.map(anonymize)
@@ -165,8 +165,8 @@ class ZoneViewSpec extends WordSpec with Matchers with VinylDNSTestHelpers {
         val diff = vinyldnsView.diff(dnsView)
 
         val expectedRecordSetChanges = Seq(
-          RecordSetChangeGenerator.forSyncDelete(vinyldnsRecords(1), testZone),
-          RecordSetChangeGenerator.forSyncDelete(vinyldnsRecords(2), testZone)
+          RecordSetChangeGenerator.forZoneSyncDelete(vinyldnsRecords(1), testZone),
+          RecordSetChangeGenerator.forZoneSyncDelete(vinyldnsRecords(2), testZone)
         )
 
         val anonymizedDiffRecordSetChanges = diff.map(anonymize)
@@ -205,7 +205,7 @@ class ZoneViewSpec extends WordSpec with Matchers with VinylDNSTestHelpers {
         val diff = vinyldnsView.diff(dnsView)
 
         val expectedRecordSetChanges = Seq(
-          RecordSetChangeGenerator.forSyncUpdate(vinyldnsRecords(1), dnsRecords(1), testZone)
+          RecordSetChangeGenerator.forZoneSyncUpdate(vinyldnsRecords(1), dnsRecords(1), testZone)
         )
 
         val anonymizedDiffRecordSetChanges = diff.map(anonymize)

--- a/modules/api/src/test/scala/vinyldns/api/engine/RecordSetChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/RecordSetChangeHandlerSpec.scala
@@ -689,7 +689,7 @@ class RecordSetChangeHandlerSpec
       processorStatus shouldBe an[AlreadyApplied]
     }
 
-    "sync in the DNS backend if record does not exist" in {
+    "remove record from database for Add if record does not exist in DNS backend" in {
       doReturn(Interfaces.result(Right(List())))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
@@ -778,7 +778,7 @@ class RecordSetChangeHandlerSpec
       processorStatus shouldBe an[AlreadyApplied]
     }
 
-    "sync in the DNS backend if record does not exist in database" in {
+    "sync in the DNS backend for update if record does not exist in database" in {
       doReturn(Interfaces.result(Right(List(rs.copy(ttl = 100)))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
@@ -845,7 +845,7 @@ class RecordSetChangeHandlerSpec
       processorStatus shouldBe a[AlreadyApplied]
     }
 
-    "sync in the DNS backend if record exists" in {
+    "sync in the DNS backend for Delete change if record exists" in {
       doReturn(Interfaces.result(Right(List(rs))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)

--- a/modules/api/src/test/scala/vinyldns/api/engine/RecordSetChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/RecordSetChangeHandlerSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import org.xbill.DNS
 import vinyldns.api.domain.dns.DnsConnection
 import vinyldns.api.domain.dns.DnsProtocol.{NoError, NotAuthorized, Refused, TryAgain}
-import vinyldns.api.engine.RecordSetChangeHandler.{AlreadyApplied, Failure, ReadyToApply, Requeue}
+import vinyldns.api.engine.RecordSetChangeHandler.{AlreadyApplied, ReadyToApply, Requeue}
 import vinyldns.api.repository.InMemoryBatchChangeRepository
 import vinyldns.api.{CatsHelpers, Interfaces}
 import vinyldns.core.domain.batch.{
@@ -129,6 +129,7 @@ class RecordSetChangeHandlerSpec
         .resolve(rs.name, rsChange.zone.name, rs.typ)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List(rs))).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       test.unsafeRunSync()
@@ -167,6 +168,7 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(NoError(mockDnsMessage))).when(mockConn).applyChange(rsChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       test.unsafeRunSync()
@@ -211,6 +213,7 @@ class RecordSetChangeHandlerSpec
         .applyChange(rsChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       test.unsafeRunSync()
@@ -256,6 +259,7 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(NoError(mockDnsMessage))).when(mockConn).applyChange(rsChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       test.unsafeRunSync()
@@ -299,6 +303,7 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(NoError(mockDnsMessage))).when(mockConn).applyChange(rsChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       a[Requeue] shouldBe thrownBy(test.unsafeRunSync())
@@ -353,6 +358,7 @@ class RecordSetChangeHandlerSpec
         .applyChange(rsChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       test.unsafeRunSync()
@@ -394,6 +400,7 @@ class RecordSetChangeHandlerSpec
         .applyChange(rsChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, rsChange)
       a[Requeue] shouldBe thrownBy(test.unsafeRunSync())
@@ -572,6 +579,9 @@ class RecordSetChangeHandlerSpec
         .applyChange(updateChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List(updateChange.recordSet)))
+        .when(mockRsRepo)
+        .getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, updateChange)
       test.unsafeRunSync()
@@ -605,7 +615,8 @@ class RecordSetChangeHandlerSpec
         changeType = RecordSetChangeType.Update,
         updates = Some(rsChange.recordSet.copy(ttl = 87))
       )
-      doReturn(Interfaces.result(Right(List(updateChange.recordSet.copy(ttl = 30)))))
+      val dnsBackendRs = updateChange.recordSet.copy(ttl = 30)
+      doReturn(Interfaces.result(Right(List(dnsBackendRs))))
         .when(mockConn)
         .resolve(rsChange.recordSet.name, rsChange.zone.name, rsChange.recordSet.typ)
       doReturn(Interfaces.result(Right(NoError(mockDnsMessage))))
@@ -613,6 +624,7 @@ class RecordSetChangeHandlerSpec
         .applyChange(updateChange)
       doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
       doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List(dnsBackendRs))).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val test = underTest.apply(mockConn, updateChange)
       test.unsafeRunSync()
@@ -643,9 +655,18 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(Right(List())))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus =
-        RecordSetChangeHandler.getProcessingStatus(rsChange, mockConn).unsafeRunSync()
+        RecordSetChangeHandler
+          .syncAndGetProcessingStatusFromDnsBackend(
+            rsChange,
+            mockConn,
+            mockRsRepo,
+            mockChangeRepo,
+            true
+          )
+          .unsafeRunSync()
       processorStatus shouldBe a[ReadyToApply]
     }
 
@@ -653,33 +674,68 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(Right(List(rs))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List(rs))).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus =
-        RecordSetChangeHandler.getProcessingStatus(rsChange, mockConn).unsafeRunSync()
+        RecordSetChangeHandler
+          .syncAndGetProcessingStatusFromDnsBackend(
+            rsChange,
+            mockConn,
+            mockRsRepo,
+            mockChangeRepo,
+            true
+          )
+          .unsafeRunSync()
       processorStatus shouldBe an[AlreadyApplied]
     }
 
-    "return Failure if changes exist in the DNS backend that do not match the requested change" in {
-      doReturn(Interfaces.result(Right(List(rs.copy(ttl = 300)))))
+    "sync in the DNS backend if record does not exist" in {
+      doReturn(Interfaces.result(Right(List())))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
 
+      doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
+      doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List(rs))).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
+
       val processorStatus =
-        RecordSetChangeHandler.getProcessingStatus(rsChange, mockConn).unsafeRunSync()
-      processorStatus shouldBe a[Failure]
+        RecordSetChangeHandler
+          .syncAndGetProcessingStatusFromDnsBackend(
+            rsChange,
+            mockConn,
+            mockRsRepo,
+            mockChangeRepo,
+            true
+          )
+          .unsafeRunSync()
+
+      verify(mockRsRepo).apply(rsRepoCaptor.capture())
+      verify(mockChangeRepo).save(changeRepoCaptor.capture())
+      verify(mockRsRepo).getRecordSetsByName(rsChange.zoneId, rs.name)
+      processorStatus shouldBe a[ReadyToApply]
     }
   }
 
   "getProcessingStatus for Update" should {
     "return ReadyToApply if change hasn't been applied and current record set matches DNS backend" in {
+      val storedRs = rs.copy(ttl = 300)
       val syncedRsChange =
-        rsChange.copy(changeType = RecordSetChangeType.Update, updates = Some(rs.copy(ttl = 300)))
+        rsChange.copy(changeType = RecordSetChangeType.Update, updates = Some(storedRs))
       doReturn(Interfaces.result(Right(List(syncedRsChange.updates.get))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List(storedRs))).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus =
-        RecordSetChangeHandler.getProcessingStatus(syncedRsChange, mockConn).unsafeRunSync()
+        RecordSetChangeHandler
+          .syncAndGetProcessingStatusFromDnsBackend(
+            syncedRsChange,
+            mockConn,
+            mockRsRepo,
+            mockChangeRepo,
+            true
+          )
+          .unsafeRunSync()
       processorStatus shouldBe a[ReadyToApply]
     }
 
@@ -687,12 +743,16 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(Right(List())))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus = RecordSetChangeHandler
-        .getProcessingStatus(
+        .syncAndGetProcessingStatusFromDnsBackend(
           rsChange
             .copy(changeType = RecordSetChangeType.Update, updates = Some(rs.copy(ttl = 300))),
-          mockConn
+          mockConn,
+          mockRsRepo,
+          mockChangeRepo,
+          true
         )
         .unsafeRunSync()
       processorStatus shouldBe a[ReadyToApply]
@@ -702,25 +762,49 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(Right(List(rsChange.recordSet))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List(rsChange.recordSet)))
+        .when(mockRsRepo)
+        .getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus = RecordSetChangeHandler
-        .getProcessingStatus(rsChange.copy(changeType = RecordSetChangeType.Update), mockConn)
+        .syncAndGetProcessingStatusFromDnsBackend(
+          rsChange.copy(changeType = RecordSetChangeType.Update),
+          mockConn,
+          mockRsRepo,
+          mockChangeRepo,
+          true
+        )
         .unsafeRunSync()
       processorStatus shouldBe an[AlreadyApplied]
     }
 
-    "return Failure if DNS backend changes exist and do not match current record set" in {
-      doReturn(Interfaces.result(Right(List(rsChange.recordSet.copy(ttl = 300)))))
+    "sync in the DNS backend if record does not exist in database" in {
+      doReturn(Interfaces.result(Right(List(rs.copy(ttl = 100)))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val processorStatus = RecordSetChangeHandler
-        .getProcessingStatus(
-          rsChange.copy(changeType = RecordSetChangeType.Update, updates = None),
-          mockConn
-        )
-        .unsafeRunSync()
-      processorStatus shouldBe a[Failure]
+      doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
+      doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty))
+        .when(mockRsRepo)
+        .getRecordSetsByName(cs.zoneId, rs.name)
+
+      val processorStatus =
+        RecordSetChangeHandler
+          .syncAndGetProcessingStatusFromDnsBackend(
+            rsChange
+              .copy(changeType = RecordSetChangeType.Update, updates = Some(rs.copy(ttl = 100))),
+            mockConn,
+            mockRsRepo,
+            mockChangeRepo,
+            true
+          )
+          .unsafeRunSync()
+
+      verify(mockRsRepo).apply(rsRepoCaptor.capture())
+      verify(mockChangeRepo).save(changeRepoCaptor.capture())
+      verify(mockRsRepo).getRecordSetsByName(rsChange.zoneId, rs.name)
+      processorStatus shouldBe a[ReadyToApply]
     }
   }
 
@@ -729,9 +813,16 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(Right(List(rs))))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List(rs))).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus = RecordSetChangeHandler
-        .getProcessingStatus(rsChange.copy(changeType = RecordSetChangeType.Delete), mockConn)
+        .syncAndGetProcessingStatusFromDnsBackend(
+          rsChange.copy(changeType = RecordSetChangeType.Delete),
+          mockConn,
+          mockRsRepo,
+          mockChangeRepo,
+          true
+        )
         .unsafeRunSync()
       processorStatus shouldBe a[ReadyToApply]
     }
@@ -740,11 +831,47 @@ class RecordSetChangeHandlerSpec
       doReturn(Interfaces.result(Right(List())))
         .when(mockConn)
         .resolve(rs.name, rsChange.zone.name, rs.typ)
+      doReturn(IO.pure(List.empty)).when(mockRsRepo).getRecordSetsByName(cs.zoneId, rs.name)
 
       val processorStatus = RecordSetChangeHandler
-        .getProcessingStatus(rsChange.copy(changeType = RecordSetChangeType.Delete), mockConn)
+        .syncAndGetProcessingStatusFromDnsBackend(
+          rsChange.copy(changeType = RecordSetChangeType.Delete),
+          mockConn,
+          mockRsRepo,
+          mockChangeRepo,
+          true
+        )
         .unsafeRunSync()
       processorStatus shouldBe a[AlreadyApplied]
+    }
+
+    "sync in the DNS backend if record exists" in {
+      doReturn(Interfaces.result(Right(List(rs))))
+        .when(mockConn)
+        .resolve(rs.name, rsChange.zone.name, rs.typ)
+
+      doReturn(IO.pure(cs)).when(mockChangeRepo).save(any[ChangeSet])
+      doReturn(IO.pure(cs)).when(mockRsRepo).apply(any[ChangeSet])
+      doReturn(IO.pure(List.empty))
+        .when(mockRsRepo)
+        .getRecordSetsByName(cs.zoneId, rs.name)
+
+      val processorStatus =
+        RecordSetChangeHandler
+          .syncAndGetProcessingStatusFromDnsBackend(
+            rsChange
+              .copy(changeType = RecordSetChangeType.Delete),
+            mockConn,
+            mockRsRepo,
+            mockChangeRepo,
+            true
+          )
+          .unsafeRunSync()
+
+      verify(mockRsRepo).apply(rsRepoCaptor.capture())
+      verify(mockChangeRepo).save(changeRepoCaptor.capture())
+      verify(mockRsRepo).getRecordSetsByName(rsChange.zoneId, rs.name)
+      processorStatus shouldBe a[ReadyToApply]
     }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -135,7 +135,7 @@ class ZoneSyncHandlerSpec
     records = List(NSData("172.17.42.1."))
   )
 
-  private val testRecordSetChange = RecordSetChangeGenerator.forSyncAdd(testRecord2, testZone)
+  private val testRecordSetChange = RecordSetChangeGenerator.forZoneSyncAdd(testRecord2, testZone)
   private val testChangeSet =
     ChangeSet.apply(testRecordSetChange).copy(status = ChangeSetStatus.Applied)
   private val testZoneChange =

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetChange.scala
@@ -23,14 +23,14 @@ import vinyldns.core.domain.zone.{Zone, ZoneCommand, ZoneCommandResult}
 
 object RecordSetChangeStatus extends Enumeration {
   type RecordSetChangeStatus = Value
-  val Pending, Complete, Failed = Value
+  val Pending, Complete, Failed, Synced = Value
 
-  def isDone(status: RecordSetChangeStatus): Boolean = (status == Complete || status == Failed)
+  def isDone(status: RecordSetChangeStatus): Boolean = status == Complete || status == Failed
 }
 
 object RecordSetChangeType extends Enumeration {
   type RecordSetChangeType = Value
-  val Create, Update, Delete = Value
+  val Create, Update, Delete, Sync = Value
 }
 import RecordSetChangeStatus._
 import RecordSetChangeType._


### PR DESCRIPTION
Tied to https://github.com/vinyldns/vinyldns/issues/853.

Changes in this pull request:
- Introduce new `RecordSetChangeType.Sync` and `RecordSetChangeStatus.Synced` enumerations
- Implement a sync against DNS backend check that happens during the `validate` stage of record set change processing
- Update unit tests
