### PR TITLE
Allow exceptions to record set validations depending on disposition of DNS backend

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -267,7 +267,8 @@ class RecordSetServiceIntegrationSpec
       TestMessageQueue,
       new AccessValidations(),
       (_, _) => mockDnsConnection,
-      configuredConnections
+      configuredConnections,
+      false
     )
   }
 

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -19,12 +19,15 @@ package vinyldns.api.domain.record
 import cats.effect._
 import cats.scalatest.EitherMatchers
 import org.joda.time.DateTime
+import org.mockito.Mockito._
 import org.scalatest.Matchers
 import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
+import vinyldns.api.Interfaces._
 import vinyldns.api._
 import vinyldns.api.domain.access.AccessValidations
+import vinyldns.api.domain.dns.DnsConnection
 import vinyldns.api.domain.zone._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.core.TestMembershipData._
@@ -34,7 +37,7 @@ import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record._
-import vinyldns.core.domain.zone.{Zone, ZoneRepository, ZoneStatus}
+import vinyldns.core.domain.zone._
 import vinyldns.dynamodb.repository.{DynamoDBRecordSetRepository, DynamoDBRepositorySettings}
 
 import scala.concurrent.Await
@@ -221,6 +224,14 @@ class RecordSetServiceIntegrationSpec
     ownerGroupId = Some(sharedGroup.id)
   )
 
+  private val zoneConnection =
+    ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
+
+  private val configuredConnections =
+    ConfiguredDnsConnections(zoneConnection, zoneConnection, List())
+
+  private val mockDnsConnection = mock[DnsConnection]
+
   def setup(): Unit = {
     recordSetRepo =
       DynamoDBRecordSetRepository(recordSetStoreConfig, dynamoIntegrationConfig).unsafeRunSync()
@@ -254,7 +265,9 @@ class RecordSetServiceIntegrationSpec
       mock[RecordChangeRepository],
       mock[UserRepository],
       TestMessageQueue,
-      new AccessValidations()
+      new AccessValidations(),
+      (_, _) => mockDnsConnection,
+      configuredConnections
     )
   }
 
@@ -368,6 +381,15 @@ class RecordSetServiceIntegrationSpec
 
     "fail to add relative record if apex record with same name already exists" in {
       val newRecord = apexTestRecordNameConflict.copy(name = "zone-test-name-conflicts")
+
+      doReturn(IO(List(newRecord)).toResult)
+        .when(mockDnsConnection)
+        .resolve(
+          zoneTestNameConflicts.name,
+          zoneTestNameConflicts.name,
+          newRecord.typ
+        )
+
       val result =
         testRecordSetService
           .addRecordSet(newRecord, auth)
@@ -381,6 +403,11 @@ class RecordSetServiceIntegrationSpec
 
     "fail to add apex record if relative record with same name already exists" in {
       val newRecord = subTestRecordNameConflict.copy(name = "relative-name-conflict.")
+
+      doReturn(IO(List(newRecord)).toResult)
+        .when(mockDnsConnection)
+        .resolve(newRecord.name, zoneTestNameConflicts.name, newRecord.typ)
+
       val result =
         testRecordSetService
           .addRecordSet(newRecord, auth)

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -30,6 +30,7 @@ import vinyldns.api.crypto.Crypto
 import vinyldns.api.domain.access.AccessValidations
 import vinyldns.api.domain.auth.MembershipAuthPrincipalProvider
 import vinyldns.api.domain.batch.{BatchChangeConverter, BatchChangeService, BatchChangeValidations}
+import vinyldns.api.domain.dns.DnsConnection
 import vinyldns.api.domain.membership._
 import vinyldns.api.domain.record.RecordSetService
 import vinyldns.api.domain.zone._
@@ -123,7 +124,15 @@ object Boot extends App {
       val membershipService = MembershipService(repositories)
       val connectionValidator =
         new ZoneConnectionValidator(connections)
-      val recordSetService = RecordSetService(repositories, messageQueue, recordAccessValidations)
+      val recordSetService =
+        RecordSetService(
+          repositories,
+          messageQueue,
+          recordAccessValidations,
+          (zone, connections) =>
+            DnsConnection(ZoneConnectionValidator.getZoneConnection(zone, connections)),
+          connections
+        )
       val zoneService = ZoneService(
         repositories,
         connectionValidator,

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -131,7 +131,8 @@ object Boot extends App {
           recordAccessValidations,
           (zone, connections) =>
             DnsConnection(ZoneConnectionValidator.getZoneConnection(zone, connections)),
-          connections
+          connections,
+          VinylDNSConfig.validateRecordLookupAgainstDnsBackend
         )
       val zoneService = ZoneService(
         repositories,

--- a/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/VinylDNSConfig.scala
@@ -160,4 +160,9 @@ object VinylDNSConfig {
       zn => DomainHelpers.ensureTrailingDot(zn.toLowerCase)
     )
   }
+
+  lazy val validateRecordLookupAgainstDnsBackend: Boolean =
+    vinyldnsConfig
+      .as[Option[Boolean]]("validate-record-lookup-against-dns-backend")
+      .getOrElse(false)
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetChangeGenerator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetChangeGenerator.scala
@@ -199,5 +199,5 @@ object RecordSetChangeGenerator extends DnsConversions {
     forSyncUpdate(replacing, newRecordSet, zone, Some("Change applied via record set sync"))
 
   def forRecordSyncDelete(recordSet: RecordSet, zone: Zone): RecordSetChange =
-    forSyncAdd(recordSet, zone, Some("Change applied via record set sync"))
+    forSyncDelete(recordSet, zone, Some("Change applied via record set sync"))
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -23,11 +23,12 @@ import vinyldns.api.domain.zone._
 import vinyldns.api.repository.ApiDataAccessor
 import vinyldns.api.route.ListRecordSetsResponse
 import vinyldns.core.domain.record._
-import vinyldns.core.domain.zone.{Zone, ZoneCommandResult, ZoneRepository}
+import vinyldns.core.domain.zone.{ConfiguredDnsConnections, Zone, ZoneCommandResult, ZoneRepository}
 import vinyldns.core.queue.MessageQueue
 import cats.data._
 import cats.effect.IO
 import vinyldns.api.domain.access.AccessValidationsAlgebra
+import vinyldns.api.domain.dns.DnsConnection
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
 
@@ -35,7 +36,9 @@ object RecordSetService {
   def apply(
       dataAccessor: ApiDataAccessor,
       messageQueue: MessageQueue,
-      accessValidation: AccessValidationsAlgebra
+      accessValidation: AccessValidationsAlgebra,
+      dnsConnection: (Zone, ConfiguredDnsConnections) => DnsConnection,
+      configuredDnsConnections: ConfiguredDnsConnections
   ): RecordSetService =
     new RecordSetService(
       dataAccessor.zoneRepository,
@@ -44,7 +47,9 @@ object RecordSetService {
       dataAccessor.recordChangeRepository,
       dataAccessor.userRepository,
       messageQueue,
-      accessValidation
+      accessValidation,
+      dnsConnection,
+      configuredDnsConnections
     )
 }
 
@@ -55,7 +60,9 @@ class RecordSetService(
     recordChangeRepository: RecordChangeRepository,
     userRepository: UserRepository,
     messageQueue: MessageQueue,
-    accessValidation: AccessValidationsAlgebra
+    accessValidation: AccessValidationsAlgebra,
+    dnsConnection: (Zone, ConfiguredDnsConnections) => DnsConnection,
+    configuredDnsConnections: ConfiguredDnsConnections
 ) extends RecordSetServiceAlgebra {
 
   import RecordSetValidations._
@@ -68,7 +75,7 @@ class RecordSetService(
       // because changes happen to the RS in forAdd itself, converting 1st and validating on that
       rsForValidations = change.recordSet
       _ <- isNotHighValueDomain(recordSet, zone).toResult
-      _ <- recordSetDoesNotExist(rsForValidations, zone)
+      _ <- recordSetDoesNotExist(dnsConnection, configuredDnsConnections, zone, rsForValidations)
       _ <- validRecordTypes(rsForValidations, zone).toResult
       _ <- validRecordNameLength(rsForValidations, zone).toResult
       _ <- canAddRecordSet(auth, rsForValidations.name, rsForValidations.typ, zone).toResult
@@ -100,6 +107,14 @@ class RecordSetService(
       existingRecordsWithName <- recordSetRepository
         .getRecordSetsByName(zone.id, rsForValidations.name)
         .toResult[List[RecordSet]]
+      _ <- isUniqueUpdate(
+        dnsConnection,
+        configuredDnsConnections,
+        rsForValidations,
+        existingRecordsWithName,
+        zone
+      )
+      _ <- noCnameWithNewName(rsForValidations, existingRecordsWithName, zone).toResult
       _ <- typeSpecificValidations(rsForValidations, existingRecordsWithName, zone, Some(existing)).toResult
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
@@ -229,7 +244,7 @@ class RecordSetService(
       )
       .toResult[RecordSet]
 
-  def recordSetDoesNotExist(recordSet: RecordSet, zone: Zone): Result[Unit] =
+  def recordSetDoesNotExistInDatabase(recordSet: RecordSet, zone: Zone): Result[Unit] =
     recordSetRepository
       .getRecordSets(zone.id, recordSet.name, recordSet.typ)
       .map {
@@ -279,4 +294,47 @@ class RecordSetService(
     } yield group
     ownerGroup.value.toResult
   }
+
+  def recordSetDoesNotExist(
+      dnsConnection: (Zone, ConfiguredDnsConnections) => DnsConnection,
+      configuredDnsConnections: ConfiguredDnsConnections,
+      zone: Zone,
+      recordSet: RecordSet
+  ): Result[Unit] =
+    recordSetDoesNotExistInDatabase(recordSet, zone).value.flatMap {
+      case Left(recordSetAlreadyExists: RecordSetAlreadyExists) =>
+        dnsConnection(zone, configuredDnsConnections)
+          .resolve(recordSet.name, zone.name, recordSet.typ)
+          .value
+          .map {
+            case Right(existingRecords) =>
+              if (existingRecords.isEmpty) Right(())
+              else Left(recordSetAlreadyExists)
+            case error => error
+          }
+      case result => IO(result)
+    }.toResult
+
+  def isUniqueUpdate(
+      dnsConnection: (Zone, ConfiguredDnsConnections) => DnsConnection,
+      configuredDnsConnections: ConfiguredDnsConnections,
+      newRecordSet: RecordSet,
+      existingRecordsWithName: List[RecordSet],
+      zone: Zone
+  ): Result[Unit] =
+    RecordSetValidations
+      .recordSetDoesNotExist(newRecordSet, existingRecordsWithName, zone) match {
+      case Left(recordSetAlreadyExists: RecordSetAlreadyExists) =>
+        dnsConnection(zone, configuredDnsConnections)
+          .resolve(newRecordSet.name, zone.name, newRecordSet.typ)
+          .value
+          .map {
+            case Right(existingRecords) =>
+              if (existingRecords.isEmpty) Right(())
+              else Left(recordSetAlreadyExists)
+            case error => error
+          }
+          .toResult
+      case result => IO(result).toResult
+    }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -73,6 +73,20 @@ object RecordSetValidations {
       !existingRecordsWithName.exists(rs => rs.id != newRecordSet.id && rs.typ == CNAME)
     )
 
+  def recordSetDoesNotExist(
+      newRecordSet: RecordSet,
+      existingRecordsWithName: List[RecordSet],
+      zone: Zone
+  ): Either[Throwable, Unit] =
+    ensuring(
+      RecordSetAlreadyExists(
+        s"RecordSet with name ${newRecordSet.name} and type ${newRecordSet.typ} already " +
+          s"exists in zone ${zone.name}"
+      )
+    )(
+      !existingRecordsWithName.exists(rs => rs.id != newRecordSet.id && rs.typ == newRecordSet.typ)
+    )
+
   def isNotDotted(
       newRecordSet: RecordSet,
       zone: Zone,

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -117,6 +117,22 @@ class RecordSetValidationsSpec
       }
     }
 
+    "isUniqueUpdate" should {
+      "return a RecordSetAlreadyExistsError if a record set already exists with the same name but different id" in {
+        val existing = List(aaaa.copy(id = "DifferentID"))
+        val error = leftValue(recordSetDoesNotExist(aaaa, existing, okZone))
+        error shouldBe a[RecordSetAlreadyExists]
+      }
+
+      "return the record set if the record set exists but has the same id" in {
+        recordSetDoesNotExist(aaaa, List(aaaa), okZone) should be(right)
+      }
+
+      "return the record set if the record set does not exist" in {
+        recordSetDoesNotExist(aaaa, List(), okZone) should be(right)
+      }
+    }
+
     "isNotDotted" should {
       "return a failure for any record with dotted hosts in forward zones" in {
         val test = aaaa.copy(name = "this.is.a.failure.")


### PR DESCRIPTION
There is a chance that the database is out-of-sync with the DNS backend. Rather than require for a change to be dependent on a zone sync if the DNS change would be permitted otherwise, we can allow the validation to be accepted and process it normally in the DNS backend.

Changes in this pull request:
- Allow certain scenarios to pass record set validations
- Update unit tests
