### PR TITLE
increase Play Framework maxMemoryBuffer to support large DNS Change requests

### DIFF
--- a/modules/portal/conf/reference.conf
+++ b/modules/portal/conf/reference.conf
@@ -10,7 +10,7 @@
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
 play.http.secret.key = "changeme"
 play.http.secret.key = ${?PLAY_HTTP_SECRET_KEY}
-
+play.http.parser.maxMemoryBuffer = 370K
 # The application languages
 # ~~~~~
 play.i18n.langs = [ "en" ]


### PR DESCRIPTION
Changes in this pull request:
Awhile back we increased the default value of maximum record changes in a batch change to 1000. However we did not account for the Play framework's maximum content length of 100kb. I tested the largest batch changes we might see and and came away with 375kb as a threshold that they be under. We might have reason to increase this further in the future if our supported record types in the DNS Change form in the portal changes.

Source for the content length information: https://www.playframework.com/documentation/2.5.x/ScalaBodyParsers#Max-content-length
