### PR TITLE
add stats mysql table

### DIFF
--- a/modules/mysql/src/main/resources/db/migration/V3.21__Stats.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.21__Stats.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+CREATE TABLE stats (
+  id INT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  count BIGINT NOT NULL,
+  created DATETIME NOT NULL,
+  PRIMARY KEY (id),
+  INDEX stats_name_index (name)
+);

--- a/modules/mysql/src/main/resources/db/migration/V3.21__Stats.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.21__Stats.sql
@@ -3,10 +3,11 @@ CREATE SCHEMA IF NOT EXISTS ${dbName};
 USE ${dbName};
 
 CREATE TABLE stats (
-  id INT NOT NULL AUTO_INCREMENT,
+  id BIGINT NOT NULL AUTO_INCREMENT,
   name VARCHAR(255) NOT NULL,
   count BIGINT NOT NULL,
   created DATETIME NOT NULL,
   PRIMARY KEY (id),
-  INDEX stats_name_index (name)
+  INDEX stats_name_index (name),
+  INDEX stats_name_created_index (name ASC, created ASC)
 );


### PR DESCRIPTION
Changes in this pull request:
- add a table named "stats" to the mysql database to support tracking and storing various database related information. An example would be tracking the number of recordsets in the database at a particular time.
