### PR TITLE
Support DNS backend checks for batch changes

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -119,7 +119,11 @@ object Boot extends App {
       val batchChangeValidations = new BatchChangeValidations(
         batchChangeLimit,
         batchAccessValidations,
-        VinylDNSConfig.scheduledChangesEnabled
+        (zone, connections) =>
+          DnsConnection(ZoneConnectionValidator.getZoneConnection(zone, connections)),
+        connections,
+        VinylDNSConfig.scheduledChangesEnabled,
+        VinylDNSConfig.validateRecordLookupAgainstDnsBackend
       )
       val membershipService = MembershipService(repositories)
       val connectionValidator =

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -130,11 +130,13 @@ class BatchChangeService(
       recordSets <- getExistingRecordSets(changesWithZones, zoneMap).toBatchResult
       withTtl = doTtlMapping(changesWithZones, recordSets)
       groupedChanges = ChangeForValidationMap(withTtl, recordSets)
-      validatedSingleChanges = validateChangesWithContext(
-        groupedChanges,
-        auth,
-        isApproved,
-        batchChangeInput.ownerGroupId
+      validatedSingleChanges <- EitherT.liftF(
+        validateChangesWithContext(
+          groupedChanges,
+          auth,
+          isApproved,
+          batchChangeInput.ownerGroupId
+        )
       )
       errorGroupIds <- getGroupIdsFromUnauthorizedErrors(validatedSingleChanges)
       validatedSingleChangesWithGroups = errorGroupMapping(errorGroupIds, validatedSingleChanges)

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -45,11 +45,12 @@ import vinyldns.core.domain.batch._
 import vinyldns.core.domain.membership.{Group, ListUsersResults, User}
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record.{RecordType, _}
-import vinyldns.core.domain.zone.Zone
+import vinyldns.core.domain.zone.{ConfiguredDnsConnections, Zone, ZoneConnection}
 import vinyldns.core.notifier.{AllNotifiers, Notification, Notifier}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import vinyldns.api.domain.access.AccessValidations
+import vinyldns.api.domain.dns.DnsConnection
 
 import scala.concurrent.ExecutionContext
 
@@ -68,7 +69,18 @@ class BatchChangeServiceSpec
   private val nonFatalError = ZoneDiscoveryError("test")
   private val fatalError = RecordAlreadyExists("test")
 
-  private val validations = new BatchChangeValidations(10, new AccessValidations())
+  private val zoneConnection =
+    ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
+  private val configuredDnsConnections =
+    ConfiguredDnsConnections(zoneConnection, zoneConnection, List())
+  private val mockDnsConnection = mock[DnsConnection]
+
+  private val validations = new BatchChangeValidations(
+    10,
+    new AccessValidations(),
+    (_, _) => mockDnsConnection,
+    configuredDnsConnections
+  )
   private val ttl = Some(200L)
 
   private val apexAddA = AddChangeInput("apex.test.com", RecordType.A, ttl, AData("1.1.1.1"))


### PR DESCRIPTION
Support DNS backend verification for `RecordDoesNotExist` and `RecordAlreadyExists` conflicts that surface when requested DNS changes conflict with the VinylDNS database disposition despite being valid via the DNS backend.

Changes in this pull request:
- Support checking against DNS backend for record existence conflicts with the VinylDNS database. **Note**: The DNS backend would only get polled for DNS records provided in the batch change. This means that the VinylDNS database will still be used as the source of truth for conflicting records that exist since updating records outside of the scope of submitted batch changes should be handled via zone syncs.
