### PR TITLE
Remove trailing whitespace from FQDN record data

### DIFF
--- a/modules/api/functional_test/live_tests/zones/create_zone_test.py
+++ b/modules/api/functional_test/live_tests/zones/create_zone_test.py
@@ -45,7 +45,7 @@ def test_create_zone_success(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
     result_zone = None
     try:
-        zone_name = 'one-time'
+        zone_name = 'one-time '
 
         zone = {
             'name': zone_name,
@@ -60,7 +60,7 @@ def test_create_zone_success(shared_zone_test_context):
         get_result = client.get_zone(result_zone['id'])
 
         get_zone = get_result['zone']
-        assert_that(get_zone['name'], is_(zone['name']+'.'))
+        assert_that(get_zone['name'], is_(zone['name'].strip()+'.'))
         assert_that(get_zone['email'], is_(zone['email']))
         assert_that(get_zone['adminGroupId'], is_(zone['adminGroupId']))
         assert_that(get_zone['latestSync'], is_not(none()))

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -32,7 +32,7 @@ import vinyldns.api.domain.zone._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData.testConnection
-import vinyldns.core.domain.HighValueDomainError
+import vinyldns.core.domain.{Fqdn, HighValueDomainError}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
 import vinyldns.core.domain.record.RecordType._
@@ -129,7 +129,7 @@ class RecordSetServiceIntegrationSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("172.17.42.1."))
+    List(NSData(Fqdn("172.17.42.1.")))
   )
 
   private val zoneTestNameConflicts = Zone(

--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneServiceIntegrationSpec.scala
@@ -29,6 +29,7 @@ import vinyldns.api.engine.TestMessageQueue
 import vinyldns.api.{MySqlApiIntegrationSpec, ResultHelpers}
 import vinyldns.core.TestMembershipData.{okAuth, okUser}
 import vinyldns.core.TestZoneData.okZone
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.{GroupRepository, UserRepository}
 import vinyldns.core.domain.record._
@@ -65,7 +66,7 @@ class ZoneServiceIntegrationSpec
     status = RecordSetStatus.Active,
     created = DateTime.now,
     records =
-      List(SOAData("172.17.42.1.", "admin.test.com.", 1439234395, 10800, 3600, 604800, 38400))
+      List(SOAData(Fqdn("172.17.42.1."), "admin.test.com.", 1439234395, 10800, 3600, 604800, 38400))
   )
   private val testRecordNS = RecordSet(
     zoneId = okZone.id,
@@ -74,7 +75,7 @@ class ZoneServiceIntegrationSpec
     ttl = 38400,
     status = RecordSetStatus.Active,
     created = DateTime.now,
-    records = List(NSData("172.17.42.1."))
+    records = List(NSData(Fqdn("172.17.42.1.")))
   )
   private val testRecordA = RecordSet(
     zoneId = okZone.id,

--- a/modules/api/src/main/scala/vinyldns/api/domain/DomainValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/DomainValidations.scala
@@ -57,6 +57,9 @@ object DomainValidations {
   val MX_PREFERENCE_MIN_VALUE: Int = 0
   val MX_PREFERENCE_MAX_VALUE: Int = 65535
 
+  def validateHostName(name: Fqdn): ValidatedNel[DomainValidationError, Fqdn] =
+    validateHostName(name.fqdn).map(_ => name)
+
   def validateHostName(name: String): ValidatedNel[DomainValidationError, String] = {
     /*
       Label rules are as follows (from RFC 952; detailed in RFC 1034):

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/GlobalAcl.scala
@@ -64,7 +64,7 @@ final case class GlobalAcls(acls: List[GlobalAcl]) {
           }
 
         // forall returns true if the list is empty
-        ptrs.nonEmpty && ptrs.forall(isAuthorized(authPrincipal, _))
+        ptrs.nonEmpty && ptrs.forall(ptrdname => isAuthorized(authPrincipal, ptrdname.fqdn))
       case _ =>
         val fqdn = if (recordName.endsWith(".")) recordName else s"$recordName.${zone.name}"
         isAuthorized(authPrincipal, fqdn)

--- a/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/dns/DnsConversions.scala
@@ -23,7 +23,7 @@ import org.joda.time.DateTime
 import org.xbill.DNS
 import scodec.bits.ByteVector
 import vinyldns.api.domain.dns.DnsProtocol._
-import vinyldns.core.domain.{DomainHelpers, record}
+import vinyldns.core.domain.{DomainHelpers, Fqdn, record}
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record._
 
@@ -231,7 +231,7 @@ trait DnsConversions {
 
   def fromCNAMERecord(r: DNS.CNAMERecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(CNAMEData(data.getAlias.toString))
+      List(CNAMEData(Fqdn(data.getAlias.toString)))
     }
 
   def fromDSRecord(r: DNS.DSRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
@@ -248,24 +248,24 @@ trait DnsConversions {
 
   def fromMXRecord(r: DNS.MXRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(MXData(data.getPriority, data.getTarget.toString))
+      List(MXData(data.getPriority, Fqdn(data.getTarget.toString)))
     }
 
   def fromNSRecord(r: DNS.NSRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(NSData(data.getTarget.toString))
+      List(NSData(Fqdn(data.getTarget.toString)))
     }
 
   def fromPTRRecord(r: DNS.PTRRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(PTRData(data.getTarget.toString))
+      List(PTRData(Fqdn(data.getTarget.toString)))
     }
 
   def fromSOARecord(r: DNS.SOARecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
       List(
         SOAData(
-          data.getHost.toString,
+          Fqdn(data.getHost.toString),
           data.getAdmin.toString,
           data.getSerial,
           data.getRefresh,
@@ -283,7 +283,7 @@ trait DnsConversions {
 
   def fromSRVRecord(r: DNS.SRVRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(SRVData(data.getPriority, data.getWeight, data.getPort, data.getTarget.toString))
+      List(SRVData(data.getPriority, data.getWeight, data.getPort, Fqdn(data.getTarget.toString)))
     }
 
   def fromNAPTRRecord(r: DNS.NAPTRRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
@@ -295,7 +295,7 @@ trait DnsConversions {
           data.getFlags,
           data.getService,
           data.getRegexp,
-          data.getReplacement.toString
+          Fqdn(data.getReplacement.toString)
         )
       )
     }
@@ -323,7 +323,7 @@ trait DnsConversions {
           new DNS.AAAARecord(recordName, DNS.DClass.IN, ttl, InetAddress.getByName(address))
 
         case CNAMEData(cname) =>
-          new DNS.CNAMERecord(recordName, DNS.DClass.IN, ttl, DNS.Name.fromString(cname))
+          new DNS.CNAMERecord(recordName, DNS.DClass.IN, ttl, DNS.Name.fromString(cname.fqdn))
 
         case DSData(keyTag, algorithm, digestType, digest) =>
           new DNS.DSRecord(
@@ -337,7 +337,7 @@ trait DnsConversions {
           )
 
         case NSData(nsdname) =>
-          new DNS.NSRecord(recordName, DNS.DClass.IN, ttl, DNS.Name.fromString(nsdname))
+          new DNS.NSRecord(recordName, DNS.DClass.IN, ttl, DNS.Name.fromString(nsdname.fqdn))
 
         case MXData(preference, exchange) =>
           new DNS.MXRecord(
@@ -345,18 +345,18 @@ trait DnsConversions {
             DNS.DClass.IN,
             ttl,
             preference,
-            DNS.Name.fromString(exchange)
+            DNS.Name.fromString(exchange.fqdn)
           )
 
         case PTRData(ptrdname) =>
-          new DNS.PTRRecord(recordName, DNS.DClass.IN, ttl, DNS.Name.fromString(ptrdname))
+          new DNS.PTRRecord(recordName, DNS.DClass.IN, ttl, DNS.Name.fromString(ptrdname.fqdn))
 
         case SOAData(mname, rname, serial, refresh, retry, expire, minimum) =>
           new DNS.SOARecord(
             recordName,
             DNS.DClass.IN,
             ttl,
-            DNS.Name.fromString(mname),
+            DNS.Name.fromString(mname.fqdn),
             DNS.Name.fromString(rname),
             serial,
             refresh,
@@ -373,7 +373,7 @@ trait DnsConversions {
             priority,
             weight,
             port,
-            DNS.Name.fromString(target)
+            DNS.Name.fromString(target.fqdn)
           )
 
         case NAPTRData(order, preference, flags, service, regexp, replacement) =>
@@ -386,7 +386,7 @@ trait DnsConversions {
             flags,
             service,
             regexp,
-            DNS.Name.fromString(replacement)
+            DNS.Name.fromString(replacement.fqdn)
           )
 
         case SSHFPData(algorithm, typ, fingerprint) =>

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
@@ -48,10 +48,10 @@ object ZoneRecordValidations {
       approvedServerList: List[Regex],
       nsData: NSData
   ): ValidatedNel[String, NSData] =
-    if (isStringInRegexList(approvedServerList, nsData.nsdname)) {
+    if (isStringInRegexList(approvedServerList, nsData.nsdname.fqdn)) {
       nsData.validNel[String]
     } else {
-      s"Name Server ${nsData.nsdname} is not an approved name server.".invalidNel[NSData]
+      s"Name Server ${nsData.nsdname.fqdn} is not an approved name server.".invalidNel[NSData]
     }
 
   /* Inspects each record in the rdata, returning back the record set itself or all ns records that are not approved */

--- a/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/email/EmailNotifier.scala
@@ -174,9 +174,9 @@ class EmailNotifier(config: EmailNotifierConfig, session: Session, userRepositor
   def formatRecordData(rd: RecordData): String = rd match {
     case AData(address) => address
     case AAAAData(address) => address
-    case CNAMEData(cname) => cname
+    case CNAMEData(cname) => cname.fqdn
     case MXData(preference, exchange) => s"Preference: $preference Exchange: $exchange"
-    case PTRData(name) => name
+    case PTRData(name) => name.fqdn
     case TXTData(text) => text
     case _ => rd.toString
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
@@ -25,6 +25,7 @@ import vinyldns.api.domain.zone.{NotAuthorizedError, RecordSetInfo, RecordSetLis
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record._
@@ -237,7 +238,7 @@ class AccessValidationsSpec
         "someRecordName",
         RecordType.PTR,
         zoneIp4,
-        List(PTRData("test.foo.comcast.net"))
+        List(PTRData(Fqdn("test.foo.comcast.net")))
       ) should be(right)
     }
   }
@@ -351,7 +352,7 @@ class AccessValidationsSpec
         RecordType.PTR,
         zoneIp4,
         None,
-        List(PTRData("test.foo.comcast.net"))
+        List(PTRData(Fqdn("test.foo.comcast.net")))
       ) should be(right)
     }
   }
@@ -436,7 +437,7 @@ class AccessValidationsSpec
         RecordType.PTR,
         zoneIp4,
         None,
-        List(PTRData("test.foo.comcast.net"))
+        List(PTRData(Fqdn("test.foo.comcast.net")))
       ) should be(right)
     }
   }
@@ -542,7 +543,7 @@ class AccessValidationsSpec
         RecordType.PTR,
         zoneIp4,
         None,
-        List(PTRData("test.foo.comcast.net"))
+        List(PTRData(Fqdn("test.foo.comcast.net")))
       ) should be(right)
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/GlobalAclSpec.scala
@@ -20,6 +20,7 @@ import cats.scalatest.EitherMatchers
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpecLike}
 import vinyldns.api.ResultHelpers
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.record.{PTRData, RecordType}
 
 class GlobalAclSpec
@@ -44,7 +45,13 @@ class GlobalAclSpec
       globalAcls.isAuthorized(okAuth, "foo", RecordType.A, okZone, Nil) shouldBe true
     }
     "return true for a PTR record if the user and record match an acl" in {
-      globalAcls.isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, List(PTRData("foo.com"))) shouldBe true
+      globalAcls.isAuthorized(
+        okAuth,
+        "foo",
+        RecordType.PTR,
+        zoneIp4,
+        List(PTRData(Fqdn("foo.com")))
+      ) shouldBe true
     }
     "normalizes the record name before testing" in {
       globalAcls.isAuthorized(okAuth, "foo.", RecordType.A, okZone, Nil) shouldBe true
@@ -55,7 +62,7 @@ class GlobalAclSpec
         "foo",
         RecordType.PTR,
         zoneIp4,
-        List(PTRData("foo.com"), PTRData("bar.com"))
+        List(PTRData(Fqdn("foo.com")), PTRData(Fqdn("bar.com")))
       ) shouldBe true
     }
     "return false for a PTR record if one of the PTR records does not match an acl" in {
@@ -64,14 +71,20 @@ class GlobalAclSpec
         "foo",
         RecordType.PTR,
         zoneIp4,
-        List(PTRData("foo.com"), PTRData("blah.net"))
+        List(PTRData(Fqdn("foo.com")), PTRData(Fqdn("blah.net")))
       ) shouldBe false
     }
     "return false for a PTR record if the record data is empty" in {
       globalAcls.isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, Nil) shouldBe false
     }
     "return false for a PTR record if the ACL is empty" in {
-      GlobalAcls(Nil).isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, List(PTRData("foo.com"))) shouldBe false
+      GlobalAcls(Nil).isAuthorized(
+        okAuth,
+        "foo",
+        RecordType.PTR,
+        zoneIp4,
+        List(PTRData(Fqdn("foo.com")))
+      ) shouldBe false
     }
     "return false for a PTR record if the ACL is empty and the record data is empty" in {
       GlobalAcls(Nil).isAuthorized(okAuth, "foo", RecordType.PTR, zoneIp4, Nil) shouldBe false

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -28,6 +28,7 @@ import vinyldns.api.repository._
 import vinyldns.core.TestMembershipData.okUser
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData.{okZone, _}
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordSetChangeType.RecordSetChangeType
 import vinyldns.core.domain.record.RecordType.{RecordType, _}
@@ -101,10 +102,10 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     makeSingleAddChange("repeat", AData("1.1.1.3")),
     makeSingleAddChange("repeat", AData("1.1.1.4")),
     makeSingleAddChange("aaaaRecord", AAAAData("1::1"), AAAA),
-    makeSingleAddChange("cnameRecord", CNAMEData("cname.com."), CNAME),
-    makeSingleAddChange("10.1.1.1", PTRData("ptrData"), PTR),
+    makeSingleAddChange("cnameRecord", CNAMEData(Fqdn("cname.com.")), CNAME),
+    makeSingleAddChange("10.1.1.1", PTRData(Fqdn("ptrData")), PTR),
     makeSingleAddChange("txtRecord", TXTData("text"), TXT),
-    makeSingleAddChange("mxRecord", MXData(1, "foo.bar."), MX)
+    makeSingleAddChange("mxRecord", MXData(1, Fqdn("foo.bar.")), MX)
   )
 
   private val addChangeForValidationGood = List(
@@ -113,10 +114,10 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     makeAddChangeForValidation("repeat", AData("1.1.1.3")),
     makeAddChangeForValidation("repeat", AData("1.1.1.4")),
     makeAddChangeForValidation("aaaaRecord", AAAAData("1::1"), AAAA),
-    makeAddChangeForValidation("cnameRecord", CNAMEData("cname.com."), CNAME),
-    makeAddChangeForValidation("10.1.1.1", PTRData("ptrData"), PTR),
+    makeAddChangeForValidation("cnameRecord", CNAMEData(Fqdn("cname.com.")), CNAME),
+    makeAddChangeForValidation("10.1.1.1", PTRData(Fqdn("ptrData")), PTR),
     makeAddChangeForValidation("txtRecord", TXTData("text"), TXT),
-    makeAddChangeForValidation("mxRecord", MXData(1, "foo.bar."), MX)
+    makeAddChangeForValidation("mxRecord", MXData(1, Fqdn("foo.bar.")), MX)
   )
 
   private val deleteSingleChangesGood = List(
@@ -139,22 +140,22 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     makeSingleDeleteRRSetChange("aToUpdate", A),
     makeSingleAddChange("aToUpdate", AData("1.1.1.1")),
     makeSingleDeleteRRSetChange("cnameToUpdate", CNAME),
-    makeSingleAddChange("cnameToUpdate", CNAMEData("newcname.com."), CNAME),
+    makeSingleAddChange("cnameToUpdate", CNAMEData(Fqdn("newcname.com.")), CNAME),
     makeSingleDeleteRRSetChange("txtToUpdate", TXT),
     makeSingleAddChange("txtToUpdate", TXTData("update"), TXT),
     makeSingleDeleteRRSetChange("mxToUpdate", MX),
-    makeSingleAddChange("mxToUpdate", MXData(1, "update.com."), MX)
+    makeSingleAddChange("mxToUpdate", MXData(1, Fqdn("update.com.")), MX)
   )
 
   private val updateChangeForValidationGood = List(
     makeDeleteRRSetChangeForValidation("aToUpdate", A),
     makeAddChangeForValidation("aToUpdate", AData("1.1.1.1")),
     makeDeleteRRSetChangeForValidation("cnameToUpdate", CNAME),
-    makeAddChangeForValidation("cnameToUpdate", CNAMEData("newcname.com."), CNAME),
+    makeAddChangeForValidation("cnameToUpdate", CNAMEData(Fqdn("newcname.com.")), CNAME),
     makeDeleteRRSetChangeForValidation("txtToUpdate", TXT),
     makeAddChangeForValidation("txtToUpdate", TXTData("update"), TXT),
     makeDeleteRRSetChangeForValidation("mxToUpdate", MX),
-    makeAddChangeForValidation("mxToUpdate", MXData(1, "update.com."), MX)
+    makeAddChangeForValidation("mxToUpdate", MXData(1, Fqdn("update.com.")), MX)
   )
 
   private val singleChangesOneBad = List(
@@ -201,7 +202,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("old.com."))
+    List(CNAMEData(Fqdn("old.com.")))
   )
   private val aToUpdate = RecordSet(
     okZone.id,
@@ -221,7 +222,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("old.com."))
+    List(CNAMEData(Fqdn("old.com.")))
   )
   private val txtToUpdate = RecordSet(
     okZone.id,
@@ -251,7 +252,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(MXData(1, "old.com."))
+    List(MXData(1, Fqdn("old.com.")))
   )
   private val mxToDelete = RecordSet(
     okZone.id,
@@ -261,7 +262,7 @@ class BatchChangeConverterSpec extends WordSpec with Matchers with CatsHelpers {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(MXData(1, "delete.com."))
+    List(MXData(1, Fqdn("delete.com.")))
   )
   private def existingRecordSets =
     ExistingRecordSets(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeInputSpec.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyList
 import org.joda.time.DateTime
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.api.VinylDNSConfig
-import vinyldns.core.domain.{DomainValidationErrorType, SingleChangeError, ZoneDiscoveryError}
+import vinyldns.core.domain.{DomainValidationErrorType, Fqdn, SingleChangeError, ZoneDiscoveryError}
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record.{AAAAData, AData, CNAMEData}
@@ -32,12 +32,12 @@ class BatchChangeInputSpec extends WordSpec with Matchers {
       val changeAAAA =
         AddChangeInput("aaaa.test.com", AAAA, Some(3600), AAAAData("1:2:3:4:5:6:7:8"))
       val changeCname =
-        AddChangeInput("cname.test.com", CNAME, Some(100), CNAMEData("testing.test.com"))
+        AddChangeInput("cname.test.com", CNAME, Some(100), CNAMEData(Fqdn("testing.test.com")))
       val changeADotted = AddChangeInput("adot.test.com.", A, Some(100), AData("1.1.1.1"))
       val changeAAAADotted =
         AddChangeInput("aaaadot.test.com.", AAAA, Some(3600), AAAAData("1:2:3:4:5:6:7:8"))
       val changeCnameDotted =
-        AddChangeInput("cnamedot.test.com.", CNAME, Some(100), CNAMEData("testing.test.com."))
+        AddChangeInput("cnamedot.test.com.", CNAME, Some(100), CNAMEData(Fqdn("testing.test.com.")))
 
       val input = BatchChangeInput(
         None,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -80,20 +80,26 @@ class BatchChangeServiceSpec
   private val dottedAddA =
     AddChangeInput("dot.ted.apex.test.com", RecordType.A, ttl, AData("1.1.1.1"))
   private val cnameAdd =
-    AddChangeInput("cname.test.com", RecordType.CNAME, ttl, CNAMEData("testing.test.com."))
+    AddChangeInput("cname.test.com", RecordType.CNAME, ttl, CNAMEData(Fqdn("testing.test.com.")))
   private val cnameApexAdd =
-    AddChangeInput("apex.test.com", RecordType.CNAME, ttl, CNAMEData("testing.test.com."))
+    AddChangeInput("apex.test.com", RecordType.CNAME, ttl, CNAMEData(Fqdn("testing.test.com.")))
   private val cnameReverseAdd = AddChangeInput(
     "cname.55.144.10.in-addr.arpa",
     RecordType.CNAME,
     ttl,
-    CNAMEData("testing.cname.com.")
+    CNAMEData(Fqdn("testing.cname.com."))
   )
-  private val ptrAdd = AddChangeInput("10.144.55.11", RecordType.PTR, ttl, PTRData("ptr"))
-  private val ptrAdd2 = AddChangeInput("10.144.55.255", RecordType.PTR, ttl, PTRData("ptr"))
-  private val ptrDelegatedAdd = AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData("ptr"))
+  private val ptrAdd = AddChangeInput("10.144.55.11", RecordType.PTR, ttl, PTRData(Fqdn("ptr")))
+  private val ptrAdd2 = AddChangeInput("10.144.55.255", RecordType.PTR, ttl, PTRData(Fqdn("ptr")))
+  private val ptrDelegatedAdd =
+    AddChangeInput("192.0.2.193", RecordType.PTR, ttl, PTRData(Fqdn("ptr")))
   private val ptrV6Add =
-    AddChangeInput("2001:0000:0000:0000:0000:ff00:0042:8329", RecordType.PTR, ttl, PTRData("ptr"))
+    AddChangeInput(
+      "2001:0000:0000:0000:0000:ff00:0042:8329",
+      RecordType.PTR,
+      ttl,
+      PTRData(Fqdn("ptr"))
+    )
 
   private val authGrp = okGroup
   private val auth = okAuth
@@ -433,7 +439,7 @@ class BatchChangeServiceSpec
         "2001:0000:0000:0001:0000:ff00:0042:8329",
         RecordType.PTR,
         ttl,
-        PTRData("ptr")
+        PTRData(Fqdn("ptr"))
       )
 
       val input = BatchChangeInput(None, List(ptr), Some(authGrp.id))
@@ -463,7 +469,7 @@ class BatchChangeServiceSpec
         "2001:0000:0000:0001:0000:ff00:0042:8329",
         RecordType.PTR,
         ttl,
-        PTRData("ptr")
+        PTRData(Fqdn("ptr"))
       )
 
       val input = BatchChangeInput(None, List(ptr), Some(authGrp.id))
@@ -1142,7 +1148,7 @@ class BatchChangeServiceSpec
         "0.1.0.0.2.ip6.arpa."
       )
 
-      val ptr = AddChangeInput(ip, RecordType.PTR, ttl, PTRData("ptr.")).validNel
+      val ptr = AddChangeInput(ip, RecordType.PTR, ttl, PTRData(Fqdn("ptr."))).validNel
       val underTestPTRZonesList: ExistingZones = await(underTest.getZonesForRequest(List(ptr)))
 
       val zoneNames = underTestPTRZonesList.zones.map(_.name)
@@ -1167,7 +1173,7 @@ class BatchChangeServiceSpec
       )
 
       val ip = "2001:0db8:0000:0000:0000:ff00:0042:8329"
-      val ptr = AddChangeInput(ip, RecordType.PTR, ttl, PTRData("ptr.")).validNel
+      val ptr = AddChangeInput(ip, RecordType.PTR, ttl, PTRData(Fqdn("ptr."))).validNel
       val underTestPTRZonesList: ExistingZones = await(underTest.getZonesForRequest(List(ptr)))
 
       val zoneNames = underTestPTRZonesList.zones.map(_.name)
@@ -1213,7 +1219,7 @@ class BatchChangeServiceSpec
 
       val ips = ip1 :: ip2s
       val ptrs = ips.map { v6Name =>
-        AddChangeInput(v6Name, RecordType.PTR, ttl, PTRData("ptr.")).validNel
+        AddChangeInput(v6Name, RecordType.PTR, ttl, PTRData(Fqdn("ptr."))).validNel
       }
 
       val underTestPTRZonesList: ExistingZones = await(underTest.getZonesForRequest(ptrs))
@@ -1383,20 +1389,20 @@ class BatchChangeServiceSpec
       val ptrv6ZoneBig = Zone("0.1.0.0.2.ip6.arpa.", "email", id = "ptrv6big")
 
       val smallZoneAdd =
-        AddChangeInput("2001:db8::ff00:42:8329", RecordType.PTR, ttl, PTRData("ptr"))
+        AddChangeInput("2001:db8::ff00:42:8329", RecordType.PTR, ttl, PTRData(Fqdn("ptr")))
       val medZoneAdd = AddChangeInput(
         "2001:0db8:0111:0000:0000:ff00:0042:8329",
         RecordType.PTR,
         ttl,
-        PTRData("ptr")
+        PTRData(Fqdn("ptr"))
       )
       val bigZoneAdd = AddChangeInput(
         "2001:0000:0000:0000:0000:ff00:0042:8329",
         RecordType.PTR,
         ttl,
-        PTRData("ptr")
+        PTRData(Fqdn("ptr"))
       )
-      val notFoundZoneAdd = AddChangeInput("::1", RecordType.PTR, ttl, PTRData("ptr"))
+      val notFoundZoneAdd = AddChangeInput("::1", RecordType.PTR, ttl, PTRData(Fqdn("ptr")))
 
       val ptripv6Adds = List(
         smallZoneAdd.validNel,
@@ -1491,7 +1497,7 @@ class BatchChangeServiceSpec
         "cname.test.com.",
         CNAME,
         ttl.get,
-        CNAMEData("testing.test.com."),
+        CNAMEData(Fqdn("testing.test.com.")),
         SingleChangeStatus.Pending,
         None,
         None,
@@ -1554,7 +1560,7 @@ class BatchChangeServiceSpec
         "cname.test.com.",
         CNAME,
         ttl.get,
-        CNAMEData("testing.test.com."),
+        CNAMEData(Fqdn("testing.test.com.")),
         SingleChangeStatus.Pending,
         None,
         None,

--- a/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/dns/DnsConversionsSpec.scala
@@ -28,6 +28,7 @@ import vinyldns.api.domain.dns.DnsProtocol._
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
 import vinyldns.core.TestRecordSetData.ds
+import vinyldns.core.domain.Fqdn
 
 import scala.collection.JavaConverters._
 
@@ -80,7 +81,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("cname.foo.vinyldns."))
+    List(CNAMEData(Fqdn("cname.foo.vinyldns.")))
   )
   private val testMX = RecordSet(
     testZone.id,
@@ -90,7 +91,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(MXData(100, "exchange.vinyldns."))
+    List(MXData(100, Fqdn("exchange.vinyldns.")))
   )
   private val testNS = RecordSet(
     testZone.id,
@@ -100,7 +101,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("nsdname.vinyldns."))
+    List(NSData(Fqdn("nsdname.vinyldns.")))
   )
   private val testPTR = RecordSet(
     testZone.id,
@@ -110,7 +111,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(PTRData("ptr.vinyldns."))
+    List(PTRData(Fqdn("ptr.vinyldns.")))
   )
   private val testSOA = RecordSet(
     testZone.id,
@@ -120,7 +121,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SOAData("mname.vinyldns.", "rname.vinyldns.", 1L, 2L, 3L, 4L, 5L))
+    List(SOAData(Fqdn("mname.vinyldns."), "rname.vinyldns.", 1L, 2L, 3L, 4L, 5L))
   )
   private val testSPF = RecordSet(
     testZone.id,
@@ -150,7 +151,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SRVData(1, 2, 3, "target.vinyldns."))
+    List(SRVData(1, 2, 3, Fqdn("target.vinyldns.")))
   )
   private val testNAPTR = RecordSet(
     testZone.id,
@@ -160,7 +161,7 @@ class DnsConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", "target.vinyldns."))
+    List(NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", Fqdn("target.vinyldns.")))
   )
   private val testSSHFP = RecordSet(
     testZone.id,

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetHelpersSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetHelpersSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.{Matchers, WordSpec}
 import vinyldns.api.domain.record.RecordSetHelpers._
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.record._
 
 class RecordSetHelpersSpec extends WordSpec with Matchers {
@@ -27,7 +28,7 @@ class RecordSetHelpersSpec extends WordSpec with Matchers {
   "RecordSetHelpers" should {
     "matches" should {
       "match record data when not AAAA" in {
-        val records = List(CNAMEData("foo."))
+        val records = List(CNAMEData(Fqdn("foo.")))
         val left = cname.copy(records = records)
         val right = cname.copy(records = records)
         matches(left, right, okZone.name) shouldBe true

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -31,6 +31,7 @@ import vinyldns.api.ResultHelpers
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
 import vinyldns.core.TestMembershipData._
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.membership.Group
 import vinyldns.core.domain.record._
 
@@ -314,7 +315,7 @@ class RecordSetValidationsSpec
             RecordSetStatus.Active,
             DateTime.now,
             None,
-            List(SOAData("something", "other", 1, 2, 3, 5, 6))
+            List(SOAData(Fqdn("something"), "other", 1, 2, 3, 5, 6))
           )
 
           typeSpecificValidations(test, List(), zoneIp4) should be(right)
@@ -327,7 +328,7 @@ class RecordSetValidationsSpec
       "return ok if the record is an NS record but not origin" in {
         val valid = invalidNsApexRs.copy(
           name = "this-is-not-origin-mate",
-          records = List(NSData("some.test.ns."))
+          records = List(NSData(Fqdn("some.test.ns.")))
         )
 
         nsValidations(valid, okZone) should be(right)
@@ -351,7 +352,7 @@ class RecordSetValidationsSpec
       }
 
       "return an InvalidRequest if an NS record data is not in the approved server list" in {
-        val ns = invalidNsApexRs.copy(records = List(NSData("not.approved.")))
+        val ns = invalidNsApexRs.copy(records = List(NSData(Fqdn("not.approved."))))
         val error = leftValue(nsValidations(ns, okZone))
         error shouldBe an[InvalidRequest]
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -27,6 +27,7 @@ import vinyldns.api.domain.dns.DnsProtocol.TypeNotFound
 import vinyldns.core.domain.record._
 import vinyldns.api.ResultHelpers
 import cats.effect._
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.zone.{ConfiguredDnsConnections, DnsBackend, Zone, ZoneConnection}
 
 import scala.concurrent.duration._
@@ -103,7 +104,7 @@ class ZoneConnectionValidatorSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SOAData("something", "other", 1, 2, 3, 5, 6))
+    List(SOAData(Fqdn("something"), "other", 1, 2, 3, 5, 6))
   )
 
   private val successNS = RecordSet(
@@ -114,7 +115,7 @@ class ZoneConnectionValidatorSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("some.test.ns."))
+    List(NSData(Fqdn("some.test.ns.")))
   )
 
   private val failureNs = RecordSet(
@@ -125,7 +126,7 @@ class ZoneConnectionValidatorSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("some.test.ns."), NSData("not.approved."))
+    List(NSData(Fqdn("some.test.ns.")), NSData(Fqdn("not.approved.")))
   )
 
   private val delegatedNS = RecordSet(
@@ -136,7 +137,7 @@ class ZoneConnectionValidatorSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("sub.some.test.ns."))
+    List(NSData(Fqdn("sub.some.test.ns.")))
   )
 
   private val mockRecordSet = mock[RecordSet]

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneRecordValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneRecordValidationsSpec.scala
@@ -21,6 +21,7 @@ import com.comcast.ip4s._
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.domain.{
   DomainValidationError,
+  Fqdn,
   HighValueDomainError,
   RecordRequiresManualReview
 }
@@ -58,12 +59,12 @@ class ZoneRecordValidationsSpec extends WordSpec with Matchers with ValidatedMat
 
   "Approved Name Server check" should {
     "return successfully if the name server is in the list of approved name servers" in {
-      val result = isApprovedNameServer(approvedNameServers, NSData("ns1.test.com"))
-      result should beValid(NSData("ns1.test.com"))
+      val result = isApprovedNameServer(approvedNameServers, NSData(Fqdn("ns1.test.com")))
+      result should beValid(NSData(Fqdn("ns1.test.com")))
     }
 
     "return an error if the name server is not in the list of approved name servers" in {
-      val result = isApprovedNameServer(approvedNameServers, NSData("blah."))
+      val result = isApprovedNameServer(approvedNameServers, NSData(Fqdn("blah.")))
       result should haveInvalid("Name Server blah. is not an approved name server.")
     }
   }
@@ -133,14 +134,14 @@ class ZoneRecordValidationsSpec extends WordSpec with Matchers with ValidatedMat
     }
 
     "return failure if none of the name servers are in the list of approved name servers" in {
-      val test = ns.copy(records = List(NSData("blah1."), NSData("blah2.")))
+      val test = ns.copy(records = List(NSData(Fqdn("blah1.")), NSData(Fqdn("blah2."))))
       containsApprovedNameServers(approvedNameServers, test) should haveInvalid(
         "Name Server blah1. is not an approved name server."
       ).and(haveInvalid("Name Server blah2. is not an approved name server."))
     }
 
     "return a failure if any of the name servers are not in the list of approved name servers" in {
-      val test = ns.copy(records = List(NSData("blah1."), NSData("ns1.test.com")))
+      val test = ns.copy(records = List(NSData(Fqdn("blah1.")), NSData(Fqdn("ns1.test.com"))))
       containsApprovedNameServers(approvedNameServers, test) should haveInvalid(
         "Name Server blah1. is not an approved name server."
       )
@@ -148,18 +149,18 @@ class ZoneRecordValidationsSpec extends WordSpec with Matchers with ValidatedMat
 
     "return success if the name server matches a regular expression" in {
       for (nameServer <- fullNameServers) {
-        val test = ns.copy(records = List(NSData(nameServer)))
+        val test = ns.copy(records = List(NSData(Fqdn(nameServer))))
         containsApprovedNameServers(fullNameServerRx, test) should beValid(test)
       }
     }
 
     "return success even if part of the ns record matches an approved name server" in {
-      val test = ns.copy(records = List(NSData("cdn-tr-001-456")))
+      val test = ns.copy(records = List(NSData(Fqdn("cdn-tr-001-456"))))
       containsApprovedNameServers(fullNameServerRx, test) should beValid(test)
     }
 
     "return a failure if the name server does not match one of the regular expressions" in {
-      val test = ns.copy(records = List(NSData("test-foo-ns.")))
+      val test = ns.copy(records = List(NSData(Fqdn("test-foo-ns."))))
       val approved = List(".*bar.*".r, "www.*".r)
       containsApprovedNameServers(approved, test) should haveInvalid(
         "Name Server test-foo-ns. is not an approved name server."

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
@@ -32,6 +32,7 @@ import vinyldns.core.domain.record._
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import cats.effect._
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.zone.{Zone, ZoneConnection, ZoneStatus}
@@ -252,7 +253,15 @@ class ZoneViewLoaderSpec extends WordSpec with Matchers with MockitoSugar with D
           status = RecordSetStatus.Active,
           created = DateTime.now,
           records = List(
-            SOAData("172.17.42.1.", "admin.vinyldns.com.", 1439234395, 10800, 3600, 604800, 38400)
+            SOAData(
+              Fqdn("172.17.42.1."),
+              "admin.vinyldns.com.",
+              1439234395,
+              10800,
+              3600,
+              604800,
+              38400
+            )
           )
         )
       )

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import vinyldns.api.VinylDNSTestHelpers
 import vinyldns.api.domain.record.RecordSetChangeGenerator
 import vinyldns.api.domain.zone.{DnsZoneViewLoader, VinylDNSZoneViewLoader, ZoneView}
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record._
@@ -114,7 +115,7 @@ class ZoneSyncHandlerSpec
     ttl = 100,
     status = RecordSetStatus.Active,
     created = DateTime.now,
-    records = List(PTRData("test.com."))
+    records = List(PTRData(Fqdn("test.com.")))
   )
   private val testReverseSOA = RecordSet(
     zoneId = testReverseZone.id,
@@ -123,7 +124,7 @@ class ZoneSyncHandlerSpec
     ttl = 100,
     status = RecordSetStatus.Active,
     created = DateTime.now,
-    records = List(SOAData("mname", "rname", 1439234395, 10800, 3600, 604800, 38400))
+    records = List(SOAData(Fqdn("mname"), "rname", 1439234395, 10800, 3600, 604800, 38400))
   )
   private val testReverseNS = RecordSet(
     zoneId = testReverseZone.id,
@@ -132,7 +133,7 @@ class ZoneSyncHandlerSpec
     ttl = 100,
     status = RecordSetStatus.Active,
     created = DateTime.now,
-    records = List(NSData("172.17.42.1."))
+    records = List(NSData(Fqdn("172.17.42.1.")))
   )
 
   private val testRecordSetChange = RecordSetChangeGenerator.forZoneSyncAdd(testRecord2, testZone)

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeJsonProtocolSpec.scala
@@ -31,6 +31,7 @@ import vinyldns.api.domain.batch._
 import vinyldns.core.TestZoneData.okZone
 import vinyldns.core.domain.{
   DomainValidationErrorType,
+  Fqdn,
   InvalidIpv4Address,
   InvalidTTL,
   SingleChangeError,
@@ -87,10 +88,15 @@ class BatchChangeJsonProtocolSpec
     buildAddChangeInputJson(Some("bar."), Some(AAAA), Some(1200), Some(AAAAData("1:2:3:4:5:6:7:8")))
 
   val addCNAMEChangeInputJson: JObject =
-    buildAddChangeInputJson(Some("bizz.baz."), Some(CNAME), Some(200), Some(CNAMEData("buzz.")))
+    buildAddChangeInputJson(
+      Some("bizz.baz."),
+      Some(CNAME),
+      Some(200),
+      Some(CNAMEData(Fqdn("buzz.")))
+    )
 
   val addPTRChangeInputJson: JObject =
-    buildAddChangeInputJson(Some("4.5.6.7"), Some(PTR), Some(200), Some(PTRData("test.com.")))
+    buildAddChangeInputJson(Some("4.5.6.7"), Some(PTR), Some(200), Some(PTRData(Fqdn("test.com."))))
 
   val deleteAChangeInputJson: JObject = buildDeleteRRSetInputJson(Some("foo."), Some(A))
 
@@ -125,9 +131,9 @@ class BatchChangeJsonProtocolSpec
 
   val addAAAAChangeInput = AddChangeInput("bar.", AAAA, Some(1200), AAAAData("1:2:3:4:5:6:7:8"))
 
-  val addCNAMEChangeInput = AddChangeInput("bizz.baz.", CNAME, Some(200), CNAMEData("buzz."))
+  val addCNAMEChangeInput = AddChangeInput("bizz.baz.", CNAME, Some(200), CNAMEData(Fqdn("buzz.")))
 
-  val addPTRChangeInput = AddChangeInput("4.5.6.7", PTR, Some(200), PTRData("test.com."))
+  val addPTRChangeInput = AddChangeInput("4.5.6.7", PTR, Some(200), PTRData(Fqdn("test.com.")))
 
   val fooDiscoveryError = ZoneDiscoveryError("foo.")
 

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -28,6 +28,7 @@ import vinyldns.api.Interfaces._
 import vinyldns.api.domain.record.{ListRecordSetChangesResponse, RecordSetServiceAlgebra}
 import vinyldns.api.domain.zone._
 import vinyldns.core.TestMembershipData.okAuth
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordSetChangeType.RecordSetChangeType
@@ -202,7 +203,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("example.com"))
+    List(CNAMEData(Fqdn("example.com")))
   )
 
   private val aaaa = RecordSet(
@@ -224,7 +225,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("cname."))
+    List(CNAMEData(Fqdn("cname.")))
   )
 
   private val mx = RecordSet(
@@ -235,7 +236,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(MXData(100, "exchange."))
+    List(MXData(100, Fqdn("exchange.")))
   )
 
   private val ns = RecordSet(
@@ -246,7 +247,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("nsrecordname"))
+    List(NSData(Fqdn("nsrecordname")))
   )
 
   private val ptr = RecordSet(
@@ -257,7 +258,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(PTRData("ptr."))
+    List(PTRData(Fqdn("ptr.")))
   )
 
   private val soa = RecordSet(
@@ -268,7 +269,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SOAData("name", "name", 1, 2, 3, 4, 5))
+    List(SOAData(Fqdn("name"), "name", 1, 2, 3, 4, 5))
   )
 
   private val spf = RecordSet(
@@ -290,7 +291,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SRVData(1, 2, 3, "target."))
+    List(SRVData(1, 2, 3, Fqdn("target.")))
   )
 
   private val naptr = RecordSet(
@@ -301,7 +302,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", "target."))
+    List(NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", Fqdn("target.")))
   )
 
   private val sshfp = RecordSet(
@@ -334,7 +335,7 @@ class RecordSetRoutingSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("cname"), CNAMEData("cname2"))
+    List(CNAMEData(Fqdn("cname")), CNAMEData(Fqdn("cname2")))
   )
 
   private val rsMissingData: JValue =
@@ -442,9 +443,7 @@ class RecordSetRoutingSpec
               Right(
                 RecordSetChange(
                   zone = okZone,
-                  recordSet = recordSets
-                    .get(other)
-                    .get
+                  recordSet = recordSets(other)
                     .copy(status = RecordSetStatus.Active, created = DateTime.now),
                   status = RecordSetChangeStatus.Complete,
                   changeType = chgType,
@@ -455,9 +454,7 @@ class RecordSetRoutingSpec
               Right(
                 RecordSetChange(
                   zone = okZone,
-                  recordSet = recordSets
-                    .get(other)
-                    .get
+                  recordSet = recordSets(other)
                     .copy(
                       status = RecordSetStatus.Active,
                       created = DateTime.now,

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -25,6 +25,7 @@ import vinyldns.api.VinylDNSTestHelpers
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.{CreateZoneInput, UpdateZoneInput, ZoneConnection}
 import vinyldns.core.TestRecordSetData._
+import vinyldns.core.domain.Fqdn
 
 class VinylDNSJsonProtocolSpec
     extends WordSpec
@@ -116,7 +117,7 @@ class VinylDNSJsonProtocolSpec
 
     "parse a create zone input with a transfer connection" in {
       val createZoneInput: JValue =
-        ("name" -> "testZone.") ~~
+        ("name" -> "testZone ") ~~
           ("email" -> "test@test.com") ~~
           ("connection" -> primaryConnection) ~~
           ("transferConnection" -> transferConnection) ~~
@@ -326,7 +327,7 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(CNAMEData("cname."))
+        records = List(CNAMEData(Fqdn("cname. ")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
@@ -339,7 +340,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "CNAME") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> List("cname" -> "cname.data"))
+          ("records" -> List("cname" -> "cname.data "))
 
       val expected = RecordSet(
         "1",
@@ -348,12 +349,12 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(CNAMEData("cname.data."))
+        records = List(CNAMEData(Fqdn("cname.data.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
       anonymize(actual) shouldBe anonymize(expected)
-      anonymize(actual).records shouldBe List(CNAMEData("cname.data."))
+      anonymize(actual).records shouldBe List(CNAMEData(Fqdn("cname.data.")))
     }
     "reject a relative CNAME record" in {
       val recordSetJValue: JValue =
@@ -362,7 +363,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "CNAME") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> List("cname" -> "cname"))
+          ("records" -> List("cname" -> "cname "))
 
       val thrown = the[MappingException] thrownBy recordSetJValue.extract[RecordSet]
       thrown.msg should include("CNAME data must be absolute")
@@ -375,7 +376,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "MX") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> Extraction.decompose(Set(MXData(1, "mx."))))
+          ("records" -> Extraction.decompose(Set(MXData(1, Fqdn("mx.")))))
 
       val expected = RecordSet(
         "1",
@@ -384,7 +385,7 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(MXData(1, "mx."))
+        records = List(MXData(1, Fqdn("mx.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
@@ -397,7 +398,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "MX") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> Extraction.decompose(Set(MXData(1, "mx"))))
+          ("records" -> Extraction.decompose(Set(MXData(1, Fqdn("mx")))))
 
       val expected = RecordSet(
         "1",
@@ -406,12 +407,12 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(MXData(1, "mx."))
+        records = List(MXData(1, Fqdn("mx.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
       anonymize(actual) shouldBe anonymize(expected)
-      anonymize(actual).records shouldBe List(MXData(1, "mx."))
+      anonymize(actual).records shouldBe List(MXData(1, Fqdn("mx.")))
     }
 
     "parse a record set with an absolute SRV target passes" in {
@@ -421,7 +422,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "SRV") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> Extraction.decompose(Set(SRVData(1, 20, 5000, "srv."))))
+          ("records" -> Extraction.decompose(Set(SRVData(1, 20, 5000, Fqdn("srv.")))))
 
       val expected = RecordSet(
         "1",
@@ -430,7 +431,7 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(SRVData(1, 20, 5000, "srv."))
+        records = List(SRVData(1, 20, 5000, Fqdn("srv.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
@@ -443,7 +444,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "SRV") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> Extraction.decompose(Set(SRVData(1, 20, 5000, "srv"))))
+          ("records" -> Extraction.decompose(Set(SRVData(1, 20, 5000, Fqdn("srv")))))
 
       val expected = RecordSet(
         "1",
@@ -452,12 +453,12 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(SRVData(1, 20, 5000, "srv."))
+        records = List(SRVData(1, 20, 5000, Fqdn("srv.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
       anonymize(actual) shouldBe anonymize(expected)
-      anonymize(actual).records shouldBe List(SRVData(1, 20, 5000, "srv."))
+      anonymize(actual).records shouldBe List(SRVData(1, 20, 5000, Fqdn("srv.")))
     }
 
     "parse a record set with an absolute NAPTR target passes" in {
@@ -468,7 +469,7 @@ class VinylDNSJsonProtocolSpec
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
           ("records" -> Extraction.decompose(
-            Set(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", "naptr."))
+            Set(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", Fqdn("naptr.")))
           ))
 
       val expected = RecordSet(
@@ -478,7 +479,7 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", "naptr."))
+        records = List(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", Fqdn("naptr.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
@@ -492,7 +493,7 @@ class VinylDNSJsonProtocolSpec
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
           ("records" -> Extraction.decompose(
-            Set(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", "naptr"))
+            Set(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", Fqdn("naptr")))
           ))
 
       val expected = RecordSet(
@@ -502,13 +503,13 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", "naptr."))
+        records = List(NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", Fqdn("naptr.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
       anonymize(actual) shouldBe anonymize(expected)
       anonymize(actual).records shouldBe List(
-        NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", "naptr.")
+        NAPTRData(1, 20, "U", "E2U+sip", "!.*!test.!", Fqdn("naptr."))
       )
     }
 
@@ -519,7 +520,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "PTR") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> Extraction.decompose(Set(PTRData("ptr."))))
+          ("records" -> Extraction.decompose(Set(PTRData(Fqdn("ptr.")))))
 
       val expected = RecordSet(
         "1",
@@ -528,7 +529,7 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(PTRData("ptr."))
+        records = List(PTRData(Fqdn("ptr.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
@@ -541,7 +542,7 @@ class VinylDNSJsonProtocolSpec
           ("type" -> "PTR") ~~
           ("ttl" -> 1000) ~~
           ("status" -> "Pending") ~~
-          ("records" -> Extraction.decompose(Set(PTRData("ptr"))))
+          ("records" -> Extraction.decompose(Set(PTRData(Fqdn("ptr")))))
 
       val expected = RecordSet(
         "1",
@@ -550,12 +551,12 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(PTRData("ptr."))
+        records = List(PTRData(Fqdn("ptr.")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
       anonymize(actual) shouldBe anonymize(expected)
-      anonymize(actual).records shouldBe List(PTRData("ptr."))
+      anonymize(actual).records shouldBe List(PTRData(Fqdn("ptr.")))
     }
     "convert non-dotted NS record to an absolute NS record" in {
       val recordSetJValue: JValue =
@@ -573,12 +574,12 @@ class VinylDNSJsonProtocolSpec
         1000,
         RecordSetStatus.Pending,
         new DateTime(2010, 1, 1, 0, 0),
-        records = List(NSData("abs.data"))
+        records = List(NSData(Fqdn("abs.data")))
       )
 
       val actual = recordSetJValue.extract[RecordSet]
       anonymize(actual) shouldBe anonymize(expected)
-      anonymize(actual).records shouldBe List(NSData("abs.data."))
+      anonymize(actual).records shouldBe List(NSData(Fqdn("abs.data.")))
     }
     "reject a relative NS record" in {
       val data = List("nsdname" -> "abs")

--- a/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
@@ -16,16 +16,19 @@
 
 package vinyldns.core.domain
 
-object DomainHelpers {
+import DomainHelpers.{ensureTrailingDot, removeWhitespace}
 
-  def ensureTrailingDot(str: String): String = if (str.endsWith(".")) str else s"$str."
-
-  def omitTrailingDot(name: String): String =
-    if (name.endsWith(".")) {
-      name.substring(0, name.length - 1)
-    } else {
-      name
+case class Fqdn(fqdn: String) {
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case Fqdn(otherFqdn) => otherFqdn.toLowerCase == fqdn.toLowerCase
+      case _ => false
     }
 
-  def removeWhitespace(str: String): String = str.replaceAll("\\s", "")
+  override def hashCode(): Int = fqdn.hashCode
+}
+
+case object Fqdn {
+  def apply(fqdn: String): Fqdn =
+    new Fqdn(ensureTrailingDot(removeWhitespace(fqdn)))
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordData.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordData.scala
@@ -17,7 +17,7 @@
 package vinyldns.core.domain.record
 
 import scodec.bits.ByteVector
-import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
+import vinyldns.core.domain.Fqdn
 
 sealed trait RecordData
 
@@ -25,36 +25,36 @@ final case class AData(address: String) extends RecordData
 
 final case class AAAAData(address: String) extends RecordData
 
-final case class CNAMEData(cname: String) extends RecordData
+final case class CNAMEData(cname: Fqdn) extends RecordData
 
 object CNAMEData {
-  def apply(cname: String): CNAMEData =
-    new CNAMEData(ensureTrailingDot(cname))
+  def apply(cname: Fqdn): CNAMEData =
+    new CNAMEData(cname)
 }
 
-final case class MXData(preference: Integer, exchange: String) extends RecordData
+final case class MXData(preference: Integer, exchange: Fqdn) extends RecordData
 
 object MXData {
-  def apply(preference: Integer, exchange: String): MXData =
-    new MXData(preference, ensureTrailingDot(exchange))
+  def apply(preference: Integer, exchange: Fqdn): MXData =
+    new MXData(preference, exchange)
 }
 
-final case class NSData(nsdname: String) extends RecordData
+final case class NSData(nsdname: Fqdn) extends RecordData
 
 object NSData {
-  def apply(nsdname: String): NSData =
-    new NSData(ensureTrailingDot(nsdname))
+  def apply(nsdname: Fqdn): NSData =
+    new NSData(nsdname)
 }
 
-final case class PTRData(ptrdname: String) extends RecordData
+final case class PTRData(ptrdname: Fqdn) extends RecordData
 
 object PTRData {
-  def apply(ptrdname: String): PTRData =
-    new PTRData(ensureTrailingDot(ptrdname))
+  def apply(ptrdname: Fqdn): PTRData =
+    new PTRData(ptrdname)
 }
 
 final case class SOAData(
-    mname: String,
+    mname: Fqdn,
     rname: String,
     serial: Long,
     refresh: Long,
@@ -65,12 +65,12 @@ final case class SOAData(
 
 final case class SPFData(text: String) extends RecordData
 
-final case class SRVData(priority: Integer, weight: Integer, port: Integer, target: String)
+final case class SRVData(priority: Integer, weight: Integer, port: Integer, target: Fqdn)
     extends RecordData
 
 object SRVData {
-  def apply(priority: Integer, weight: Integer, port: Integer, target: String): SRVData =
-    new SRVData(priority, weight, port, ensureTrailingDot(target))
+  def apply(priority: Integer, weight: Integer, port: Integer, target: Fqdn): SRVData =
+    new SRVData(priority, weight, port, target)
 }
 
 final case class NAPTRData(
@@ -79,7 +79,7 @@ final case class NAPTRData(
     flags: String,
     service: String,
     regexp: String,
-    replacement: String
+    replacement: Fqdn
 ) extends RecordData
 
 object NAPTRData {
@@ -89,9 +89,9 @@ object NAPTRData {
       flags: String,
       service: String,
       regexp: String,
-      replacement: String
+      replacement: Fqdn
   ): NAPTRData =
-    new NAPTRData(order, preference, flags, service, regexp, ensureTrailingDot(replacement))
+    new NAPTRData(order, preference, flags, service, regexp, replacement)
 }
 
 final case class SSHFPData(algorithm: Integer, typ: Integer, fingerprint: String) extends RecordData

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -25,7 +25,7 @@ import vinyldns.core.domain.membership.{LockStatus, User, UserChange, UserChange
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone._
-import vinyldns.core.domain.{record, zone}
+import vinyldns.core.domain.{Fqdn, record, zone}
 import vinyldns.proto.VinylDNSProto
 
 import scala.collection.JavaConverters._
@@ -175,7 +175,7 @@ trait ProtobufConversions {
 
   def fromPB(data: VinylDNSProto.AAAAData): AAAAData = AAAAData(data.getAddress)
 
-  def fromPB(data: VinylDNSProto.CNAMEData): CNAMEData = CNAMEData(data.getCname)
+  def fromPB(data: VinylDNSProto.CNAMEData): CNAMEData = CNAMEData(Fqdn(data.getCname))
 
   def fromPB(data: VinylDNSProto.DSData): DSData =
     DSData(
@@ -185,15 +185,16 @@ trait ProtobufConversions {
       ByteVector.apply(data.getDigest.asReadOnlyByteBuffer())
     )
 
-  def fromPB(data: VinylDNSProto.MXData): MXData = MXData(data.getPreference, data.getExchange)
+  def fromPB(data: VinylDNSProto.MXData): MXData =
+    MXData(data.getPreference, Fqdn(data.getExchange))
 
-  def fromPB(data: VinylDNSProto.NSData): NSData = NSData(data.getNsdname)
+  def fromPB(data: VinylDNSProto.NSData): NSData = NSData(Fqdn(data.getNsdname))
 
-  def fromPB(data: VinylDNSProto.PTRData): PTRData = PTRData(data.getPtrdname)
+  def fromPB(data: VinylDNSProto.PTRData): PTRData = PTRData(Fqdn(data.getPtrdname))
 
   def fromPB(data: VinylDNSProto.SOAData): SOAData =
     SOAData(
-      data.getMname,
+      Fqdn(data.getMname),
       data.getRname,
       data.getSerial,
       data.getRefresh,
@@ -205,7 +206,7 @@ trait ProtobufConversions {
   def fromPB(data: VinylDNSProto.SPFData): SPFData = SPFData(data.getText)
 
   def fromPB(data: VinylDNSProto.SRVData): SRVData =
-    SRVData(data.getPriority, data.getWeight, data.getPort, data.getTarget)
+    SRVData(data.getPriority, data.getWeight, data.getPort, Fqdn(data.getTarget))
 
   def fromPB(data: VinylDNSProto.NAPTRData): NAPTRData =
     NAPTRData(
@@ -214,7 +215,7 @@ trait ProtobufConversions {
       data.getFlags,
       data.getService,
       data.getRegexp,
-      data.getReplacement
+      Fqdn(data.getReplacement)
     )
 
   def fromPB(data: VinylDNSProto.SSHFPData): SSHFPData =
@@ -249,7 +250,7 @@ trait ProtobufConversions {
     VinylDNSProto.AAAAData.newBuilder().setAddress(data.address).build()
 
   def toPB(data: CNAMEData): VinylDNSProto.CNAMEData =
-    VinylDNSProto.CNAMEData.newBuilder().setCname(data.cname).build()
+    VinylDNSProto.CNAMEData.newBuilder().setCname(data.cname.fqdn).build()
 
   def toPB(data: DSData): VinylDNSProto.DSData =
     VinylDNSProto.DSData
@@ -264,20 +265,20 @@ trait ProtobufConversions {
     VinylDNSProto.MXData
       .newBuilder()
       .setPreference(data.preference)
-      .setExchange(data.exchange)
+      .setExchange(data.exchange.fqdn)
       .build()
 
   def toPB(data: PTRData): VinylDNSProto.PTRData =
-    VinylDNSProto.PTRData.newBuilder().setPtrdname(data.ptrdname).build()
+    VinylDNSProto.PTRData.newBuilder().setPtrdname(data.ptrdname.fqdn).build()
 
   def toPB(data: NSData): VinylDNSProto.NSData =
-    VinylDNSProto.NSData.newBuilder().setNsdname(data.nsdname).build()
+    VinylDNSProto.NSData.newBuilder().setNsdname(data.nsdname.fqdn).build()
 
   def toPB(data: SOAData): VinylDNSProto.SOAData =
     VinylDNSProto.SOAData
       .newBuilder()
       .setRname(data.rname)
-      .setMname(data.mname)
+      .setMname(data.mname.fqdn)
       .setExpire(data.expire)
       .setMinimum(data.minimum)
       .setRefresh(data.refresh)
@@ -293,7 +294,7 @@ trait ProtobufConversions {
       .newBuilder()
       .setPort(data.port)
       .setPriority(data.priority)
-      .setTarget(data.target)
+      .setTarget(data.target.fqdn)
       .setWeight(data.weight)
       .build()
 
@@ -305,7 +306,7 @@ trait ProtobufConversions {
       .setFlags(data.flags)
       .setService(data.service)
       .setRegexp(data.regexp)
-      .setReplacement(data.replacement)
+      .setReplacement(data.replacement.fqdn)
       .build()
 
   def toPB(data: SSHFPData): VinylDNSProto.SSHFPData =

--- a/modules/core/src/test/scala/vinyldns/core/TestRecordSetData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestRecordSetData.scala
@@ -23,6 +23,7 @@ import vinyldns.core.domain.record._
 import TestZoneData._
 import TestMembershipData._
 import scodec.bits.ByteVector
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.zone.Zone
 
 object TestRecordSetData {
@@ -80,7 +81,7 @@ object TestRecordSetData {
     RecordSetStatus.Pending,
     DateTime.now,
     None,
-    List(CNAMEData("cname"))
+    List(CNAMEData(Fqdn("cname")))
   )
 
   val ptrIp4: RecordSet = RecordSet(
@@ -91,7 +92,7 @@ object TestRecordSetData {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(PTRData("ptr"))
+    List(PTRData(Fqdn("ptr")))
   )
 
   val ptrIp6: RecordSet = RecordSet(
@@ -102,7 +103,7 @@ object TestRecordSetData {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(PTRData("ptr"))
+    List(PTRData(Fqdn("ptr")))
   )
 
   val srv: RecordSet = RecordSet(
@@ -113,7 +114,7 @@ object TestRecordSetData {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SRVData(1, 2, 3, "target"))
+    List(SRVData(1, 2, 3, Fqdn("target")))
   )
 
   val naptr: RecordSet = RecordSet(
@@ -124,7 +125,7 @@ object TestRecordSetData {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NAPTRData(1, 2, "S", "E2U+sip", "", "target"))
+    List(NAPTRData(1, 2, "S", "E2U+sip", "", Fqdn("target")))
   )
 
   val mx: RecordSet = RecordSet(
@@ -135,7 +136,7 @@ object TestRecordSetData {
     RecordSetStatus.Pending,
     DateTime.now,
     None,
-    List(MXData(3, "mx"))
+    List(MXData(3, Fqdn("mx")))
   )
 
   val ns: RecordSet = RecordSet(
@@ -146,7 +147,7 @@ object TestRecordSetData {
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    records = List(NSData("ns1.test.com"), NSData("ns2.test.com"))
+    records = List(NSData(Fqdn("ns1.test.com")), NSData(Fqdn("ns2.test.com")))
   )
 
   val txt: RecordSet = RecordSet(
@@ -218,7 +219,7 @@ object TestRecordSetData {
       RecordSetStatus.Pending,
       DateTime.now,
       None,
-      List(MXData(3, "mx"))
+      List(MXData(3, Fqdn("mx")))
     )
 
   /* RECORDSET CHANGES */

--- a/modules/core/src/test/scala/vinyldns/core/domain/record/RecordSetSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/record/RecordSetSpec.scala
@@ -18,6 +18,7 @@ package vinyldns.core.domain.record
 
 import org.scalatest.{Matchers, WordSpec}
 import vinyldns.core.TestRecordSetData._
+import vinyldns.core.domain.Fqdn
 
 class RecordSetSpec extends WordSpec with Matchers {
 
@@ -43,31 +44,31 @@ class RecordSetSpec extends WordSpec with Matchers {
     "ensure trailing dot on CNAME record cname" in {
       val result = cname
 
-      result.records shouldBe List(CNAMEData("cname."))
+      result.records shouldBe List(CNAMEData(Fqdn("cname.")))
     }
 
     "ensure trailing dot on MX record exchange" in {
       val result = mx
 
-      result.records shouldBe List(MXData(3, "mx."))
+      result.records shouldBe List(MXData(3, Fqdn("mx.")))
     }
 
     "ensure trailing dot on PTR record ptrdname" in {
       val result = ptrIp4
 
-      result.records shouldBe List(PTRData("ptr."))
+      result.records shouldBe List(PTRData(Fqdn("ptr.")))
     }
 
     "ensure trailing dot on SRV record target" in {
       val result = srv
 
-      result.records shouldBe List(SRVData(1, 2, 3, "target."))
+      result.records shouldBe List(SRVData(1, 2, 3, Fqdn("target.")))
     }
 
     "ensure trailing dot on NAPTR record target" in {
       val result = naptr
 
-      result.records shouldBe List(NAPTRData(1, 2, "S", "E2U+sip", "", "target."))
+      result.records shouldBe List(NAPTRData(1, 2, "S", "E2U+sip", "", Fqdn("target.")))
     }
   }
 }

--- a/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
@@ -19,6 +19,7 @@ package vinyldns.core.protobuf
 import org.joda.time.DateTime
 import org.scalatest.{Assertion, Matchers, OptionValues, WordSpec}
 import vinyldns.core.TestRecordSetData.ds
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.membership.UserChange.{CreateUser, UpdateUser}
 import vinyldns.core.domain.membership.{LockStatus, User, UserChangeType}
 import vinyldns.core.domain.record._
@@ -103,7 +104,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(CNAMEData("cname"))
+    List(CNAMEData(Fqdn("cname")))
   )
   private val mx = RecordSet(
     zone.id,
@@ -113,7 +114,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(MXData(100, "exchange"))
+    List(MXData(100, Fqdn("exchange")))
   )
   private val ns = RecordSet(
     zone.id,
@@ -123,7 +124,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NSData("nsrecordname"))
+    List(NSData(Fqdn("nsrecordname")))
   )
   private val ptr = RecordSet(
     zone.id,
@@ -133,7 +134,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(PTRData("ptr"))
+    List(PTRData(Fqdn("ptr")))
   )
   private val soa = RecordSet(
     zone.id,
@@ -143,7 +144,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SOAData("name", "name", 1, 2, 3, 4, 5))
+    List(SOAData(Fqdn("name"), "name", 1, 2, 3, 4, 5))
   )
   private val spf = RecordSet(
     zone.id,
@@ -163,7 +164,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(SRVData(1, 2, 3, "target"))
+    List(SRVData(1, 2, 3, Fqdn("target")))
   )
   private val naptr = RecordSet(
     zone.id,
@@ -173,7 +174,7 @@ class ProtobufConversionsSpec
     RecordSetStatus.Active,
     DateTime.now,
     None,
-    List(NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", "target"))
+    List(NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", Fqdn("target")))
   )
   private val sshfp = RecordSet(
     zone.id,
@@ -587,26 +588,26 @@ class ProtobufConversionsSpec
     }
 
     "convert to protobuf for CNAME data" in {
-      val pb = toPB(CNAMEData("www."))
+      val pb = toPB(CNAMEData(Fqdn("www.")))
       pb.getCname shouldBe "www."
     }
 
     "convert from protobuf for CNAME data" in {
-      val pb = toPB(CNAMEData("www."))
+      val pb = toPB(CNAMEData(Fqdn("www.")))
       val data = fromPB(pb)
 
       data.cname shouldBe "www."
     }
 
     "convert to protobuf for MX data" in {
-      val mxData = MXData(100, "mx.test.com")
+      val mxData = MXData(100, Fqdn("mx.test.com"))
       val pb = toPB(mxData)
       pb.getPreference shouldBe mxData.preference
       pb.getExchange shouldBe mxData.exchange
     }
 
     "convert from protobuf for MX data" in {
-      val mxData = MXData(100, "mx.test.com")
+      val mxData = MXData(100, Fqdn("mx.test.com"))
       val pb = toPB(mxData)
       val data = fromPB(pb)
 
@@ -614,13 +615,13 @@ class ProtobufConversionsSpec
     }
 
     "convert to protobuf for NS data" in {
-      val nsData = NSData("ns1.test.com")
+      val nsData = NSData(Fqdn("ns1.test.com"))
       val pb = toPB(nsData)
       pb.getNsdname shouldBe nsData.nsdname
     }
 
     "convert from protobuf for NS data" in {
-      val nsData = NSData("ns1.test.com")
+      val nsData = NSData(Fqdn("ns1.test.com"))
       val pb = toPB(nsData)
       val data = fromPB(pb)
 
@@ -628,13 +629,13 @@ class ProtobufConversionsSpec
     }
 
     "convert to protobuf for PTR data" in {
-      val from = PTRData("ns1.test.com")
+      val from = PTRData(Fqdn("ns1.test.com"))
       val pb = toPB(from)
       pb.getPtrdname shouldBe from.ptrdname
     }
 
     "convert from protobuf for PTR data" in {
-      val from = PTRData("ns1.test.com")
+      val from = PTRData(Fqdn("ns1.test.com"))
       val pb = toPB(from)
       val data = fromPB(pb)
 
@@ -642,7 +643,7 @@ class ProtobufConversionsSpec
     }
 
     "convert to protobuf for SOA data" in {
-      val from = SOAData("name", "name", 1, 2, 3, 4, 5)
+      val from = SOAData(Fqdn("name"), "name", 1, 2, 3, 4, 5)
       val pb = toPB(from)
       pb.getExpire shouldBe from.expire
       pb.getMinimum shouldBe from.minimum
@@ -654,7 +655,7 @@ class ProtobufConversionsSpec
     }
 
     "convert from protobuf for SOA data" in {
-      val from = SOAData("name", "name", 1, 2, 3, 4, 5)
+      val from = SOAData(Fqdn("name"), "name", 1, 2, 3, 4, 5)
       val pb = toPB(from)
       val data = fromPB(pb)
 
@@ -676,7 +677,7 @@ class ProtobufConversionsSpec
     }
 
     "convert to protobuf for SRV data" in {
-      val from = SRVData(1, 2, 3, "target")
+      val from = SRVData(1, 2, 3, Fqdn("target"))
       val pb = toPB(from)
       pb.getPort shouldBe from.port
       pb.getPriority shouldBe from.priority
@@ -685,7 +686,7 @@ class ProtobufConversionsSpec
     }
 
     "convert from protobuf for SRV data" in {
-      val from = SRVData(1, 2, 3, "target")
+      val from = SRVData(1, 2, 3, Fqdn("target"))
       val pb = toPB(from)
       val data = fromPB(pb)
 
@@ -693,7 +694,7 @@ class ProtobufConversionsSpec
     }
 
     "convert to protobuf for NAPTR data" in {
-      val from = NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", "target")
+      val from = NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", Fqdn("target"))
       val pb = toPB(from)
       pb.getOrder shouldBe from.order
       pb.getPreference shouldBe from.preference
@@ -704,7 +705,7 @@ class ProtobufConversionsSpec
     }
 
     "convert from protobuf for NAPTR data" in {
-      val from = NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", "target")
+      val from = NAPTRData(1, 2, "U", "E2U+sip", "!.*!test.!", Fqdn("target"))
       val pb = toPB(from)
       val data = fromPB(pb)
 

--- a/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
@@ -596,14 +596,14 @@ class ProtobufConversionsSpec
       val pb = toPB(CNAMEData(Fqdn("www.")))
       val data = fromPB(pb)
 
-      data.cname shouldBe "www."
+      data.cname.fqdn shouldBe "www."
     }
 
     "convert to protobuf for MX data" in {
       val mxData = MXData(100, Fqdn("mx.test.com"))
       val pb = toPB(mxData)
       pb.getPreference shouldBe mxData.preference
-      pb.getExchange shouldBe mxData.exchange
+      pb.getExchange shouldBe mxData.exchange.fqdn
     }
 
     "convert from protobuf for MX data" in {
@@ -617,7 +617,7 @@ class ProtobufConversionsSpec
     "convert to protobuf for NS data" in {
       val nsData = NSData(Fqdn("ns1.test.com"))
       val pb = toPB(nsData)
-      pb.getNsdname shouldBe nsData.nsdname
+      pb.getNsdname shouldBe nsData.nsdname.fqdn
     }
 
     "convert from protobuf for NS data" in {
@@ -631,7 +631,7 @@ class ProtobufConversionsSpec
     "convert to protobuf for PTR data" in {
       val from = PTRData(Fqdn("ns1.test.com"))
       val pb = toPB(from)
-      pb.getPtrdname shouldBe from.ptrdname
+      pb.getPtrdname shouldBe from.ptrdname.fqdn
     }
 
     "convert from protobuf for PTR data" in {
@@ -647,7 +647,7 @@ class ProtobufConversionsSpec
       val pb = toPB(from)
       pb.getExpire shouldBe from.expire
       pb.getMinimum shouldBe from.minimum
-      pb.getMname shouldBe from.mname
+      pb.getMname shouldBe from.mname.fqdn
       pb.getRefresh shouldBe from.refresh
       pb.getRetry shouldBe from.retry
       pb.getRname shouldBe from.rname
@@ -681,7 +681,7 @@ class ProtobufConversionsSpec
       val pb = toPB(from)
       pb.getPort shouldBe from.port
       pb.getPriority shouldBe from.priority
-      pb.getTarget shouldBe from.target
+      pb.getTarget shouldBe from.target.fqdn
       pb.getWeight shouldBe from.weight
     }
 
@@ -701,7 +701,7 @@ class ProtobufConversionsSpec
       pb.getFlags shouldBe from.flags
       pb.getService shouldBe from.service
       pb.getRegexp shouldBe from.regexp
-      pb.getReplacement shouldBe from.replacement
+      pb.getReplacement shouldBe from.replacement.fqdn
     }
 
     "convert from protobuf for NAPTR data" in {


### PR DESCRIPTION
There are certain DNS records (e.g. `CNAME`, `PTR`, etc.) that take in FQDNs as record data which should not allow whitespace. Updated these records to remove whitespace.

Changes in this pull request:
- Create `Fqdn` class to facilitate string manipulations for FQDNs (`ensureTrailingDot` and `removeWhitespace`).
- Override `equal` check for `Fqdn` class to be case-insensitive.
