### PR TITLE
Don't refresh when toggling record types during record set search

### DIFF
--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -39,6 +39,7 @@
                 <div class="collapse" id="collapseInstruction">
                     <div class="well">
                         <p>The search is based on the fully qualified domain name (FQDN) of a record. You can do an exact match search or fuzzy match to lookup records.</p>
+                        <p>A minimum of two alphanumeric characters for the record name is <i>required</i> for searching.</p>
                         <p><strong>Examples:</strong>
                         <ul>
                             <li>test.example.com. -> test.example.com.</li>

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -533,7 +533,7 @@ angular.module('controller.records', [])
                 var recordSets = response.data.recordSets;
                 recordsPaging = pagingService.nextPageUpdate(recordSets, response.data.nextId, recordsPaging);
 
-                if(recordSets.length > 0 ){
+                if (recordSets.length > 0){
                     updateRecordDisplay(recordSets);
                 }
             })
@@ -555,11 +555,10 @@ angular.module('controller.records', [])
 
     $scope.toggleCheckedRecordType = function(recordType) {
         if($scope.selectedRecordTypes.includes(recordType)) {
-            $scope.selectedRecordTypes.splice($scope.selectedRecordTypes.indexOf(recordType),1)
+            $scope.selectedRecordTypes.splice($scope.selectedRecordTypes.indexOf(recordType), 1);
         } else {
             $scope.selectedRecordTypes.push(recordType);
         }
-        return $scope.refreshRecords();
     };
 
     /**

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -389,6 +389,7 @@ describe('Controller: RecordsController', function () {
         var expectedSort = "asc";
 
         this.scope.toggleCheckedRecordType("A");
+        this.scope.refreshRecords();
 
         expect(listRecordSetsByZone.calls.count()).toBe(1);
         expect(listRecordSetsByZone.calls.mostRecent().args).toEqual(

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -80,7 +80,6 @@
                 } else {
                     $scope.selectedRecordTypes.push(recordType);
                 }
-                return $scope.refreshRecords();
             };
 
             function updateRecordDisplay(records) {


### PR DESCRIPTION
Changes in this pull request:
- Add information about global record search criteria
- Don't invoke page refresh when toggling record types
