### PR TITLE
Upgrade scalikejdbc version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   lazy val prometheusV = "0.4.0"
   lazy val catsEffectV = "2.1.3"
   lazy val configV = "1.4.0"
-  lazy val scalikejdbcV = "3.3.1"
+  lazy val scalikejdbcV = "3.4.1"
   lazy val scalaTestV = "3.1.1"
   lazy val scodecV = "1.1.14"
   lazy val playV = "2.7.4"


### PR DESCRIPTION
Upgrade one more dependency, `scalikejdbc` to `3.4.1`. Needed to do this for some weird edge-case stuff when using the vinyl artifacts in other tools/clients -- we were getting some issues with the version of `scala-collection-compat` that `scallikejdbc` `3.3.1` included. It does not appear that there are any issues in rolling this forward.