### PR TITLE
Slightly reduce long txt record test size

### DIFF
--- a/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
+++ b/modules/api/functional_test/live_tests/recordsets/create_recordset_test.py
@@ -1644,7 +1644,7 @@ def test_create_long_txt_record_succeeds(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
 
     zone = shared_zone_test_context.system_test_zone
-    record_data = 'a' * 64763
+    record_data = 'a' * 64761
     long_txt_rs = get_recordset_json(zone, 'long-txt-record', 'TXT', [{'text': record_data}])
 
     try:


### PR DESCRIPTION
The BLOB type is juuuust too small for the previous value. Reduce the
number of characters by two -- the purpose of the test is still being
fulfilled. A migration to MEDIUMBLOB or LARGEBLOB will be required if we
need this to be bigger.

