### PR TITLE
.asHealthCheck takes a class param for reporting

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorIntegrationSpec.scala
@@ -39,7 +39,8 @@ class ZoneConnectionValidatorIntegrationSpec extends AnyWordSpec with Matchers w
         new ZoneConnectionValidator(toTest)
           .healthCheck(10000)
           .unsafeRunSync()
-      result should beLeft(HealthCheckError("Connection refused (Connection refused)"))
+      result should beLeft(HealthCheckError("vinyldns.api.domain.zone.ZoneConnectionValidator health " +
+        "check failed with msg='Connection refused (Connection refused)'"))
     }
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -150,7 +150,7 @@ class ZoneConnectionValidator(connections: ConfiguredDnsConnections)
           IO(socket.connect(new InetSocketAddress(healthCheckAddress, healthCheckPort), timeout))
       )
       .attempt
-      .asHealthCheck
+      .asHealthCheck(classOf[ZoneConnectionValidator])
 
   def isValidBackendId(backendId: Option[String]): Either[Throwable, Unit] =
     ensuring(InvalidRequest(s"Invalid backendId: [$backendId]; please check system configuration")) {

--- a/modules/api/src/test/scala/vinyldns/api/engine/TestMessageQueue.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/TestMessageQueue.scala
@@ -47,5 +47,5 @@ object TestMessageQueue extends MessageQueue {
 
   override def send[A <: ZoneCommand](command: A): IO[Unit] = IO.unit
 
-  override def healthCheck(): HealthCheck = IO.unit.attempt.asHealthCheck
+  override def healthCheck(): HealthCheck = IO.unit.attempt.asHealthCheck(TestMessageQueue.getClass)
 }

--- a/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
+++ b/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
@@ -28,11 +28,14 @@ object HealthCheck {
   private val logger = LoggerFactory.getLogger("HealthCheck")
 
   implicit class HealthCheckImprovements(io: IO[Either[Throwable, _]]) {
-    def asHealthCheck: HealthCheck =
+    def asHealthCheck(caller: Class[_]): HealthCheck =
       io.map {
         case Left(err) =>
-          logger.error("HealthCheck Failed", err)
-          Left(HealthCheckError(Option(err.getMessage).getOrElse("no message from error")))
+          logger.error(s"HealthCheck for ${caller.getCanonicalName} Failed", err)
+          val msg = Option(err.getMessage).getOrElse("no message from error")
+          Left(
+            HealthCheckError(s"${caller.getCanonicalName} health check failed with msg='${msg}'")
+          )
         case _ => Right(())
       }
   }

--- a/modules/core/src/test/scala/vinyldns/core/health/HealthServiceSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/health/HealthServiceSpec.scala
@@ -24,16 +24,16 @@ import org.scalatest.wordspec.AnyWordSpec
 class HealthServiceSpec extends AnyWordSpec with Matchers {
 
   "Checking Status" should {
-    val successCheck: HealthCheck = IO.unit.attempt.asHealthCheck
+    val successCheck: HealthCheck = IO.unit.attempt.asHealthCheck(classOf[HealthServiceSpec])
     val failCheck: HealthCheck =
-      IO.raiseError(new RuntimeException("bad!")).attempt.asHealthCheck
+      IO.raiseError(new RuntimeException("bad!")).attempt.asHealthCheck(classOf[HealthServiceSpec])
 
     "return all health check failures" in {
       val dsHealthCheck = List(successCheck, failCheck)
       val underTest = new HealthService(dsHealthCheck)
       val result = underTest.checkHealth().unsafeRunSync()
       result.length shouldBe 1
-      result.head.message shouldBe "bad!"
+      result.head.message shouldBe "vinyldns.core.health.HealthServiceSpec health check failed with msg='bad!'"
     }
 
     "return an empty list when no errors" in {

--- a/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProvider.scala
+++ b/modules/dynamodb/src/main/scala/vinyldns/dynamodb/repository/DynamoDBDataStoreProvider.scala
@@ -147,5 +147,5 @@ class DynamoDBDataStoreProvider extends DataStoreProvider {
     IO {
       val client = DynamoDBClient(dynamoConfig)
       client.listTables(1)
-    }.attempt.asHealthCheck
+    }.attempt.asHealthCheck(classOf[DynamoDBDataStoreProvider])
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
@@ -281,5 +281,5 @@ class MySqlMessageQueue(maxRetries: Int)
       NamedDB(QUEUE_CONNECTION_NAME).readOnly { implicit s =>
         HEALTH_CHECK.map(_ => ()).first.apply()
       }
-    }.attempt.asHealthCheck
+    }.attempt.asHealthCheck(classOf[MySqlMessageQueue])
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -110,5 +110,5 @@ class MySqlDataStoreProvider extends DataStoreProvider {
       DB.readOnly { implicit s =>
         HEALTH_CHECK.map(_ => ()).first.apply()
       }
-    }.attempt.asHealthCheck
+    }.attempt.asHealthCheck(classOf[MySqlDataStoreProvider])
 }

--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -293,7 +293,7 @@ class LdapAuthenticator(
         case Some(Left(e)) => e.asLeft
         case _ => ().asRight
       }
-    }.asHealthCheck
+    }.asHealthCheck(classOf[LdapAuthenticator])
 
   // List[User] => List[Either[LdapException, LdapUserDetails]] => List[User]
   def getUsersNotInLdap(users: List[User]): IO[List[User]] =

--- a/modules/portal/test/controllers/HealthControllerSpec.scala
+++ b/modules/portal/test/controllers/HealthControllerSpec.scala
@@ -34,7 +34,8 @@ class HealthControllerSpec extends Specification {
 
   "HealthController" should {
     "send 200 if the healthcheck succeeds" in {
-      val healthService = new HealthService(List(IO.unit.attempt.asHealthCheck))
+      val healthService =
+        new HealthService(List(IO.unit.attempt.asHealthCheck(classOf[HealthControllerSpec])))
       val controller = new HealthController(components, healthService)
 
       val result = controller
@@ -44,8 +45,12 @@ class HealthControllerSpec extends Specification {
       status(result) must beEqualTo(200)
     }
     "send 500 if a healthcheck fails" in {
-      val err = IO.raiseError(new RuntimeException("bad!!")).attempt.asHealthCheck
-      val healthService = new HealthService(List(IO.unit.attempt.asHealthCheck, err))
+      val err = IO
+        .raiseError(new RuntimeException("bad!!"))
+        .attempt
+        .asHealthCheck(classOf[HealthControllerSpec])
+      val healthService =
+        new HealthService(List(IO.unit.attempt.asHealthCheck(classOf[HealthControllerSpec]), err))
       val controller = new HealthController(components, healthService)
 
       val result = controller

--- a/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
@@ -701,7 +701,7 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
   }
   "return a successful health check" in {
     val mockLdapAuth = mock[LdapAuthenticator]
-    mockLdapAuth.healthCheck().returns(IO(Right(())).asHealthCheck)
+    mockLdapAuth.healthCheck().returns(IO(Right(())).asHealthCheck(classOf[LdapAuthenticatorSpec]))
 
     new TestAuthenticator(mockLdapAuth).healthCheck().unsafeRunSync() should beRight[Unit]
   }

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -175,7 +175,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
         .withAttributeNames(QueueAttributeName.CreatedTimestamp)
         .withQueueUrl(queueUrl),
       client.getQueueAttributesAsync
-    ).as(()).attempt.asHealthCheck
+    ).as(()).attempt.asHealthCheck(classOf[SqsMessageQueue])
 }
 
 object SqsMessageQueue extends ProtobufConversions {


### PR DESCRIPTION
Previously if a health check failed, there was no way of knowing _which_
one failed, unless you can isolate the particular type of failure --
though they're often very general (connection timeout, etc). If a health
check fails, it's important to know which one, or at least to log which
one it was.

I'm not sure if there's a way to infer the calling class without doing
some gnarly and expensive call-stack stuff, so here's a simple fix. If
there's a better way, I'm all ears.

I did experiment a little bit parameterizing the HealthCheck, but that
honestly seemed like more trouble than it was worth for now.

Fixes #.

Changes in this pull request:
- .asHealthCheck takes a single parameter, a class type, enabling more 
descriptive logging

