### PR TITLE
Adding scripts to update support users

### DIFF
--- a/bin/update-support-user.sh
+++ b/bin/update-support-user.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+usage () {
+    echo -e "Description: Updates a user in VinylDNS to a support user, or removes the user as a support user.\n"
+    echo -e "Usage: update-support-user.sh [OPTIONS] [VINYLDNS USERNAME] [SUPPORT - True | False]\n"
+    echo -e "Must define as an environment variables the following (or pass them in on the command line)\n"
+    echo -e "DB_USER (user name for accessing the vinyldns database)"
+    echo -e "DB_PASS (user password for accessing the vinyldns database)"
+    echo -e "DB_HOST (host name for the mysql server of the vinyldns database)"
+    echo -e "DB_NAME (name of the vinyldns database, defaults to vinyldns)\n"
+    echo -e "DB_PORT (port of the vinyldns database, defaults to 3306)\n"
+    echo -e "\t-u|--user \tuser name for accessing the vinyldns database"
+    echo -e "\t-p|--password  \tuser password for accessing the vinyldns database"
+    echo -e "\t-h|--host  \thost name for the mysql server of the vinyldns database"
+    echo -e "\t-n|--name    \tname of the vinyldns database, defaults to vinyldns"
+    echo -e "\t-n|--port    \port of the vinyldns database, defaults to 3306"
+}
+
+DIR=$( cd $(dirname $0) ; pwd -P )
+WORK_DIR=$DIR/../docker
+
+MAKE_SUPPORT="${@: -1}"
+VINYL_USER="${@:(-2):1}"
+
+echo "$VINYL_USER - $MAKE_SUPPORT"
+
+DB_USER=$DB_USER
+DB_PASS=$DB_PASS
+DB_HOST=$DB_HOST
+DB_NAME=${DB_NAME:-vinyldns}
+DB_PORT=${DB_PORT:-19002}
+
+while [ "$1" != "" ]; do
+	case "$1" in
+		-u | --user  	    ) DB_USER="$2";  shift;;
+        -p | --password  	) DB_PASS="$2";  shift;;
+		-h | --host     	) DB_HOST="$2";  shift;;
+		-n | --name     	) DB_NAME="$2";  shift;;
+		-c | --port         ) DB_PORT="$2";  shift;;
+		* ) break;;
+	esac
+	shift
+done
+
+ERROR=
+if [[ -z "$DB_USER" ]]
+then
+    echo "No DB_USER environment variable found"
+    ERROR="1"
+fi
+
+if [[ -z "$DB_PASS" ]]
+then
+    echo "No DB_PASS environment variable found"
+    ERROR="1"
+fi
+
+if [[ -z "$DB_HOST" ]]
+then
+    echo "No DB_HOST environment variable found"
+    ERROR="1"
+fi
+
+if [[ -z "$DB_NAME" ]]
+then
+    echo "No DB_NAME environment variable found"
+    ERROR="1"
+fi
+
+if [[ -n "$ERROR" ]]
+then
+    usage
+    exit 1
+fi
+
+docker build -t vinyldns/admin $WORK_DIR/admin
+
+docker run \
+    -e "DB_USER=$DB_USER" \
+    -e "DB_PASS=$DB_PASS" \
+    -e "DB_HOST=$DB_HOST" \
+    -e "DB_NAME=$DB_NAME" \
+    -e "DB_PORT=$DB_PORT" \
+    vinyldns/admin:latest update-support-user.py $VINYL_USER $MAKE_SUPPORT

--- a/docker/admin/Dockerfile
+++ b/docker/admin/Dockerfile
@@ -1,0 +1,25 @@
+FROM znly/protoc:0.4.0 as pbcompile
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+# needs to protoc compile modules/core/src/main/protobuf/VinylDNSProto.proto
+RUN git clone -b master --single-branch --depth 1 https://github.com/vinyldns/vinyldns.git /vinyldns
+
+# create a compiled protobuf in /vinyldns/target
+RUN mkdir -p /vinyldns/target && \
+    cp vinyldns/modules/core/src/main/protobuf/VinylDNSProto.proto /vinyldns/target && \
+    protoc --version && \
+    protoc --proto_path=/vinyldns/target --python_out=/vinyldns/target /vinyldns/target/VinylDNSProto.proto
+
+
+FROM python:3.7-alpine
+
+RUN apk add --update --no-cache bind-tools netcat-openbsd bash curl
+RUN pip install mysql-connector-python
+
+COPY --from=pbcompile /vinyldns/target /app/
+COPY update-support-user.py /app/update-support-user.py
+
+WORKDIR /app
+ENTRYPOINT ["python"]

--- a/docker/admin/update-support-user.py
+++ b/docker/admin/update-support-user.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+import mysql.connector
+import VinylDNSProto_pb2
+import sys
+import os
+
+# arguments
+user_name = sys.argv[1]
+make_support = sys.argv[2][0].upper()=='T' if len(sys.argv) >= 2 else None
+
+# environment variables to connect to database
+db_user = os.environ.get('DB_USER')
+db_pass = os.environ.get('DB_PASS')
+db_host = os.environ.get('DB_HOST')
+db_name = os.environ.get('DB_NAME')
+db_port = os.environ.get('DB_PORT')
+
+cnx = mysql.connector.connect(user=db_user, password=db_pass, host=db_host, database=db_name, port=db_port)
+
+query = "SELECT data FROM user where user_name = %(user_name)s"
+update = "UPDATE user SET data = %(pb)s WHERE user_name = %(user_name)s"
+
+cursor = cnx.cursor(dictionary=True)
+
+cursor.execute(query, { 'user_name': user_name })
+user = VinylDNSProto_pb2.User()
+for row in cursor:
+    user_raw = row['data']
+    user = VinylDNSProto_pb2.User()
+    user.ParseFromString(user_raw)
+    print("FOUND USER NAME {}, IS SUPPORT = {}".format(user.userName, user.isSupport))
+
+if make_support is not None:
+    print("Updating {}, Support = {}".format(user_name, make_support))
+    user.isSupport = make_support
+    cursor.execute(update, { 'pb': user.SerializeToString(), 'user_name': user_name })
+    cnx.commit()
+else:
+    print("Skipping making support as no make support value provided")
+
+cursor.close()
+cnx.close()


### PR DESCRIPTION
In order to update support users, we need to be able to unpack/pack the VinylDNS protobuf.

This requires us to 1) compile the proto file and 2) call out to the vinyldns Database

Added `update-support-user.py` that provides a simple way to pass in a vinyldns username and `Boolean` to update a user to be a support user.

Built a dockerfile that compiles the Vinyldns.proto file to Python.  This is to avoid a user from having to have `protoc` installed locally and having to know the correct commands.  An alternative would be to run `protoc` and output the proto file to `target` or something.  This approach requires `docker` which felt preferable, but I could go either way.

To execute, you must setup the environment variables or pass them in on the command line.

```
> ./bin/update-support-user.sh -u root -p pass -h host.docker.internal -name --port 19002 vinyldns dummy False
```

The above is useful when running against the quick start setup.

