### PR TITLE
Increase max groups list result size

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
@@ -30,6 +30,7 @@ class MembershipRoute(
     with VinylDNSDirectives[Throwable] {
   final private val DEFAULT_MAX_ITEMS: Int = 100
   final private val MAX_ITEMS_LIMIT: Int = 1000
+  final private val MAX_GROUPS_LIST_LIMIT: Int = 1500
 
   def getRoutes: Route = membershipRoute
 
@@ -85,10 +86,10 @@ class MembershipRoute(
               {
                 handleRejections(invalidQueryHandler) {
                   validate(
-                    check = 0 < maxItems && maxItems <= MAX_ITEMS_LIMIT,
+                    check = 0 < maxItems && maxItems <= MAX_GROUPS_LIST_LIMIT,
                     errorMsg = s"""
                            | maxItems was $maxItems, maxItems must be between 0 exclusive
-                           | and $MAX_ITEMS_LIMIT inclusive"
+                           | and $MAX_GROUPS_LIST_LIMIT inclusive"
                          """.stripMargin
                   ) {
                     authenticateAndExecute(

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -253,8 +253,8 @@ class MembershipRoutingSpec
         status shouldBe StatusCodes.BadRequest
       }
     }
-    "return a 400 response when maxItems is more than 1000" in {
-      Get("/groups?maxItems=1001") ~> Route.seal(membershipRoute) ~> check {
+    "return a 400 response when maxItems is more than 1500" in {
+      Get("/groups?maxItems=1501") ~> Route.seal(membershipRoute) ~> check {
         status shouldBe StatusCodes.BadRequest
       }
     }

--- a/modules/portal/public/lib/services/groups/service.groups.js
+++ b/modules/portal/public/lib/services/groups/service.groups.js
@@ -72,7 +72,7 @@ angular.module('service.groups', [])
 
         this.getGroups = function (ignoreAccess) {
             var url = '/api/groups';
-            url = this.urlBuilder(url, { maxItems: 1000, ignoreAccess: ignoreAccess});
+            url = this.urlBuilder(url, { maxItems: 1500, ignoreAccess: ignoreAccess});
             return $http.get(url);
         };
 


### PR DESCRIPTION
Groups ultimately need pagination and searching (#603, #415) as well as support for LDAP (#929) groups. As such this fix is to extend the life of the existing implementation until we have time to revisit this (likely with #968).