### PR TITLE
Skip CI for certain tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val testSettings = Seq(
   parallelExecution in Test := true,
   parallelExecution in IntegrationTest := false,
   fork in IntegrationTest := true,
-  testOptions in Test += Tests.Argument("-oDNCXEPQRMIK"),
+  testOptions in Test += Tests.Argument("-oDNCXEPQRMIK", "-l", "SkipCI"),
   logBuffered in Test := false,
   // Hide stack traces in tests
   traceLevel in Test := -1,

--- a/modules/api/src/it/scala/vinyldns/api/notifier/email/EmailNotifierIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/notifier/email/EmailNotifierIntegrationSpec.scala
@@ -18,7 +18,7 @@ package vinyldns.api.notifier.email
 
 import com.typesafe.config.{Config, ConfigFactory}
 import vinyldns.core.notifier._
-import vinyldns.api.MySqlApiIntegrationSpec
+import vinyldns.api.{MySqlApiIntegrationSpec, SkipCI}
 import vinyldns.mysql.MySqlIntegrationSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -28,7 +28,9 @@ import vinyldns.core.domain.record.AData
 import org.joda.time.DateTime
 import vinyldns.core.TestMembershipData._
 import java.nio.file.{Files, Path, Paths}
+
 import cats.effect.{IO, Resource}
+
 import scala.collection.JavaConverters._
 import org.scalatest.BeforeAndAfterEach
 import cats.implicits._
@@ -54,7 +56,7 @@ class EmailNotifierIntegrationSpec
 
   "Email Notifier" should {
 
-    "send an email" in {
+    "send an email" taggedAs (SkipCI) in {
       val batchChange = BatchChange(
         okUser.id,
         okUser.userName,

--- a/modules/api/src/test/scala/vinyldns/api/SkipCI.scala
+++ b/modules/api/src/test/scala/vinyldns/api/SkipCI.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api
+
+import org.scalatest.Tag
+
+object SkipCI extends Tag("SkipCI")


### PR DESCRIPTION
The `EmailNotifierIntegrationSpec` does not work in Github actions for some reason, likely due to sending an email.

1. Added a `SkipCI` tag that will enable us to by default skip certain tests in CI.
2. Updated the `build.sbt` to by default exclude `SkipCI` tests
3. Added `taggedAs(SkipCI)` to the email integration test

