### PR TITLE
[ci skip] Change docker quickstart

### DIFF
--- a/bin/docker-up-vinyldns.sh
+++ b/bin/docker-up-vinyldns.sh
@@ -80,6 +80,8 @@ DOCKER_COMPOSE_CONFIG="${DIR}/../docker/docker-compose-quick-start.yml"
 SERVICE=""
 # when CLEAN is set to 1, existing docker images are deleted so they are re-pulled
 CLEAN=0
+# default to latest for docker versions
+export VINYLDNS_VERSION=latest
 
 # source env before parsing args so vars can be overwritten
 set -a # Required in order to source docker/.env

--- a/docker/.env
+++ b/docker/.env
@@ -16,6 +16,3 @@ MYSQL_ENDPOINT=vinyldns-mysql:3306
 USER_TABLE_NAME=users
 USER_CHANGE_TABLE_NAME=userChange
 TEST_LOGIN=true
-
-# api and portal docker tag
-VINYLDNS_VERSION=0.9.5

--- a/docker/.env.quickstart
+++ b/docker/.env.quickstart
@@ -16,6 +16,3 @@ MYSQL_ENDPOINT=vinyldns-mysql:3306
 USER_TABLE_NAME=users
 USER_CHANGE_TABLE_NAME=userChange
 TEST_LOGIN=true
-
-# api and portal docker tag
-VINYLDNS_VERSION=0.9.5


### PR DESCRIPTION
Changed up the docker quick start to assert the latest tagged release unless overridden via the version argument