### PR TITLE
review comment replaced with text area

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -174,7 +174,7 @@
                             <h3 class="panel-title">Review DNS Change</h3>
                         </div>
                         <div class="panel-body">
-                            <label>Review Comment (optional):</label> <input type="text" ng-model="$parent.reviewComment">
+                            <label>Review Comment (optional):</label> <textarea ng-model="$parent.reviewComment" class="form-control" rows="3"></textarea>
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="!reviewType" class="pull-right">


### PR DESCRIPTION
Fixes #995.

Changes in this pull request:

- `dnsChangeDetail.scala.html` modified with the introduction of a `textArea` instead of the `input` tag.
