### PR TITLE
Route 53 fixes for connect

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/route53/Route53ApiIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/route53/Route53ApiIntegrationSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.route53
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatestplus.mockito.MockitoSugar
+import scalikejdbc.DB
+import vinyldns.api.engine.ZoneSyncHandler
+import vinyldns.api.{MySqlApiIntegrationSpec, ResultHelpers}
+import vinyldns.core.TestRecordSetData._
+import vinyldns.core.domain.backend.{Backend, BackendResolver}
+import vinyldns.core.domain.record.{NameSort, RecordType}
+import vinyldns.core.domain.zone.{Zone, ZoneChange, ZoneChangeType}
+import vinyldns.core.health.HealthCheck.HealthCheck
+import vinyldns.route53.backend.{Route53Backend, Route53BackendConfig}
+
+class Route53ApiIntegrationSpec
+    extends MySqlApiIntegrationSpec
+    with AnyWordSpecLike
+    with ScalaFutures
+    with Matchers
+    with MockitoSugar
+    with ResultHelpers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach {
+
+  private val testZone = Zone("example.com.", "test@test.com", backendId = Some("test"))
+  private def testConnection: Route53Backend =
+    Route53Backend
+      .load(
+        Route53BackendConfig("test", "access", "secret", "http://127.0.0.1:19009", "us-east-1")
+      )
+      .unsafeRunSync()
+
+  override def afterEach(): Unit = clear()
+
+  private def clear(): Unit =
+    DB.localTx { implicit s =>
+      s.executeUpdate("DELETE FROM record_change")
+      s.executeUpdate("DELETE FROM recordset")
+      s.executeUpdate("DELETE FROM zone_access")
+      s.executeUpdate("DELETE FROM zone")
+      ()
+    }
+
+  "Route53 backend" should {
+    "connect to an existing route53 zone" in {
+      val conn = testConnection
+
+      val backendResolver = new BackendResolver {
+        override def resolve(zone: Zone): Backend = conn
+
+        override def healthCheck(timeout: Int): HealthCheck = IO.pure(Right(()))
+
+        override def isRegistered(backendId: String): Boolean = true
+
+        override def ids: NonEmptyList[String] = NonEmptyList.one("r53")
+      }
+      conn.createZone(testZone).unsafeRunSync()
+
+      val addRecord = makeTestAddChange(rsOk, testZone)
+      conn.applyChange(addRecord).unsafeRunSync()
+
+      // Simulate a create in Vinyl
+      val syncHandler = ZoneSyncHandler.apply(
+        recordSetRepository,
+        recordChangeRepository,
+        zoneChangeRepository,
+        zoneRepository,
+        backendResolver
+      )
+      val zoneSync = ZoneChange(testZone, "system", ZoneChangeType.Create)
+      syncHandler.apply(zoneSync).unsafeRunSync()
+
+      // We should have both the record we created above as well as at least one NS record
+      val results = recordSetRepository
+        .listRecordSets(Some(testZone.id), None, None, None, None, None, NameSort.ASC)
+        .unsafeRunSync()
+      results.recordSets.map(_.typ).distinct should contain theSameElementsAs List(
+        rsOk.typ,
+        RecordType.NS
+      )
+      results.recordSets.map(_.name) should contain(rsOk.name)
+    }
+  }
+}

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -124,7 +124,7 @@ object Boot extends App {
       )
       val membershipService = MembershipService(repositories)
       val connectionValidator =
-        new ZoneConnectionValidator(backendResolver)
+        new ZoneConnectionValidator(backendResolver, VinylDNSConfig.approvedNameServers)
       val recordSetService =
         RecordSetService(
           repositories,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneConnectionValidator.scala
@@ -19,19 +19,19 @@ package vinyldns.api.domain.zone
 import cats.effect._
 import cats.syntax.all._
 import vinyldns.api.Interfaces._
-import vinyldns.api.VinylDNSConfig
 import vinyldns.core.domain.backend.{Backend, BackendResolver}
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone.Zone
 
 import scala.concurrent.duration._
+import scala.util.matching.Regex
 
 trait ZoneConnectionValidatorAlgebra {
   def validateZoneConnections(zone: Zone): Result[Unit]
   def isValidBackendId(backendId: Option[String]): Either[Throwable, Unit]
 }
 
-class ZoneConnectionValidator(backendResolver: BackendResolver)
+class ZoneConnectionValidator(backendResolver: BackendResolver, approvedNameServers: List[Regex])
     extends ZoneConnectionValidatorAlgebra {
 
   import ZoneRecordValidations._
@@ -44,7 +44,7 @@ class ZoneConnectionValidator(backendResolver: BackendResolver)
 
   def hasApexNS(zoneView: ZoneView): Result[Unit] = {
     val apexRecord = zoneView.recordSetsMap.get(zoneView.zone.name, RecordType.NS) match {
-      case Some(ns) => containsApprovedNameServers(VinylDNSConfig.approvedNameServers, ns)
+      case Some(ns) => containsApprovedNameServers(approvedNameServers, ns)
       case None => "Missing apex NS record".invalidNel
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.BeforeAndAfterEach
 import vinyldns.core.domain.record._
-import vinyldns.api.ResultHelpers
+import vinyldns.api.{ResultHelpers, VinylDNSConfig}
 import cats.effect._
 import org.mockito.Matchers.any
 import vinyldns.core.domain.Fqdn
@@ -66,7 +66,8 @@ class ZoneConnectionValidatorSpec
       recordSets = recordSets.toList
     )
 
-  class TestConnectionValidator() extends ZoneConnectionValidator(mockBackendResolver) {
+  class TestConnectionValidator()
+      extends ZoneConnectionValidator(mockBackendResolver, VinylDNSConfig.approvedNameServers) {
     override val opTimeout: FiniteDuration = 10.milliseconds
     override def loadDns(zone: Zone): IO[ZoneView] = testLoadDns(zone)
     override def isValidBackendId(backendId: Option[String]): Either[Throwable, Unit] =
@@ -223,7 +224,7 @@ class ZoneConnectionValidatorSpec
       doReturn(false).when(mockBackendResolver).isRegistered("bad")
 
       val underTest =
-        new ZoneConnectionValidator(mockBackendResolver)
+        new ZoneConnectionValidator(mockBackendResolver, Nil)
 
       "return success if the backendId exists" in {
         underTest.isValidBackendId(Some("some-test-backend")) shouldBe right

--- a/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
@@ -26,6 +26,15 @@ case class Fqdn(fqdn: String) {
   // Everything up to the first dot, includes the dot to make it absolute
   def firstLabelAbsolute: String = fqdn.substring(0, fqdn.indexOf('.') + 1)
 
+  def matches(value: String): Boolean =
+    // fqdns always are absolute / trailing dot
+    if (value.endsWith(".")) value.toLowerCase == fqdn.toLowerCase
+    else value.toLowerCase == fqdn.dropRight(1).toLowerCase
+
+  // Returns the record name relative to the zone name, or the zone name if it is a match
+  def zoneRecordName(zoneName: String): String =
+    if (matches(zoneName)) fqdn else firstLabel
+
   override def equals(obj: Any): Boolean =
     obj match {
       case Fqdn(otherFqdn) => otherFqdn.toLowerCase == fqdn.toLowerCase

--- a/modules/r53/src/it/scala/vinyldns/route53/backend/Route53IntegrationSpec.scala
+++ b/modules/r53/src/it/scala/vinyldns/route53/backend/Route53IntegrationSpec.scala
@@ -48,7 +48,13 @@ class Route53IntegrationSpec
   private def testConnection: Route53Backend =
     Route53Backend
       .load(
-        Route53BackendConfig("test", Option("access"), Option("secret"), "http://127.0.0.1:19009", "us-east-1")
+        Route53BackendConfig(
+          "test",
+          Option("access"),
+          Option("secret"),
+          "http://127.0.0.1:19009",
+          "us-east-1"
+        )
       )
       .unsafeRunSync()
 

--- a/modules/r53/src/main/scala/vinyldns/route53/backend/Route53Conversions.scala
+++ b/modules/r53/src/main/scala/vinyldns/route53/backend/Route53Conversions.scala
@@ -72,7 +72,7 @@ trait Route53Conversions {
     val typ = toVinylRecordType(RRType.fromValue(r53RecordSet.getType))
     RecordSet(
       zoneId,
-      Fqdn.merge(r53RecordSet.getName, zoneName).firstLabel,
+      Fqdn.merge(r53RecordSet.getName, zoneName).zoneRecordName(zoneName),
       typ,
       r53RecordSet.getTTL,
       RecordSetStatus.Active,

--- a/modules/r53/src/main/scala/vinyldns/route53/backend/Route53Conversions.scala
+++ b/modules/r53/src/main/scala/vinyldns/route53/backend/Route53Conversions.scala
@@ -16,10 +16,15 @@
 
 package vinyldns.route53.backend
 
-import com.amazonaws.services.route53.model.{RRType, ResourceRecord, ResourceRecordSet}
+import com.amazonaws.services.route53.model.{
+  DelegationSet,
+  RRType,
+  ResourceRecord,
+  ResourceRecordSet
+}
 import org.joda.time.DateTime
 import vinyldns.core.domain.Fqdn
-import vinyldns.core.domain.record.{RecordData, RecordSet, RecordSetStatus}
+import vinyldns.core.domain.record.{NSData, RecordData, RecordSet, RecordSetStatus, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.zone.Zone
@@ -59,10 +64,14 @@ trait Route53Conversions {
   def toVinyl(typ: RecordType, resourceRecord: ResourceRecord): Option[RecordData] =
     RecordData.fromString(resourceRecord.getValue, typ)
 
-  def toVinylRecordSet(zoneName: String, r53RecordSet: ResourceRecordSet): RecordSet = {
+  def toVinylRecordSet(
+      zoneName: String,
+      zoneId: String,
+      r53RecordSet: ResourceRecordSet
+  ): RecordSet = {
     val typ = toVinylRecordType(RRType.fromValue(r53RecordSet.getType))
     RecordSet(
-      "unknown",
+      zoneId,
       Fqdn.merge(r53RecordSet.getName, zoneName).firstLabel,
       typ,
       r53RecordSet.getTTL,
@@ -76,9 +85,31 @@ trait Route53Conversions {
 
   def toVinylRecordSets(
       r53RecordSets: java.util.List[ResourceRecordSet],
-      zoneName: String
+      zoneName: String,
+      zoneId: String = "unknown"
   ): List[RecordSet] =
-    r53RecordSets.asScala.toList.map(toVinylRecordSet(zoneName, _))
+    r53RecordSets.asScala.toList.map(toVinylRecordSet(zoneName, zoneId, _))
+
+  def toVinylNSRecordSet(
+      delegationSet: DelegationSet,
+      zoneName: String,
+      zoneId: String
+  ): RecordSet = {
+    val nsData = delegationSet.getNameServers.asScala.toList.map { ns =>
+      NSData(Fqdn(ns))
+    }
+    RecordSet(
+      zoneId,
+      zoneName,
+      RecordType.NS,
+      7200,
+      RecordSetStatus.Active,
+      DateTime.now,
+      Some(DateTime.now),
+      nsData,
+      fqdn = Some(Fqdn(zoneName).fqdn)
+    )
+  }
 
   def toR53RecordSet(zone: Zone, vinylRecordSet: RecordSet): Option[ResourceRecordSet] =
     toRoute53RecordType(vinylRecordSet.typ).map { typ =>


### PR DESCRIPTION
Fixes #1012 

Changes in this pull request:
- When available, ensure that the `zoneId` is passed when loading vinyldns record sets
- Use the `DelegationSet` on the hosted zone to _simulate_ NS records.  NS records do not exist by default on private hosted zones
