### PR TITLE
Fix route53 issue with merge fqdn

### DIFF
--- a/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
@@ -33,9 +33,6 @@ case class Fqdn(fqdn: String) {
 
   // Returns the record name relative to the zone name, or the zone name if it is a match
   def zoneRecordName(zoneName: String): String = {
-    println(
-      s"***calculating record name for $fqdn and zone $zoneName; match is ${matches(zoneName)}"
-    )
     if (matches(zoneName)) fqdn else firstLabel
   }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/Fqdn.scala
@@ -32,8 +32,12 @@ case class Fqdn(fqdn: String) {
     else value.toLowerCase == fqdn.dropRight(1).toLowerCase
 
   // Returns the record name relative to the zone name, or the zone name if it is a match
-  def zoneRecordName(zoneName: String): String =
+  def zoneRecordName(zoneName: String): String = {
+    println(
+      s"***calculating record name for $fqdn and zone $zoneName; match is ${matches(zoneName)}"
+    )
     if (matches(zoneName)) fqdn else firstLabel
+  }
 
   override def equals(obj: Any): Boolean =
     obj match {
@@ -57,7 +61,7 @@ case object Fqdn {
     val zname = dropTrailingDot(zoneName)
 
     val zIndex = rname.lastIndexOf(zname)
-    if (zIndex > 0) {
+    if (zIndex >= 0) {
       // zone name already there, or record name = zone name, so just return
       Fqdn(rname + ".")
     } else {

--- a/modules/core/src/test/scala/vinyldns/core/domain/FqdnSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/FqdnSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FqdnSpec extends AnyWordSpec with Matchers {
+
+  "Fqdn" should {
+    "merge when record name matches zone name" in {
+      Fqdn.merge("test.com", "test.com") shouldBe Fqdn("test.com.")
+    }
+    "merge when record name does not match zone name" in {
+      Fqdn.merge("www.", "test.com") shouldBe Fqdn("www.test.com.")
+    }
+    "merge properly when record name is not absolute" in {
+      Fqdn.merge("www", "test.com.") shouldBe Fqdn("www.test.com.")
+    }
+    "merge properly when zone name and record name are not absolute" in {
+      Fqdn.merge("www", "test.com") shouldBe Fqdn("www.test.com.")
+    }
+    "merge properly for dotted hosts" in {
+      Fqdn.merge("www.foo", "test.com") shouldBe Fqdn("www.foo.test.com.")
+    }
+    "merge properly when the record name is already an fqdn" in {
+      Fqdn.merge("www.test.com", "test.com") shouldBe Fqdn("www.test.com")
+    }
+  }
+}


### PR DESCRIPTION
Addresses #1012

Was able to get a "real" public hosted zone connected.  The `Fqdn.merge` was not working properly when merging record name and zone names when they matched.

Added a bunch of unit tests along with the fix.

This was tested against a "real" public hosted zone.  Verified connect, load zone, add record, delete record.