### PR TITLE
Enabling important features by default

### DIFF
--- a/docker/api/docker.conf
+++ b/docker/api/docker.conf
@@ -17,6 +17,8 @@
 ################################################################################################################
 vinyldns {
 
+  approved-name-servers = [ ".*" ]
+
   # configured backend providers
   backend {
     # Use "default" when dns backend legacy = true

--- a/docker/portal/application.conf
+++ b/docker/portal/application.conf
@@ -55,5 +55,8 @@ mysql {
   }
 }
 
+shared-display-enabled = true
+multi-record-batch-change-enabled = true
+
 # You generate this yourself following https://www.playframework.com/documentation/2.7.x/ApplicationSecret
 play.http.secret.key = "rpkTGtoJvLIdIV?WU=0@yW^x:pcEGyAt`^p/P3G0fpbj9:uDnD@caSjCDqA0@tB="


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- Added `approved-name-servers` and assigned a default value to it.
- Enabled the `shared` drop-down-list option for the zone in the portal by default.
