### PR TITLE
Drop warning for dotted hosts on valid records

### DIFF
--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -29,6 +29,19 @@ akka.http {
 }
 
 vinyldns {
+  queue {
+    class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
+
+    messages-per-poll = 10
+    polling-interval = 250.millis
+    max-retries = 100 # Max retries for message on queue; currently only applies to MySqlMessageQueue
+
+    settings {
+      # AWS access key and secret.
+      access-key = "x"
+      secret-key = "x"
+    }
+  }  
   data-stores = ["mysql"]
 
   mysql {

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -310,6 +310,14 @@ class RecordSetValidationsSpec
 
           typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
         }
+      }
+      "Skip dotted checks on TXT" should {
+        "return success for a TXT record with dots in a reverse zone" in {
+          val test = txt.copy(name = "sub.txt.example.com.")
+          val zone = okZone.copy(name = "example.com.")
+
+          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+        }
 
       }
       "Skip dotted checks on SOA in reverse zones" should {

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -121,11 +121,11 @@
             <tbody>
                 <tr ng-repeat="(recordName, record) in records track by $index">
                     <td>
-                        <div ng-if="record.isDotted" class="text-danger wrap-long-text" data-toggle="tooltip" data-placement="top"
+                        <div ng-if="record.isDotted && record.type != 'TXT' && record.type != 'SRV' && record.type != 'NAPTR'" class="text-danger wrap-long-text" data-toggle="tooltip" data-placement="top"
                         title="Dotted hosts are invalid! Please delete or update without a '.'">
                             {{record.name}} <span class="fa fa-warning" />
                         </div>
-                        <div class="wrap-long-text" ng-if="!record.isDotted">
+                        <div class="wrap-long-text" ng-if="!record.isDotted || (record.type != 'TXT' || record.type != 'SRV' || record.type != 'NAPTR')">
                             {{record.name}}
                         </div>
                     </td>

--- a/modules/portal/prepare-portal.sh
+++ b/modules/portal/prepare-portal.sh
@@ -3,9 +3,9 @@ DIR=$( cd $(dirname $0) ; pwd -P )
 
 cd $DIR
 
-npm install
+npm install -f
 
-npm install grunt -g
+npm install grunt -g -f
 grunt default
 $DIR/../../bin/add-license-headers.sh -d=$DIR/public/lib -f=js
 


### PR DESCRIPTION
Fixes #1034 

Changes in this pull request:
- Update record view for managing records to _not_ display a warning next to records that are valid dotted hosts.
- Update the prepare portal script to do a force (needed for clean machine)
- Add queue coordinates for starting up the api locally using `reStart` - the coordinates were removed from `reference.conf` in a prior PR that looks to have broken starting up using `reStart` locally
- Added a unit test to double check we allow dotted TXT records in the API