### PR TITLE
Add error for group creation with email that already exists

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,6 +35,7 @@ Thank you! If you have contributed in any way, but do not see your name here, pl
 - Joshulyne Park
 - Nathan Pierce
 - Michael Pilquist
+- Aravindh Raju
 - Sriram Ramakrishnan
 - Khalid Reid
 - Timo Schmid
@@ -47,4 +48,3 @@ Thank you! If you have contributed in any way, but do not see your name here, pl
 - Fei Wan
 - Andrew Wang
 - Peter Willis
-- Aravindh Raju

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -47,3 +47,4 @@ Thank you! If you have contributed in any way, but do not see your name here, pl
 - Fei Wan
 - Andrew Wang
 - Peter Willis
+- Aravindh Raju

--- a/build.sbt
+++ b/build.sbt
@@ -371,7 +371,6 @@ lazy val docSettings = Seq(
   fork in mdoc := true,
   mdocIn := (sourceDirectory in Compile).value / "mdoc",
   micrositeCssDirectory := (resourceDirectory in Compile).value / "microsite" / "css",
-  micrositeCompilingDocsTool := WithMdoc,
   micrositeFavicons := Seq(MicrositeFavicon("favicon16x16.png", "16x16"), MicrositeFavicon("favicon32x32.png", "32x32")),
   micrositeEditButton := Some(MicrositeEditButton("Improve this page", "/edit/master/modules/docs/src/main/mdoc/{{ page.path }}")),
   micrositeFooterText := None,

--- a/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
+++ b/modules/api/functional_test/live_tests/batch/create_batch_change_test.py
@@ -1399,15 +1399,15 @@ def test_create_batch_change_with_readonly_user_fails(shared_zone_test_context):
         errors = dummy_client.create_batch_change(batch_change_input, status=400)
 
         assert_failed_change_in_error_response(errors[0], input_name="relative.ok.", record_data="4.5.6.7",
-                                               error_messages=['User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(errors[1], input_name="delete.ok.", change_type="DeleteRecordSet",
                                                record_data="4.5.6.7",
-                                               error_messages=['User "dummy" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User "dummy" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(errors[2], input_name="update.ok.", record_data="1.2.3.4",
-                                               error_messages=['User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(errors[3], input_name="update.ok.", change_type="DeleteRecordSet",
                                                record_data=None,
-                                               error_messages=['User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes.'])
     finally:
         clear_ok_acl_rules(shared_zone_test_context)
         clear_recordset_list(to_delete, ok_client)
@@ -1504,7 +1504,7 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_cname_fqdn + "\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[9], input_name="user-add-unauthorized.dummy.",
                                                record_data="1.2.3.4",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -1644,16 +1644,16 @@ def test_a_recordtype_update_delete_checks(shared_zone_test_context):
                                                    'Record "non-existent.ok." Does Not Exist: cannot delete a record that does not exist.'])
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn,
                                                change_type="DeleteRecordSet",
-                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn,
                                                change_type="DeleteRecordSet",
-                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(response[13], input_name=rs_update_dummy_fqdn, ttl=300,
-                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(response[14], input_name=rs_update_dummy_with_owner_fqdn, change_type="DeleteRecordSet",
-                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(response[15], input_name=rs_update_dummy_with_owner_fqdn, ttl=300,
-                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
 
     finally:
         # Clean up updates
@@ -1756,7 +1756,7 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_cname_fqdn+ "\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[9], input_name="user-add-unauthorized.dummy.",
                                                record_type="AAAA", record_data="1::1",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -1881,13 +1881,13 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_type="AAAA", record_data="1::1")
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn,
                                                record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn,
                                                record_type="AAAA", record_data="1::1",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
         assert_failed_change_in_error_response(response[13], input_name=rs_update_dummy_fqdn,
                                                record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         # Clean up updates
@@ -2042,7 +2042,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_reverse_fqdn + "\" and type \"PTR\" conflicts with this record."])
         assert_failed_change_in_error_response(response[16], input_name="user-add-unauthorized.dummy.",
                                                record_type="CNAME", record_data="test.com.",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -2173,13 +2173,13 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_type="CNAME", record_data="test.com.")
         assert_failed_change_in_error_response(response[13], input_name="delete-unauthorized3.dummy.",
                                                record_type="CNAME", change_type="DeleteRecordSet",
-                                               error_messages=['User "ok" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User "ok" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(response[14], input_name="update-unauthorized3.dummy.",
                                                record_type="CNAME", change_type="DeleteRecordSet",
-                                               error_messages=['User "ok" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User "ok" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_failed_change_in_error_response(response[15], input_name="update-unauthorized3.dummy.",
                                                record_type="CNAME", ttl=300, record_data="test.com.",
-                                               error_messages=['User "ok" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User "ok" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes.'])
         assert_successful_change_in_error_response(response[16], input_name="existing-cname2.parent.com.",
                                                    record_type="CNAME", change_type="DeleteRecordSet")
         assert_failed_change_in_error_response(response[17], input_name="existing-cname2.parent.com.",
@@ -2235,19 +2235,19 @@ def test_ptr_recordtype_auth_checks(shared_zone_test_context):
 
         assert_failed_change_in_error_response(errors[0], input_name="192.0.2.5", record_type="PTR",
                                                record_data="not.authorized.ipv4.ptr.base.",
-                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes."])
         assert_failed_change_in_error_response(errors[1], input_name="192.0.2.193", record_type="PTR",
                                                record_data="not.authorized.ipv4.ptr.classless.delegation.",
-                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes."])
         assert_failed_change_in_error_response(errors[2], input_name="fd69:27cc:fe91:1000::1234", record_type="PTR",
                                                record_data="not.authorized.ipv6.ptr.",
-                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes."])
         assert_failed_change_in_error_response(errors[3], input_name="192.0.2.25", record_type="PTR", record_data=None,
                                                change_type="DeleteRecordSet",
-                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes."])
         assert_failed_change_in_error_response(errors[4], input_name="fd69:27cc:fe91:1000::1234", record_type="PTR",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"dummy\" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes."])
     finally:
         clear_recordset_list(to_delete, ok_client)
 
@@ -2721,7 +2721,7 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_cname_fqdn + "\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[7], input_name="user-add-unauthorized.dummy.",
                                                record_type="TXT", record_data="test",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -2832,13 +2832,13 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data="test")
         assert_failed_change_in_error_response(response[9], input_name=rs_delete_dummy_fqdn, record_type="TXT",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
         assert_failed_change_in_error_response(response[10], input_name=rs_update_dummy_fqdn, record_type="TXT",
                                                record_data="test",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
         assert_failed_change_in_error_response(response[11], input_name=rs_update_dummy_fqdn, record_type="TXT",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         # Clean up updates
@@ -2944,7 +2944,7 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
                                                    "CNAME Conflict: CNAME record names must be unique. Existing record with name \"" + existing_cname_fqdn + "\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[10], input_name="user-add-unauthorized.dummy.",
                                                record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         clear_recordset_list(to_delete, client)
@@ -3068,13 +3068,13 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data={"preference": 1000, "exchange": "foo.bar."})
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn, record_type="MX",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn, record_type="MX",
                                                record_data={"preference": 1000, "exchange": "foo.bar."},
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
         assert_failed_change_in_error_response(response[13], input_name=rs_update_dummy_fqdn, record_type="MX",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at test@test.com to make DNS changes."])
+                                               error_messages=["User \"ok\" is not authorized. Contact zone owner group: dummy-group at dummy@test.com to make DNS changes."])
 
     finally:
         # Clean up updates
@@ -3636,7 +3636,7 @@ def test_create_batch_delete_recordset_for_unassociated_user_not_in_owner_group_
 
         assert_failed_change_in_error_response(response[0], input_name=shared_delete_fqdn,
                                                change_type="DeleteRecordSet",
-                                               error_messages=['User "list-group-user" is not authorized. Contact record owner group: record-ownergroup at test@test.com to make DNS changes.'])
+                                               error_messages=['User "list-group-user" is not authorized. Contact record owner group: record-ownergroup at record@test.com to make DNS changes.'])
 
     finally:
         if create_rs:
@@ -3957,7 +3957,7 @@ def test_create_batch_delete_record_access_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[3], input_name=txt_update_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[4], input_name=txt_update_fqdn, record_type="TXT", record_data="updated text")
         assert_failed_change_in_error_response(response[5], input_name=txt_delete_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecordSet",
-                                               error_messages=['User "dummy" is not authorized. Contact zone owner group: ok-group at test@test.com to make DNS changes.'])
+                                               error_messages=['User "dummy" is not authorized. Contact zone owner group: ok-group at ok@test.com to make DNS changes.'])
 
     finally:
         clear_ok_acl_rules(shared_zone_test_context)

--- a/modules/api/functional_test/live_tests/list_groups_test_context.py
+++ b/modules/api/functional_test/live_tests/list_groups_test_context.py
@@ -16,7 +16,7 @@ class ListGroupsTestContext(object):
             for runner in range(0, 50):
                 new_group = {
                     'name': "test-list-my-groups-{0:0>3}".format(runner),
-                    'email': 'test@test.com',
+                    'email': 'test-list-{0:0>3}@test.com'.format(runner),
                     'members': [{'id': 'list-group-user'}],
                     'admins': [{'id': 'list-group-user'}]
                 }

--- a/modules/api/functional_test/live_tests/list_recordsets_test_context.py
+++ b/modules/api/functional_test/live_tests/list_recordsets_test_context.py
@@ -23,7 +23,7 @@ class ListRecordSetsTestContext(object):
         self.tear_down()
         group = {
             'name': 'list-records-group',
-            'email': 'test@test.com',
+            'email': 'list-records@test.com',
             'description': 'this is a description',
             'members': [{'id': 'list-records-user'}],
             'admins': [{'id': 'list-records-user'}]
@@ -32,7 +32,7 @@ class ListRecordSetsTestContext(object):
         zone_change = self.client.create_zone(
             {
                 'name': 'list-records.',
-                'email': 'test@test.com',
+                'email': 'list-records@test.com',
                 'shared': False,
                 'adminGroupId': self.group['id'],
                 'isTest': True,

--- a/modules/api/functional_test/live_tests/list_zones_test_context.py
+++ b/modules/api/functional_test/live_tests/list_zones_test_context.py
@@ -12,7 +12,7 @@ class ListZonesTestContext(object):
         self.tear_down()
         group = {
             'name': 'list-zones-group',
-            'email': 'test@test.com',
+            'email': 'list@test.com',
             'description': 'this is a description',
             'members': [{'id': 'list-zones-user'}],
             'admins': [{'id': 'list-zones-user'}]
@@ -21,7 +21,7 @@ class ListZonesTestContext(object):
         search_zone_1_change = self.client.create_zone(
             {
                 'name': 'list-zones-test-searched-1.',
-                'email': 'test@test.com',
+                'email': 'list@test.com',
                 'shared': False,
                 'adminGroupId': list_zones_group['id'],
                 'isTest': True,
@@ -31,7 +31,7 @@ class ListZonesTestContext(object):
         search_zone_2_change = self.client.create_zone(
             {
                 'name': 'list-zones-test-searched-2.',
-                'email': 'test@test.com',
+                'email': 'list@test.com',
                 'shared': False,
                 'adminGroupId': list_zones_group['id'],
                 'isTest': True,
@@ -41,7 +41,7 @@ class ListZonesTestContext(object):
         search_zone_3_change = self.client.create_zone(
             {
                 'name': 'list-zones-test-searched-3.',
-                'email': 'test@test.com',
+                'email': 'list@test.com',
                 'shared': False,
                 'adminGroupId': list_zones_group['id'],
                 'isTest': True,
@@ -51,7 +51,7 @@ class ListZonesTestContext(object):
         non_search_zone_1_change = self.client.create_zone(
             {
                 'name': 'list-zones-test-unfiltered-1.',
-                'email': 'test@test.com',
+                'email': 'list@test.com',
                 'shared': False,
                 'adminGroupId': list_zones_group['id'],
                 'isTest': True,
@@ -61,7 +61,7 @@ class ListZonesTestContext(object):
         non_search_zone_2_change = self.client.create_zone(
             {
                 'name': 'list-zones-test-unfiltered-2.',
-                'email': 'test@test.com',
+                'email': 'list@test.com',
                 'shared': False,
                 'adminGroupId': list_zones_group['id'],
                 'isTest': True,

--- a/modules/api/functional_test/live_tests/membership/create_group_test.py
+++ b/modules/api/functional_test/live_tests/membership/create_group_test.py
@@ -13,7 +13,7 @@ def test_create_group_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-create-group-success',
-            'email': 'test@test.com',
+            'email': 'test-create@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -46,7 +46,7 @@ def test_creator_is_an_admin(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-create-group-success',
-            'email': 'test@test.com',
+            'email': 'test-create@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': []
@@ -76,7 +76,7 @@ def test_create_group_without_name(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
 
     new_group = {
-        'email': 'test@test.com',
+        'email': 'test-create@test.com',
         'description': 'this is a description',
         'members': [{'id': 'ok'}],
         'admins': [{'id': 'ok'}]
@@ -128,7 +128,7 @@ def test_create_group_without_members_or_admins(shared_zone_test_context):
 
     new_group = {
         'name': 'some-group-name',
-        'email': 'test@test.com',
+        'email': 'test-create@test.com',
         'description': 'this is a description'
     }
     errors = client.create_group(new_group, status=400)['errors']
@@ -149,7 +149,7 @@ def test_create_group_adds_admins_as_members(shared_zone_test_context):
 
         new_group = {
             'name': 'test-create-group-add-admins-as-members',
-            'email': 'test@test.com',
+            'email': 'test-create@test.com',
             'description': 'this is a description',
             'members': [],
             'admins': [{'id': 'ok'}]
@@ -178,7 +178,7 @@ def test_create_group_duplicate(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-create-group-duplicate',
-            'email': 'test@test.com',
+            'email': 'test-create@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -202,7 +202,7 @@ def test_create_group_no_members(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-create-group-no-members',
-            'email': 'test@test.com',
+            'email': 'test-create@test.com',
             'description': 'this is a description',
             'members': [],
             'admins': []
@@ -226,7 +226,7 @@ def test_create_group_adds_admins_to_member_list(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-create-group-add-admins-to-members',
-            'email': 'test@test.com',
+            'email': 'test-create@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'dummy'}]

--- a/modules/api/functional_test/live_tests/membership/delete_group_test.py
+++ b/modules/api/functional_test/live_tests/membership/delete_group_test.py
@@ -17,7 +17,7 @@ def test_delete_group_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-delete-group-success',
-            'email': 'test@test.com',
+            'email': 'test-delete@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
@@ -49,7 +49,7 @@ def test_delete_group_that_is_already_deleted(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-delete-group-already',
-            'email': 'test@test.com',
+            'email': 'test-delete@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
@@ -76,7 +76,7 @@ def test_delete_admin_group(shared_zone_test_context):
         #Create group
         new_group = {
             'name': 'test-delete-group-already',
-            'email': 'test@test.com',
+            'email': 'test-delete@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
@@ -88,7 +88,7 @@ def test_delete_admin_group(shared_zone_test_context):
         #Create zone with that group ID as admin
         zone = {
             'name': 'one-time.',
-            'email': 'test@test.com',
+            'email': 'test-delete@test.com',
             'adminGroupId': result_group['id'],
             'connection': {
                 'name': 'vinyldns.',
@@ -131,7 +131,7 @@ def test_delete_group_not_authorized(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-delete-group-not-authorized',
-            'email': 'test@test.com',
+            'email': 'test-delete@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]

--- a/modules/api/functional_test/live_tests/membership/get_group_changes_test.py
+++ b/modules/api/functional_test/live_tests/membership/get_group_changes_test.py
@@ -166,7 +166,7 @@ def test_get_group_changes_unauthed(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-list-group-admins-unauthed-2',
-            'email': 'test@test.com',
+            'email': 'test-get-group@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }

--- a/modules/api/functional_test/live_tests/membership/get_group_test.py
+++ b/modules/api/functional_test/live_tests/membership/get_group_test.py
@@ -15,7 +15,7 @@ def test_get_group_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-get-group-success',
-            'email': 'test@test.com',
+            'email': 'test-get@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
@@ -54,7 +54,7 @@ def test_get_deleted_group(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-get-deleted-group',
-            'email': 'test@test.com',
+            'email': 'test-get@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
@@ -79,7 +79,7 @@ def test_get_group_unauthed(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-get-group-unauthed',
-            'email': 'test@test.com',
+            'email': 'test-get@test.com',
             'description': 'this is a description',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]

--- a/modules/api/functional_test/live_tests/membership/list_group_admins_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_group_admins_test.py
@@ -17,7 +17,7 @@ def test_list_group_admins_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-list-group-admins-success',
-            'email': 'test@test.com',
+            'email': 'test-admins@test.com',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'}, { 'id': 'dummy'} ]
         }
@@ -67,7 +67,7 @@ def test_list_group_admins_unauthed(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-list-group-admins-unauthed',
-            'email': 'test@test.com',
+            'email': 'test-admins@test.com',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
         }

--- a/modules/api/functional_test/live_tests/membership/list_group_members_test.py
+++ b/modules/api/functional_test/live_tests/membership/list_group_members_test.py
@@ -17,7 +17,7 @@ def test_list_group_members_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-list-group-members-success',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': [ { 'id': 'ok'}, { 'id': 'dummy' } ],
             'admins': [ { 'id': 'ok'} ]
         }
@@ -86,7 +86,7 @@ def test_list_group_members_start_from(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-start-from',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -142,7 +142,7 @@ def test_list_group_members_start_from_non_user(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-start-from-nonexistent',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -198,7 +198,7 @@ def test_list_group_members_max_item(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-max-items',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -254,7 +254,7 @@ def test_list_group_members_max_item_default(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-max-items-default',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -309,7 +309,7 @@ def test_list_group_members_max_item_zero(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-max-items-zero',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -346,7 +346,7 @@ def test_list_group_members_max_item_over_1000(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-max-items-over-limit',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -383,7 +383,7 @@ def test_list_group_members_next_id_correct(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-next-id',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -438,7 +438,7 @@ def test_list_group_members_next_id_exhausted(shared_zone_test_context):
 
         new_group = {
             'name': 'test-list-group-members-next-id-exhausted',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -492,7 +492,7 @@ def test_list_group_members_next_id_exhausted_two_pages(shared_zone_test_context
 
         new_group = {
             'name': 'test-list-group-members-next-id-exhausted-two-pages',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': members,
             'admins': [ { 'id': 'ok'} ]
         }
@@ -564,7 +564,7 @@ def test_list_group_members_unauthed(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-list-group-members-unauthed',
-            'email': 'test@test.com',
+            'email': 'test-members@test.com',
             'members': [ { 'id': 'ok'} ],
             'admins': [ { 'id': 'ok'} ]
         }

--- a/modules/api/functional_test/live_tests/membership/update_group_test.py
+++ b/modules/api/functional_test/live_tests/membership/update_group_test.py
@@ -285,7 +285,7 @@ def test_update_group_conflict(shared_zone_test_context):
 
 def test_update_group_email_conflict(shared_zone_test_context):
     """
-    Tests that we can not update a groups name to a name already in use
+    Tests that we can not update a groups email to an email already in use when email configuration is set true
     """
 
     client = shared_zone_test_context.ok_vinyldns_client
@@ -321,7 +321,8 @@ def test_update_group_email_conflict(shared_zone_test_context):
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }
-        client.update_group(update_group['id'], update_group, status=409)
+        # Status code will be 409 if email configuration was set true in GroupEmailConfig.scala else it'll be 200
+        client.update_group(update_group['id'], update_group, status=(200, 409))
     finally:
         if result:
             client.delete_group(result['id'], status=(200, 404))

--- a/modules/api/functional_test/live_tests/membership/update_group_test.py
+++ b/modules/api/functional_test/live_tests/membership/update_group_test.py
@@ -14,7 +14,7 @@ def test_update_group_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-group-success',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -64,7 +64,7 @@ def test_update_group_without_name(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-without-name',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -95,7 +95,7 @@ def test_update_group_without_email(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-without-email',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -127,7 +127,7 @@ def test_updating_group_without_name_or_email(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-without-name-and-email',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -163,7 +163,7 @@ def test_updating_group_without_members_or_admins(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-without-members',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -175,7 +175,7 @@ def test_updating_group_without_members_or_admins(shared_zone_test_context):
         update_group = {
             'id': result['id'],
             'name': 'test-update-without-members',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
         }
         errors = client.update_group(update_group['id'], update_group, status=400)['errors']
@@ -200,7 +200,7 @@ def test_update_group_adds_admins_as_members(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-group-admins-as-members',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -219,7 +219,7 @@ def test_update_group_adds_admins_as_members(shared_zone_test_context):
         update_group = {
             'id': group['id'],
             'name': 'test-update-group-admins-as-members',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}, {'id': 'dummy'}]
@@ -283,6 +283,53 @@ def test_update_group_conflict(shared_zone_test_context):
             client.delete_group(conflict_group['id'], status=(200, 404))
 
 
+def test_update_group_email_conflict(shared_zone_test_context):
+    """
+    Tests that we can not update a groups name to a name already in use
+    """
+
+    client = shared_zone_test_context.ok_vinyldns_client
+    result = None
+    conflict_group = None
+    try:
+        new_group = {
+            'name': 'test_update_group_conflict',
+            'email': 'test-update@test.com',
+            'description': 'this is a description',
+            'members': [{'id': 'ok'}],
+            'admins': [{'id': 'ok'}]
+        }
+        conflict_group = client.create_group(new_group, status=200)
+        assert_that(conflict_group['email'], is_(new_group['email']))
+
+        other_group = {
+            'name': 'change_me',
+            'email': 'test-other@test.com',
+            'description': 'this is a description',
+            'members': [{'id': 'ok'}],
+            'admins': [{'id': 'ok'}]
+        }
+        result = client.create_group(other_group, status=200)
+        assert_that(result['email'], is_(other_group['email']))
+
+        # change the email id of the other_group to the first group (conflict)
+        update_group = {
+            'id': result['id'],
+            'name': 'change_me',
+            'email': 'test-update@test.com',
+            'description': 'this is a description',
+            'members': [{'id': 'ok'}],
+            'admins': [{'id': 'ok'}]
+        }
+        client.update_group(update_group['id'], update_group, status=409)
+    finally:
+        if result:
+            client.delete_group(result['id'], status=(200, 404))
+        if conflict_group:
+            client.delete_group(conflict_group['id'], status=(200, 404))
+
+
+
 def test_update_group_not_found(shared_zone_test_context):
     """test_user_cannot_update_zone_to_nonmember_admin_group
     Tests that we can not update a group that has not been created
@@ -312,7 +359,7 @@ def test_update_group_deleted(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-group-deleted',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -344,7 +391,7 @@ def test_add_member_via_update_group_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-add-member-to-via-update-group-success',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }
@@ -353,7 +400,7 @@ def test_add_member_via_update_group_success(shared_zone_test_context):
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-add-member-to-via-update-group-success',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}]
         }
@@ -378,7 +425,7 @@ def test_add_member_to_group_twice_via_update_group(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-add-member-to-group-twice-success-via-update-group',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }
@@ -387,7 +434,7 @@ def test_add_member_to_group_twice_via_update_group(shared_zone_test_context):
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-add-member-to-group-twice-success-via-update-group',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}]
         }
@@ -414,7 +461,7 @@ def test_add_not_found_member_to_group_via_update_group(shared_zone_test_context
     try:
         new_group = {
             'name': 'test-add-not-found-member-to-group-via-update-group',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }
@@ -425,7 +472,7 @@ def test_add_not_found_member_to_group_via_update_group(shared_zone_test_context
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-add-not-found-member-to-group-via-update-group',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'not_found'}],
             'admins': [{'id': 'ok'}]
         }
@@ -447,7 +494,7 @@ def test_remove_member_via_update_group_success(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-remove-member-via-update-group-success',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}]
         }
@@ -457,7 +504,7 @@ def test_remove_member_via_update_group_success(shared_zone_test_context):
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-remove-member-via-update-group-success',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }
@@ -480,7 +527,7 @@ def test_remove_member_and_admin(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-remove-member-and-admin',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}, {'id': 'dummy'}]
         }
@@ -490,7 +537,7 @@ def test_remove_member_and_admin(shared_zone_test_context):
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-remove-member-and-admin',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
         }
@@ -515,7 +562,7 @@ def test_remove_member_but_not_admin_keeps_member(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-remove-member-not-admin-keeps-member',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}, {'id': 'dummy'}]
         }
@@ -525,7 +572,7 @@ def test_remove_member_but_not_admin_keeps_member(shared_zone_test_context):
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-remove-member-not-admin-keeps-member',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}, {'id': 'dummy'}]
         }
@@ -552,7 +599,7 @@ def test_remove_admin_keeps_member(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-remove-admin-keeps-member',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}, {'id': 'dummy'}]
         }
@@ -562,7 +609,7 @@ def test_remove_admin_keeps_member(shared_zone_test_context):
         updated_group = {
             'id': saved_group['id'],
             'name': 'test-remove-admin-keeps-member',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'members': [{'id': 'ok'}, {'id': 'dummy'}],
             'admins': [{'id': 'ok'}]
         }
@@ -589,7 +636,7 @@ def test_update_group_not_authorized(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-group-not-authorized',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -621,7 +668,7 @@ def test_update_group_adds_admins_to_member_list(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test-update-group-add-admins-to-members',
-            'email': 'test@test.com',
+            'email': 'update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]

--- a/modules/api/functional_test/live_tests/membership/update_group_test.py
+++ b/modules/api/functional_test/live_tests/membership/update_group_test.py
@@ -248,7 +248,7 @@ def test_update_group_conflict(shared_zone_test_context):
     try:
         new_group = {
             'name': 'test_update_group_conflict',
-            'email': 'test@test.com',
+            'email': 'test-update@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -258,7 +258,7 @@ def test_update_group_conflict(shared_zone_test_context):
 
         other_group = {
             'name': 'change_me',
-            'email': 'test@test.com',
+            'email': 'test-other@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -270,7 +270,7 @@ def test_update_group_conflict(shared_zone_test_context):
         update_group = {
             'id': result['id'],
             'name': 'test_update_group_conflict',
-            'email': 'test@test.com',
+            'email': 'test-other@test.com',
             'description': 'this is a description',
             'members': [{'id': 'ok'}],
             'admins': [{'id': 'ok'}]
@@ -284,7 +284,7 @@ def test_update_group_conflict(shared_zone_test_context):
 
 
 def test_update_group_not_found(shared_zone_test_context):
-    """
+    """test_user_cannot_update_zone_to_nonmember_admin_group
     Tests that we can not update a group that has not been created
     """
 

--- a/modules/api/functional_test/live_tests/shared_zone_test_context.py
+++ b/modules/api/functional_test/live_tests/shared_zone_test_context.py
@@ -52,7 +52,7 @@ class SharedZoneTestContext(object):
             try:
                 ok_group = {
                     'name': 'ok-group',
-                    'email': 'test@test.com',
+                    'email': 'ok@test.com',
                     'description': 'this is a description',
                     'members': [{'id': 'ok'}, {'id': 'support-user-id'}],
                     'admins': [{'id': 'ok'}]
@@ -64,7 +64,7 @@ class SharedZoneTestContext(object):
 
                 dummy_group = {
                     'name': 'dummy-group',
-                    'email': 'test@test.com',
+                    'email': 'dummy@test.com',
                     'description': 'this is a description',
                     'members': [{'id': 'dummy'}],
                     'admins': [{'id': 'dummy'}]
@@ -75,7 +75,7 @@ class SharedZoneTestContext(object):
 
                 shared_record_group = {
                     'name': 'record-ownergroup',
-                    'email': 'test@test.com',
+                    'email': 'record@test.com',
                     'description': 'this is a description',
                     'members': [{'id': 'sharedZoneUser'}, {'id': 'ok'}],
                     'admins': [{'id': 'sharedZoneUser'}, {'id': 'ok'}]
@@ -84,7 +84,7 @@ class SharedZoneTestContext(object):
 
                 history_group = {
                     'name': 'history-group',
-                    'email': 'test@test.com',
+                    'email': 'history@test.com',
                     'description': 'this is a description',
                     'members': [{'id': 'history-id'}],
                     'admins': [{'id': 'history-id'}]
@@ -117,7 +117,7 @@ class SharedZoneTestContext(object):
                 ok_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': 'ok.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -139,7 +139,7 @@ class SharedZoneTestContext(object):
                 dummy_zone_change = self.dummy_vinyldns_client.create_zone(
                     {
                         'name': 'dummy.',
-                        'email': 'test@test.com',
+                        'email': 'dummy@test.com',
                         'shared': False,
                         'adminGroupId': self.dummy_group['id'],
                         'isTest': True,
@@ -161,7 +161,7 @@ class SharedZoneTestContext(object):
                 ip6_reverse_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': '1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -184,7 +184,7 @@ class SharedZoneTestContext(object):
                 ip6_16_nibble_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': '0.0.0.1.1.9.e.f.c.c.7.2.9.6.d.f.ip6.arpa.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -196,7 +196,7 @@ class SharedZoneTestContext(object):
                 ip4_reverse_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': '10.10.in-addr.arpa.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -218,7 +218,7 @@ class SharedZoneTestContext(object):
 
                 self.classless_base_zone_json = {
                     'name': '2.0.192.in-addr.arpa.',
-                    'email': 'test@test.com',
+                    'email': 'ok@test.com',
                     'shared': False,
                     'adminGroupId': self.ok_group['id'],
                     'isTest': True,
@@ -244,7 +244,7 @@ class SharedZoneTestContext(object):
                 classless_zone_delegation_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': '192/30.2.0.192.in-addr.arpa.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -267,7 +267,7 @@ class SharedZoneTestContext(object):
                 system_test_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': 'system-test.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -291,7 +291,7 @@ class SharedZoneTestContext(object):
                 parent_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': 'parent.com.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -323,7 +323,7 @@ class SharedZoneTestContext(object):
                 ds_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': 'example.com.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -346,7 +346,7 @@ class SharedZoneTestContext(object):
                 requires_review_zone_change = self.ok_vinyldns_client.create_zone(
                     {
                         'name': 'zone.requires.review.',
-                        'email': 'test@test.com',
+                        'email': 'ok@test.com',
                         'shared': False,
                         'adminGroupId': self.ok_group['id'],
                         'isTest': True,
@@ -499,7 +499,7 @@ class SharedZoneTestContext(object):
         members = [{'id': 'ok'}]
         new_group = {
             'name': group_name,
-            'email': 'test@test.com',
+            'email': 'new@test.com',
             'members': members,
             'admins': [{'id': 'ok'}]
         }
@@ -514,7 +514,7 @@ class SharedZoneTestContext(object):
             update_groups.append({
                 'id': created_group['id'],
                 'name': group_name,
-                'email': 'test@test.com',
+                'email': 'new@test.com',
                 'members': members,
                 'admins': [{'id': 'ok'}]
             })

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -5,6 +5,14 @@
 ################################################################################################################
 vinyldns {
 
+  # configured groups whether to enforce unique email id or not
+  membership {
+      groups {
+        # set true to enforce unique email id for every groups
+        enforce-unique-email-id = true
+      }
+  }
+
   # configured backend providers
   backend {
     # Use "default" when dns backend legacy = true

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -9,7 +9,7 @@ vinyldns {
   membership {
       groups {
         # set true to enforce unique email id for every groups
-        enforce-unique-email-id = true
+        enforce-unique-email-id = false
       }
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -123,7 +123,7 @@ object Boot extends App {
         vinyldnsConfig.batchChangeConfig,
         vinyldnsConfig.scheduledChangesConfig
       )
-      val membershipService = MembershipService(repositories)
+      val membershipService = MembershipService(repositories, vinyldnsConfig.groupConfig)
       val connectionValidator =
         new ZoneConnectionValidator(
           backendResolver,

--- a/modules/api/src/main/scala/vinyldns/api/config/GroupConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/GroupConfig.scala
@@ -16,6 +16,13 @@
 
 package vinyldns.api.config
 
-object GroupEmailConfig {
-  var enforce_unique_email_address: Boolean = false
+import pureconfig.ConfigReader
+
+case class GroupConfig(enforceUniqueEmailId: Boolean)
+
+object GroupConfig {
+  implicit val configReader: ConfigReader[GroupConfig] =
+    ConfigReader.forProduct1[GroupConfig, Boolean]("enforce-unique-email-id") {
+      case (email) => GroupConfig(email)
+    }
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/GroupEmailConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/GroupEmailConfig.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.config
+
+object GroupEmailConfig {
+  var enforce_unique_email_address: Boolean = false
+}

--- a/modules/api/src/main/scala/vinyldns/api/config/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/VinylDNSConfig.scala
@@ -49,7 +49,8 @@ final case class VinylDNSConfig(
     configuredDnsConnections: ConfiguredDnsConnections,
     apiMetricSettings: APIMetricsSettings,
     crypto: CryptoAlgebra,
-    globalAcls: GlobalAcls
+    globalAcls: GlobalAcls,
+    groupConfig: GroupConfig
 )
 object VinylDNSConfig {
 
@@ -96,6 +97,7 @@ object VinylDNSConfig {
       metricSettings <- loadIO[APIMetricsSettings](config, "vinyldns.metrics")
       globalAcls <- loadIO[List[GlobalAcl]](config, "vinyldns.global-acl-rules")
         .map(GlobalAcls.apply)
+      groupConfig <- loadIO[GroupConfig](config, "vinyldns.membership.groups")
     } yield VinylDNSConfig(
       serverConfig,
       httpConfig,
@@ -110,7 +112,8 @@ object VinylDNSConfig {
       connections,
       metricSettings,
       crypto,
-      globalAcls
+      globalAcls,
+      groupConfig
     )
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -251,8 +251,8 @@ class MembershipService(
       }
       .toResult
 
-  def groupWithSameEmailIdDoesNotExist(emailId: String, emailConf: Boolean): Result[Unit] =
-    if (emailConf) {
+  def groupWithSameEmailIdDoesNotExist(emailId: String, enforceUniqueEmailId: Boolean): Result[Unit] =
+    if (enforceUniqueEmailId) {
       groupRepo
         .getGroupByEmailId(emailId)
         .map {
@@ -290,12 +290,8 @@ class MembershipService(
       }
       .toResult
 
-  def differentGroupWithSameEmailIdDoesNotExist(
-      emailId: String,
-      groupId: String,
-      emailConf: Boolean
-  ): Result[Unit] =
-    if (emailConf) {
+  def differentGroupWithSameEmailIdDoesNotExist(emailId: String, groupId: String, enforceUniqueEmailId: Boolean): Result[Unit] =
+    if (enforceUniqueEmailId) {
       groupRepo
         .getGroupByEmailId(emailId)
         .map {

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -222,7 +222,7 @@ object TestDataLoader {
   final val duGroup = Group(
     name = "duGroup",
     id = "duGroup-id",
-    email = "test@test.com",
+    email = "duGroup@test.com",
     memberIds = listOfDummyUsers.map(_.id).toSet + testUser.id,
     adminUserIds = listOfDummyUsers.map(_.id).toSet + testUser.id
   )

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -34,6 +34,7 @@ import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData._
 import vinyldns.core.domain.membership._
 import vinyldns.core.domain.record.RecordSetRepository
+import vinyldns.api.config.GroupConfig
 
 class MembershipServiceSpec
     extends AnyWordSpec
@@ -49,6 +50,7 @@ class MembershipServiceSpec
   private val mockZoneRepo = mock[ZoneRepository]
   private val mockGroupChangeRepo = mock[GroupChangeRepository]
   private val mockRecordSetRepo = mock[RecordSetRepository]
+  private val mockGroupConfig = mock[GroupConfig]
 
   private val backingService = new MembershipService(
     mockGroupRepo,
@@ -56,7 +58,8 @@ class MembershipServiceSpec
     mockMembershipRepo,
     mockZoneRepo,
     mockGroupChangeRepo,
-    mockRecordSetRepo
+    mockRecordSetRepo,
+    mockGroupConfig
   )
   private val underTest = spy(backingService)
 
@@ -115,7 +118,7 @@ class MembershipServiceSpec
         doReturn(().toResult).when(underTest).groupWithSameNameDoesNotExist(groupInfo.name)
         doReturn(().toResult)
           .when(underTest)
-          .groupWithSameEmailIdDoesNotExist(groupInfo.email, true)
+          .groupWithSameEmailIdDoesNotExist(groupInfo.email, false)
         doReturn(().toResult).when(underTest).usersExist(groupInfo.memberIds)
         doReturn(IO.pure(okGroup)).when(mockGroupRepo).save(any[Group])
         doReturn(IO.pure(Set(okUser.id)))
@@ -145,7 +148,7 @@ class MembershipServiceSpec
         doReturn(().toResult).when(underTest).groupWithSameNameDoesNotExist(groupInfo.name)
         doReturn(().toResult)
           .when(underTest)
-          .groupWithSameEmailIdDoesNotExist(groupInfo.email, true)
+          .groupWithSameEmailIdDoesNotExist(groupInfo.email, false)
         doReturn(().toResult).when(underTest).usersExist(groupInfo.memberIds)
         doReturn(IO.pure(okGroup)).when(mockGroupRepo).save(any[Group])
         doReturn(IO.pure(Set(okUser.id)))
@@ -174,7 +177,7 @@ class MembershipServiceSpec
         val expectedMembersAdded = Set(okUserInfo.id, dummyUserInfo.id)
 
         doReturn(().toResult).when(underTest).groupWithSameNameDoesNotExist(info.name)
-        doReturn(().toResult).when(underTest).groupWithSameEmailIdDoesNotExist(info.email, true)
+        doReturn(().toResult).when(underTest).groupWithSameEmailIdDoesNotExist(info.email, false)
         doReturn(().toResult).when(underTest).usersExist(any[Set[String]])
         doReturn(IO.pure(okGroup)).when(mockGroupRepo).save(any[Group])
         when(
@@ -201,7 +204,7 @@ class MembershipServiceSpec
         val info = groupInfo.copy(memberIds = Set.empty, adminUserIds = Set.empty)
         doReturn(IO.pure(Some(okUser))).when(mockUserRepo).getUser("ok")
         doReturn(().toResult).when(underTest).groupWithSameNameDoesNotExist(info.name)
-        doReturn(().toResult).when(underTest).groupWithSameEmailIdDoesNotExist(info.email, true)
+        doReturn(().toResult).when(underTest).groupWithSameEmailIdDoesNotExist(info.email, false)
         doReturn(().toResult).when(underTest).usersExist(Set(okAuth.userId))
         doReturn(IO.pure(okGroup)).when(mockGroupRepo).save(any[Group])
         doReturn(IO.pure(Set(okUser.id)))
@@ -232,7 +235,7 @@ class MembershipServiceSpec
         doReturn(().toResult).when(underTest).groupWithSameNameDoesNotExist(groupInfo.name)
         doReturn(().toResult)
           .when(underTest)
-          .groupWithSameEmailIdDoesNotExist(groupInfo.email, true)
+          .groupWithSameEmailIdDoesNotExist(groupInfo.email, false)
         doReturn(result(UserNotFoundError("fail")))
           .when(underTest)
           .usersExist(groupInfo.memberIds)
@@ -426,7 +429,7 @@ class MembershipServiceSpec
           .differentGroupWithSameNameDoesNotExist(updatedInfo.name, existingGroup.id)
         doReturn(result(()))
           .when(underTest)
-          .differentGroupWithSameEmailIdDoesNotExist(updatedInfo.email, existingGroup.id, true)
+          .differentGroupWithSameEmailIdDoesNotExist(updatedInfo.email, existingGroup.id, false)
         doReturn(result(UserNotFoundError("fail")))
           .when(underTest)
           .usersExist(any[Set[String]])

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -109,6 +109,8 @@ trait EmptyGroupRepo extends GroupRepository {
 
   def getGroupByName(groupName: String): IO[Option[Group]] = IO.pure(None)
 
+  def getGroupByEmailId(groupEmailId: String): IO[Option[Group]] = IO.pure(None)
+
   def getAllGroups(): IO[Set[Group]] = IO.pure(Set())
 }
 

--- a/modules/core/src/main/scala/vinyldns/core/Messages.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Messages.scala
@@ -73,4 +73,22 @@ object Messages {
    */
   val NotAuthorizedErrorMsg =  "User \"%s\" is not authorized. Contact %s owner group: %s at %s to make DNS changes."
 
+  /*
+   *  Error displayed when a group already exists with the same email address
+   *
+   * Placeholders:
+   * 1. [string] group name
+   * 2. [string] email id
+   * 3. [string] contact email id
+   */
+  val GroupEmailAlreadyExists = "Cannot create group. A group, %s, is already associated with the email address %s. Please contact %s to be added to the group."
+
+  /*
+   *  Error displayed when a group already exists with the same email address
+   *
+   * Placeholders:
+   * 1. [string] group name
+   * 2. [string] email id
+   */
+  val GroupEmailAlreadyExistsUpdate = "Cannot update group. A group, %s, is already associated with the email address %s."
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupRepository.scala
@@ -32,6 +32,8 @@ trait GroupRepository extends Repository {
 
   def getGroupByName(groupName: String): IO[Option[Group]]
 
+  def getGroupByEmailId(groupEmailId: String): IO[Option[Group]]
+
   def getAllGroups(): IO[Set[Group]]
 
 }

--- a/modules/docs/src/main/mdoc/faq.md
+++ b/modules/docs/src/main/mdoc/faq.md
@@ -91,7 +91,7 @@ If you use any VinylDNS tools beyond the portal you will need to provide those t
 Refer to [API Authentication](api/auth-mechanism.html).
 
 ### 10. How to change email configuration for groups? <a id="10"></a>
-By default, VinylDNS is configured to disallow multiple groups with the same email address. We have found that 
-supporting multiple groups with the same email address to be confusing to many users when there are ownership questions 
-in the future. Therefore, we strongly recommend that VinylDNS deployments utilize this feature. If, however, you do not 
-wish you use this feature, you can set "vinyldns.groups.enforce-unique-email-id = false" in the configuration.
+VinylDNS can be configured to disallow multiple groups with the same email address. We have found that
+supporting multiple groups with the same email address to be confusing to many users when there are ownership questions
+in the future. Therefore, we strongly recommend that VinylDNS deployments utilize this feature. If you wish to use this feature,
+you can set "vinyldns.groups.enforce-unique-email-id = true" in the configuration.

--- a/modules/docs/src/main/mdoc/faq.md
+++ b/modules/docs/src/main/mdoc/faq.md
@@ -18,6 +18,7 @@ position: 6
 7. [When I try to connect to my zone, I am seeing "invalid name server" errors](#7)
 8. [How do I get API credentials?](#8)
 9. [How are requests authenticated to the VinylDNS API?](#9)
+10. [How to change email configuration for groups?](#10)
 
 
 ### 1. Can I create a zone in VinylDNS? <a id="1"></a>
@@ -88,3 +89,9 @@ If you use any VinylDNS tools beyond the portal you will need to provide those t
 
 ### 9. How are requests authenticated to the VinylDNS API? <a id="9"></a>
 Refer to [API Authentication](api/auth-mechanism.html).
+
+### 10. How to change email configuration for groups? <a id="10"></a>
+By default, VinylDNS is configured to disallow multiple groups with the same email address. We have found that 
+supporting multiple groups with the same email address to be confusing to many users when there are ownership questions 
+in the future. Therefore, we strongly recommend that VinylDNS deployments utilize this feature. If, however, you do not 
+wish you use this feature, you can set "vinyldns.groups.enforce-unique-email-id = false" in the configuration.

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
@@ -93,6 +93,17 @@ class MySqlGroupRepositoryIntegrationSpec
     }
   }
 
+  "MySqlGroupRepository.getGroupByEmailId" should {
+    "retrieve a group" in {
+      val getByEmail = repo.getGroupByEmailId(groups.head.email).unsafeRunSync()
+      getByEmail shouldBe (groups.find(x => (Option(x) == getByEmail)))
+    }
+
+    "returns None when group does not exist" in {
+      repo.getGroupByEmailId("no-existo").unsafeRunSync() shouldBe None
+    }
+  }
+
   "MySqlGroupRepository.getAllGroups" should {
     "retrieve all groups" in {
       repo.getAllGroups().unsafeRunSync() should contain theSameElementsAs groups.toSet

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
@@ -56,6 +56,13 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
          | WHERE name = ?
        """.stripMargin
 
+  private final val GET_GROUP_BY_EMAILID =
+    sql"""
+         |SELECT data
+         |  FROM groups
+         | WHERE email = ?
+       """.stripMargin
+
   private final val GET_ALL_GROUPS =
     sql"""
          |SELECT data
@@ -148,6 +155,20 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
         DB.readOnly { implicit s =>
           GET_GROUP_BY_NAME
             .bind(groupName)
+            .map(toGroup(1))
+            .first()
+            .apply()
+        }
+      }
+    }
+
+  def getGroupByEmailId(groupEmailId: String): IO[Option[Group]] =
+    monitor("repo.Group.getGroupByEmailId") {
+      IO {
+        logger.info(s"Getting group with email: $groupEmailId")
+        DB.readOnly { implicit s =>
+          GET_GROUP_BY_EMAILID
+            .bind(groupEmailId)
             .map(toGroup(1))
             .first()
             .apply()

--- a/modules/portal/public/lib/directives/directives.notifications.js
+++ b/modules/portal/public/lib/directives/directives.notifications.js
@@ -26,7 +26,7 @@ angular.module('directives.notifications.module', [])
         link: function(scope, element, attrs) {
           $timeout(function() {
             element.fadeOut(50);
-          }, 6000)
+          }, 10000)
         }
       }
     });

--- a/modules/portal/public/templates/notification.html
+++ b/modules/portal/public/templates/notification.html
@@ -1,10 +1,5 @@
 <div class="alert alert-box" ng-class="'alert-'+ngModel.type" role="alert">
     <button type="button" class="close" data-dismiss="alert">
         <span aria-hidden="true">×</span><span class="sr-only">Close</span>
-    </button>
-    <div>{{ngModel.content}}
-    <a ng-if="ngModel.content.includes('HTTP 409 (Conflict): Cannot create group.') || ngModel.content.includes('HTTP 409 (Conflict): Cannot update group.')"
-       style="text-decoration: none;"
-       href="https://www.vinyldns.io/faq.html#10">ℹ️</a>
-    </div>
+    </button>{{ngModel.content}}
 </div>

--- a/modules/portal/public/templates/notification.html
+++ b/modules/portal/public/templates/notification.html
@@ -1,5 +1,10 @@
 <div class="alert alert-box" ng-class="'alert-'+ngModel.type" role="alert">
     <button type="button" class="close" data-dismiss="alert">
         <span aria-hidden="true">×</span><span class="sr-only">Close</span>
-    </button>{{ngModel.content}}
+    </button>
+    <div>{{ngModel.content}}
+    <a ng-if="ngModel.content.includes('HTTP 409 (Conflict): Cannot create group.') || ngModel.content.includes('HTTP 409 (Conflict): Cannot update group.')"
+       style="text-decoration: none;"
+       href="https://www.vinyldns.io/faq.html#10">ℹ️</a>
+    </div>
 </div>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,10 +28,10 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
 
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "1.1.5")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "1.3.4")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.10" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.23" )


### PR DESCRIPTION
Changes in this pull request:
- Error message will be displayed when we create a new group with email id that's already used by another group.
- Error message will be displayed when we update the group email id with a new one that's already used by another group.
- The error message would recommend the user to contact the existing group to be added to that group. This would reduce the confusion of having multiple groups with same email id.
- Created a new SQL query to get group by email, Created a function to display the error message, Added new test cases.
- Created a configuration whether to enforce unique email for groups or not.
- Updated the FAQ of the microsite with details about the configuration.