### PR TITLE
Fix portal login redirect

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -417,7 +417,8 @@ class CommandHandlerSpec
       }
 
       // sleep to allow the flow to run once
-      Thread.sleep(200)
+      // TODO: arbitrary sleep statements lead to non-deterministic tests - find a more reliable mechanism
+      Thread.sleep(1000)
 
       // shutoff processing on the flow
       stop.set(true).unsafeRunSync()

--- a/modules/portal/app/actions/ApiAction.scala
+++ b/modules/portal/app/actions/ApiAction.scala
@@ -44,7 +44,7 @@ class LegacyApiAction @Inject() (
   override val logger = LoggerFactory.getLogger(classOf[LegacyApiAction])
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
 
-  def notLoggedInResult: Future[Result] =
+  def notLoggedInResult(requestURI: String): Future[Result] =
     Future.successful(
       Unauthorized("You are not logged in. Please login to continue.").withHeaders(cacheHeaders: _*)
     )

--- a/modules/portal/app/actions/FrontendAction.scala
+++ b/modules/portal/app/actions/FrontendAction.scala
@@ -43,9 +43,9 @@ class LegacyFrontendAction(
   override val logger = LoggerFactory.getLogger(classOf[LegacyFrontendAction])
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
 
-  def notLoggedInResult: Future[Result] =
+  def notLoggedInResult(requestURI: String): Future[Result] =
     Future.successful(
-      Redirect("/login")
+      Redirect(s"/login?target=$requestURI")
         .flashing(VinylDNS.Alerts.error("You are not logged in. Please login to continue."))
         .withNewSession
         .withHeaders(cacheHeaders: _*)

--- a/modules/portal/app/actions/LegacySecuritySupport.scala
+++ b/modules/portal/app/actions/LegacySecuritySupport.scala
@@ -45,10 +45,10 @@ class LegacySecuritySupport @Inject() (
     implicit request =>
       if (oidcAuthenticator.oidcEnabled) {
         request.session.get(VinylDNS.ID_TOKEN) match {
-          case Some(_) => Redirect("/index")
+          case Some(_) => Redirect(request.getQueryString("target").getOrElse("/index"))
           case None =>
             logger.info(s"No ${VinylDNS.ID_TOKEN} in session; Initializing oidc login")
-            Redirect(oidcAuthenticator.getCodeCall.toString, 302)
+            Redirect(oidcAuthenticator.getCodeCall(request.uri).toString, 302)
         }
       } else {
         request.session.get("username") match {

--- a/modules/portal/app/actions/VinylDnsAction.scala
+++ b/modules/portal/app/actions/VinylDnsAction.scala
@@ -34,7 +34,7 @@ trait VinylDnsAction extends ActionFunction[Request, UserRequest] {
 
   implicit val executionContext: ExecutionContext
 
-  def notLoggedInResult: Future[Result]
+  def notLoggedInResult(requestURI: String): Future[Result]
 
   def cantFindAccountResult(un: String): Future[Result]
 
@@ -62,7 +62,7 @@ trait VinylDnsAction extends ActionFunction[Request, UserRequest] {
     userName match {
       case None =>
         logger.info("User is not logged in or token expired; redirecting to login screen")
-        notLoggedInResult
+        notLoggedInResult(request.uri)
 
       case Some(un) =>
         // user name in session, let's get it from the repo

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -105,10 +105,10 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     processor
   }
 
-  def getCodeCall: Uri = {
+  def getCodeCall(requestURI: String): Uri = {
     val nonce = new Nonce()
     val loginId = UUID.randomUUID().toString
-    val redirectUri = s"${oidcInfo.redirectUri}/callback/$loginId"
+    val redirectUri = s"${oidcInfo.redirectUri}/callback/${loginId}:${java.util.Base64.getEncoder.encodeToString(requestURI.getBytes)}"
 
     val query = Query(
       "client_id" -> oidcInfo.clientId,
@@ -247,7 +247,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       implicit executionContext: ExecutionContext
   ): EitherT[IO, ErrorResponse, JWTClaimsSet] =
     EitherT {
-      val redirectUriString = s"${oidcInfo.redirectUri}/callback/$loginId"
+      val redirectUriString = s"${oidcInfo.redirectUri}/callback/${loginId}"
       val redirectUri = new URI(redirectUriString)
       val codeGrant = new AuthorizationCodeGrant(code, redirectUri)
       val request = new TokenRequest(tokenEndpoint, clientAuth, codeGrant)

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -105,7 +105,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     processor
   }
 
-  def getCodeCall(requestURI: String): Uri = {
+  def getCodeCall(requestURI: String = ""): Uri = {
     val nonce = new Nonce()
     val loginId = UUID.randomUUID().toString
     val redirectUri = s"${oidcInfo.redirectUri}/callback/${loginId}:${java.util.Base64.getEncoder.encodeToString(requestURI.getBytes)}"

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -53,6 +53,7 @@ object VinylDNS {
   object Alerts {
     private val TYPE = "alertType"
     private val MSG = "alertMessage"
+
     def error(msg: String): Flash = Flash(Map(TYPE -> "danger", MSG -> msg))
 
     def fromFlash(flash: Flash): Option[Alert] =
@@ -162,7 +163,7 @@ class VinylDNS @Inject() (
             Try {
               new String(java.util.Base64.getDecoder.decode(loginId.split(":").last))
             } match {
-              case Success(x) => x
+              case Success(x) => if (x.nonEmpty) x else "/index"
               case Failure(_) => "/index"
             }
 

--- a/modules/portal/app/views/setOidcSession.scala.html
+++ b/modules/portal/app/views/setOidcSession.scala.html
@@ -1,18 +1,25 @@
 @(setSessionUrl: String)(implicit requestHeader: RequestHeader)
 <!DOCTYPE html>
 <html lang="en" class="body-full-height">
-<head>
-    <!-- META SECTION -->
+  <head>
+      <!-- META SECTION -->
     <title>Login</title>
     <meta name="google" content="notranslate" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta id="oidc" content="@setSessionUrl" />
-    <!-- END META SECTION -->
-</head>
-<body>
+      <!-- END META SECTION -->
+  </head>
+  <body>
     <a href="@{setSessionUrl}">Finishing login, if not redirected, click this link</a>
-@*    <script src="/public/js/vinyldns.js"></script>*@
-</body>
+    <script>
+      window.setTimeout(function() {
+        let element = document.getElementById('oidc');
+        if (element != null) {
+          window.location = element.getAttribute('content');
+        }
+      }, 0);
+    </script>
+  </body>
 </html>

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -45,7 +45,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
   val mockOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   val enabledOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   enabledOidcAuthenticator.oidcEnabled.returns(true)
-  enabledOidcAuthenticator.getCodeCall().returns(Uri("http://test.com"))
+  enabledOidcAuthenticator.getCodeCall(anyString).returns(Uri("http://test.com"))
   enabledOidcAuthenticator.oidcLogoutUrl.returns("http://logout-test.com")
   enabledOidcAuthenticator.getValidUsernameFromToken(any[String]).returns(Some("test"))
 

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -45,7 +45,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
   val mockOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   val enabledOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   enabledOidcAuthenticator.oidcEnabled.returns(true)
-  enabledOidcAuthenticator.getCodeCall.returns(Uri("http://test.com"))
+  enabledOidcAuthenticator.getCodeCall().returns(Uri("http://test.com"))
   enabledOidcAuthenticator.oidcLogoutUrl.returns("http://logout-test.com")
   enabledOidcAuthenticator.getValidUsernameFromToken(any[String]).returns(Some("test"))
 
@@ -84,7 +84,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.index()(FakeRequest(GET, "/"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/")
       }
       "render the index page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -100,7 +100,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
         "redirect to the login page when a user is not logged in" in new WithApplication(app) {
           val result = underTest.index()(FakeRequest(GET, "/index"))
           status(result) must equalTo(SEE_OTHER)
-          headers(result) must contain("Location" -> "/login")
+          headers(result) must contain("Location" -> "/login?target=/index")
         }
         "render the DNS Changes page when the user is logged in" in new WithApplication(app) {
           val result =
@@ -124,7 +124,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
         "redirect to the login page when a user is not logged in" in new WithApplication(app) {
           val result = oidcUnderTest.index()(FakeRequest(GET, "/index").withCSRFToken)
           status(result) must equalTo(SEE_OTHER)
-          headers(result) must contain("Location" -> "/login")
+          headers(result) must contain("Location" -> "/login?target=/index")
         }
         "render the DNS Changes page when the user is logged in" in new WithApplication(app) {
           val result =
@@ -144,7 +144,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewAllGroups()(FakeRequest(GET, "/groups"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/groups")
       }
       "render the groups view page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -168,7 +168,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewGroup("some-id")(FakeRequest(GET, "/groups/some-id"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/groups/some-id")
       }
       "render the groups view page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -192,7 +192,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewAllZones()(FakeRequest(GET, "/zones"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/zones")
       }
       "render the zone view page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -216,7 +216,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewZone("some-id")(FakeRequest(GET, "/zones/some-id"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/zones/some-id")
       }
       "render the zones view page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -336,7 +336,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewAllBatchChanges()(FakeRequest(GET, "/dnschanges"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/dnschanges")
       }
       "render the batch changes view page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -362,7 +362,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewBatchChange("some-id")(FakeRequest(GET, "/dnschanges/some-id"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/dnschanges/some-id")
       }
       "render the DNS change view page when the user is logged in" in new WithApplication(app) {
         val result =
@@ -390,7 +390,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
       "redirect to the login page when a user is not logged in" in new WithApplication(app) {
         val result = underTest.viewNewBatchChange()(FakeRequest(GET, "/dnschanges/new"))
         status(result) must equalTo(SEE_OTHER)
-        headers(result) must contain("Location" -> "/login")
+        headers(result) must contain("Location" -> "/login?target=/dnschanges/new")
       }
       "render the new batch change view page when the user is logged in" in new WithApplication(app) {
         val result =

--- a/modules/portal/test/controllers/OidcAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/OidcAuthenticatorSpec.scala
@@ -92,7 +92,7 @@ class OidcAuthenticatorSpec extends Specification with Mockito {
   "OidcAuthenticator" should {
     "Initial code call" should {
       "properly generate the code call" in {
-        val codeCall = testOidcAuthenticator.getCodeCall
+        val codeCall = testOidcAuthenticator.getCodeCall("/abcd")
         val query = codeCall.queryString().get
 
         codeCall.toString must startWith("http://test.authorization.url")

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -1287,11 +1287,11 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
           TestVinylDNS(config, mockLdapAuthenticator, mockUserAccessor, ws, components, crypto)
 
         val result: Future[Result] = underTest.serveCredsFile("credsfile.csv")(
-          FakeRequest(GET, s"/download-creds-file/credsfile.csv")
+          FakeRequest(GET, "/download-creds-file/credsfile.csv")
         )
 
         status(result) mustEqual 303
-        redirectLocation(result) must beSome("/login")
+        redirectLocation(result) must beSome("/login?target=/download-creds-file/credsfile.csv")
         flash(result).get("alertType") must beSome("danger")
         flash(result).get("alertMessage") must beSome(
           "You are not logged in. Please login to continue."

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.2"
+version in ThisBuild := "0.10.3"


### PR DESCRIPTION
With the release of `0.10.0` the redirect for OIDC authentication was not working.

- Re-enable redirect in `setOidcSession.scala.html`
- Add support for redirecting to requested page after login, rather than `/index`-purgatory
