### PR TITLE
Upgrade dependencies

### DIFF
--- a/modules/portal/Gruntfile.js
+++ b/modules/portal/Gruntfile.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
           {expand: true, flatten: true, src: ['node_modules/font-awesome/css/font-awesome.min.css'], dest: 'public/css'},
 
           // We're picking just the resources we need from the gentelella UI framework and temporarily storing them in mapped/ui/
-          {expand: true, flatten: true, cwd: 'node_modules/gentelella', dest: 'mapped/ui', src: '**/jquery.{smartWizard,mCustomScrollbar.concat.min,dataTables.min,mousewheel.min}.js'},
+          {expand: true, flatten: true, cwd: 'node_modules/gentelella', dest: 'mapped/ui', src: '**/jquery.{smartWizard,dataTables.min,mousewheel.min}.js'},
           {expand: true, flatten: true, cwd: 'node_modules/gentelella', dest: 'mapped/ui', src: '**/bootstrap-daterangepicker/daterangepicker.js'},
           {expand: true, flatten: true, cwd: 'node_modules/gentelella', dest: 'mapped/ui', src: '**/build/css/custom.min.css'},
           {expand: true, flatten: true, cwd: 'node_modules/gentelella', dest: 'mapped/ui', src: '**/{daterangepicker,animate.min}.css'},

--- a/modules/portal/package.json
+++ b/modules/portal/package.json
@@ -19,17 +19,18 @@
   },
   "devDependencies": {
     "angular-mocks": "1.6.1",
-    "grunt-karma": "^2.0.0",
+    "grunt-karma": "^4.0.2",
     "grunt-mocha-phantomjs": "^3.0.0",
     "jasmine-core": "^2.99.1",
     "jasmine-jquery": "2.1.1",
-    "jquery": "^2.2.4",
-    "karma": "^2.0.5",
+    "jquery": "^3.6.0",
+    "karma": "^6.3.17",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.0.2",
-    "karma-mocha-reporter": "^2.0.3",
+    "karma-mocha-reporter": "^2.1.0",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-spec-reporter": "^0.0.26",
+    "malihu-custom-scrollbar-plugin": "^3.1.5",
     "phantomjs-prebuilt": "^2.1.16"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #1093 

Changes in this pull request:
- Upgraded dependencies mentioned in `npm audit` and `Dependabot` to newer versions. There is no vulnerability displayed in `npm audit` and `Dependabot` after the upgrades.
- Removed `malihu-custom-scrollbar-plugin` from `gentelella` and added using `npm` in `package.json` as installing through `gentelella` only gives version `3.1.3` but using `npm` we get  version `3.1.5` which is the upgraded version that supports `jquery` version > 3.0.0
- Checked the working locally and the portal works fine after upgrading the dependencies.
