### PR TITLE
Allow Users to View Members of Other Groups

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -10,9 +10,6 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump context
-        uses: crazy-max/ghaction-dump-context@v1.2.0
-
       - name: Send Slack Notification On Success
         uses: slackapi/slack-github-action@v1.18.0
         if: github.event.workflow_run.conclusion == 'success'

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -40,6 +40,6 @@ object MembershipValidations {
 
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin
+      authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin || true
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -23,6 +23,8 @@ import vinyldns.core.domain.membership.Group
 
 object MembershipValidations {
 
+  private val canViewGroupDetails = true
+
   def hasMembersAndAdmins(group: Group): Either[Throwable, Unit] =
     ensuring(InvalidGroupError("Group must have at least one member and one admin")) {
       group.memberIds.nonEmpty && group.adminUserIds.nonEmpty
@@ -40,6 +42,6 @@ object MembershipValidations {
 
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
     ensuring(NotAuthorizedError("Not authorized")) {
-      authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin || true
+      authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin || canViewGroupDetails
     }
 }

--- a/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
+++ b/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
@@ -151,7 +151,7 @@ def test_get_group_changes_paging(group_activity_context, shared_zone_test_conte
 
 def test_get_group_changes_unauthed(shared_zone_test_context):
     """
-    Tests that we cant get group changes without access
+    Tests that non-group members can still get group changes
     """
     client = shared_zone_test_context.ok_vinyldns_client
     dummy_client = shared_zone_test_context.dummy_vinyldns_client
@@ -165,7 +165,7 @@ def test_get_group_changes_unauthed(shared_zone_test_context):
         }
         saved_group = client.create_group(new_group, status=200)
 
-        dummy_client.get_group_changes(saved_group["id"], status=403)
+        dummy_client.get_group_changes(saved_group["id"], status=200)
         client.get_group_changes(saved_group["id"], status=200)
     finally:
         if saved_group:

--- a/modules/api/src/test/functional/tests/membership/get_group_test.py
+++ b/modules/api/src/test/functional/tests/membership/get_group_test.py
@@ -64,7 +64,7 @@ def test_get_deleted_group(shared_zone_test_context):
 
 def test_get_group_unauthed(shared_zone_test_context):
     """
-    Tests that we cant get a group were not in
+    Tests that non-group members can still get group
     """
     client = shared_zone_test_context.ok_vinyldns_client
     dummy_client = shared_zone_test_context.dummy_vinyldns_client
@@ -79,7 +79,7 @@ def test_get_group_unauthed(shared_zone_test_context):
         }
         saved_group = client.create_group(new_group, status=200)
 
-        dummy_client.get_group(saved_group["id"], status=403)
+        dummy_client.get_group(saved_group["id"], status=200)
         client.get_group(saved_group["id"], status=200)
     finally:
         if saved_group:

--- a/modules/api/src/test/functional/tests/membership/list_group_admins_test.py
+++ b/modules/api/src/test/functional/tests/membership/list_group_admins_test.py
@@ -50,7 +50,7 @@ def test_list_group_admins_group_not_found(shared_zone_test_context):
 
 def test_list_group_admins_unauthed(shared_zone_test_context):
     """
-    Tests that we cant list admins without access
+    Tests that non-group members can still list group admins
     """
     client = shared_zone_test_context.ok_vinyldns_client
     dummy_client = shared_zone_test_context.dummy_vinyldns_client
@@ -64,7 +64,7 @@ def test_list_group_admins_unauthed(shared_zone_test_context):
         }
         saved_group = client.create_group(new_group, status=200)
 
-        dummy_client.list_group_admins(saved_group["id"], status=403)
+        dummy_client.list_group_admins(saved_group["id"], status=200)
         client.list_group_admins(saved_group["id"], status=200)
     finally:
         if saved_group:

--- a/modules/api/src/test/functional/tests/membership/list_group_members_test.py
+++ b/modules/api/src/test/functional/tests/membership/list_group_members_test.py
@@ -523,7 +523,7 @@ def test_list_group_members_next_id_exhausted_two_pages(shared_zone_test_context
 
 def test_list_group_members_unauthed(shared_zone_test_context):
     """
-    Tests that we cant list members without access
+    Tests that non-group members can still list group members
     """
     client = shared_zone_test_context.ok_vinyldns_client
     dummy_client = shared_zone_test_context.dummy_vinyldns_client
@@ -537,7 +537,7 @@ def test_list_group_members_unauthed(shared_zone_test_context):
         }
         saved_group = client.create_group(new_group, status=200)
 
-        dummy_client.list_members_group(saved_group["id"], status=403)
+        dummy_client.list_members_group(saved_group["id"], status=200)
         client.list_members_group(saved_group["id"], status=200)
     finally:
         if saved_group:

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -548,11 +548,8 @@ class MembershipServiceSpec
         val result: Group = rightResultOf(underTest.getGroup(okGroup.id, okAuth).value)
         result shouldBe okGroup
       }
-      //TODO
       "return an error if not authorized" in {
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
-//        val error = leftResultOf(underTest.getGroup(okGroup.id, dummyAuth).value)
-//        error shouldBe a[NotAuthorizedError]
         val result: Group = rightResultOf(underTest.getGroup(okGroup.id, dummyAuth).value)
         result shouldBe okGroup
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -548,11 +548,6 @@ class MembershipServiceSpec
         val result: Group = rightResultOf(underTest.getGroup(okGroup.id, okAuth).value)
         result shouldBe okGroup
       }
-      "return an error if not authorized" in {
-        doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
-        val result: Group = rightResultOf(underTest.getGroup(okGroup.id, dummyAuth).value)
-        result shouldBe okGroup
-      }
 
       "return an error if the group is not found" in {
         doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(anyString)

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -89,11 +89,10 @@ class MembershipValidationsSpec
         val supportAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, supportAuth) should be(right)
       }
-      "return an error when the user has no access and is not super" in {
+      "return true even when a user is not a member of the group or super" in {
         val user = User("some", "new", "user")
         val nonSuperAuth = AuthPrincipal(user, Seq())
-        val error = leftValue(canSeeGroup(okGroup.id, nonSuperAuth))
-        error shouldBe an[NotAuthorizedError]
+        canSeeGroup(okGroup.id, nonSuperAuth) should be(right)
       }
 
     }

--- a/modules/portal/app/views/groups/groups.scala.html
+++ b/modules/portal/app/views/groups/groups.scala.html
@@ -86,7 +86,7 @@
                                             <td class="wrap-long-text">{{group.description}}</td>
                                             <td>
                                                 <div class="table-form-group">
-                                                    <a ng-if="canSeeGroup(group)" class="btn btn-info btn-rounded" ng-href="/groups/{{group.id}}">
+                                                    <a class="btn btn-info btn-rounded" ng-href="/groups/{{group.id}}">
                                                         View</a>
                                                     <a ng-if="groupAdmin(group)" class="btn btn-warning btn-rounded" ng-click="editGroup(group);">
                                                         Edit</a>


### PR DESCRIPTION
All logged in users can now view the group details of any group, not just groups they are part of. This allows users to see the members and admins of other groups without reaching out to support. This is read-only, users still cannot modify groups they are not part of.

Resolves https://github.com/vinyldns/vinyldns/issues/1088

