### PR TITLE
Fix Dev Deployment Failure due to Flyway DB Migration Issue

### DIFF
--- a/build/docker/.env
+++ b/build/docker/.env
@@ -17,4 +17,4 @@ JDBC_URL=jdbc:mariadb://vinyldns-integration:19002/vinyldns?user=root&password=p
 JDBC_MIGRATION_URL=jdbc:mariadb://vinyldns-integration:19002/?user=root&password=pass
 JDBC_USER=root
 JDBC_PASSWORD=pass
-FLYWAY_OUT_OF_ORDER=true
+FLYWAY_OUT_OF_ORDER=false

--- a/build/docker/.env
+++ b/build/docker/.env
@@ -17,3 +17,4 @@ JDBC_URL=jdbc:mariadb://vinyldns-integration:19002/vinyldns?user=root&password=p
 JDBC_MIGRATION_URL=jdbc:mariadb://vinyldns-integration:19002/?user=root&password=pass
 JDBC_USER=root
 JDBC_PASSWORD=pass
+FLYWAY_OUT_OF_ORDER=true

--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -186,6 +186,8 @@ vinyldns {
       user = ${?JDBC_USER}
       password = "pass"
       password = ${?JDBC_PASSWORD}
+      flyway-out-of-order = false
+      flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
     }
 
     # TODO: Remove the need for these useless configuration blocks

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -186,6 +186,8 @@ vinyldns {
       user = ${?JDBC_USER}
       password = "pass"
       password = ${?JDBC_PASSWORD}
+      flyway-out-of-order = false
+      flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
     }
 
     # TODO: Remove the need for these useless configuration blocks

--- a/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnectionConfig.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnectionConfig.scala
@@ -35,6 +35,7 @@ final case class MySqlConnectionConfig(
     url: String,
     user: String,
     password: String,
+    flywayOutOfOrder: Boolean,
     migrationSchemaTable: Option[String],
     // Optional settings, will use Hikari defaults if unset
     // see https://github.com/brettwooldridge/HikariCP#frequently-used

--- a/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnector.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnector.scala
@@ -48,7 +48,7 @@ object MySqlConnector {
         val placeholders = Map("dbName" -> config.name)
         val migration = Flyway
           .configure()
-          .outOfOrder(true)
+          .outOfOrder(config.flywayOutOfOrder)
           .dataSource(migrationDataSource)
           .placeholders(placeholders.asJava)
           .schemas(config.name)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnector.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/MySqlConnector.scala
@@ -48,6 +48,7 @@ object MySqlConnector {
         val placeholders = Map("dbName" -> config.name)
         val migration = Flyway
           .configure()
+          .outOfOrder(true)
           .dataSource(migrationDataSource)
           .placeholders(placeholders.asJava)
           .schemas(config.name)

--- a/quickstart/.env
+++ b/quickstart/.env
@@ -23,4 +23,4 @@ JDBC_URL=jdbc:mariadb://vinyldns-integration:19002/vinyldns?user=root&password=p
 JDBC_MIGRATION_URL=jdbc:mariadb://vinyldns-integration:19002/?user=root&password=pass
 JDBC_USER=root
 JDBC_PASSWORD=pass
-FLYWAY_OUT_OF_ORDER=true
+FLYWAY_OUT_OF_ORDER=false

--- a/quickstart/.env
+++ b/quickstart/.env
@@ -23,3 +23,4 @@ JDBC_URL=jdbc:mariadb://vinyldns-integration:19002/vinyldns?user=root&password=p
 JDBC_MIGRATION_URL=jdbc:mariadb://vinyldns-integration:19002/?user=root&password=pass
 JDBC_USER=root
 JDBC_PASSWORD=pass
+FLYWAY_OUT_OF_ORDER=true


### PR DESCRIPTION
This fix adds an "OutOfOrder" flag to the flyway migration, allowing migration files to be added regardless of the order of the version numbers. The flag will only be set to true if the "vinyldns_environment" variable is set to "dev". This means that the out of order flag will only apply during the dev deployment job, and will not affect other deployments.

Fixes #1101