### PR TITLE
Fix loading TSIG algorithm from config

### DIFF
--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -49,6 +49,7 @@ vinyldns {
                 key-name = ${?DEFAULT_DNS_KEY_NAME}
                 key = "nzisn+4G2ldMn0q1CV3vsg=="
                 key = ${?DEFAULT_DNS_KEY_SECRET}
+                algorithm = "HMAC-MD5"
                 primary-server = "127.0.0.1:19001"
                 primary-server = ${?DEFAULT_DNS_ADDRESS}
               }
@@ -58,6 +59,7 @@ vinyldns {
                 key-name = ${?DEFAULT_DNS_KEY_NAME}
                 key = "nzisn+4G2ldMn0q1CV3vsg=="
                 key = ${?DEFAULT_DNS_KEY_SECRET}
+                algorithm = "HMAC-MD5"
                 primary-server = "127.0.0.1:19001"
                 primary-server = ${?DEFAULT_DNS_ADDRESS}
               },


### PR DESCRIPTION
Fixes #1042

Because `Algorithm` is a sealed case class, PureConfig will by default expect a object in the config file. It needs a custom `ConfigReader` to instead ingest only a simple string, and turn it into the appropriate instance. The custom reader is placed inside the companion object so it is always automatically in scope. I opted for a [cursor-based one](https://pureconfig.github.io/docs/error-handling.html#validations-in-custom-readers) so I can re-use the `fromString` method as-is and nicely integrate it with PureConfig's validation capabilities. 

Adding the `algorithm` key with the default value to the `application.conf` for integration test of the `api` module was enough to reproduce/trigger the error, and serves as test for the bugfix.