### PR TITLE
Hotfix: Flyway Migration Issue

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -130,6 +130,7 @@ vinyldns {
       url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
       user = "root"
       password = "pass"
+      flyway-out-of-order = false
     }
 
     repositories {

--- a/modules/portal/conf/reference.conf
+++ b/modules/portal/conf/reference.conf
@@ -65,6 +65,7 @@ mysql {
     url = "jdbc:mariadb://"${mysql.endpoint}"/vinyldns?user=root&password=pass"
     user = "root"
     password = "pass"
+    flyway-out-of-order = false
   }
 
   repositories {


### PR DESCRIPTION
Hotfix for changes made in https://github.com/vinyldns/vinyldns/pull/1104

The new config variable `flyway-out-of-order` was only added to application.conf in the previous PR. It also needs to be added to reference.conf in order to start the portal correctly.