### PR TITLE
Various logging fixes

### DIFF
--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -327,8 +327,8 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }
 

--- a/build/docker/api/logback.xml
+++ b/build/docker/api/logback.xml
@@ -7,25 +7,13 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="org.flywaydb" level="DEBUG"/>
+    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG"/>
+    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG"/>
 
-    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="vinyldns.core.route.Monitor" level="OFF"/>
 
-    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="vinyldns.core.route.Monitor" level="OFF">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="scalikejdbc.StatementExecutor$$anon$1" level="OFF">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="scalikejdbc.StatementExecutor$$anon$1" level="OFF"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/build/docker/api/logback.xml
+++ b/build/docker/api/logback.xml
@@ -7,10 +7,6 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb" level="DEBUG"/>
-    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG"/>
-    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG"/>
-
     <logger name="vinyldns.core.route.Monitor" level="OFF"/>
 
     <logger name="scalikejdbc.StatementExecutor$$anon$1" level="OFF"/>

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -329,8 +329,8 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }
 

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -327,8 +327,8 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }
 

--- a/modules/api/src/main/resources/logback.xml
+++ b/modules/api/src/main/resources/logback.xml
@@ -7,17 +7,9 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="org.flywaydb" level="DEBUG"/>
+    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG"/>
+    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/modules/api/src/main/resources/logback.xml
+++ b/modules/api/src/main/resources/logback.xml
@@ -7,10 +7,6 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb" level="DEBUG"/>
-    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG"/>
-    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG"/>
-
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/modules/api/src/main/resources/test/logback.xml
+++ b/modules/api/src/main/resources/test/logback.xml
@@ -7,17 +7,9 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-
-    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="org.flywaydb" level="DEBUG"/>
+    <logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="DEBUG"/>
+    <logger name="org.flywaydb.core.internal.command.DbMigrate" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
@@ -118,17 +118,19 @@ class Aws4Authenticator {
     // calculate the sig using the generated signing key
     val signature = calculateSig(canonicalRequest, dateTime, signatureScope, secret)
 
-    // This is worthwhile during the upgrade to akka http and beyond as debugging auth issues is difficult
-    val sb = new StringBuilder
-    sb.append(s"SIGNATURE_SCOPE: $signatureScope\r\n")
-    sb.append(s"SIGNATURE_HEADERS: $signatureHeaders\r\n")
-    sb.append(s"SIGNED_HEADERS: $signedHeaders\r\n")
-    sb.append(s"DATE_TIME: $dateTime\r\n")
-    sb.append(s"HEADERS: $headers\r\n")
-    sb.append(s"CANONICAL_REQUEST: $canonicalRequest\r\n")
-    sb.append(s"SIGNATURE_RECEIVED: $signatureReceived\r\n")
-    sb.append(s"CALCULATED_SIGNATURE: $signature\r\n")
-    logger.info(sb.toString)
+    if (logger.isDebugEnabled) {
+      logger.debug(
+        s"""SIGNATURE_SCOPE: $signatureScope
+           |SIGNATURE_HEADERS: $signatureHeaders
+           |SIGNED_HEADERS: $signedHeaders
+           |DATE_TIME: $dateTime
+           |HEADERS: $headers
+           |CANONICAL_REQUEST: $canonicalRequest
+           |SIGNATURE_RECEIVED: $signatureReceived
+           |CALCULATED_SIGNATURE: $signature"""
+        .stripMargin
+      )
+    }
 
     signature.equals(signatureReceived)
   }

--- a/modules/api/src/test/resources/application.conf
+++ b/modules/api/src/test/resources/application.conf
@@ -336,8 +336,8 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }
 

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -327,8 +327,8 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }
 

--- a/modules/core/src/test/resources/logback.xml
+++ b/modules/core/src/test/resources/logback.xml
@@ -7,13 +7,9 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb" level="INFO">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="org.flywaydb" level="INFO"/>
 
-    <logger name="vinyldns.core.route.Monitor" level="OFF">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="vinyldns.core.route.Monitor" level="OFF"/>
 
     <root level="OFF">
         <appender-ref ref="CONSOLE"/>

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -792,8 +792,8 @@ v6-discovery-nibble-boundaries {
      }
    
      parsing {
-        # akka-http doesn't like the AWS4 headers
-        illegal-header-warnings = on
+        # Don't complain about the / in the AWS SigV4 auth header
+        ignore-illegal-header-for = ["authorization"]
      }
   }
 }

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -75,7 +75,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
     */
   def receive(count: MessageCount): IO[List[SqsMessage]] =
     monitor("queue.SQS.receive") {
-      logger.debug(s"Receiving $count messages.\n")
+      logger.debug(s"Receiving $count messages.")
       sqsAsync[ReceiveMessageRequest, ReceiveMessageResult](
         // Can return 1-10 messages.
         // (see: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/
@@ -112,7 +112,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
 
   def delete(receiptHandle: String): IO[Unit] =
     monitor("queue.SQS.delete") {
-      logger.info(s"Deleting message with receipt handle: $receiptHandle.\n")
+      logger.info(s"Deleting message with receipt handle: $receiptHandle.")
       sqsAsync[DeleteMessageRequest, DeleteMessageResult](
         new DeleteMessageRequest(queueUrl, receiptHandle),
         client.deleteMessageAsync
@@ -130,7 +130,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
 
   def send[A <: ZoneCommand](command: A): IO[Unit] =
     monitor("queue.SQS.send") {
-      logger.info(s"Sending command: $command.\n")
+      logger.info(s"Sending command: $command.")
       sqsAsync[SendMessageRequest, SendMessageResult](
         toSendMessageRequest(command)
           .withQueueUrl(queueUrl),
@@ -157,7 +157,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
   /* Change message visibility timeout. Valid values: 0 to 43200 seconds (ie. 12 hours) */
   def changeMessageTimeout(message: CommandMessage, duration: FiniteDuration): IO[Unit] =
     monitor("queue.SQS.changeMessageTimeout") {
-      logger.info(s"Updating visibility timeout to $duration for message: $message.\n")
+      logger.info(s"Updating visibility timeout to $duration for message: $message.")
       IO.fromEither(validateMessageTimeout(duration)).flatMap { validDuration =>
         sqsAsync[ChangeMessageVisibilityRequest, ChangeMessageVisibilityResult](
           new ChangeMessageVisibilityRequest()

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueueProvider.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueueProvider.scala
@@ -49,7 +49,7 @@ class SqsMessageQueueProvider extends MessageQueueProvider {
       _ <- IO.fromEither(validateQueueName(settingsConfig.queueName))
       client <- setupClient(settingsConfig)
       queueUrl <- setupQueue(client, settingsConfig.queueName)
-      _ <- IO(logger.info(s"Queue URL: $queueUrl\n"))
+      _ <- IO(logger.info(s"Queue URL: $queueUrl"))
     } yield new SqsMessageQueue(queueUrl, client)
 
   def validateQueueName(queueName: String): Either[InvalidQueueName, String] = {

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -40,6 +40,7 @@ services:
         DOCKER_FILE_PATH: "build/docker/api"
     volumes:
       - ../build/docker/api/application.conf:/opt/vinyldns/conf/application.conf
+      - ../build/docker/api/logback.xml:/opt/vinyldns/conf/logback.xml
     env_file:
       - .env
     ports:
@@ -64,6 +65,7 @@ services:
       - "${PORTAL_PORT}:${PORTAL_PORT}"
     volumes:
       - ../build/docker/portal/application.conf:/opt/vinyldns/conf/application.conf
+      - ../build/docker/portal/logback.xml:/opt/vinyldns/conf/logback.xml
     depends_on:
       - ldap
 

--- a/test/api/functional/application.conf
+++ b/test/api/functional/application.conf
@@ -297,7 +297,7 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }

--- a/test/api/integration/application.conf
+++ b/test/api/integration/application.conf
@@ -352,7 +352,7 @@ akka.http {
   }
 
   parsing {
-    # Spray doesn't like the AWS4 headers
-    illegal-header-warnings = on
+    # Don't complain about the / in the AWS SigV4 auth header
+    ignore-illegal-header-for = ["authorization"]
   }
 }


### PR DESCRIPTION
The goal of this PR to improve the logging in various ways. Below is a listing of the full commit messages with detailed explanations.

## Remove duplicate log output
[Appenders in logback are additive](https://logback.qos.ch/manual/configuration.html#cumulative), specifying them multiple times leads to log lines being output multiple times. It is usually enough to set the appender on the root logger, and nowhere else.
Setting the same log level on multiple package levels is also kind of unneeded, the top-most one would be enough.

## Reduce flyway log output
Let's establish a sane default by not having flyway run on full-blast debug output by default. For normal operation I found INFO to be verbose enough (as the flyway devs intended I guess).

## Disable illegal header warning from akka-http
Fixes #864

## Demote full SigV4 logging to DEBUG level
As the existing code comment said, it is for debugging; so make it DEBUG level. This means ~15 lines less logging per request. Also wrapped it in a loglevel guard to skip the string interpolation when not needed.

## Remove trailing newlines from log messages
The goal is to reduce visual jitter.