### PR TITLE
Added http status code check for the recordset search spinner

### DIFF
--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -40,7 +40,10 @@ angular.module('service.records', [])
                 "recordOwnerGroupFilter": ownerGroupFilter
             };
             var url = utilityService.urlBuilder("/api/recordsets", params);
-            if ($http.get(url)){
+            var http = new XMLHttpRequest();
+            http.open('HEAD', url, false);
+            http.send();
+            if ($http.get(url)  && http.status == 200){
              $("#loader").modal({
                              backdrop: "static", //remove ability to close modal with click
                              keyboard: false, //remove option to close with keyboard


### PR DESCRIPTION
Changes in this pull request:
- Added http status code check for the recordset search spinner. This will hide the spinner, when user, search records with null(empty) in Global recordset.

