### PR TITLE
Minor Updates

### DIFF
--- a/build/docker/api/logback.xml
+++ b/build/docker/api/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    <variable name="VINYLDNS_LOG_LEVEL" value="${VINYLDNS_LOG_LEVEL:-INFO}" />
+
     <!-- Test configuration, log to console so we can get the docker logs -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="co.elastic.logging.logback.EcsEncoder">
@@ -11,7 +13,7 @@
 
     <logger name="scalikejdbc.StatementExecutor$$anon$1" level="OFF"/>
 
-    <root level="INFO">
+    <root level="${VINYLDNS_LOG_LEVEL}">
         <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>

--- a/build/docker/portal/logback.xml
+++ b/build/docker/portal/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    
+  <variable name="VINYLDNS_LOG_LEVEL" value="${VINYLDNS_LOG_LEVEL:-INFO}" />
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -15,7 +15,7 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
-  <root level="INFO">
+  <root level="${VINYLDNS_LOG_LEVEL}">
     <appender-ref ref="CONSOLE" />
   </root>
 

--- a/quickstart/quickstart-vinyldns.sh
+++ b/quickstart/quickstart-vinyldns.sh
@@ -153,7 +153,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Load environment variables
-export $(echo $(cat "${ENV_FILE}" | sed 's/#.*//g'| xargs) | envsubst)
+export $(echo $(cat "${ENV_FILE}" | sed 's/#.*//g'| xargs))
 
 if [[ $SHELL_REQUESTED -eq 1 ]]; then
   echo "Please wait.. creating a new shell with the environment variables set."


### PR DESCRIPTION
- Allow log level to be set via environment
- Remove `envsubst` from `quickstart.sh` for macOS compat
