### PR TITLE
Allow deletion of records that doesn't exist

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
@@ -70,6 +70,7 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       recordSetChanges: List[RecordSetChange]
   ): BatchResult[Unit] = {
     val convertedIds = recordSetChanges.flatMap(_.singleBatchChangeIds).toSet
+
     singleChanges.find(ch => !convertedIds.contains(ch.id)) match {
       // Each single change has a corresponding recordset id
       // If they're not equal, then there's a delete request for a record that doesn't exist. So we allow this to process
@@ -80,7 +81,7 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       case Some(change) => BatchConversionError(change).toLeftBatchResult
       case None =>
         logger.info(s"Successfully converted SingleChanges [${singleChanges
-            .map(_.id)}] to RecordSetChanges [${recordSetChanges.map(_.id)}]")
+          .map(_.id)}] to RecordSetChanges [${recordSetChanges.map(_.id)}]")
         ().toRightBatchResult
     }
   }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -347,7 +347,7 @@ class BatchChangeValidations(
           userCanDeleteRecordSet(change, auth, rs.ownerGroupId, rs.records) |+|
             zoneDoesNotRequireManualReview(change, isApproved) |+|
             ensureRecordExists(change, groupedChanges)
-        case None => RecordDoesNotExist(change.inputChange.inputName).invalidNel
+        case None => RecordDoesNotExist(change.inputChange.inputName).validNel
       }
     validations.map(_ => change)
   }
@@ -401,7 +401,7 @@ class BatchChangeValidations(
             zoneDoesNotRequireManualReview(change, isApproved) |+|
             ensureRecordExists(change, groupedChanges)
         case None =>
-          RecordDoesNotExist(change.inputChange.inputName).invalidNel
+          RecordDoesNotExist(change.inputChange.inputName).validNel
       }
 
     validations.map(_ => change)

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -3724,7 +3724,7 @@ def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_co
 
 def test_create_batch_delete_record_that_does_not_exists_completes(shared_zone_test_context):
     """
-    Test delete record set fails for non-existent record and non-existent record data
+    Test delete record set completes for non-existent record
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone_name = shared_zone_test_context.ok_zone["name"]
@@ -3739,7 +3739,7 @@ def test_create_batch_delete_record_that_does_not_exists_completes(shared_zone_t
     response = client.create_batch_change(batch_change_input, status=202)
     get_batch = client.get_batch_change(response["id"])
 
-    assert_that(get_batch["changes"][0]["systemMessage"], is_("ℹ️ This record does not exist." +
+    assert_that(get_batch["changes"][0]["systemMessage"], is_("This record does not exist." +
                                                               "No further action is required."))
 
     assert_successful_change_in_error_response(response["changes"][0], input_name=f"delete-non-existent-record.{ok_zone_name}", record_data="1.1.1.1", change_type="DeleteRecordSet")

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -1542,6 +1542,7 @@ def test_a_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_A_AAAA_json(rs_delete_fqdn, change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(rs_update_fqdn, change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(rs_update_fqdn, ttl=300),
+            get_change_A_AAAA_json(f"non-existent.{ok_zone_name}", change_type="DeleteRecordSet"),
 
             # input validations failures
             get_change_A_AAAA_json("$invalid.host.name.", change_type="DeleteRecordSet"),
@@ -1555,7 +1556,6 @@ def test_a_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_A_AAAA_json("zone.discovery.error.", change_type="DeleteRecordSet"),
 
             # context validation failures: record does not exist, not authorized
-            get_change_A_AAAA_json(f"non-existent.{ok_zone_name}", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(rs_delete_dummy_fqdn, change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(rs_update_dummy_fqdn, change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(rs_update_dummy_fqdn, ttl=300),
@@ -1592,43 +1592,40 @@ def test_a_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[0], input_name=rs_delete_fqdn, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[1], input_name=rs_update_fqdn, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[2], input_name=rs_update_fqdn, ttl=300)
+        assert_successful_change_in_error_response(response[3], input_name=f"non-existent.{ok_zone_name}", change_type="DeleteRecordSet")
 
         # input validations failures
-        assert_failed_change_in_error_response(response[3], input_name="$invalid.host.name.",
+        assert_failed_change_in_error_response(response[4], input_name="$invalid.host.name.",
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid domain name: "$invalid.host.name.", valid domain names must be letters, '
                                                                'numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[4], input_name="reverse.zone.in-addr.arpa.",
+        assert_failed_change_in_error_response(response[5], input_name="reverse.zone.in-addr.arpa.",
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid Record Type In Reverse Zone: record with name "reverse.zone.in-addr.arpa." and type "A" '
                                                                'is not allowed in a reverse zone.'])
-        assert_failed_change_in_error_response(response[5], input_name="$another.invalid.host.name.", ttl=300,
+        assert_failed_change_in_error_response(response[6], input_name="$another.invalid.host.name.", ttl=300,
                                                error_messages=['Invalid domain name: "$another.invalid.host.name.", valid domain names must be letters, '
                                                                'numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[6], input_name="$another.invalid.host.name.",
+        assert_failed_change_in_error_response(response[7], input_name="$another.invalid.host.name.",
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid domain name: "$another.invalid.host.name.", valid domain names must be letters, '
                                                                'numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[7], input_name="another.reverse.zone.in-addr.arpa.", ttl=10,
+        assert_failed_change_in_error_response(response[8], input_name="another.reverse.zone.in-addr.arpa.", ttl=10,
                                                error_messages=['Invalid Record Type In Reverse Zone: record with name "another.reverse.zone.in-addr.arpa." '
                                                                'and type "A" is not allowed in a reverse zone.',
                                                                'Invalid TTL: "10", must be a number between 30 and 2147483647.'])
-        assert_failed_change_in_error_response(response[8], input_name="another.reverse.zone.in-addr.arpa.",
+        assert_failed_change_in_error_response(response[9], input_name="another.reverse.zone.in-addr.arpa.",
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid Record Type In Reverse Zone: record with name "another.reverse.zone.in-addr.arpa." '
                                                                'and type "A" is not allowed in a reverse zone.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[9], input_name="zone.discovery.error.",
+        assert_failed_change_in_error_response(response[10], input_name="zone.discovery.error.",
                                                change_type="DeleteRecordSet",
                                                error_messages=['Zone Discovery Failed: zone for "zone.discovery.error." does not exist in VinylDNS. '
                                                                'If zone exists, then it must be connected to in VinylDNS.'])
 
         # context validation failures: record does not exist, not authorized
-        assert_failed_change_in_error_response(response[10], input_name=f"non-existent.{ok_zone_name}",
-                                               change_type="DeleteRecordSet",
-                                               error_messages=[
-                                                   f'Record "non-existent.{ok_zone_name}" Does Not Exist: cannot delete a record that does not exist.'])
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn,
                                                change_type="DeleteRecordSet",
                                                error_messages=[f'User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
@@ -1781,6 +1778,8 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_A_AAAA_json(rs_delete_fqdn, record_type="AAAA", change_type="DeleteRecordSet", address="1:0::4:5:6:7:8"),
             get_change_A_AAAA_json(rs_update_fqdn, record_type="AAAA", ttl=300, address="1:2:3:4:5:6:7:8"),
             get_change_A_AAAA_json(rs_update_fqdn, record_type="AAAA", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(f"delete-nonexistent.{ok_zone_name}", record_type="AAAA", change_type="DeleteRecordSet"),
+            get_change_A_AAAA_json(f"update-nonexistent.{ok_zone_name}", record_type="AAAA", change_type="DeleteRecordSet"),
 
             # input validations failures
             get_change_A_AAAA_json(f"invalid-name$.{ok_zone_name}", record_type="AAAA", change_type="DeleteRecordSet"),
@@ -1792,8 +1791,6 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_A_AAAA_json("no.zone.at.all.", record_type="AAAA", change_type="DeleteRecordSet"),
 
             # context validation failures
-            get_change_A_AAAA_json(f"delete-nonexistent.{ok_zone_name}", record_type="AAAA", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(f"update-nonexistent.{ok_zone_name}", record_type="AAAA", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(f"update-nonexistent.{ok_zone_name}", record_type="AAAA", address="1::1"),
             get_change_A_AAAA_json(rs_delete_dummy_fqdn, record_type="AAAA", change_type="DeleteRecordSet"),
             get_change_A_AAAA_json(rs_update_dummy_fqdn, record_type="AAAA", address="1::1"),
@@ -1826,39 +1823,37 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data="1:2:3:4:5:6:7:8")
         assert_successful_change_in_error_response(response[2], input_name=rs_update_fqdn, record_type="AAAA",
                                                    record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[3], input_name=f"delete-nonexistent.{ok_zone_name}", record_type="AAAA",
+                                                   record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=f"update-nonexistent.{ok_zone_name}", record_type="AAAA",
+                                                   record_data=None, change_type="DeleteRecordSet")
 
         # input validations failures: invalid input name, reverse zone error, invalid ttl
-        assert_failed_change_in_error_response(response[3], input_name=f"invalid-name$.{ok_zone_name}", record_type="AAAA",
+        assert_failed_change_in_error_response(response[5], input_name=f"invalid-name$.{ok_zone_name}", record_type="AAAA",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=[f'Invalid domain name: "invalid-name$.{ok_zone_name}", '
                                                                f'valid domain names must be letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[4], input_name="reverse.zone.in-addr.arpa.", record_type="AAAA",
+        assert_failed_change_in_error_response(response[6], input_name="reverse.zone.in-addr.arpa.", record_type="AAAA",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Invalid Record Type In Reverse Zone: record with name \"reverse.zone.in-addr.arpa.\" and "
                                                                "type \"AAAA\" is not allowed in a reverse zone."])
-        assert_failed_change_in_error_response(response[5], input_name=f"bad-ttl-and-invalid-name$-update.{ok_zone_name}",
+        assert_failed_change_in_error_response(response[7], input_name=f"bad-ttl-and-invalid-name$-update.{ok_zone_name}",
                                                record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=[f'Invalid domain name: "bad-ttl-and-invalid-name$-update.{ok_zone_name}", '
                                                                f'valid domain names must be letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[6], input_name=f"bad-ttl-and-invalid-name$-update.{ok_zone_name}", ttl=29,
+        assert_failed_change_in_error_response(response[8], input_name=f"bad-ttl-and-invalid-name$-update.{ok_zone_name}", ttl=29,
                                                record_type="AAAA", record_data="1:2:3:4:5:6:7:8",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                                f'Invalid domain name: "bad-ttl-and-invalid-name$-update.{ok_zone_name}", '
                                                                f'valid domain names must be letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[7], input_name="no.zone.at.all.", record_type="AAAA",
+        assert_failed_change_in_error_response(response[9], input_name="no.zone.at.all.", record_type="AAAA",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Zone Discovery Failed: zone for \"no.zone.at.all.\" does not exist in VinylDNS. "
                                                                "If zone exists, then it must be connected to in VinylDNS."])
 
         # context validation failures: record does not exist, not authorized
-        assert_failed_change_in_error_response(response[8], input_name=f"delete-nonexistent.{ok_zone_name}", record_type="AAAA",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"delete-nonexistent.{ok_zone_name}\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[9], input_name=f"update-nonexistent.{ok_zone_name}", record_type="AAAA",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"update-nonexistent.{ok_zone_name}\" Does Not Exist: cannot delete a record that does not exist."])
         assert_successful_change_in_error_response(response[10], input_name=f"update-nonexistent.{ok_zone_name}", record_type="AAAA", record_data="1::1")
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn,
                                                record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
@@ -2058,6 +2053,8 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_CNAME_json(f"delete3.{ok_zone_name}", change_type="DeleteRecordSet"),
             get_change_CNAME_json(f"update3.{ok_zone_name}", change_type="DeleteRecordSet"),
             get_change_CNAME_json(f"update3.{ok_zone_name}", ttl=300),
+            get_change_CNAME_json(f"non-existent-delete.{ok_zone_name}", change_type="DeleteRecordSet"),
+            get_change_CNAME_json(f"non-existent-update.{ok_zone_name}", change_type="DeleteRecordSet"),
 
             # valid changes - reverse zone
             get_change_CNAME_json(f"200.{ip4_zone_name}", change_type="DeleteRecordSet"),
@@ -2073,8 +2070,6 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_CNAME_json("zone.discovery.error.", change_type="DeleteRecordSet"),
 
             # context validation failures: record does not exist, not authorized, failure on update with multiple adds
-            get_change_CNAME_json(f"non-existent-delete.{ok_zone_name}", change_type="DeleteRecordSet"),
-            get_change_CNAME_json(f"non-existent-update.{ok_zone_name}", change_type="DeleteRecordSet"),
             get_change_CNAME_json(f"non-existent-update.{ok_zone_name}"),
             get_change_CNAME_json(f"delete-unauthorized3.{dummy_zone_name}", change_type="DeleteRecordSet"),
             get_change_CNAME_json(f"update-unauthorized3.{dummy_zone_name}", change_type="DeleteRecordSet"),
@@ -2111,25 +2106,29 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                    change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[2], input_name=f"update3.{ok_zone_name}", record_type="CNAME", ttl=300,
                                                    record_data="test.com.")
+        assert_successful_change_in_error_response(response[3], input_name=f"non-existent-delete.{ok_zone_name}", record_type="CNAME",
+                                                   change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=f"non-existent-update.{ok_zone_name}", record_type="CNAME",
+                                                   change_type="DeleteRecordSet")
 
         # valid changes - reverse zone
-        assert_successful_change_in_error_response(response[3], input_name=f"200.{ip4_zone_name}",
+        assert_successful_change_in_error_response(response[5], input_name=f"200.{ip4_zone_name}",
                                                    record_type="CNAME", change_type="DeleteRecordSet")
-        assert_successful_change_in_error_response(response[4], input_name=f"201.{ip4_zone_name}",
+        assert_successful_change_in_error_response(response[6], input_name=f"201.{ip4_zone_name}",
                                                    record_type="CNAME", change_type="DeleteRecordSet")
-        assert_successful_change_in_error_response(response[5], input_name=f"201.{ip4_zone_name}",
+        assert_successful_change_in_error_response(response[7], input_name=f"201.{ip4_zone_name}",
                                                    record_type="CNAME", ttl=300, record_data="test.com.")
 
         # ttl, domain name, data
-        assert_failed_change_in_error_response(response[6], input_name="$invalid.host.name.", record_type="CNAME",
+        assert_failed_change_in_error_response(response[8], input_name="$invalid.host.name.", record_type="CNAME",
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid domain name: "$invalid.host.name.", valid domain names must be letters, numbers, '
                                                                'underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[7], input_name="$another.invalid.host.name.",
+        assert_failed_change_in_error_response(response[9], input_name="$another.invalid.host.name.",
                                                record_type="CNAME", change_type="DeleteRecordSet",
                                                error_messages=['Invalid domain name: "$another.invalid.host.name.", valid domain names must be letters, numbers, '
                                                                'underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[8], input_name="$another.invalid.host.name.", ttl=20,
+        assert_failed_change_in_error_response(response[10], input_name="$another.invalid.host.name.", ttl=20,
                                                record_type="CNAME", record_data="$another.invalid.cname.",
                                                error_messages=['Invalid TTL: "20", must be a number between 30 and 2147483647.',
                                                                'Invalid domain name: "$another.invalid.host.name.", valid domain names must be letters, numbers, '
@@ -2138,20 +2137,12 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                                'underscores, and hyphens, joined by dots, and terminated with a dot.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[9], input_name="zone.discovery.error.", record_type="CNAME",
+        assert_failed_change_in_error_response(response[11], input_name="zone.discovery.error.", record_type="CNAME",
                                                change_type="DeleteRecordSet",
                                                error_messages=[
                                                    'Zone Discovery Failed: zone for "zone.discovery.error." does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.'])
 
         # context validation failures: record does not exist, not authorized
-        assert_failed_change_in_error_response(response[10], input_name=f"non-existent-delete.{ok_zone_name}", record_type="CNAME",
-                                               change_type="DeleteRecordSet",
-                                               error_messages=[
-                                                   f'Record "non-existent-delete.{ok_zone_name}" Does Not Exist: cannot delete a record that does not exist.'])
-        assert_failed_change_in_error_response(response[11], input_name=f"non-existent-update.{ok_zone_name}", record_type="CNAME",
-                                               change_type="DeleteRecordSet",
-                                               error_messages=[
-                                                   f'Record "non-existent-update.{ok_zone_name}" Does Not Exist: cannot delete a record that does not exist.'])
         assert_successful_change_in_error_response(response[12], input_name=f"non-existent-update.{ok_zone_name}",
                                                    record_type="CNAME", record_data="test.com.")
         assert_failed_change_in_error_response(response[13], input_name=f"delete-unauthorized3.{dummy_zone_name}",
@@ -2384,6 +2375,8 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_PTR_json(f"{ip4_prefix}.25", change_type="DeleteRecordSet"),
             get_change_PTR_json(f"{ip4_prefix}.193", ttl=300, ptrdname="has-updated.ptr."),
             get_change_PTR_json(f"{ip4_prefix}.193", change_type="DeleteRecordSet"),
+            get_change_PTR_json(f"{ip4_prefix}.199", change_type="DeleteRecordSet"),
+            get_change_PTR_json(f"{ip4_prefix}.200", change_type="DeleteRecordSet"),
 
             # valid changes: delete and add of same record name but different type
             get_change_CNAME_json(f"21.{ip4_zone_name}", change_type="DeleteRecordSet"),
@@ -2400,9 +2393,7 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_PTR_json("192.1.1.25", change_type="DeleteRecordSet"),
 
             # context validation failures
-            get_change_PTR_json(f"{ip4_prefix}.199", change_type="DeleteRecordSet"),
             get_change_PTR_json(f"{ip4_prefix}.200", ttl=300, ptrdname="has-updated.ptr."),
-            get_change_PTR_json(f"{ip4_prefix}.200", change_type="DeleteRecordSet"),
         ]
     }
 
@@ -2423,25 +2414,29 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data="has-updated.ptr.")
         assert_successful_change_in_error_response(response[2], input_name=f"{ip4_prefix}.193", record_type="PTR",
                                                    record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[3], input_name=f"{ip4_prefix}.199", record_type="PTR",
+                                                   record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=f"{ip4_prefix}.200", record_type="PTR",
+                                                   record_data=None, change_type="DeleteRecordSet")
 
         # successful changes: add and delete of same record name but different type
-        assert_successful_change_in_error_response(response[3], input_name=f"21.{ip4_zone_name}",
+        assert_successful_change_in_error_response(response[5], input_name=f"21.{ip4_zone_name}",
                                                    record_type="CNAME", record_data=None, change_type="DeleteRecordSet")
-        assert_successful_change_in_error_response(response[4], input_name=f"{ip4_prefix}.21", record_type="PTR",
+        assert_successful_change_in_error_response(response[6], input_name=f"{ip4_prefix}.21", record_type="PTR",
                                                    record_data="replace-cname.ptr.")
-        assert_successful_change_in_error_response(response[5], input_name=f"17.{ip4_zone_name}",
+        assert_successful_change_in_error_response(response[7], input_name=f"17.{ip4_zone_name}",
                                                    record_type="CNAME", record_data="replace-ptr.cname.")
-        assert_successful_change_in_error_response(response[6], input_name=f"{ip4_prefix}.17", record_type="PTR",
+        assert_successful_change_in_error_response(response[8], input_name=f"{ip4_prefix}.17", record_type="PTR",
                                                    record_data=None, change_type="DeleteRecordSet")
 
         # input validations failures: invalid IP, ttl, and record data
-        assert_failed_change_in_error_response(response[7], input_name="1.1.1", record_type="PTR", record_data=None,
+        assert_failed_change_in_error_response(response[9], input_name="1.1.1", record_type="PTR", record_data=None,
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid IP address: "1.1.1".'])
-        assert_failed_change_in_error_response(response[8], input_name="192.0.2.", record_type="PTR", record_data=None,
+        assert_failed_change_in_error_response(response[10], input_name="192.0.2.", record_type="PTR", record_data=None,
                                                change_type="DeleteRecordSet",
                                                error_messages=['Invalid IP address: "192.0.2.".'])
-        assert_failed_change_in_error_response(response[9], ttl=29, input_name="192.0.2.", record_type="PTR",
+        assert_failed_change_in_error_response(response[11], ttl=29, input_name="192.0.2.", record_type="PTR",
                                                record_data="failed-update$.ptr.",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                                'Invalid IP address: "192.0.2.".',
@@ -2449,19 +2444,13 @@ def test_ipv4_ptr_recordtype_update_delete_checks(shared_zone_test_context):
                                                                'joined by dots, and terminated with a dot.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[10], input_name="192.1.1.25", record_type="PTR",
+        assert_failed_change_in_error_response(response[12], input_name="192.1.1.25", record_type="PTR",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Zone Discovery Failed: zone for \"192.1.1.25\" does not exist in VinylDNS. If zone exists, "
                                                                "then it must be connected to in VinylDNS."])
 
         # context validation failures: record does not exist
-        assert_failed_change_in_error_response(response[11], input_name=f"{ip4_prefix}.199", record_type="PTR",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"{ip4_prefix}.199\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[12], ttl=300, input_name=f"{ip4_prefix}.200", record_type="PTR", record_data="has-updated.ptr.")
-        assert_failed_change_in_error_response(response[13], input_name=f"{ip4_prefix}.200", record_type="PTR",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"{ip4_prefix}.200\" Does Not Exist: cannot delete a record that does not exist."])
+        assert_successful_change_in_error_response(response[13], ttl=300, input_name=f"{ip4_prefix}.200", record_type="PTR", record_data="has-updated.ptr.")
     finally:
         clear_recordset_list(to_delete, ok_client)
 
@@ -2556,6 +2545,8 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_PTR_json(f"{ip6_prefix}:1000::aaaa", change_type="DeleteRecordSet"),
             get_change_PTR_json(f"{ip6_prefix}:1000::62", ttl=300, ptrdname="has-updated.ptr."),
             get_change_PTR_json(f"{ip6_prefix}:1000::62", change_type="DeleteRecordSet"),
+            get_change_PTR_json(f"{ip6_prefix}:1000::60", change_type="DeleteRecordSet"),
+            get_change_PTR_json(f"{ip6_prefix}:1000::65", change_type="DeleteRecordSet"),
 
             # input validations failures
             get_change_PTR_json("fd69:27cc:fe91de::ab", change_type="DeleteRecordSet"),
@@ -2566,9 +2557,7 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_PTR_json("fedc:ba98:7654::abc", change_type="DeleteRecordSet"),
 
             # context validation failures
-            get_change_PTR_json(f"{ip6_prefix}:1000::60", change_type="DeleteRecordSet"),
             get_change_PTR_json(f"{ip6_prefix}:1000::65", ttl=300, ptrdname="has-updated.ptr."),
-            get_change_PTR_json(f"{ip6_prefix}:1000::65", change_type="DeleteRecordSet")
         ]
     }
 
@@ -2589,15 +2578,19 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_type="PTR", record_data="has-updated.ptr.")
         assert_successful_change_in_error_response(response[2], input_name=f"{ip6_prefix}:1000::62", record_type="PTR",
                                                    record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[3], input_name=f"{ip6_prefix}:1000::60", record_type="PTR",
+                                                   record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=f"{ip6_prefix}:1000::65", record_type="PTR",
+                                                   record_data=None, change_type="DeleteRecordSet")
 
         # input validations failures: invalid IP, ttl, and record data
-        assert_failed_change_in_error_response(response[3], input_name="fd69:27cc:fe91de::ab", record_type="PTR",
+        assert_failed_change_in_error_response(response[5], input_name="fd69:27cc:fe91de::ab", record_type="PTR",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=['Invalid IP address: "fd69:27cc:fe91de::ab".'])
-        assert_failed_change_in_error_response(response[4], input_name="fd69:27cc:fe91de::ba", record_type="PTR",
+        assert_failed_change_in_error_response(response[6], input_name="fd69:27cc:fe91de::ba", record_type="PTR",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=['Invalid IP address: "fd69:27cc:fe91de::ba".'])
-        assert_failed_change_in_error_response(response[5], ttl=29, input_name="fd69:27cc:fe91de::ba",
+        assert_failed_change_in_error_response(response[7], ttl=29, input_name="fd69:27cc:fe91de::ba",
                                                record_type="PTR", record_data="failed-update$.ptr.",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.',
                                                                'Invalid IP address: "fd69:27cc:fe91de::ba".',
@@ -2605,20 +2598,14 @@ def test_ipv6_ptr_recordtype_update_delete_checks(shared_zone_test_context):
                                                                'and hyphens, joined by dots, and terminated with a dot.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[6], input_name="fedc:ba98:7654::abc", record_type="PTR",
+        assert_failed_change_in_error_response(response[8], input_name="fedc:ba98:7654::abc", record_type="PTR",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Zone Discovery Failed: zone for \"fedc:ba98:7654::abc\" does not exist in VinylDNS. "
                                                                "If zone exists, then it must be connected to in VinylDNS."])
 
         # context validation failures: record does not exist, failure on update with double add
-        assert_failed_change_in_error_response(response[7], input_name=f"{ip6_prefix}:1000::60", record_type="PTR",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"{ip6_prefix}:1000::60\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_successful_change_in_error_response(response[8], ttl=300, input_name=f"{ip6_prefix}:1000::65",
+        assert_successful_change_in_error_response(response[9], ttl=300, input_name=f"{ip6_prefix}:1000::65",
                                                    record_type="PTR", record_data="has-updated.ptr.")
-        assert_failed_change_in_error_response(response[9], input_name=f"{ip6_prefix}:1000::65", record_type="PTR",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"{ip6_prefix}:1000::65\" Does Not Exist: cannot delete a record that does not exist."])
 
     finally:
         clear_recordset_list(to_delete, ok_client)
@@ -2747,6 +2734,8 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_TXT_json(rs_delete_fqdn, change_type="DeleteRecordSet"),
             get_change_TXT_json(rs_update_fqdn, change_type="DeleteRecordSet"),
             get_change_TXT_json(rs_update_fqdn, ttl=300),
+            get_change_TXT_json(f"delete-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
+            get_change_TXT_json(f"update-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
 
             # input validations failures
             get_change_TXT_json(f"invalid-name$.{ok_zone_name}", change_type="DeleteRecordSet"),
@@ -2756,8 +2745,6 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_TXT_json("no.zone.at.all.", change_type="DeleteRecordSet"),
 
             # context validation failures
-            get_change_TXT_json(f"delete-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
-            get_change_TXT_json(f"update-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
             get_change_TXT_json(f"update-nonexistent.{ok_zone_name}", text="test"),
             get_change_TXT_json(rs_delete_dummy_fqdn, change_type="DeleteRecordSet"),
             get_change_TXT_json(rs_update_dummy_fqdn, text="test"),
@@ -2787,25 +2774,23 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[0], input_name=rs_delete_fqdn, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[1], input_name=rs_update_fqdn, record_type="TXT", record_data=None, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[2], ttl=300, input_name=rs_update_fqdn, record_type="TXT", record_data="test")
+        assert_successful_change_in_error_response(response[3], input_name=f"delete-nonexistent.{ok_zone_name}", record_type="TXT", record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=f"update-nonexistent.{ok_zone_name}", record_type="TXT", record_data=None, change_type="DeleteRecordSet")
 
         # input validations failures: invalid input name, reverse zone error, invalid ttl
-        assert_failed_change_in_error_response(response[3], input_name=f"invalid-name$.{ok_zone_name}", record_type="TXT", record_data="test", change_type="DeleteRecordSet",
+        assert_failed_change_in_error_response(response[5], input_name=f"invalid-name$.{ok_zone_name}", record_type="TXT", record_data="test", change_type="DeleteRecordSet",
                                                error_messages=[f'Invalid domain name: "invalid-name$.{ok_zone_name}", valid domain names must be '
                                                                f'letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[4], input_name=f"invalid-ttl.{ok_zone_name}", ttl=29, record_type="TXT", record_data="bad-ttl",
+        assert_failed_change_in_error_response(response[6], input_name=f"invalid-ttl.{ok_zone_name}", ttl=29, record_type="TXT", record_data="bad-ttl",
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[5], input_name="no.zone.at.all.", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
+        assert_failed_change_in_error_response(response[7], input_name="no.zone.at.all.", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=[
                                                    "Zone Discovery Failed: zone for \"no.zone.at.all.\" does not exist in VinylDNS. "
                                                    "If zone exists, then it must be connected to in VinylDNS."])
 
         # context validation failures: record does not exist, not authorized
-        assert_failed_change_in_error_response(response[6], input_name=f"delete-nonexistent.{ok_zone_name}", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"delete-nonexistent.{ok_zone_name}\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[7], input_name=f"update-nonexistent.{ok_zone_name}", record_type="TXT", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"update-nonexistent.{ok_zone_name}\" Does Not Exist: cannot delete a record that does not exist."])
         assert_successful_change_in_error_response(response[8], input_name=f"update-nonexistent.{ok_zone_name}", record_type="TXT", record_data="test")
         assert_failed_change_in_error_response(response[9], input_name=rs_delete_dummy_fqdn, record_type="TXT", record_data=None, change_type="DeleteRecordSet",
                                                error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
@@ -2958,6 +2943,8 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_MX_json(rs_delete_fqdn, change_type="DeleteRecordSet"),
             get_change_MX_json(rs_update_fqdn, change_type="DeleteRecordSet"),
             get_change_MX_json(rs_update_fqdn, ttl=300),
+            get_change_MX_json(f"delete-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
+            get_change_MX_json(f"update-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
 
             # input validations failures
             get_change_MX_json(f"invalid-name$.{ok_zone_name}", change_type="DeleteRecordSet"),
@@ -2969,8 +2956,6 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
             get_change_MX_json("no.zone.at.all.", change_type="DeleteRecordSet"),
 
             # context validation failures
-            get_change_MX_json(f"delete-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
-            get_change_MX_json(f"update-nonexistent.{ok_zone_name}", change_type="DeleteRecordSet"),
             get_change_MX_json(f"update-nonexistent.{ok_zone_name}", preference=1000, exchange="foo.bar."),
             get_change_MX_json(rs_delete_dummy_fqdn, change_type="DeleteRecordSet"),
             get_change_MX_json(rs_update_dummy_fqdn, preference=1000, exchange="foo.bar."),
@@ -3000,37 +2985,35 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[0], input_name=rs_delete_fqdn, record_type="MX", record_data=None, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[1], input_name=rs_update_fqdn, record_type="MX", record_data=None, change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[2], ttl=300, input_name=rs_update_fqdn, record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."})
+        assert_successful_change_in_error_response(response[3], input_name=f"delete-nonexistent.{ok_zone_name}", record_type="MX",
+                                                   record_data=None, change_type="DeleteRecordSet")
+        assert_successful_change_in_error_response(response[4], input_name=f"update-nonexistent.{ok_zone_name}", record_type="MX",
+                                                   record_data=None, change_type="DeleteRecordSet")
 
         # input validations failures: invalid input name, reverse zone error, invalid ttl
-        assert_failed_change_in_error_response(response[3], input_name=f"invalid-name$.{ok_zone_name}", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
+        assert_failed_change_in_error_response(response[5], input_name=f"invalid-name$.{ok_zone_name}", record_type="MX", record_data={"preference": 1, "exchange": "foo.bar."},
                                                change_type="DeleteRecordSet",
                                                error_messages=[f'Invalid domain name: "invalid-name$.{ok_zone_name}", valid domain names must be letters, '
                                                                f'numbers, underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[4], input_name=f"delete.{ok_zone_name}", ttl=29, record_type="MX",
+        assert_failed_change_in_error_response(response[6], input_name=f"delete.{ok_zone_name}", ttl=29, record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=['Invalid TTL: "29", must be a number between 30 and 2147483647.'])
-        assert_failed_change_in_error_response(response[5], input_name=f"bad-exchange.{ok_zone_name}", record_type="MX",
+        assert_failed_change_in_error_response(response[7], input_name=f"bad-exchange.{ok_zone_name}", record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo$.bar."},
                                                error_messages=['Invalid domain name: "foo$.bar.", valid domain names must be letters, numbers, '
                                                                'underscores, and hyphens, joined by dots, and terminated with a dot.'])
-        assert_failed_change_in_error_response(response[6], input_name=f"mx.{ip4_zone_name}", record_type="MX",
+        assert_failed_change_in_error_response(response[8], input_name=f"mx.{ip4_zone_name}", record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
                                                error_messages=[f'Invalid Record Type In Reverse Zone: record with name "mx.{ip4_zone_name}" '
                                                                f'and type "MX" is not allowed in a reverse zone.'])
 
         # zone discovery failure
-        assert_failed_change_in_error_response(response[7], input_name="no.zone.at.all.", record_type="MX",
+        assert_failed_change_in_error_response(response[9], input_name="no.zone.at.all.", record_type="MX",
                                                record_data=None, change_type="DeleteRecordSet",
                                                error_messages=["Zone Discovery Failed: zone for \"no.zone.at.all.\" does not exist in VinylDNS. "
                                                                "If zone exists, then it must be connected to in VinylDNS."])
 
         # context validation failures: record does not exist, not authorized
-        assert_failed_change_in_error_response(response[8], input_name=f"delete-nonexistent.{ok_zone_name}", record_type="MX",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"delete-nonexistent.{ok_zone_name}\" Does Not Exist: cannot delete a record that does not exist."])
-        assert_failed_change_in_error_response(response[9], input_name=f"update-nonexistent.{ok_zone_name}", record_type="MX",
-                                               record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"Record \"update-nonexistent.{ok_zone_name}\" Does Not Exist: cannot delete a record that does not exist."])
         assert_successful_change_in_error_response(response[10], input_name=f"update-nonexistent.{ok_zone_name}", record_type="MX",
                                                    record_data={"preference": 1000, "exchange": "foo.bar."})
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn, record_type="MX",
@@ -3739,39 +3722,27 @@ def test_create_batch_with_zone_name_requiring_manual_review(shared_zone_test_co
             rejecter.reject_batch_change(response["id"], status=200)
 
 
-def test_create_batch_delete_record_for_invalid_record_data_fails(shared_zone_test_context):
+def test_create_batch_delete_record_that_does_not_exists_completes(shared_zone_test_context):
     """
     Test delete record set fails for non-existent record and non-existent record data
     """
     client = shared_zone_test_context.ok_vinyldns_client
     ok_zone_name = shared_zone_test_context.ok_zone["name"]
 
-    a_delete_name = generate_record_name()
-    a_delete_fqdn = a_delete_name + f".{ok_zone_name}"
-    a_delete = create_recordset(shared_zone_test_context.ok_zone, a_delete_fqdn, "A", [{"address": "1.1.1.1"}])
-
     batch_change_input = {
         "comments": "test delete record failures",
         "changes": [
-            get_change_A_AAAA_json(f"delete-non-existent-record.{ok_zone_name}", change_type="DeleteRecordSet"),
-            get_change_A_AAAA_json(a_delete_fqdn, address="4.5.6.7", change_type="DeleteRecordSet")
+            get_change_A_AAAA_json(f"delete-non-existent-record.{ok_zone_name}", change_type="DeleteRecordSet")
         ]
     }
 
-    to_delete = []
+    response = client.create_batch_change(batch_change_input, status=202)
+    get_batch = client.get_batch_change(response["id"])
 
-    try:
-        create_rs = client.create_recordset(a_delete, status=202)
-        to_delete.append(client.wait_until_recordset_change_status(create_rs, "Complete"))
+    assert_that(get_batch["changes"][0]["systemMessage"], is_("ℹ️ This record does not exist." +
+                                                              "No further action is required."))
 
-        errors = client.create_batch_change(batch_change_input, status=400)
-
-        assert_failed_change_in_error_response(errors[0], input_name=f"delete-non-existent-record.{ok_zone_name}", record_data="1.1.1.1", change_type="DeleteRecordSet",
-                                               error_messages=[f'Record "delete-non-existent-record.{ok_zone_name}" Does Not Exist: cannot delete a record that does not exist.'])
-        assert_failed_change_in_error_response(errors[1], input_name=a_delete_fqdn, record_data="4.5.6.7", change_type="DeleteRecordSet",
-                                               error_messages=["Record data 4.5.6.7 does not exist for \"" + a_delete_fqdn + "\"."])
-    finally:
-        clear_recordset_list(to_delete, client)
+    assert_successful_change_in_error_response(response["changes"][0], input_name=f"delete-non-existent-record.{ok_zone_name}", record_data="1.1.1.1", change_type="DeleteRecordSet")
 
 
 @pytest.mark.serial

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -568,13 +568,11 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers with CatsHelper
 
       val returnedBatch = result.batchChange
 
-      // validate failed status update returned
+      // validate completed status returned
       val receivedChange = returnedBatch.changes(0)
       receivedChange.status shouldBe SingleChangeStatus.Complete
       receivedChange.recordChangeId shouldBe None
       receivedChange.systemMessage shouldBe Some(completedMessage)
-
-      // validate other changes have no update
       returnedBatch.changes(0) shouldBe singleChangesOneDelete(0).copy(systemMessage = Some(completedMessage), status = SingleChangeStatus.Complete)
 
       // check the update has been made in the DB

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -37,7 +37,7 @@ import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
 
 class BatchChangeConverterSpec extends AnyWordSpec with Matchers with CatsHelpers {
-  private val notExistCompletedMessage: String = "ℹ️ This record does not exist." +
+  private val notExistCompletedMessage: String = "This record does not exist." +
     "No further action is required."
 
   private def makeSingleAddChange(
@@ -545,7 +545,7 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers with CatsHelper
       savedBatch shouldBe Some(returnedBatch)
     }
 
-    "set status to complete when deleting a record that does not exists" in {
+    "set status to complete when deleting a record that does not exist" in {
       val batchWithBadChange =
         BatchChange(
           okUser.id,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -37,7 +37,7 @@ import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
 
 class BatchChangeConverterSpec extends AnyWordSpec with Matchers with CatsHelpers {
-  private val completedMessage: String = "ℹ️ This record does not exist." +
+  private val notExistCompletedMessage: String = "ℹ️ This record does not exist." +
     "No further action is required."
 
   private def makeSingleAddChange(
@@ -572,8 +572,8 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers with CatsHelper
       val receivedChange = returnedBatch.changes(0)
       receivedChange.status shouldBe SingleChangeStatus.Complete
       receivedChange.recordChangeId shouldBe None
-      receivedChange.systemMessage shouldBe Some(completedMessage)
-      returnedBatch.changes(0) shouldBe singleChangesOneDelete(0).copy(systemMessage = Some(completedMessage), status = SingleChangeStatus.Complete)
+      receivedChange.systemMessage shouldBe Some(notExistCompletedMessage)
+      returnedBatch.changes(0) shouldBe singleChangesOneDelete(0).copy(systemMessage = Some(notExistCompletedMessage), status = SingleChangeStatus.Complete)
 
       // check the update has been made in the DB
       val savedBatch: Option[BatchChange] =

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1004,7 +1004,7 @@ class BatchChangeValidationsSpec
     )
   }
 
-  property("validateChangesWithContext: should fail for update if record does not exist") {
+  property("validateChangesWithContext: should complete for update if record does not exist") {
     val deleteRRSet = makeDeleteUpdateDeleteRRSet("deleteRRSet")
     val deleteRecord = makeDeleteUpdateDeleteRRSet("deleteRecord", Some(AData("1.1.1.1")))
     val deleteNonExistentEntry = makeDeleteUpdateDeleteRRSet("ok", Some(AData("1.1.1.1")))
@@ -1026,15 +1026,8 @@ class BatchChangeValidationsSpec
     )
 
     result(0) shouldBe valid
-    result(1) should haveInvalid[DomainValidationError](
-      RecordDoesNotExist(deleteRRSet.inputChange.inputName)
-    )
-    result(3) should haveInvalid[DomainValidationError](
-      RecordDoesNotExist(deleteRecord.inputChange.inputName)
-    )
-    result(3) should haveInvalid[DomainValidationError](
-      RecordDoesNotExist(deleteRecord.inputChange.inputName)
-    )
+    result(1) shouldBe valid
+    result(3) shouldBe valid
     result(4) shouldBe valid
     deleteNonExistentEntry.inputChange.record.foreach { record =>
       result(5) should haveInvalid[DomainValidationError](
@@ -1589,7 +1582,7 @@ class BatchChangeValidationsSpec
   }
 
   property(
-    """validateChangesWithContext: should fail DeleteChangeForValidation with RecordDoesNotExist
+    """validateChangesWithContext: should complete DeleteChangeForValidation
       |if record does not exist""".stripMargin
   ) {
     val deleteRRSet = makeDeleteUpdateDeleteRRSet("record-does-not-exist")
@@ -1606,12 +1599,8 @@ class BatchChangeValidationsSpec
         None
       )
 
-    result(0) should haveInvalid[DomainValidationError](
-      RecordDoesNotExist(deleteRRSet.inputChange.inputName)
-    )
-    result(1) should haveInvalid[DomainValidationError](
-      RecordDoesNotExist(deleteRecord.inputChange.inputName)
-    )
+    result(0) shouldBe valid
+    result(1) shouldBe valid
   }
 
   property("""validateChangesWithContext: should succeed for DeleteChangeForValidation

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
@@ -47,6 +47,13 @@ sealed trait SingleChange {
       delete.copy(status = SingleChangeStatus.Failed, systemMessage = Some(error))
   }
 
+  def withDoesNotExistMessage(error: String): SingleChange = this match {
+    case add: SingleAddChange =>
+      add.copy(status = SingleChangeStatus.Failed, systemMessage = Some("Error queueing RecordSetChange for processing"))
+    case delete: SingleDeleteRRSetChange =>
+      delete.copy(status = SingleChangeStatus.Complete, systemMessage = Some(error))
+  }
+
   def withProcessingError(message: Option[String], failedRecordChangeId: String): SingleChange =
     this match {
       case add: SingleAddChange =>

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
@@ -49,7 +49,7 @@ sealed trait SingleChange {
 
   def withDoesNotExistMessage(error: String): SingleChange = this match {
     case add: SingleAddChange =>
-      add.copy(status = SingleChangeStatus.Failed, systemMessage = Some("Error queueing RecordSetChange for processing"))
+      add.copy(status = SingleChangeStatus.Failed, systemMessage = Some(error))
     case delete: SingleDeleteRRSetChange =>
       delete.copy(status = SingleChangeStatus.Complete, systemMessage = Some(error))
   }


### PR DESCRIPTION
Fixes #1138 

Changes in this pull request:
- If a user requests the deletion of records that does not exist, we now allow the change with a message `This record does not exist. No further action is required.` next to the affected records without throwing an error.
