### PR TITLE
Add an Option to Filter Out PTR Zones in the Zones View

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -266,7 +266,8 @@ case class ListZonesResponse(
                               startFrom: Option[String] = None,
                               nextId: Option[String] = None,
                               maxItems: Int = 100,
-                              ignoreAccess: Boolean = false
+                              ignoreAccess: Boolean = false,
+                              includeReverse: Boolean = true
                             )
 
 // Errors

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -147,7 +147,8 @@ class ZoneService(
       nameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      ignoreAccess: Boolean = false
+      ignoreAccess: Boolean = false,
+      includeReverse: Boolean = true
   ): Result[ListZonesResponse] = {
     for {
       listZonesResult <- zoneRepository.listZones(
@@ -155,7 +156,8 @@ class ZoneService(
         nameFilter,
         startFrom,
         maxItems,
-        ignoreAccess
+        ignoreAccess,
+        includeReverse
       )
       zones = listZonesResult.zones
       groupIds = zones.map(_.adminGroupId).toSet
@@ -167,7 +169,8 @@ class ZoneService(
       listZonesResult.startFrom,
       listZonesResult.nextId,
       listZonesResult.maxItems,
-      listZonesResult.ignoreAccess
+      listZonesResult.ignoreAccess,
+      listZonesResult.includeReverse
     )
   }.toResult
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -42,7 +42,8 @@ trait ZoneServiceAlgebra {
       nameFilter: Option[String],
       startFrom: Option[String],
       maxItems: Int,
-      ignoreAccess: Boolean
+      ignoreAccess: Boolean,
+      includeReverse: Boolean
   ): Result[ListZonesResponse]
 
   def listZoneChanges(

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -78,13 +78,15 @@ class ZoneRoute(
           "nameFilter".?,
           "startFrom".as[String].?,
           "maxItems".as[Int].?(DEFAULT_MAX_ITEMS),
-          "ignoreAccess".as[Boolean].?(false)
+          "ignoreAccess".as[Boolean].?(false),
+          "includeReverse".as[Boolean].?(true)
         ) {
           (
               nameFilter: Option[String],
               startFrom: Option[String],
               maxItems: Int,
-              ignoreAccess: Boolean
+              ignoreAccess: Boolean,
+              includeReverse: Boolean
           ) =>
             {
               handleRejections(invalidQueryHandler) {
@@ -94,7 +96,7 @@ class ZoneRoute(
                 ) {
                   authenticateAndExecute(
                     zoneService
-                      .listZones(_, nameFilter, startFrom, maxItems, ignoreAccess)
+                      .listZones(_, nameFilter, startFrom, maxItems, ignoreAccess, includeReverse)
                   ) { result =>
                     complete(StatusCodes.OK, result)
                   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -515,7 +515,7 @@ class ZoneServiceSpec
     "not fail with no zones returned" in {
       doReturn(IO.pure(ListZonesResults(List())))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false)
+        .listZones(abcAuth, None, None, 100, false, true)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
@@ -530,7 +530,7 @@ class ZoneServiceSpec
     "return the appropriate zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false)
+        .listZones(abcAuth, None, None, 100, false, true)
       doReturn(IO.pure(Set(abcGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -547,7 +547,7 @@ class ZoneServiceSpec
     "return all zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone), ignoreAccess = true)))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, true)
+        .listZones(abcAuth, None, None, 100, true, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -565,7 +565,7 @@ class ZoneServiceSpec
     "return Unknown group name if zone admin group cannot be found" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false)
+        .listZones(abcAuth, None, None, 100, false, true)
       doReturn(IO.pure(Set(okGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
@@ -589,7 +589,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 2, false)
+        .listZones(abcAuth, None, None, 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -615,7 +615,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, Some("foo"), None, 2, false)
+        .listZones(abcAuth, Some("foo"), None, 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -639,7 +639,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, Some("zone4."), 2, false)
+        .listZones(abcAuth, None, Some("zone4."), 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -662,7 +662,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, Some("zone4."), 2, false)
+        .listZones(abcAuth, None, Some("zone4."), 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -89,7 +89,8 @@ trait EmptyZoneRepo extends ZoneRepository {
                  zoneNameFilter: Option[String] = None,
                  startFrom: Option[String] = None,
                  maxItems: Int = 100,
-                 ignoreAccess: Boolean = false
+                 ignoreAccess: Boolean = false,
+                 includeReverse: Boolean = true
                ): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]] = IO.pure(List())

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -252,7 +252,8 @@ class ZoneRoutingSpec
         nameFilter: Option[String],
         startFrom: Option[String],
         maxItems: Int,
-        ignoreAccess: Boolean = false
+        ignoreAccess: Boolean = false,
+        includeReverse: Boolean = true
     ): Result[ListZonesResponse] = {
 
       val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess) match {

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
@@ -22,5 +22,6 @@ case class ListZonesResults(
     startFrom: Option[String] = None,
     maxItems: Int = 100,
     ignoreAccess: Boolean = false,
-    zonesFilter: Option[String] = None
+    zonesFilter: Option[String] = None,
+    includeReverse: Boolean = true
 )

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -40,7 +40,8 @@ trait ZoneRepository extends Repository {
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      ignoreAccess: Boolean = false
+      ignoreAccess: Boolean = false,
+      includeReverse: Boolean = true
   ): IO[ListZonesResults]
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -201,6 +201,9 @@ class MySqlZoneRepositoryIntegrationSpec
       repo
         .getZonesByFilters(Set("67.345.12.in-addr.arpa.", "extraZone"))
         .unsafeRunSync() should contain theSameElementsAs expectedZones
+
+      println(repo
+        .getZonesByFilters(Set("67.345.12.in-addr.arpa.", "extraZone")).unsafeRunSync())
     }
 
     "get authorized zones" in {
@@ -450,19 +453,19 @@ class MySqlZoneRepositoryIntegrationSpec
     "apply the zone filter as a normal user" in {
 
       val testZones = Seq(
-        testZone("system-test.", adminGroupId = "foo"),
+        testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
         testZone("system-temp.", adminGroupId = "foo"),
         testZone("system-nomatch.", adminGroupId = "bar")
       )
 
-      val expectedZones = Seq(testZones(0), testZones(1)).sortBy(_.name)
+      val expectedZones = Seq(testZones(1)).sortBy(_.name)
 
       val auth = AuthPrincipal(dummyUser, Seq("foo"))
 
       val f =
         for {
           _ <- saveZones(testZones)
-          retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"))
+          retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"), includeReverse = false)
         } yield retrieved
 
       (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -201,9 +201,6 @@ class MySqlZoneRepositoryIntegrationSpec
       repo
         .getZonesByFilters(Set("67.345.12.in-addr.arpa.", "extraZone"))
         .unsafeRunSync() should contain theSameElementsAs expectedZones
-
-      println(repo
-        .getZonesByFilters(Set("67.345.12.in-addr.arpa.", "extraZone")).unsafeRunSync())
     }
 
     "get authorized zones" in {
@@ -450,11 +447,76 @@ class MySqlZoneRepositoryIntegrationSpec
       f.unsafeRunSync().zones should contain theSameElementsAs expectedZones
     }
 
+    "apply the reverse zone filter as a super user" in {
+
+      val testZones = Seq(
+        testZone("system-test."),
+        testZone("system-test.ip6.arpa."),
+        testZone("system-temp.in-addr.arpa."),
+        testZone("nomatch.in-addr.arpa.")
+      )
+
+      val expectedZones = Seq(testZones(0))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(superUserAuth, includeReverse = false)
+        } yield retrieved
+
+      f.unsafeRunSync().zones should contain theSameElementsAs expectedZones
+    }
+
+    "apply the zone filter and reverse zone filter as a super user" in {
+
+      val testZones = Seq(
+        testZone("system-test."),
+        testZone("system-temp.ip6.arpa."),
+        testZone("system-test.ip6.arpa."),
+        testZone("system-temp.in-addr.arpa."),
+        testZone("no-match.")
+      )
+
+      val expectedZones = Seq(testZones(0)).sortBy(_.name)
+
+      val auth = AuthPrincipal(dummyUser, Seq("foo"))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"), includeReverse = false)
+        } yield retrieved
+
+      (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)
+    }
+
     "apply the zone filter as a normal user" in {
 
       val testZones = Seq(
         testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
         testZone("system-temp.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar")
+      )
+
+      val expectedZones = Seq(testZones(0), testZones(1)).sortBy(_.name)
+
+      val auth = AuthPrincipal(dummyUser, Seq("foo"))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"))
+        } yield retrieved
+
+      (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)
+    }
+
+    "apply the zone filter and reverse zone filter as a normal user" in {
+
+      val testZones = Seq(
+        testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
+        testZone("system-temp.", adminGroupId = "foo"),
+        testZone("system-temp.in-addr.arpa.", adminGroupId = "foo"),
         testZone("system-nomatch.", adminGroupId = "bar")
       )
 
@@ -466,6 +528,30 @@ class MySqlZoneRepositoryIntegrationSpec
         for {
           _ <- saveZones(testZones)
           retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"), includeReverse = false)
+        } yield retrieved
+
+      (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)
+    }
+
+    "apply the reverse zone filter as a normal user" in {
+
+      val testZones = Seq(
+        testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
+        testZone("system-test.in-addr.arpa.", adminGroupId = "foo"),
+        testZone("system-temp.in-addr.arpa.", adminGroupId = "foo"),
+        testZone("system-match.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar"),
+        testZone("system-nomatch.in-addr.arpa.", adminGroupId = "bar")
+      )
+
+      val expectedZones = Seq(testZones(3)).sortBy(_.name)
+
+      val auth = AuthPrincipal(dummyUser, Seq("foo"))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(auth, includeReverse = false)
         } yield retrieved
 
       (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -284,19 +284,12 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           sb.append(s" LIMIT ${maxItems + 1}")
 
           val query = sb.toString
-          println(query)
 
           val results: List[Zone] = SQL(query)
             .bind(accessors: _*)
             .map(extractZone(1))
             .list()
             .apply()
-
-          for(element<-results)
-          {
-            println(element)
-          }
-
 
           val (newResults, nextId) =
             if (results.size > maxItems)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -270,8 +270,14 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           }
 
           if (!includeReverse) {
-            sb.append(" AND ")
-            sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
+            if (filters.nonEmpty) {
+              sb.append(" AND ")
+              sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
+            }
+            else {
+              sb.append(" WHERE ")
+              sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
+            }
           }
 
           sb.append(s" GROUP BY z.name ")

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -1,15 +1,4 @@
 @(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
-<!--<div class="input-group">-->
-<!--    <div class="ptr-zone-filter">-->
-<!--        <form action="">-->
-<!--            <div class="checkbox pull-right">-->
-<!--                <label>-->
-<!--                    <input type="checkbox"> Hide PTR Zones-->
-<!--                </label>-->
-<!--            </div>-->
-<!--        </form>-->
-<!--    </div>-->
-<!--</div>-->
 @content = {
 <!-- PAGE CONTENT -->
 <div class="right_col" role="main">

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -1,5 +1,15 @@
 @(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
-
+<!--<div class="input-group">-->
+<!--    <div class="ptr-zone-filter">-->
+<!--        <form action="">-->
+<!--            <div class="checkbox pull-right">-->
+<!--                <label>-->
+<!--                    <input type="checkbox"> Hide PTR Zones-->
+<!--                </label>-->
+<!--            </div>-->
+<!--        </form>-->
+<!--    </div>-->
+<!--</div>-->
 @content = {
 <!-- PAGE CONTENT -->
 <div class="right_col" role="main">
@@ -50,6 +60,19 @@
                                         </button>
                                     </div>
 
+                                    <div class="pull-right">
+                                        <div class="input-group" style="padding-left: 10px;">
+                                            <div class="ptr-zone-filter">
+                                                <form action="">
+                                                    <div class="checkbox pull-right">
+                                                        <label>
+                                                            <input type="checkbox" ng-model="isReverse" ng-true-value="false" ng-change="refreshZones()"> Hide PTR Zones
+                                                        </label>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
                                     <!-- SEARCH BOX -->
                                     <div class="pull-right">
                                         <form class="input-group" ng-submit="refreshZones()">

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -66,7 +66,7 @@
                                                 <form action="">
                                                     <div class="checkbox pull-right">
                                                         <label>
-                                                            <input type="checkbox" ng-model="isReverse" ng-true-value="false" ng-change="refreshZones()"> Hide PTR Zones
+                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-change="refreshZones()"> Hide PTR Zones
                                                         </label>
                                                     </div>
                                                 </form>

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -66,7 +66,7 @@
                                                 <form action="">
                                                     <div class="checkbox pull-right">
                                                         <label>
-                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-change="refreshZones()"> Hide PTR Zones
+                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones
                                                         </label>
                                                     </div>
                                                 </form>

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -208,7 +208,7 @@ angular.module('controller.zones', [])
     $scope.prevPageMyZones = function() {
         var startFrom = pagingService.getPrevStartFrom(zonesPaging);
         return zonesService
-            .getZones(zonesPaging.maxItems, startFrom, $scope.query, false)
+            .getZones(zonesPaging.maxItems, startFrom, $scope.query, false, true)
             .then(function(response) {
                 zonesPaging = pagingService.prevPageUpdate(response.data.nextId, zonesPaging);
                 updateZoneDisplay(response.data.zones);
@@ -221,7 +221,7 @@ angular.module('controller.zones', [])
     $scope.prevPageAllZones = function() {
         var startFrom = pagingService.getPrevStartFrom(allZonesPaging);
         return zonesService
-            .getZones(allZonesPaging.maxItems, startFrom, $scope.query, true)
+            .getZones(allZonesPaging.maxItems, startFrom, $scope.query, true, true)
             .then(function(response) {
                 allZonesPaging = pagingService.prevPageUpdate(response.data.nextId, allZonesPaging);
                 updateAllZonesDisplay(response.data.zones);
@@ -233,7 +233,7 @@ angular.module('controller.zones', [])
 
     $scope.nextPageMyZones = function () {
         return zonesService
-            .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query, false)
+            .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query, false, true)
             .then(function(response) {
                 var zoneSets = response.data.zones;
                 zonesPaging = pagingService.nextPageUpdate(zoneSets, response.data.nextId, zonesPaging);
@@ -249,7 +249,7 @@ angular.module('controller.zones', [])
 
     $scope.nextPageAllZones = function () {
         return zonesService
-            .getZones(allZonesPaging.maxItems, allZonesPaging.next, $scope.query, true)
+            .getZones(allZonesPaging.maxItems, allZonesPaging.next, $scope.query, true, true)
             .then(function(response) {
                 var zoneSets = response.data.zones;
                 allZonesPaging = pagingService.nextPageUpdate(zoneSets, response.data.nextId, allZonesPaging);

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -25,6 +25,7 @@ angular.module('controller.zones', [])
     $scope.allGroups = [];
 
     $scope.query = "";
+    $scope.includeReverse = true;
 
     $scope.keyAlgorithms = ['HMAC-MD5', 'HMAC-SHA1', 'HMAC-SHA224', 'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512'];
 
@@ -87,7 +88,7 @@ angular.module('controller.zones', [])
         allZonesPaging = pagingService.resetPaging(allZonesPaging);
 
         zonesService
-            .getZones(zonesPaging.maxItems, undefined, $scope.query)
+            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.includeReverse)
             .then(function (response) {
                 $log.log('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 zonesPaging.next = response.data.nextId;

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -88,7 +88,7 @@ angular.module('controller.zones', [])
         allZonesPaging = pagingService.resetPaging(allZonesPaging);
 
         zonesService
-            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.includeReverse)
+            .getZones(zonesPaging.maxItems, undefined, $scope.query, true, $scope.includeReverse)
             .then(function (response) {
                 $log.log('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 zonesPaging.next = response.data.nextId;

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -77,12 +77,13 @@ describe('Controller: ZonesController', function () {
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
         var expectedignoreAccess = false;
+        var expectedincludeReverse = true;
 
         this.scope.nextPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess, expectedincludeReverse]);
     });
 
     it('prevPageMyZones should call getZones with the correct parameters', function () {
@@ -94,18 +95,19 @@ describe('Controller: ZonesController', function () {
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
         var expectedignoreAccess = false;
+        var expectedincludeReverse = true;
 
         this.scope.prevPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess, expectedincludeReverse]);
 
         this.scope.nextPageMyZones();
         this.scope.prevPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(3);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess, expectedincludeReverse]);
     });
 });

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -19,7 +19,7 @@
 angular.module('service.zones', [])
     .service('zonesService', function ($http, groupsService, $log, utilityService) {
 
-        this.getZones = function (limit, startFrom, query, ignoreAccess) {
+        this.getZones = function (limit, startFrom, query, ignoreAccess, includeReverse) {
             if (query == "") {
                 query = null;
             }
@@ -27,7 +27,8 @@ angular.module('service.zones', [])
                 "maxItems": limit,
                 "startFrom": startFrom,
                 "nameFilter": query,
-                "ignoreAccess": ignoreAccess
+                "ignoreAccess": ignoreAccess,
+                "includeReverse": includeReverse
             };
             var url = groupsService.urlBuilder("/api/zones", params);
             return $http.get(url);

--- a/modules/portal/public/lib/services/zones/service.zones.spec.js
+++ b/modules/portal/public/lib/services/zones/service.zones.spec.js
@@ -27,8 +27,8 @@ describe('Service: zoneService', function () {
     }));
 
     it('http backend gets called properly when getting zones', function () {
-        this.$httpBackend.expectGET('/api/zones?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=false').respond('zone returned');
-        this.zonesService.getZones('100', 'start', 'someQuery', false)
+        this.$httpBackend.expectGET('/api/zones?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=false&includeReverse=true').respond('zone returned');
+        this.zonesService.getZones('100', 'start', 'someQuery', false, true)
             .then(function(response) {
                 expect(response.data).toBe('zone returned');
             });


### PR DESCRIPTION
Fixes #1122

A checkbox option to filter out PTR zones has been added in the zones view. This filter will still apply when searching for zone names
