### PR TITLE
Add group change history

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -60,7 +60,8 @@ final case class GroupChangeInfo(
     oldGroup: Option[GroupInfo] = None,
     id: String = UUID.randomUUID().toString,
     created: DateTime = DateTime.now,
-    userName: String
+    userName: String,
+    groupChangeMessage: String
 )
 
 object GroupChangeInfo {
@@ -71,7 +72,8 @@ object GroupChangeInfo {
     oldGroup = groupChange.oldGroup.map(GroupInfo.apply),
     id = groupChange.id,
     created = groupChange.created,
-    userName = groupChange.userName.getOrElse("unknown user")
+    userName = groupChange.userName.getOrElse("unknown user"),
+    groupChangeMessage = groupChange.groupChangeMessage.getOrElse("")
   )
 }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -59,7 +59,8 @@ final case class GroupChangeInfo(
     userId: String,
     oldGroup: Option[GroupInfo] = None,
     id: String = UUID.randomUUID().toString,
-    created: String = DateTime.now.getMillis.toString
+    created: DateTime = DateTime.now,
+    userName: String
 )
 
 object GroupChangeInfo {
@@ -69,7 +70,8 @@ object GroupChangeInfo {
     userId = groupChange.userId,
     oldGroup = groupChange.oldGroup.map(GroupInfo.apply),
     id = groupChange.id,
-    created = groupChange.created.getMillis.toString
+    created = groupChange.created,
+    userName = groupChange.userName.getOrElse("unknown user")
   )
 }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -257,29 +257,29 @@ class MembershipService(
       val sb = new StringBuilder
       if (change.oldGroup.isDefined) {
         if (change.oldGroup.get.name != change.newGroup.name) {
-          sb.append(s"Group name changed to '${change.newGroup.name}'.")
+          sb.append(s"Group name changed to '${change.newGroup.name}'. ")
         }
         if (change.oldGroup.get.email != change.newGroup.email) {
-          sb.append(s"Group email changed to '${change.newGroup.email}'.")
+          sb.append(s"Group email changed to '${change.newGroup.email}'. ")
         }
         if (change.oldGroup.get.description != change.newGroup.description) {
-          sb.append(s"Group description changed to '${change.newGroup.description.get}'.")
+          sb.append(s"Group description changed to '${change.newGroup.description.get}'. ")
         }
         val adminAddDifference = change.newGroup.adminUserIds.diff(change.oldGroup.get.adminUserIds)
         if (adminAddDifference.nonEmpty) {
-          sb.append(s"Group admin/s with userId/s (${adminAddDifference.mkString(",")}) added.")
+          sb.append(s"Group admin/s with userId/s (${adminAddDifference.mkString(",")}) added. ")
         }
         val adminRemoveDifference = change.oldGroup.get.adminUserIds.diff(change.newGroup.adminUserIds)
         if (adminRemoveDifference.nonEmpty) {
-          sb.append(s"Group admin/s with userId/s (${adminRemoveDifference.mkString(",")}) removed.")
+          sb.append(s"Group admin/s with userId/s (${adminRemoveDifference.mkString(",")}) removed. ")
         }
         val memberAddDifference = change.newGroup.memberIds.diff(change.oldGroup.get.memberIds)
         if (memberAddDifference.nonEmpty) {
-          sb.append(s"Group member/s with userId/s (${memberAddDifference.mkString(",")}) added.")
+          sb.append(s"Group member/s with userId/s (${memberAddDifference.mkString(",")}) added. ")
         }
         val memberRemoveDifference = change.oldGroup.get.memberIds.diff(change.newGroup.memberIds)
         if (memberRemoveDifference.nonEmpty) {
-          sb.append(s"Group member/s with userId/s (${memberRemoveDifference.mkString(",")}) removed.")
+          sb.append(s"Group member/s with userId/s (${memberRemoveDifference.mkString(",")}) removed. ")
         }
         groupChangeMessage = groupChangeMessage :+ sb.toString()
       }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -239,7 +239,7 @@ class MembershipService(
         .getGroupChanges(groupId, startFrom, maxItems)
         .toResult[ListGroupChangesResults]
       userIds = result.changes.map(_.userId).toSet
-      users <- userRepo.getUsers(userIds, None, None).map(_.users).toResult[Seq[User]]
+      users <- getUsers(userIds).map(_.users)
       userMap = users.map(u => (u.id, u.userName)).toMap
     } yield ListGroupChangesResponse(
       result.changes.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))),

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -281,7 +281,7 @@ class MembershipService(
         if (memberRemoveDifference.nonEmpty) {
           sb.append(s"Group member/s with userId/s (${memberRemoveDifference.mkString(",")}) removed. ")
         }
-        groupChangeMessage = groupChangeMessage :+ sb.toString()
+        groupChangeMessage = groupChangeMessage :+ sb.toString().trim
       }
       // It'll be a newly created group, so we will have no group change message
       else {

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -281,12 +281,10 @@ class MembershipService(
         if (memberRemoveDifference.nonEmpty) {
           sb.append(s"Group member/s with userId/s (${memberRemoveDifference.mkString(",")}) removed.")
         }
-        println("Query: ", sb)
         groupChangeMessage = groupChangeMessage :+ sb.toString()
       }
       // It'll be a newly created group, so we will have no group change message
       else {
-        println("Query: ", sb)
         groupChangeMessage = groupChangeMessage :+ sb.toString()
       }
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -238,8 +238,11 @@ class MembershipService(
       result <- groupChangeRepo
         .getGroupChanges(groupId, startFrom, maxItems)
         .toResult[ListGroupChangesResults]
+      userIds = result.changes.map(_.userId).toSet
+      users <- userRepo.getUsers(userIds, None, None).map(_.users).toResult[Seq[User]]
+      userMap = users.map(u => (u.id, u.userName)).toMap
     } yield ListGroupChangesResponse(
-      result.changes.map(GroupChangeInfo.apply),
+      result.changes.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))),
       startFrom,
       result.lastEvaluatedTimeStamp,
       maxItems

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
@@ -39,6 +39,8 @@ trait MembershipServiceAlgebra {
 
   def getGroup(id: String, authPrincipal: AuthPrincipal): Result[Group]
 
+  def getGroupChange(id: String, authPrincipal: AuthPrincipal): Result[GroupChangeInfo]
+
   def listMyGroups(
       groupNameFilter: Option[String],
       startFrom: Option[String],

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -19,7 +19,7 @@ package vinyldns.api.domain.membership
 import vinyldns.api.Interfaces.ensuring
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.api.domain.zone.NotAuthorizedError
-import vinyldns.core.domain.membership.Group
+import vinyldns.core.domain.membership.{Group, GroupChange}
 
 object MembershipValidations {
 
@@ -44,4 +44,9 @@ object MembershipValidations {
     ensuring(NotAuthorizedError("Not authorized")) {
       authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin || canViewGroupDetails
     }
+
+  def isGroupChangePresent(groupChange: Option[GroupChange]): Either[Throwable, Unit] =
+    ensuring(InvalidGroupRequestError("Invalid Group Change ID")) {
+      groupChange.isDefined
+  }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -21,7 +21,6 @@ import cats.data._
 import cats.implicits._
 import org.joda.time.DateTime
 import org.json4s._
-import org.json4s.JsonDSL._
 import vinyldns.api.domain.membership._
 import vinyldns.core.domain.membership.{Group, GroupChangeType, GroupStatus, LockStatus}
 
@@ -114,7 +113,7 @@ trait MembershipJsonProtocol extends JsonValidation {
   }
 
   case object GroupChangeInfoSerializer extends ValidationSerializer[GroupChangeInfo] {
-    override def fromJson(js: JValue): ValidatedNel[String, GroupChangeInfo] = {
+    override def fromJson(js: JValue): ValidatedNel[String, GroupChangeInfo] =
       (
         (js \ "newGroup").required[GroupInfo]("Missing new group"),
         (js \ "changeType").required(GroupChangeType, "Missing change type"),
@@ -125,16 +124,5 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "userName").required[String]("Missing userName"),
         (js \ "groupChangeMessage").required[String]("Missing groupChangeMessage"),
         ).mapN(GroupChangeInfo.apply)
-    }
-
-    override def toJson(gci: GroupChangeInfo): JValue =
-      ("newGroup" -> Extraction.decompose(gci.newGroup)) ~
-      ("changeType" -> Extraction.decompose(gci.changeType)) ~
-      ("userId" -> gci.userId) ~
-      ("oldGroup" -> Extraction.decompose(gci.oldGroup)) ~
-      ("id" -> gci.id) ~
-      ("created" -> gci.created.toString) ~
-      ("userName" -> gci.userName) ~
-      ("groupChangeMessage" -> gci.groupChangeMessage)
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -120,7 +120,8 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "userId").required[String]("Missing userId"),
         (js \ "oldGroup").optional[GroupInfo],
         (js \ "id").default[String](UUID.randomUUID().toString),
-        (js \ "created").default[String](DateTime.now.getMillis.toString)
-      ).mapN(GroupChangeInfo.apply)
+        (js \ "created").default[DateTime](DateTime.now),
+        (js \ "userName").required[String]("Missing userName"),
+        ).mapN(GroupChangeInfo.apply)
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -122,6 +122,7 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "id").default[String](UUID.randomUUID().toString),
         (js \ "created").default[DateTime](DateTime.now),
         (js \ "userName").required[String]("Missing userName"),
+        (js \ "groupChangeMessage").required[String]("Missing groupChangeMessage"),
         ).mapN(GroupChangeInfo.apply)
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -21,6 +21,7 @@ import cats.data._
 import cats.implicits._
 import org.joda.time.DateTime
 import org.json4s._
+import org.json4s.JsonDSL._
 import vinyldns.api.domain.membership._
 import vinyldns.core.domain.membership.{Group, GroupChangeType, GroupStatus, LockStatus}
 
@@ -113,7 +114,7 @@ trait MembershipJsonProtocol extends JsonValidation {
   }
 
   case object GroupChangeInfoSerializer extends ValidationSerializer[GroupChangeInfo] {
-    override def fromJson(js: JValue): ValidatedNel[String, GroupChangeInfo] =
+    override def fromJson(js: JValue): ValidatedNel[String, GroupChangeInfo] = {
       (
         (js \ "newGroup").required[GroupInfo]("Missing new group"),
         (js \ "changeType").required(GroupChangeType, "Missing change type"),
@@ -124,5 +125,16 @@ trait MembershipJsonProtocol extends JsonValidation {
         (js \ "userName").required[String]("Missing userName"),
         (js \ "groupChangeMessage").required[String]("Missing groupChangeMessage"),
         ).mapN(GroupChangeInfo.apply)
+    }
+
+    override def toJson(gci: GroupChangeInfo): JValue =
+      ("newGroup" -> Extraction.decompose(gci.newGroup)) ~
+      ("changeType" -> Extraction.decompose(gci.changeType)) ~
+      ("userId" -> gci.userId) ~
+      ("oldGroup" -> Extraction.decompose(gci.oldGroup)) ~
+      ("id" -> gci.id) ~
+      ("created" -> gci.created.toString) ~
+      ("userName" -> gci.userName) ~
+      ("groupChangeMessage" -> gci.groupChangeMessage)
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
@@ -178,6 +178,13 @@ class MembershipRoute(
         }
       }
     } ~
+    path("groups" / "change" / Segment) { groupChangeId =>
+      (get & monitor("Endpoint.groupSingleChange")) {
+        authenticateAndExecute(membershipService.getGroupChange(groupChangeId, _)) { groupChange =>
+          complete(StatusCodes.OK, groupChange)
+        }
+      }
+    } ~
     path("users" / Segment / "lock") { id =>
       (put & monitor("Endpoint.lockUser")) {
         authenticateAndExecute(membershipService.updateUserLockStatus(id, LockStatus.Locked, _)) {

--- a/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
+++ b/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime
+
 from hamcrest import *
 
 
@@ -25,18 +25,13 @@ def test_list_group_activity_start_from_success(group_activity_context, shared_z
 
     # we grab 3 items, which when sorted by most recent will give the 3 most recent items
     page_one = client.get_group_changes(created_group["id"], max_items=3, status=200)
-    # our start from will align with the created on the 3rd change in the list
-    start_from_index = 2
-    # using epoch time to start from a timestamp
-    epoch = datetime.utcfromtimestamp(0)
-    # start from a known good timestamp
-    start_from = str(int((datetime.strptime(page_one["changes"][start_from_index]["created"], "%Y-%m-%dT%H:%M:%S.%fZ") - epoch).total_seconds() * 1000))
+
     # now, we say give me all changes since the start_from, which should yield 8-7-6-5-4
-    result = client.get_group_changes(created_group["id"], start_from=start_from, max_items=5, status=200)
+    result = client.get_group_changes(created_group["id"], start_from=page_one["nextId"], max_items=5, status=200)
 
     assert_that(result["changes"], has_length(5))
     assert_that(result["maxItems"], is_(5))
-    assert_that(result["startFrom"], is_(start_from))
+    assert_that(result["startFrom"], is_(page_one["nextId"]))
     assert_that(result["nextId"], is_not(none()))
 
     # we should have, in order, changes 8 7 6 5 4

--- a/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
+++ b/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
@@ -1,5 +1,5 @@
 import pytest
-
+from datetime import datetime
 from hamcrest import *
 
 
@@ -25,13 +25,18 @@ def test_list_group_activity_start_from_success(group_activity_context, shared_z
 
     # we grab 3 items, which when sorted by most recent will give the 3 most recent items
     page_one = client.get_group_changes(created_group["id"], max_items=3, status=200)
-
+    # our start from will align with the created on the 3rd change in the list
+    start_from_index = 2
+    # using epoch time to start from a timestamp
+    epoch = datetime.utcfromtimestamp(0)
+    # start from a known good timestamp
+    start_from = str(int((datetime.strptime(page_one["changes"][start_from_index]["created"], "%Y-%m-%dT%H:%M:%S.%fZ") - epoch).total_seconds() * 1000))
     # now, we say give me all changes since the start_from, which should yield 8-7-6-5-4
-    result = client.get_group_changes(created_group["id"], start_from=page_one["nextId"], max_items=5, status=200)
+    result = client.get_group_changes(created_group["id"], start_from=start_from, max_items=5, status=200)
 
     assert_that(result["changes"], has_length(5))
     assert_that(result["maxItems"], is_(5))
-    assert_that(result["startFrom"], is_(page_one["nextId"]))
+    assert_that(result["startFrom"], is_(start_from))
     assert_that(result["nextId"], is_not(none()))
 
     # we should have, in order, changes 8 7 6 5 4

--- a/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
+++ b/modules/api/src/test/functional/tests/membership/get_group_changes_test.py
@@ -26,16 +26,12 @@ def test_list_group_activity_start_from_success(group_activity_context, shared_z
     # we grab 3 items, which when sorted by most recent will give the 3 most recent items
     page_one = client.get_group_changes(created_group["id"], max_items=3, status=200)
 
-    # our start from will align with the created on the 3rd change in the list
-    start_from_index = 2
-    start_from = page_one["changes"][start_from_index]["created"]  # start from a known good timestamp
-
     # now, we say give me all changes since the start_from, which should yield 8-7-6-5-4
-    result = client.get_group_changes(created_group["id"], start_from=start_from, max_items=5, status=200)
+    result = client.get_group_changes(created_group["id"], start_from=page_one["nextId"], max_items=5, status=200)
 
     assert_that(result["changes"], has_length(5))
     assert_that(result["maxItems"], is_(5))
-    assert_that(result["startFrom"], is_(start_from))
+    assert_that(result["startFrom"], is_(page_one["nextId"]))
     assert_that(result["nextId"], is_not(none()))
 
     # we should have, in order, changes 8 7 6 5 4

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -773,7 +773,7 @@ class MembershipServiceSpec
         // Newly created group won't have group change message
         result(0) shouldBe ""
         // Updated group with group change message
-        result(1) shouldBe "Group name changed to 'dummy-group'. Group email changed to 'dummy@test.com'. Group description changed to 'dummy group'. Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group admin/s with userId/s (ok) removed. Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group member/s with userId/s (ok) removed. "
+        result(1) shouldBe "Group name changed to 'dummy-group'. Group email changed to 'dummy@test.com'. Group description changed to 'dummy group'. Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group admin/s with userId/s (ok) removed. Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group member/s with userId/s (ok) removed."
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -766,6 +766,17 @@ class MembershipServiceSpec
     }
   }
 
+    "determine group difference" should {
+      "return difference between two groups" in {
+        val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate)
+        val result: Seq[String] = rightResultOf(underTest.determineGroupDifference(groupChange).value)
+        // Newly created group won't have group change message
+        result(0) shouldBe ""
+        // Updated group with group change message
+        result(1) shouldBe "Group name changed to 'ok'.Group email changed to 'test@test.com'."
+      }
+    }
+
     "listAdmins" should {
       "return a list of admins" in {
         val testGroup =

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -714,6 +714,59 @@ class MembershipServiceSpec
       }
     }
 
+    "getGroupChange" should {
+      "return the single group change" in {
+        val groupChangeRepoResponse = listOfDummyGroupChanges.take(1).head
+        doReturn(IO.pure(Option(groupChangeRepoResponse)))
+          .when(mockGroupChangeRepo)
+          .getGroupChange(anyString)
+
+        doReturn(IO.pure(ListUsersResults(Seq(dummyUser), Some("1"))))
+          .when(mockUserRepo)
+          .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
+
+        val userMap = Seq(dummyUser).map(u => (u.id, u.userName)).toMap
+        val expected: GroupChangeInfo =
+          listOfDummyGroupChanges.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))).take(1).head
+
+        val result: GroupChangeInfo =
+          rightResultOf(underTest.getGroupChange(dummyGroup.id, dummyAuth).value)
+        result shouldBe expected
+      }
+
+      "return the single group change even if the user is not authorized" in {
+        val groupChangeRepoResponse = listOfDummyGroupChanges.take(1).head
+        doReturn(IO.pure(Some(groupChangeRepoResponse)))
+          .when(mockGroupChangeRepo)
+          .getGroupChange(anyString)
+
+        doReturn(IO.pure(ListUsersResults(Seq(dummyUser), Some("1"))))
+          .when(mockUserRepo)
+          .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
+
+        val userMap = Seq(dummyUser).map(u => (u.id, u.userName)).toMap
+        val expected: GroupChangeInfo =
+          listOfDummyGroupChanges.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))).take(1).head
+
+        val result: GroupChangeInfo =
+          rightResultOf(underTest.getGroupChange(dummyGroup.id, okAuth).value)
+        result shouldBe expected
+      }
+
+      "return a InvalidGroupRequestError if the group change id is not valid" in {
+        doReturn(IO.pure(None))
+          .when(mockGroupChangeRepo)
+          .getGroupChange(anyString)
+
+        doReturn(IO.pure(ListUsersResults(Seq(dummyUser), Some("1"))))
+          .when(mockUserRepo)
+          .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
+
+        val result = leftResultOf(underTest.getGroupChange(dummyGroup.id, okAuth).value)
+        result shouldBe a[InvalidGroupRequestError]
+      }
+    }
+
     "getGroupActivity" should {
       "return the group activity" in {
         val groupChangeRepoResponse = ListGroupChangesResults(
@@ -768,12 +821,14 @@ class MembershipServiceSpec
 
     "determine group difference" should {
       "return difference between two groups" in {
-        val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate)
+        val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate, okGroupChange.copy(changeType = GroupChangeType.Delete))
         val result: Seq[String] = rightResultOf(underTest.determineGroupDifference(groupChange).value)
-        // Newly created group won't have group change message
-        result(0) shouldBe ""
-        // Updated group with group change message
+        // Newly created group's change message
+        result(0) shouldBe "Group Created."
+        // Updated group's change message
         result(1) shouldBe "Group name changed to 'dummy-group'. Group email changed to 'dummy@test.com'. Group description changed to 'dummy group'. Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group admin/s with userId/s (ok) removed. Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group member/s with userId/s (ok) removed."
+        // Deleted group's change message
+        result(2) shouldBe "Group Deleted."
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -724,8 +724,13 @@ class MembershipServiceSpec
           .when(mockGroupChangeRepo)
           .getGroupChanges(anyString, any[Option[String]], anyInt)
 
+        doReturn(IO.pure(ListUsersResults(Seq(dummyUser), Some("1"))))
+          .when(mockUserRepo)
+          .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
+
+        val userMap = Seq(dummyUser).map(u => (u.id, u.userName)).toMap
         val expected: List[GroupChangeInfo] =
-          listOfDummyGroupChanges.map(GroupChangeInfo.apply).take(100)
+          listOfDummyGroupChanges.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))).take(100)
 
         val result: ListGroupChangesResponse =
           rightResultOf(underTest.getGroupActivity(dummyGroup.id, None, 100, dummyAuth).value)
@@ -744,8 +749,13 @@ class MembershipServiceSpec
         .when(mockGroupChangeRepo)
         .getGroupChanges(anyString, any[Option[String]], anyInt)
 
+      doReturn(IO.pure(ListUsersResults(Seq(dummyUser), Some("1"))))
+        .when(mockUserRepo)
+        .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
+
+      val userMap = Seq(dummyUser).map(u => (u.id, u.userName)).toMap
       val expected: List[GroupChangeInfo] =
-        listOfDummyGroupChanges.map(GroupChangeInfo.apply).take(100)
+        listOfDummyGroupChanges.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))).take(100)
 
       val result: ListGroupChangesResponse =
         rightResultOf(underTest.getGroupActivity(dummyGroup.id, None, 100, okAuth).value)

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -773,7 +773,7 @@ class MembershipServiceSpec
         // Newly created group won't have group change message
         result(0) shouldBe ""
         // Updated group with group change message
-        result(1) shouldBe "Group name changed to 'dummy-group'.Group email changed to 'dummy@test.com'.Group description changed to 'dummy group'.Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added.Group admin/s with userId/s (ok) removed.Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added.Group member/s with userId/s (ok) removed."
+        result(1) shouldBe "Group name changed to 'dummy-group'. Group email changed to 'dummy@test.com'. Group description changed to 'dummy group'. Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group admin/s with userId/s (ok) removed. Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group member/s with userId/s (ok) removed. "
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -773,7 +773,7 @@ class MembershipServiceSpec
         // Newly created group won't have group change message
         result(0) shouldBe ""
         // Updated group with group change message
-        result(1) shouldBe "Group name changed to 'ok'.Group email changed to 'test@test.com'."
+        result(1) shouldBe "Group name changed to 'dummy-group'.Group email changed to 'dummy@test.com'.Group description changed to 'dummy group'.Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added.Group admin/s with userId/s (ok) removed.Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added.Group member/s with userId/s (ok) removed."
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -96,5 +96,16 @@ class MembershipValidationsSpec
       }
 
     }
+
+    "isGroupChangePresent" should {
+      "return true when there is a group change present for the requested group change id" in {
+        isGroupChangePresent(Some(okGroupChange)) should be(right)
+      }
+      "return an error when there is a group change present for the requested group change id" in {
+        val error = leftValue(isGroupChangePresent(None))
+        error shouldBe an[InvalidGroupRequestError]
+      }
+
+    }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -296,28 +296,6 @@ class MembershipRoutingSpec
     }
   }
 
-  "GET group change" should {
-    "return a 200 response with the group change when found" in {
-      val grpChange = GroupChangeInfo(okGroupChange)
-      doReturn(result(grpChange)).when(membershipService).getGroupChange("ok", okAuth)
-      Get("/groups/change/ok") ~> Route.seal(membershipRoute) ~> check {
-        status shouldBe StatusCodes.OK
-
-        val result = responseAs[GroupChangeInfo]
-        result shouldBe grpChange
-      }
-    }
-
-    "return a 400 Bad Request when the group change id is not valid" in {
-      doReturn(result(InvalidGroupRequestError("Invalid Group Change ID")))
-        .when(membershipService)
-        .getGroupChange("notValid", okAuth)
-      Get("/groups/change/notValid") ~> Route.seal(membershipRoute) ~> check {
-        status shouldBe StatusCodes.BadRequest
-      }
-    }
-  }
-
   "DELETE group" should {
     "return a 200 response with the deleted group when it exists" in {
       val grpBaseTime = deletedGroup.copy(created = baseTime)
@@ -747,6 +725,37 @@ class MembershipRoutingSpec
         .when(membershipService)
         .getGroupActivity("bad", None, 100, okAuth)
       Get(s"/groups/bad/activity") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.InternalServerError
+      }
+    }
+  }
+
+  "GET group change" should {
+    "return a 200 response with the group change when found" in {
+      val grpChange = GroupChangeInfo(okGroupChange)
+      doReturn(result(grpChange)).when(membershipService).getGroupChange("ok", okAuth)
+      Get("/groups/change/ok") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.OK
+
+        val result = responseAs[GroupChangeInfo]
+        result shouldBe grpChange
+      }
+    }
+
+    "return a 400 Bad Request when the group change id is not valid" in {
+      doReturn(result(InvalidGroupRequestError("Invalid Group Change ID")))
+        .when(membershipService)
+        .getGroupChange("notValid", okAuth)
+      Get("/groups/change/notValid") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.BadRequest
+      }
+    }
+
+    "return a 500 response on failure" in {
+      doReturn(result(new RuntimeException("fail")))
+        .when(membershipService)
+        .getGroupChange("bad", okAuth)
+      Get(s"/groups/change/bad") ~> Route.seal(membershipRoute) ~> check {
         status shouldBe StatusCodes.InternalServerError
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -296,6 +296,28 @@ class MembershipRoutingSpec
     }
   }
 
+  "GET group change" should {
+    "return a 200 response with the group change when found" in {
+      val grpChange = GroupChangeInfo(okGroupChange)
+      doReturn(result(grpChange)).when(membershipService).getGroupChange("ok", okAuth)
+      Get("/groups/change/ok") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.OK
+
+        val result = responseAs[GroupChangeInfo]
+        result shouldBe grpChange
+      }
+    }
+
+    "return a 400 Bad Request when the group change id is not valid" in {
+      doReturn(result(InvalidGroupRequestError("Invalid Group Change ID")))
+        .when(membershipService)
+        .getGroupChange("notValid", okAuth)
+      Get("/groups/change/notValid") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.BadRequest
+      }
+    }
+  }
+
   "DELETE group" should {
     "return a 200 response with the deleted group when it exists" in {
       val grpBaseTime = deletedGroup.copy(created = baseTime)

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupChange.scala
@@ -35,7 +35,8 @@ case class GroupChange(
     oldGroup: Option[Group] = None,
     id: String = UUID.randomUUID().toString,
     created: DateTime = DateTime.now,
-    userName: Option[String] = None
+    userName: Option[String] = None,
+    groupChangeMessage: Option[String] = None
 )
 
 object GroupChange {

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupChange.scala
@@ -34,7 +34,8 @@ case class GroupChange(
     userId: String,
     oldGroup: Option[Group] = None,
     id: String = UUID.randomUUID().toString,
-    created: DateTime = DateTime.now
+    created: DateTime = DateTime.now,
+    userName: Option[String] = None
 )
 
 object GroupChange {

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupChangeRepository.scala
@@ -24,7 +24,8 @@ import vinyldns.core.repository.Repository
 trait GroupChangeRepository extends Repository {
   def save(db: DB, groupChange: GroupChange): IO[GroupChange]
 
-  def getGroupChange(groupChangeId: String): IO[Option[GroupChange]] // For testing
+  def getGroupChange(groupChangeId: String): IO[Option[GroupChange]]
+
   def getGroupChanges(
       groupId: String,
       startFrom: Option[String],

--- a/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
@@ -158,10 +158,12 @@ object TestMembershipData {
     )
   }
   val dummyGroupChangeUpdate: GroupChange = GroupChange(
-    okGroup,
+    okGroup.copy(name = "dummy-group", email = "dummy@test.com", description = Some("dummy group"),
+      memberIds = Set(dummyUser.copy(id="12345-abcde-6789").id, superUser.copy(id="56789-edcba-1234").id),
+      adminUserIds = Set(dummyUser.copy(id="12345-abcde-6789").id, superUser.copy(id="56789-edcba-1234").id)),
     GroupChangeType.Update,
     okUser.id,
-    Some(okGroup.copy(name = "dummy-group", email = "dummy@test.com")),
+    Some(okGroup),
     created = DateTime.now.secondOfDay().roundFloorCopy()
   )
 }

--- a/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
@@ -157,4 +157,11 @@ object TestMembershipData {
       id = s"$i"
     )
   }
+  val dummyGroupChangeUpdate: GroupChange = GroupChange(
+    okGroup,
+    GroupChangeType.Update,
+    okUser.id,
+    Some(okGroup.copy(name = "dummy-group", email = "dummy@test.com")),
+    created = DateTime.now.secondOfDay().roundFloorCopy()
+  )
 }

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -215,7 +215,6 @@ class VinylDNS @Inject() (
   }
 
   def listGroupChanges(id: String): Action[AnyContent] = userAction.async { implicit request =>
-    // $COVERAGE-OFF$
     val queryParameters = new HashMap[String, java.util.List[String]]()
     for {
       (name, values) <- request.queryString
@@ -230,7 +229,6 @@ class VinylDNS @Inject() (
       Status(response.status)(response.body)
         .withHeaders(cacheHeaders: _*)
     })
-    // $COVERAGE-ON$
   }
 
   def getUser(id: String): Action[AnyContent] = userAction.async { implicit request =>

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -214,6 +214,25 @@ class VinylDNS @Inject() (
     })
   }
 
+  def listGroupChanges(id: String): Action[AnyContent] = userAction.async { implicit request =>
+    // $COVERAGE-OFF$
+    val queryParameters = new HashMap[String, java.util.List[String]]()
+    for {
+      (name, values) <- request.queryString
+    } queryParameters.put(name, values.asJava)
+    val vinyldnsRequest = new VinylDNSRequest(
+      "GET",
+      s"$vinyldnsServiceBackend",
+      s"groups/$id/activity",
+      parameters = queryParameters
+    )
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+    // $COVERAGE-ON$
+  }
+
   def getUser(id: String): Action[AnyContent] = userAction.async { implicit request =>
     val vinyldnsRequest = VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"users/$id")
     executeRequest(vinyldnsRequest, request.user).map(response => {

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -214,6 +214,15 @@ class VinylDNS @Inject() (
     })
   }
 
+  def getGroupChange(gcid: String): Action[AnyContent] = userAction.async { implicit request =>
+    val vinyldnsRequest = VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"groups/change/$gcid")
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      logger.info(s"group change [$gcid] retrieved with status [${response.status}]")
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+  }
+
   def listGroupChanges(id: String): Action[AnyContent] = userAction.async { implicit request =>
     val queryParameters = new HashMap[String, java.util.List[String]]()
     for {

--- a/modules/portal/app/views/groups/groupDetail.scala.html
+++ b/modules/portal/app/views/groups/groupDetail.scala.html
@@ -150,7 +150,7 @@
                                             <td>{{change.created}}</td>
                                             <td>{{change.id}}</td>
                                             <td>{{change.changeType}}</td>
-                                            <td class="col-md-3 wrap-long-text">{{change.groupChangeMessage}}</td>
+                                            <td class="col-md-3 wrap-long-text" ng-bind-html="changeMessage(change.groupChangeMessage)"></td>
                                             <td class="col-md-3 wrap-long-text">
                                                 <a ng-if="change.changeType =='Create'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
 

--- a/modules/portal/app/views/groups/groupDetail.scala.html
+++ b/modules/portal/app/views/groups/groupDetail.scala.html
@@ -140,6 +140,7 @@
                                             <th>Time</th>
                                             <th>Group Change ID</th>
                                             <th>Change Type</th>
+                                            <th>Change Message</th>
                                             <th>Change Info</th>
                                             <th>User</th>
                                         </tr>
@@ -149,11 +150,12 @@
                                             <td>{{change.created}}</td>
                                             <td>{{change.id}}</td>
                                             <td>{{change.changeType}}</td>
+                                            <td class="col-md-3 wrap-long-text">{{change.groupChangeMessage}}</td>
                                             <td class="col-md-3 wrap-long-text">
-                                                <a ng-if="change.changeType =='Create'" ng-click="viewCreatedOrOldGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
+                                                <a ng-if="change.changeType =='Create'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
 
-                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewNewGroupInfo(change.newGroup, change.oldGroup)" class="force-cursor">View new group</a></div>
-                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewCreatedOrOldGroupInfo(change.oldGroup)" class="force-cursor">View old group</a></div>
+                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View new group</a></div>
+                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewGroupInfo(change.oldGroup)" class="force-cursor">View old group</a></div>
                                             </td>
                                             <td>{{change.userName}}</td>
                                         </tr>
@@ -190,18 +192,6 @@
     <form name="viewGroupForm" role="form" class="form-horizontal" novalidate>
         <modal modal-id="group_modal" modal-title="{{ groupModal.title }}">
             <modal-body>
-                <modal-element ng-if="isCreatedOrNew" label="Group Changes Made">
-                <textarea id="create-group-change-text"
-                          name="groupChangeMessage"
-                          ng-model="currentGroup.changeMessage"
-                          rows="5"
-                          class="form-control"
-                          ng-trim="false"
-                          ng-class="groupModal.details.class"
-                          ng-readonly="groupModal.details.readOnly">
-                </textarea>
-                </modal-element>
-
                 <modal-element label="Group ID">
                     <input id="create-group-id-text" type="text" name="groupID" class="form-control"
                            ng-model="currentGroup.id"

--- a/modules/portal/app/views/groups/groupDetail.scala.html
+++ b/modules/portal/app/views/groups/groupDetail.scala.html
@@ -2,110 +2,279 @@
 
 @content = {
 
-    <!-- PAGE CONTENT -->
-    <div class="right_col" role="main" >
+<!-- PAGE CONTENT -->
+<div class="right_col" role="main" >
 
-<div>
-        <!-- START BREADCRUMB -->
-        <ul class="breadcrumb">
-            <li><a href="/">Home</a></li>
-            <li><a href="/groups">Groups</a></li>
-            <li class="active">{{membership.group.name}}</li>
-        </ul>
-        <!-- END BREADCRUMB -->
+    <div>
+            <!-- START BREADCRUMB -->
+            <ul class="breadcrumb">
+                <li><a href="/">Home</a></li>
+                <li><a href="/groups">Groups</a></li>
+                <li class="active">{{membership.group.name}}</li>
+            </ul>
+            <!-- END BREADCRUMB -->
 
-        <!-- PAGE TITLE -->
-        <div class="page-title">
-            <h3><span class="fa fa-group"></span> Group {{membership.group.name}}</h3>
-        </div>
-        <!-- END PAGE TITLE -->
-
-        <!-- PAGE CONTENT WRAPPER -->
-        <div class="page-content-wrap">
-
-            <div class="alert-wrapper">
-                <div ng-repeat="alert in alerts">
-                    <notification ng-model="alert"></notification>
-                </div>
+            <!-- PAGE TITLE -->
+            <div class="page-title">
+                <h3><span class="fa fa-group"></span> Group {{membership.group.name}}</h3>
             </div>
+            <!-- END PAGE TITLE -->
 
-            <div class="row">
-                <div class="col-md-12">
-                    <p ng-if="membership.group.description"><strong>Description:</strong> {{membership.group.description}}</p>
-                    <p><strong>Group Email:</strong> {{membership.group.email}}</p>
-                    <!-- START SIMPLE DATATABLE -->
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <div ng-if="isGroupAdmin">
-                                <form class="form-inline" role="form" name="addMemberForm" ng-submit="addMemberForm.$valid && addMember();">
-                                    <div class="col-md-8">
-                                        <div class="form-group">
-                                            <div class="input-group">
-                                                <input type="text" ng-model="newMemberData.login" name="newMemberLogin" class="form-control" placeholder="User Name" required/>
+            <!-- PAGE CONTENT WRAPPER -->
+            <div class="page-content-wrap">
+
+                <div class="alert-wrapper">
+                    <div ng-repeat="alert in alerts">
+                        <notification ng-model="alert"></notification>
+                    </div>
+                </div>
+
+                <!-- START VERTICAL TABS -->
+                <div class="panel panel-default panel-tabs">
+                    <ul class="nav nav-tabs bar_tabs">
+                        <li class="active"><a href="#tab1" data-toggle="tab">Manage Groups</a></li>
+                        <li><a href="#tab2" data-toggle="tab">Change History</a></li>
+                    </ul>
+                    <div class="panel-body tab-content">
+
+                        <div class="tab-pane active" id="tab1">
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <p ng-if="membership.group.description"><strong>Description:</strong> {{membership.group.description}}</p>
+                                    <p><strong>Group Email:</strong> {{membership.group.email}}</p>
+                                    <!-- START SIMPLE DATATABLE -->
+                                    <div class="panel panel-default">
+                                        <div class="panel-heading">
+                                            <div ng-if="isGroupAdmin">
+                                                <form class="form-inline" role="form" name="addMemberForm" ng-submit="addMemberForm.$valid && addMember();">
+                                                    <div class="col-md-8">
+                                                        <div class="form-group">
+                                                            <div class="input-group">
+                                                                <input type="text" ng-model="newMemberData.login" name="newMemberLogin" class="form-control" placeholder="User Name" required/>
+                                                            </div>
+                                                        </div>
+                                                        <div class="form-group" style="padding-left: 10px;">
+                                                            <label class="check">
+                                                                <input type="checkbox"
+                                                                       ng-model="newMemberData.isAdmin" name="newMemberAdmin"
+                                                                       class="icheckbox_minimal-grey"/>
+                                                                Is Group Manager?</label>
+                                                        </div>
+                                                        <div class="form-group" style="padding-left: 10px;">
+                                                            <div class="input-group">
+                                                                <button type="submit" class="btn btn-sm vinyldns-btn-dark">Add Group Member</button>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </form>
                                             </div>
                                         </div>
-                                        <div class="form-group" style="padding-left: 10px;">
-                                            <label class="check">
-                                                <input type="checkbox"
-                                                    ng-model="newMemberData.isAdmin" name="newMemberAdmin"
-                                                    class="icheckbox_minimal-grey"/>
-                                                Is Group Manager?</label>
-                                        </div>
-                                        <div class="form-group" style="padding-left: 10px;">
-                                            <div class="input-group">
-                                            <button type="submit" class="btn btn-sm vinyldns-btn-dark">Add Group Member</button>
-                                            </div>
+                                        <div class="panel-body">
+                                            <p id="no-group-list" ng-if="!membershipLoaded">Loading members...</p>
+                                            <p id="no-group-list" ng-if="!membership.members.length && membershipLoaded">You don't have any members yet.</p>
+                                            <table class="table datatable_simple group-members" ng-if="membership.members.length">
+                                                <thead>
+                                                <tr>
+                                                    <th>User Name</th>
+                                                    <th>Name</th>
+                                                    <th>Email</th>
+                                                    <th>Group Manager</th>
+                                                    <th>Status</th>
+                                                    <th ng-if="isGroupAdmin">Actions</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                <tr ng-repeat="member in membership.members | orderBy:'+userName'">
+                                                    <td>{{member.userName}}</td>
+                                                    <td>{{([member.lastName, member.firstName] | filter: "" ).join(", ")}}</td>
+                                                    <td>{{member.email}}</td>
+                                                    <td>
+                                                        <label class="switch col-md-1">
+                                                            <input class="switch-checkbox" type="checkbox" ng-model="member.isAdmin" ng-disabled="!isGroupAdmin" ng-change="toggleAdmin(member);"/>
+                                                            <span class="slider"></span>
+                                                        </label>
+                                                    </td>
+                                                    <td>{{member.lockStatus}}</td>
+                                                    <td ng-if="isGroupAdmin">
+                                                        <button class="btn btn-danger btn-rounded" ng-click="removeMember(member.id);">
+                                                            Delete
+                                                        </button>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
                                         </div>
                                     </div>
-                                </form>
+                                    <!-- END SIMPLE DATATABLE -->
+
+                                </div>
                             </div>
                         </div>
-                        <div class="panel-body">
-                            <p id="no-group-list" ng-if="!membershipLoaded">Loading members...</p>
-                            <p id="no-group-list" ng-if="!membership.members.length && membershipLoaded">You don't have any members yet.</p>
-                            <table class="table datatable_simple group-members" ng-if="membership.members.length">
-                                <thead>
-                                    <tr>
-                                        <th>User Name</th>
-                                        <th>Name</th>
-                                        <th>Email</th>
-                                        <th>Group Manager</th>
-                                        <th>Status</th>
-                                        <th ng-if="isGroupAdmin">Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr ng-repeat="member in membership.members | orderBy:'+userName'">
-                                        <td>{{member.userName}}</td>
-                                        <td>{{([member.lastName, member.firstName] | filter: "" ).join(", ")}}</td>
-                                        <td>{{member.email}}</td>
-                                        <td>
-                                            <label class="switch col-md-1">
-                                                <input class="switch-checkbox" type="checkbox" ng-model="member.isAdmin" ng-disabled="!isGroupAdmin" ng-change="toggleAdmin(member);"/>
-                                                <span class="slider"></span>
-                                            </label>
-                                        </td>
-                                        <td>{{member.lockStatus}}</td>
-                                        <td ng-if="isGroupAdmin">
-                                            <button class="btn btn-danger btn-rounded" ng-click="removeMember(member.id);">
-                                                Delete
-                                            </button>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                        <div class="tab-pane" id="tab2">
+                            <!-- START SIMPLE DATATABLE -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <h3 class="panel-title">All Group Changes {{ getChangePageTitle() }}</h3>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="btn-group">
+                                        <button class="btn btn-default" ng-click="refreshGroupChanges()"><span class="fa fa-refresh"></span> Refresh</button>
+                                    </div>
+
+                                    <!-- PAGINATION -->
+                                    <div class="dataTables_paginate">
+                                        <ul class="pagination">
+                                            <li class="paginate_button previous">
+                                                <a ng-if="changePrevPageEnabled()" ng-click="changePrevPage()" class="paginate_button">Previous</a>
+                                            </li>
+                                            <li class="paginate_button next">
+                                                <a ng-if="changeNextPageEnabled()" ng-click="changeNextPage()" class="paginate_button">Next</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                    <!-- END PAGINATION -->
+
+                                    <table id="changeDataTable" class="table table-hover table-striped">
+                                        <thead>
+                                        <tr>
+                                            <th>Time</th>
+                                            <th>Group Change ID</th>
+                                            <th>Change Type</th>
+                                            <th>Change Info</th>
+                                            <th>User</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        <tr ng-repeat="change in groupChanges track by $index">
+                                            <td>{{change.created}}</td>
+                                            <td>{{change.id}}</td>
+                                            <td>{{change.changeType}}</td>
+                                            <td class="col-md-3 wrap-long-text">
+                                                <a ng-if="change.changeType =='Create'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
+
+                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View new group</a></div>
+                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewGroupInfo(change.oldGroup)" class="force-cursor">View old group</a></div>
+                                            </td>
+                                            <td>{{change.userName}}</td>
+                                        </tr>
+                                        </tbody>
+
+                                    </table>
+
+                                    <!-- PAGINATION -->
+                                    <div class="dataTables_paginate">
+                                        <ul class="pagination">
+                                            <li class="paginate_button previous">
+                                                <a ng-if="changePrevPageEnabled()" ng-click="changePrevPage()" class="paginate_button">Previous</a>
+                                            </li>
+                                            <li class="paginate_button next">
+                                                <a ng-if="changeNextPageEnabled()" ng-click="changeNextPage()" class="paginate_button">Next</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                    <!-- END PAGINATION -->
+
+                                </div>
+                                <div class="panel-footer"></div>
+                            </div>
+                            <!-- END SIMPLE DATATABLE -->
                         </div>
                     </div>
-                    <!-- END SIMPLE DATATABLE -->
-
                 </div>
-            </div>
+                <!-- END VERTICAL TABS -->
 
-        </div>
-        <!-- PAGE CONTENT WRAPPER -->
-</div>
+            </div>
+            <!-- PAGE CONTENT WRAPPER -->
     </div>
-    <!-- END PAGE CONTENT -->
+
+    <form name="viewGroupForm" role="form" class="form-horizontal" novalidate>
+        <modal modal-id="group_modal" modal-title="{{ groupModal.title }}">
+            <modal-body>
+                <modal-element label="Group Name">
+                    <input id="create-group-id-text" type="text" name="groupID" class="form-control"
+                           ng-model="currentGroup.id"
+                           ng-class="groupModal.details.class"
+                           ng-readonly="groupModal.details.readOnly"/>
+                </modal-element>
+
+                <modal-element label="Group Name">
+                    <input id="create-group-name-text" type="text" name="groupName" class="form-control"
+                           ng-model="currentGroup.name"
+                           ng-class="groupModal.details.class"
+                           ng-readonly="groupModal.details.readOnly"/>
+                </modal-element>
+
+                <modal-element label="Group Description">
+                    <input id="create-group-description-text" type="text" name="groupDescription" class="form-control"
+                           ng-model="currentGroup.description"
+                           ng-class="groupModal.details.class"
+                           ng-readonly="groupModal.details.readOnly"/>
+                </modal-element>
+
+                <modal-element label="Email">
+                    <input id="create-group-email-text" type="text"
+                           name="groupEmail"
+                           class="form-control"
+                           ng-model="currentGroup.email"
+                           ng-class="groupModal.details.class"
+                           ng-readonly="groupModal.details.readOnly"/>
+                </modal-element>
+
+                <modal-element label="Group Created">
+                    <input id="create-group-created-text" type="text"
+                           name="groupCreated"
+                           class="form-control"
+                           ng-model="currentGroup.created"
+                           ng-class="groupModal.details.class"
+                           ng-readonly="groupModal.details.readOnly"/>
+                </modal-element>
+
+                <modal-element label="Group Status">
+                    <input id="create-group-status-text" type="text"
+                           name="groupStatus"
+                           class="form-control"
+                           ng-model="currentGroup.status"
+                           ng-class="groupModal.details.class"
+                           ng-readonly="groupModal.details.readOnly"/>
+                </modal-element>
+
+                <modal-element label="Group Members IDs (one per line)">
+                <textarea id="create-group-members-ids-text"
+                          name="groupMembers"
+                          ng-model="currentGroup.memberIds"
+                          rows="5"
+                          class="form-control"
+                          ng-list="&#10;"
+                          ng-trim="false"
+                          ng-class="groupModal.details.class"
+                          ng-readonly="groupModal.details.readOnly">
+                </textarea>
+                </modal-element>
+
+                <modal-element label="Group Admins IDs (one per line)">
+                <textarea id="create-group-admins-ids-text"
+                          name="groupAdmins"
+                          ng-model="currentGroup.adminIds"
+                          rows="5"
+                          class="form-control"
+                          ng-list="&#10;"
+                          ng-trim="false"
+                          ng-class="groupModal.details.class"
+                          ng-readonly="groupModal.details.readOnly">
+                </textarea>
+                </modal-element>
+
+            </modal-body>
+            <modal-footer>
+                <span ng-if="groupModal.action == groupModalState.VIEW_DETAILS">
+                    <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="closeGroupModal()">Close</button>
+                </span>
+            </modal-footer>
+        </modal>
+    </form>
+
+</div>
+<!-- END PAGE CONTENT -->
 }
 
 @plugins = {

--- a/modules/portal/app/views/groups/groupDetail.scala.html
+++ b/modules/portal/app/views/groups/groupDetail.scala.html
@@ -150,10 +150,10 @@
                                             <td>{{change.id}}</td>
                                             <td>{{change.changeType}}</td>
                                             <td class="col-md-3 wrap-long-text">
-                                                <a ng-if="change.changeType =='Create'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
+                                                <a ng-if="change.changeType =='Create'" ng-click="viewCreatedOrOldGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
 
-                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View new group</a></div>
-                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewGroupInfo(change.oldGroup)" class="force-cursor">View old group</a></div>
+                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewNewGroupInfo(change.newGroup, change.oldGroup)" class="force-cursor">View new group</a></div>
+                                                <div><a ng-if="change.changeType =='Update'" ng-click="viewCreatedOrOldGroupInfo(change.oldGroup)" class="force-cursor">View old group</a></div>
                                             </td>
                                             <td>{{change.userName}}</td>
                                         </tr>
@@ -190,7 +190,19 @@
     <form name="viewGroupForm" role="form" class="form-horizontal" novalidate>
         <modal modal-id="group_modal" modal-title="{{ groupModal.title }}">
             <modal-body>
-                <modal-element label="Group Name">
+                <modal-element ng-if="isCreatedOrNew" label="Group Changes Made">
+                <textarea id="create-group-change-text"
+                          name="groupChangeMessage"
+                          ng-model="currentGroup.changeMessage"
+                          rows="5"
+                          class="form-control"
+                          ng-trim="false"
+                          ng-class="groupModal.details.class"
+                          ng-readonly="groupModal.details.readOnly">
+                </textarea>
+                </modal-element>
+
+                <modal-element label="Group ID">
                     <input id="create-group-id-text" type="text" name="groupID" class="form-control"
                            ng-model="currentGroup.id"
                            ng-class="groupModal.details.class"

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -45,6 +45,7 @@ GET           /api/zones/:id/recordsetchanges    @controllers.VinylDNS.listRecor
 GET           /api/groups                        @controllers.VinylDNS.getGroups
 GET           /api/groups/:gid                   @controllers.VinylDNS.getGroup(gid: String)
 GET           /api/groups/:gid/groupchanges      @controllers.VinylDNS.listGroupChanges(gid: String)
+GET           /api/groups/change/:gcid           @controllers.VinylDNS.getGroupChange(gcid: String)
 POST          /api/groups                        @controllers.VinylDNS.newGroup
 PUT           /api/groups/:gid                   @controllers.VinylDNS.updateGroup(gid: String)
 DELETE        /api/groups/:gid                   @controllers.VinylDNS.deleteGroup(gid: String)

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -44,6 +44,7 @@ GET           /api/zones/:id/recordsetchanges    @controllers.VinylDNS.listRecor
 
 GET           /api/groups                        @controllers.VinylDNS.getGroups
 GET           /api/groups/:gid                   @controllers.VinylDNS.getGroup(gid: String)
+GET           /api/groups/:gid/groupchanges           @controllers.VinylDNS.listGroupChanges(gid: String)
 POST          /api/groups                        @controllers.VinylDNS.newGroup
 PUT           /api/groups/:gid                   @controllers.VinylDNS.updateGroup(gid: String)
 DELETE        /api/groups/:gid                   @controllers.VinylDNS.deleteGroup(gid: String)

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -44,7 +44,7 @@ GET           /api/zones/:id/recordsetchanges    @controllers.VinylDNS.listRecor
 
 GET           /api/groups                        @controllers.VinylDNS.getGroups
 GET           /api/groups/:gid                   @controllers.VinylDNS.getGroup(gid: String)
-GET           /api/groups/:gid/groupchanges           @controllers.VinylDNS.listGroupChanges(gid: String)
+GET           /api/groups/:gid/groupchanges      @controllers.VinylDNS.listGroupChanges(gid: String)
 POST          /api/groups                        @controllers.VinylDNS.newGroup
 PUT           /api/groups/:gid                   @controllers.VinylDNS.updateGroup(gid: String)
 DELETE        /api/groups/:gid                   @controllers.VinylDNS.deleteGroup(gid: String)

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -238,10 +238,10 @@ angular.module('controller.membership', []).controller('MembershipController', f
             id = id.substring(id.lastIndexOf('/') + 1);
             id = id.substring(0, id.indexOf('#'))
         }
-        $log.log('refreshGroupChanges, loading group with id ', id);
+        $log.debug('refreshGroupChanges, loading group with id ', id);
         changePaging = pagingService.resetPaging(changePaging);
         function success(response) {
-            $log.log('groupsService::getGroupChanges-success');
+            $log.debug('groupsService::getGroupChanges-success');
             changePaging.next = response.data.nextId;
             updateChangeDisplay(response.data.changes)
         }
@@ -281,7 +281,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
         var id = $location.absUrl().toString();
         id = id.substring(id.lastIndexOf('/') + 1);
         id = id.substring(0, id.indexOf('#'))
-        $log.log('changePrevPage, loading group with id ', id);
+        $log.debug('changePrevPage, loading group with id ', id);
         return groupsService
             .getGroupChanges(id, changePaging.maxItems, startFrom)
             .then(function(response) {
@@ -297,7 +297,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
         var id = $location.absUrl().toString();
         id = id.substring(id.lastIndexOf('/') + 1);
         id = id.substring(0, id.indexOf('#'))
-        $log.log('changeNextPage, loading group with id ', id);
+        $log.debug('changeNextPage, loading group with id ', id);
         return groupsService
             .getGroupChanges(id, changePaging.maxItems, changePaging.next)
             .then(function(response) {

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -23,7 +23,6 @@ angular.module('controller.membership', []).controller('MembershipController', f
     $scope.isGroupAdmin = false;
     $scope.groupChanges = {};
     $scope.currentGroup = {};
-    $scope.isCreatedOrNew = false;
 
     $scope.groupModalState = {
         VIEW_DETAILS: 1
@@ -310,56 +309,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
             });
     };
 
-    function determineGroupDifference(newGroup, oldGroup) {
-        var newGroupData = angular.copy(newGroup);
-        var changeMessage = "";
-        if(oldGroup.name !== newGroup.name){
-            changeMessage += "Group name changed to '" + newGroup.name + "'.";
-        }
-        if(oldGroup.email !== newGroup.email){
-            changeMessage += "Group email changed to '" + newGroup.email + "'.";
-        }
-        if(oldGroup.description !== newGroup.description){
-            changeMessage += "Group description changed to '" + newGroup.description + "'.";
-        }
-        oldGroup.adminIds = [];
-        angular.forEach(oldGroup.admins, function(admin) {
-            oldGroup.adminIds.push(admin.id);
-        });
-        newGroupData.adminIds = [];
-        angular.forEach(newGroup.admins, function(admin) {
-            newGroupData.adminIds.push(admin.id);
-        });
-        var adminAddDifference = newGroupData.adminIds.filter(x => !oldGroup.adminIds.includes(x));
-        if(adminAddDifference.length !== 0){
-            changeMessage += "Group admin/s with userId/s (" + adminAddDifference + ") added.";
-        }
-        var adminRemoveDifference = oldGroup.adminIds.filter(x => !newGroupData.adminIds.includes(x));
-        if(adminRemoveDifference.length !== 0){
-            changeMessage += "Group admin/s with userId/s (" + adminRemoveDifference + ") removed.";
-        }
-        oldGroup.memberIds = [];
-        angular.forEach(oldGroup.members, function(member) {
-            oldGroup.memberIds.push(member.id);
-        });
-        newGroupData.memberIds = [];
-        angular.forEach(newGroup.members, function(member) {
-            newGroupData.memberIds.push(member.id);
-        });
-        var memberAddDifference = newGroupData.memberIds.filter(x => !oldGroup.memberIds.includes(x));
-        if(memberAddDifference.length !== 0){
-            changeMessage += "Group member/s with userId/s (" + memberAddDifference + ") added.";
-        }
-        var memberRemoveDifference = oldGroup.memberIds.filter(x => !newGroupData.memberIds.includes(x));
-        if(memberRemoveDifference.length !== 0){
-            changeMessage += "Group member/s with userId/s (" + memberRemoveDifference + ") removed.";
-        }
-        newGroupData.changeMessage = changeMessage;
-        return newGroupData;
-    }
-
-    $scope.viewCreatedOrOldGroupInfo = function(group) {
-        $scope.isCreatedOrNew = false;
+    $scope.viewGroupInfo = function(group) {
         var newGroup = angular.copy(group);
         newGroup.adminIds = [];
         angular.forEach(group.admins, function(admin) {
@@ -372,19 +322,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
         $scope.currentGroup = newGroup;
         $scope.groupModal = {
             action: $scope.groupModalState.VIEW_DETAILS,
-            title: "Created/Old Group Info",
-            basics: $scope.groupModalParams.readOnly,
-            details: $scope.groupModalParams.readOnly,
-        };
-        $("#group_modal").modal("show");
-    };
-
-    $scope.viewNewGroupInfo = function(newGroup, oldGroup) {
-        $scope.isCreatedOrNew = true;
-        $scope.currentGroup = determineGroupDifference(newGroup, oldGroup);
-        $scope.groupModal = {
-            action: $scope.groupModalState.VIEW_DETAILS,
-            title: "New Group Info",
+            title: "Group Info",
             basics: $scope.groupModalParams.readOnly,
             details: $scope.groupModalParams.readOnly,
         };

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-angular.module('controller.membership', []).controller('MembershipController', function ($scope, $log, $location, $timeout, pagingService,
+angular.module('controller.membership', []).controller('MembershipController', function ($scope, $log, $location, $sce, $timeout, pagingService,
                                                                                          groupsService, profileService, utilityService) {
 
     $scope.membership = { members: [], group: {} };
@@ -34,6 +34,11 @@ angular.module('controller.membership', []).controller('MembershipController', f
             class: "",
             readOnly: true
         }
+    };
+
+    $scope.changeMessage = function (groupChangeMessage) {
+        message = groupChangeMessage.replaceAll('. ', '.<br>')
+        return $sce.trustAsHtml(message);
     };
 
     // paging status for group changes

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -14,13 +14,31 @@
  * limitations under the License.
  */
 
-angular.module('controller.membership', []).controller('MembershipController', function ($scope, $log, $location, $timeout,
+angular.module('controller.membership', []).controller('MembershipController', function ($scope, $log, $location, $timeout, pagingService,
                                                                                          groupsService, profileService, utilityService) {
 
     $scope.membership = { members: [], group: {} };
     $scope.membershipLoaded = false;
     $scope.alerts = [];
     $scope.isGroupAdmin = false;
+    $scope.groupChanges = {};
+    $scope.currentGroup = {};
+
+    $scope.groupModalState = {
+        VIEW_DETAILS: 1
+    };
+    $scope.disabledStates = [$scope.groupModalState.VIEW_DETAILS];
+
+    // read-only data for setting various classes/attributes in group modal
+    $scope.groupModalParams = {
+        readOnly: {
+            class: "",
+            readOnly: true
+        }
+    };
+
+    // paging status for group changes
+    var changePaging = pagingService.getNewPagingParams(100);
 
     function handleError(error, type) {
         var alert = utilityService.failure(error, type);
@@ -207,8 +225,113 @@ angular.module('controller.membership', []).controller('MembershipController', f
 
         $scope.resetNewMemberData();
         $scope.getGroupInfo(id);
+        $scope.refreshGroupChanges(id);
     };
 
+    $scope.refreshGroupChanges = function(id) {
+        if(!id){
+            var id = $location.absUrl().toString();
+            id = id.substring(id.lastIndexOf('/') + 1);
+            id = id.substring(0, id.indexOf('#'))
+        }
+        $log.log('refreshGroupChanges, loading group with id ', id);
+        changePaging = pagingService.resetPaging(changePaging);
+        function success(response) {
+            $log.log('groupsService::getGroupChanges-success');
+            changePaging.next = response.data.nextId;
+            updateChangeDisplay(response.data.changes)
+        }
+        return groupsService
+            .getGroupChanges(id, changePaging.maxItems, undefined)
+            .then(success)
+            .catch(function (error){
+                handleError(error, 'groupsService::getGroupChanges-failure');
+            });
+    };
+
+    function updateChangeDisplay(changes) {
+        var newChanges = [];
+        angular.forEach(changes, function(change) {
+            newChanges.push(change);
+        });
+        $scope.groupChanges = newChanges;
+    }
+
+    /**
+     * Group change paging
+     */
+    $scope.getChangePageTitle = function() {
+        return pagingService.getPanelTitle(changePaging);
+    };
+
+    $scope.changePrevPageEnabled = function() {
+        return pagingService.prevPageEnabled(changePaging);
+    };
+
+    $scope.changeNextPageEnabled = function() {
+        return pagingService.nextPageEnabled(changePaging);
+    };
+
+    $scope.changePrevPage = function() {
+        var startFrom = pagingService.getPrevStartFrom(changePaging);
+        var id = $location.absUrl().toString();
+        id = id.substring(id.lastIndexOf('/') + 1);
+        id = id.substring(0, id.indexOf('#'))
+        $log.log('changePrevPage, loading group with id ', id);
+        return groupsService
+            .getGroupChanges(id, changePaging.maxItems, startFrom)
+            .then(function(response) {
+                changePaging = pagingService.prevPageUpdate(response.data.nextId, changePaging);
+                updateChangeDisplay(response.data.changes);
+            })
+            .catch(function (error) {
+                handleError(error, 'groupsService::changePrevPage-failure');
+            });
+    };
+
+    $scope.changeNextPage = function() {
+        var id = $location.absUrl().toString();
+        id = id.substring(id.lastIndexOf('/') + 1);
+        id = id.substring(0, id.indexOf('#'))
+        $log.log('changeNextPage, loading group with id ', id);
+        return groupsService
+            .getGroupChanges(id, changePaging.maxItems, changePaging.next)
+            .then(function(response) {
+                var changes = response.data.changes;
+                changePaging = pagingService.nextPageUpdate(changes, response.data.nextId, changePaging);
+
+                if(changes.length > 0 ){
+                    updateChangeDisplay(changes);
+                }
+            })
+            .catch(function (error) {
+                handleError(error, 'groupsService::changeNextPage-failure');
+            });
+    };
+
+    $scope.viewGroupInfo = function(group) {
+        var newGroup = angular.copy(group);
+        newGroup.adminIds = [];
+        angular.forEach(group.admins, function(admin) {
+            newGroup.adminIds.push(admin.id);
+        });
+        newGroup.memberIds = [];
+        angular.forEach(group.members, function(member) {
+            newGroup.memberIds.push(member.id);
+        });
+        $scope.currentGroup = newGroup;
+        $scope.groupModal = {
+            action: $scope.groupModalState.VIEW_DETAILS,
+            title: "Group Info",
+            basics: $scope.groupModalParams.readOnly,
+            details: $scope.groupModalParams.readOnly,
+        };
+        $("#group_modal").modal("show");
+    };
+
+    $scope.closeGroupModal = function() {
+        $scope.viewGroupForm.$setPristine();
+    };
 
     $timeout($scope.refresh, 0);
 });

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -27,7 +27,6 @@ angular.module('controller.membership', []).controller('MembershipController', f
     $scope.groupModalState = {
         VIEW_DETAILS: 1
     };
-    $scope.disabledStates = [$scope.groupModalState.VIEW_DETAILS];
 
     // read-only data for setting various classes/attributes in group modal
     $scope.groupModalParams = {

--- a/modules/portal/public/lib/controllers/controller.membership.spec.js
+++ b/modules/portal/public/lib/controllers/controller.membership.spec.js
@@ -20,14 +20,16 @@ describe('Controller: MembershipController', function () {
         module('service.groups'),
         module('service.profile'),
         module('service.utility'),
+        module('service.paging'),
         module('controller.membership')
     });
-    beforeEach(inject(function ($rootScope, $controller, $q, groupsService, profileService, utilityService) {
+    beforeEach(inject(function ($rootScope, $controller, $q, groupsService, profileService, utilityService, pagingService) {
         this.rootScope = $rootScope;
         this.scope = $rootScope.$new();
         this.groupsService = groupsService;
         this.profileService = profileService;
         this.utilityService = utilityService;
+        this.pagingService = pagingService;
         this.q = $q;
         var mockGroup = {
             data: {
@@ -110,7 +112,8 @@ describe('Controller: MembershipController', function () {
         expect(profileService.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.utilitySuccess.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual([this.mockSuccessAlert]);
+        expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('addMember correctly calls utilityService when failing getUserDataByUsername', function(){
@@ -151,9 +154,10 @@ describe('Controller: MembershipController', function () {
         this.scope.$digest();
 
         expect(profileService.calls.count()).toBe(1);
-        expect(this.utilityFailure.calls.count()).toBe(1);
+        expect(this.utilityFailure.calls.count()).toBe(2);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual([this.mockFailureAlert]);
+        expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -177,7 +181,8 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual([this.mockSuccessAlert]);
+        expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -199,9 +204,10 @@ describe('Controller: MembershipController', function () {
         this.scope.removeMember('memberId');
         this.scope.$digest();
 
-        expect(this.utilityFailure.calls.count()).toBe(1);
+        expect(this.utilityFailure.calls.count()).toBe(2);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual([this.mockFailureAlert]);
+        expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -229,7 +235,8 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual([this.mockSuccessAlert]);
+        expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -255,9 +262,10 @@ describe('Controller: MembershipController', function () {
         this.scope.toggleAdmin(mockMember);
         this.scope.$digest();
 
-        expect(this.utilityFailure.calls.count()).toBe(1);
+        expect(this.utilityFailure.calls.count()).toBe(2);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual([this.mockFailureAlert]);
+        expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('refresh correctly handles error when failing getGroup', function() {
@@ -269,7 +277,7 @@ describe('Controller: MembershipController', function () {
         this.scope.$digest();
 
         expect(getGroup.calls.count()).toBe(1);
-        expect(this.utilityFailure.calls.count()).toBe(1);
+        expect(this.utilityFailure.calls.count()).toBe(2);
     });
 
     it('refresh correctly handles error when failing getGroupMemberList', function() {
@@ -281,7 +289,7 @@ describe('Controller: MembershipController', function () {
         this.scope.$digest();
 
         expect(getGroupMemberList.calls.count()).toBe(1);
-        expect(this.utilityFailure.calls.count()).toBe(1);
+        expect(this.utilityFailure.calls.count()).toBe(2);
     });
 
     it('getGroupInfo sets the group info, admin status when the user is an admin', function() {

--- a/modules/portal/public/lib/controllers/controller.membership.spec.js
+++ b/modules/portal/public/lib/controllers/controller.membership.spec.js
@@ -445,6 +445,56 @@ describe('Controller: MembershipController', function () {
         expect(this.scope.isGroupAdmin).toBe(true);
     });
 
+    it('test that we properly get group change data', function(){
+        this.scope.groupChanges = {};
+        var response = {
+            data: {
+                changes: [
+                    {
+                        newGroup: {
+                            id: "f9329f39-595d-45c9-8cdf-ac36e96e085d",
+                            name: "test-group",
+                            email: "test@test.com",
+                            created: "2022-07-20T10:14:49Z",
+                            status: "Active",
+                            members: [
+                                {
+                                    id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                },
+                                {
+                                    id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                }
+                            ],
+                            admins: [
+                                {
+                                    id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                },
+                                {
+                                    id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                }
+                            ]
+                        },
+                        changeType: "Delete",
+                        userId: "ea7ec24e-3cc2-4740-b1b8-acde0158271f",
+                        id: "13516a79-1c61-4b9d-b442-0a773fc9c99f",
+                        created: "2022-07-20T10:24:28Z",
+                        userName: "professor"
+                    }
+                ],
+                maxItems: 100
+            }
+        };
+        var getGroupChangesSets = spyOn(this.groupsService, 'getGroupChanges')
+            .and.stub()
+            .and.returnValue(this.q.when(response));
+
+        this.scope.refresh();
+        this.scope.$digest();
+
+        expect(getGroupChangesSets.calls.count()).toBe(1);
+        expect(this.scope.groupChanges).toEqual(response.data.changes);
+    });
+
     it('nextPage should call getGroupChanges with the correct parameters', function () {
 
         var response = {

--- a/modules/portal/public/lib/controllers/controller.membership.spec.js
+++ b/modules/portal/public/lib/controllers/controller.membership.spec.js
@@ -153,7 +153,7 @@ describe('Controller: MembershipController', function () {
         expect(profileService.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.utilitySuccess.calls.count()).toBe(1);
-        expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts).toEqual(this.mockSuccessAlert);
     });
 
     it('addMember correctly calls utilityService when failing getUserDataByUsername', function(){
@@ -196,7 +196,7 @@ describe('Controller: MembershipController', function () {
         expect(profileService.calls.count()).toBe(1);
         expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -220,7 +220,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts).toEqual(this.mockSuccessAlert);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -244,7 +244,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -272,7 +272,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts).toEqual(this.mockSuccessAlert);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -300,7 +300,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts).toEqual(this.mockFailureAlert);
     });
 
     it('refresh correctly handles error when failing getGroup', function() {

--- a/modules/portal/public/lib/controllers/controller.membership.spec.js
+++ b/modules/portal/public/lib/controllers/controller.membership.spec.js
@@ -70,6 +70,47 @@ describe('Controller: MembershipController', function () {
         this.groupsService.getGroupMemberList = function() {
             return $q.when(mockGroupList);
         };
+
+        this.groupsService.getGroupChanges = function () {
+            return $q.when({
+                data: {
+                    changes: [
+                        {
+                            newGroup: {
+                                id: "f9329f39-595d-45c9-8cdf-ac36e96e085d",
+                                name: "test-group",
+                                email: "test@test.com",
+                                created: "2022-07-20T10:14:49Z",
+                                status: "Active",
+                                members: [
+                                    {
+                                        id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                    },
+                                    {
+                                        id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                    }
+                                ],
+                                admins: [
+                                    {
+                                        id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                    },
+                                    {
+                                        id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                    }
+                                ]
+                            },
+                            changeType: "Delete",
+                            userId: "ea7ec24e-3cc2-4740-b1b8-acde0158271f",
+                            id: "13516a79-1c61-4b9d-b442-0a773fc9c99f",
+                            created: "2022-07-20T10:24:28Z",
+                            userName: "professor"
+                        }
+                    ],
+                    maxItems: 100
+                }
+            });
+        };
+
         this.controller = $controller('MembershipController', {'$scope': this.scope});
 
         this.mockSuccessAlert = "success";
@@ -113,7 +154,6 @@ describe('Controller: MembershipController', function () {
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
-        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('addMember correctly calls utilityService when failing getUserDataByUsername', function(){
@@ -154,10 +194,9 @@ describe('Controller: MembershipController', function () {
         this.scope.$digest();
 
         expect(profileService.calls.count()).toBe(1);
-        expect(this.utilityFailure.calls.count()).toBe(2);
+        expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
-        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -182,7 +221,6 @@ describe('Controller: MembershipController', function () {
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
-        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -204,10 +242,9 @@ describe('Controller: MembershipController', function () {
         this.scope.removeMember('memberId');
         this.scope.$digest();
 
-        expect(this.utilityFailure.calls.count()).toBe(2);
+        expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
-        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -236,7 +273,6 @@ describe('Controller: MembershipController', function () {
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.scope.alerts[0]).toEqual(this.mockSuccessAlert);
-        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -262,10 +298,9 @@ describe('Controller: MembershipController', function () {
         this.scope.toggleAdmin(mockMember);
         this.scope.$digest();
 
-        expect(this.utilityFailure.calls.count()).toBe(2);
+        expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.scope.alerts[0]).toEqual(this.mockFailureAlert);
-        expect(this.scope.alerts[1]).toEqual(this.mockFailureAlert);
     });
 
     it('refresh correctly handles error when failing getGroup', function() {
@@ -277,7 +312,7 @@ describe('Controller: MembershipController', function () {
         this.scope.$digest();
 
         expect(getGroup.calls.count()).toBe(1);
-        expect(this.utilityFailure.calls.count()).toBe(2);
+        expect(this.utilityFailure.calls.count()).toBe(1);
     });
 
     it('refresh correctly handles error when failing getGroupMemberList', function() {
@@ -289,7 +324,7 @@ describe('Controller: MembershipController', function () {
         this.scope.$digest();
 
         expect(getGroupMemberList.calls.count()).toBe(1);
-        expect(this.utilityFailure.calls.count()).toBe(2);
+        expect(this.utilityFailure.calls.count()).toBe(1);
     });
 
     it('getGroupInfo sets the group info, admin status when the user is an admin', function() {
@@ -408,5 +443,120 @@ describe('Controller: MembershipController', function () {
         expect(this.scope.membership.group).toEqual(expectedGroup);
         expect(this.scope.membership.members).toEqual(expectedMembership);
         expect(this.scope.isGroupAdmin).toBe(true);
+    });
+
+    it('nextPage should call getGroupChanges with the correct parameters', function () {
+
+        var response = {
+            data: {
+                changes: [
+                    {
+                        newGroup: {
+                            id: "f9329f39-595d-45c9-8cdf-ac36e96e085d",
+                            name: "test-group",
+                            email: "test@test.com",
+                            created: "2022-07-20T10:14:49Z",
+                            status: "Active",
+                            members: [
+                                {
+                                    id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                },
+                                {
+                                    id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                }
+                            ],
+                            admins: [
+                                {
+                                    id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                },
+                                {
+                                    id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                }
+                            ]
+                        },
+                        changeType: "Delete",
+                        userId: "ea7ec24e-3cc2-4740-b1b8-acde0158271f",
+                        id: "13516a79-1c61-4b9d-b442-0a773fc9c99f",
+                        created: "2022-07-20T10:24:28Z",
+                        userName: "professor"
+                    }
+                ],
+                maxItems: 100
+            }
+        };
+        var getGroupChangesSets = spyOn(this.groupsService, 'getGroupChanges')
+            .and.stub()
+            .and.returnValue(this.q.when(response));
+
+        var expectedId = "";
+        var expectedMaxItems = 100;
+        var expectedStartFrom = undefined;
+
+        this.scope.changeNextPage();
+
+        expect(getGroupChangesSets.calls.count()).toBe(1);
+        expect(getGroupChangesSets.calls.mostRecent().args).toEqual(
+          [expectedId, expectedMaxItems, expectedStartFrom]);
+    });
+
+    it('prevPage should call getGroupChanges with the correct parameters', function () {
+
+        var response = {
+            data: {
+                changes: [
+                    {
+                        newGroup: {
+                            id: "f9329f39-595d-45c9-8cdf-ac36e96e085d",
+                            name: "test-group",
+                            email: "test@test.com",
+                            created: "2022-07-20T10:14:49Z",
+                            status: "Active",
+                            members: [
+                                {
+                                    id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                },
+                                {
+                                    id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                }
+                            ],
+                            admins: [
+                                {
+                                    id: "ea7ec24e-3cc2-4740-b1b8-acde0158271f"
+                                },
+                                {
+                                    id: "5bda099e-be26-4aac-a310-ecf221ee2451"
+                                }
+                            ]
+                        },
+                        changeType: "Delete",
+                        userId: "ea7ec24e-3cc2-4740-b1b8-acde0158271f",
+                        id: "13516a79-1c61-4b9d-b442-0a773fc9c99f",
+                        created: "2022-07-20T10:24:28Z",
+                        userName: "professor"
+                    }
+                ],
+                maxItems: 100
+            }
+        };
+        var getGroupChangesSets = spyOn(this.groupsService, 'getGroupChanges')
+            .and.stub()
+            .and.returnValue(this.q.when(response));
+
+        var expectedId = "";
+        var expectedMaxItems = 100;
+        var expectedStartFrom = undefined;
+
+        this.scope.changePrevPage();
+
+        expect(getGroupChangesSets.calls.count()).toBe(1);
+        expect(getGroupChangesSets.calls.mostRecent().args).toEqual(
+            [expectedId, expectedMaxItems, expectedStartFrom]);
+
+        this.scope.changeNextPage();
+        this.scope.changePrevPage();
+
+        expect(getGroupChangesSets.calls.count()).toBe(3);
+        expect(getGroupChangesSets.calls.mostRecent().args).toEqual(
+            [expectedId, expectedMaxItems, expectedStartFrom]);
     });
 });

--- a/modules/portal/public/lib/controllers/controller.membership.spec.js
+++ b/modules/portal/public/lib/controllers/controller.membership.spec.js
@@ -153,7 +153,7 @@ describe('Controller: MembershipController', function () {
         expect(profileService.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
         expect(this.utilitySuccess.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts).toEqual([this.mockSuccessAlert]);
     });
 
     it('addMember correctly calls utilityService when failing getUserDataByUsername', function(){
@@ -196,7 +196,7 @@ describe('Controller: MembershipController', function () {
         expect(profileService.calls.count()).toBe(1);
         expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts).toEqual([this.mockFailureAlert]);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -220,7 +220,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts).toEqual([this.mockSuccessAlert]);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -244,7 +244,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts).toEqual([this.mockFailureAlert]);
     });
 
     it('removeMember correctly calls utilityService when passing updateGroup', function(){
@@ -272,7 +272,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilitySuccess.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual(this.mockSuccessAlert);
+        expect(this.scope.alerts).toEqual([this.mockSuccessAlert]);
     });
 
     it('removeMember correctly calls utilityService when failing updateGroup', function(){
@@ -300,7 +300,7 @@ describe('Controller: MembershipController', function () {
 
         expect(this.utilityFailure.calls.count()).toBe(1);
         expect(updateGroup.calls.count()).toBe(1);
-        expect(this.scope.alerts).toEqual(this.mockFailureAlert);
+        expect(this.scope.alerts).toEqual([this.mockFailureAlert]);
     });
 
     it('refresh correctly handles error when failing getGroup', function() {

--- a/modules/portal/public/lib/services/groups/service.groups.js
+++ b/modules/portal/public/lib/services/groups/service.groups.js
@@ -105,6 +105,12 @@ angular.module('service.groups', [])
             return $http.get(url);
         };
 
+        this.getGroupChanges = function (groupId, count, startFrom) {
+            var url = '/api/groups/' + groupId + '/groupchanges';
+            url = this.urlBuilder(url, { 'startFrom': startFrom, 'maxItems': count });
+            return $http.get(url);
+        };
+
         this.getGroupsStored = function () {
             if (_refreshMyGroups || _myGroupsPromise == undefined) {
                 _myGroupsPromise = this.getGroups().then(

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -145,6 +145,26 @@ trait TestApplicationData { this: Mockito =>
        | }
     """.stripMargin)
 
+  val hobbitGroupChangeId = "b6018a9b-c893-40e9-aa25-4ccfee460c18"
+  val hobbitGroupChange: JsValue = Json.parse(s"""{
+      | "newGroup": {
+      | "id":          "$hobbitGroupId",
+      | "name":        "hobbits",
+      | "email":       "hobbitAdmin@shire.me",
+      | "description": "Hobbits of the shire",
+      | "members":     [ { "id": "${frodoUser.id}" },  { "id": "samwise-userId" } ],
+      | "admins":      [ { "id": "${frodoUser.id}" } ]
+      | },
+      | "changeType": "Create",
+      | "userId": "${frodoUser.id}",
+      | "oldGroup": {},
+      | "id": "b6018a9b-c893-40e9-aa25-4ccfee460c18",
+      | "created": "2022-07-22T08:19:22Z",
+      | "userName": "$frodoUser",
+      | "groupChangeMessage": ""
+      | }
+    """.stripMargin)
+
   val hobbitGroupChanges: JsValue = Json.parse(s"""{
        | "changes": [{
        | "newGroup": {

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -145,6 +145,28 @@ trait TestApplicationData { this: Mockito =>
        | }
     """.stripMargin)
 
+  val hobbitGroupChanges: JsValue = Json.parse(s"""{
+       | "changes": [{
+       | "newGroup": {
+       | "id":          "$hobbitGroupId",
+       | "name":        "hobbits",
+       | "email":       "hobbitAdmin@shire.me",
+       | "description": "Hobbits of the shire",
+       | "members":     [ { "id": "${frodoUser.id}" },  { "id": "samwise-userId" } ],
+       | "admins":      [ { "id": "${frodoUser.id}" } ]
+       | },
+       | "changeType": "Create",
+       | "userId": "${frodoUser.id}",
+       | "oldGroup": {},
+       | "id": "b6018a9b-c893-40e9-aa25-4ccfee460c18",
+       | "created": "2022-07-22T08:19:22Z",
+       | "userName": "$frodoUser",
+       | "groupChangeMessage": ""
+       | }],
+       | "maxItems": 100
+       | }
+    """.stripMargin)
+
   val ringbearerGroup: JsValue = Json.parse(
     s"""{
        |  "id":          "ringbearer-group-uuid",

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -800,6 +800,104 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
       }
     }
 
+    ".getGroupChange" should {
+      tag("slow")
+      "return the group change if it is found - status ok (200)" in new WithApplication(app) {
+        val client = MockWS {
+          case (GET, u) if u == s"http://localhost:9001/groups/change/${hobbitGroupChangeId}" =>
+            defaultActionBuilder { Results.Ok(hobbitGroupChange) }
+        }
+
+        val mockUserAccessor = mock[UserAccountAccessor]
+        mockUserAccessor.get(anyString).returns(IO.pure(Some(frodoUser)))
+        mockUserAccessor.getUserByKey(anyString).returns(IO.pure(Some(frodoUser)))
+        val underTest = withClient(client)
+        val result =
+          underTest.getGroupChange(hobbitGroupChangeId)(
+            FakeRequest(GET, s"/groups/change/$hobbitGroupChangeId")
+              .withSession("username" -> frodoUser.userName, "accessKey" -> frodoUser.accessKey)
+          )
+
+        status(result) must beEqualTo(OK)
+        hasCacheHeaders(result)
+        contentAsJson(result) must beEqualTo(hobbitGroupChange)
+      }
+      "return authentication failed (401) when auth fails in the backend" in new WithApplication(
+        app
+      ) {
+        val client = MockWS {
+          case (GET, u) if u == s"http://localhost:9001/groups/change/${hobbitGroupChangeId}" =>
+            defaultActionBuilder { Results.Unauthorized("Invalid credentials") }
+        }
+        val mockUserAccessor = mock[UserAccountAccessor]
+        mockUserAccessor.get(anyString).returns(IO.pure(Some(frodoUser)))
+        mockUserAccessor.getUserByKey(anyString).returns(IO.pure(Some(frodoUser)))
+        val underTest = withClient(client)
+        val result =
+          underTest.getGroupChange(hobbitGroupChangeId)(
+            FakeRequest(GET, s"/groups/change/$hobbitGroupChangeId")
+              .withSession("username" -> frodoUser.userName, "accessKey" -> frodoUser.accessKey)
+          )
+
+        status(result) must beEqualTo(UNAUTHORIZED)
+        hasCacheHeaders(result)
+      }
+      "return a not found (404) if the group change does not exist" in new WithApplication(app) {
+        val client = MockWS {
+          case (GET, u) if u == "http://localhost:9001/groups/change/not-hobbits" =>
+            defaultActionBuilder { Results.NotFound }
+        }
+        val mockUserAccessor = mock[UserAccountAccessor]
+        mockUserAccessor.get(anyString).returns(IO.pure(Some(frodoUser)))
+        mockUserAccessor.getUserByKey(anyString).returns(IO.pure(Some(frodoUser)))
+        val underTest = withClient(client)
+        val result = underTest.getGroupChange("not-hobbits")(
+          FakeRequest(GET, "/groups/change/not-hobbits")
+            .withSession("username" -> frodoUser.userName, "accessKey" -> frodoUser.accessKey)
+        )
+
+        status(result) must beEqualTo(NOT_FOUND)
+        hasCacheHeaders(result)
+      }
+      "return status forbidden (403) if the user account is locked" in new WithApplication(app) {
+        val client = mock[WSClient]
+        val underTest =
+          TestVinylDNS(
+            testConfigLdap,
+            mockLdapAuthenticator,
+            mockLockedUserAccessor,
+            client,
+            components,
+            crypto,
+            mockOidcAuth
+          )
+        val result =
+          underTest.getGroupChange(hobbitGroupChangeId)(
+            FakeRequest(GET, s"/groups/change/$hobbitGroupChangeId")
+              .withSession(
+                "username" -> lockedFrodoUser.userName,
+                "accessKey" -> lockedFrodoUser.accessKey
+              )
+          )
+
+        status(result) mustEqual 403
+        hasCacheHeaders(result)
+        contentAsString(result) must beEqualTo(
+          s"User account for `${lockedFrodoUser.userName}` is locked."
+        )
+      }
+      "return unauthorized (401) if user is not logged in" in new WithApplication(app) {
+        val client = mock[WSClient]
+        val underTest = withClient(client)
+        val result =
+          underTest.getGroupChange(hobbitGroupChangeId)(FakeRequest(GET, s"/groups/change/$hobbitGroupChangeId"))
+
+        status(result) must beEqualTo(401)
+        contentAsString(result) must beEqualTo("You are not logged in. Please login to continue.")
+        hasCacheHeaders(result)
+      }
+    }
+
     ".listGroupChanges" should {
       "return group changes - status ok (200)" in new WithApplication(app) {
         val client = MockWS {

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -800,6 +800,37 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
       }
     }
 
+    ".listGroupChanges" should {
+      "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
+        val client = mock[WSClient]
+        val underTest = withClient(client)
+        val result =
+          underTest.listGroupChanges(hobbitGroupId)(
+            FakeRequest(GET, s"/api/groups/$hobbitGroupId/activity")
+          )
+
+        status(result) mustEqual 401
+        hasCacheHeaders(result)
+        contentAsString(result) must beEqualTo("You are not logged in. Please login to continue.")
+      }
+      "return forbidden (403) if user account is locked" in new WithApplication(app) {
+        val client = mock[WSClient]
+        val underTest = withLockedClient(client)
+        val result = underTest.listGroupChanges(hobbitGroupId)(
+          FakeRequest(GET, s"/api/groups/$hobbitGroupId/activity").withSession(
+            "username" -> lockedFrodoUser.userName,
+            "accessKey" -> lockedFrodoUser.accessKey
+          )
+        )
+
+        status(result) mustEqual 403
+        hasCacheHeaders(result)
+        contentAsString(result) must beEqualTo(
+          s"User account for `${lockedFrodoUser.userName}` is locked."
+        )
+      }
+    }
+
     ".deleteGroup" should {
       "return ok with no content (204) when delete is successful" in new WithApplication(app) {
         val client = MockWS {


### PR DESCRIPTION
Fixes #1153 

Changes in this pull request:
- Added `group change history` in portal to view what changes have been made to groups (admin added & removed, member added & removed etc) and by whom it was made. It was done similar to `record set changes history` in zones view.
