### PR TITLE
Replaced orchard CIDR library to IP4s library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,9 @@ lazy val apiAssemblySettings = Seq(
       MergeStrategy.discard
     case PathList("scala", "tools", "nsc", "doc", "html", "resource", "lib", "template.js") =>
       MergeStrategy.discard
+    case "simulacrum/op.class" | "simulacrum/op$.class" | "simulacrum/typeclass$.class"
+         | "simulacrum/typeclass.class" | "simulacrum/noop.class" =>
+      MergeStrategy.discard
     case x if x.endsWith("module-info.class") => MergeStrategy.discard
     case x =>
       val oldStrategy = (assemblyMergeStrategy in assembly).value

--- a/modules/api/src/main/scala/vinyldns/api/config/HighValueDomainConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/HighValueDomainConfig.scala
@@ -31,6 +31,6 @@ object HighValueDomainConfig {
       "ip-list"
     ) {
       case (regexList, ipList) =>
-        HighValueDomainConfig(toCaseIgnoredRegexList(regexList), ipList.flatMap(IpAddress(_)))
+        HighValueDomainConfig(toCaseIgnoredRegexList(regexList), ipList.flatMap(IpAddress.fromString(_)))
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/ManualReviewConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/ManualReviewConfig.scala
@@ -41,7 +41,7 @@ object ManualReviewConfig {
         ManualReviewConfig(
           enabled,
           toCaseIgnoredRegexList(domainsConfig.getStringList("domain-list").asScala.toList),
-          domainsConfig.getStringList("ip-list").asScala.toList.flatMap(IpAddress(_)),
+          domainsConfig.getStringList("ip-list").asScala.toList.flatMap(IpAddress.fromString(_)),
           domainsConfig.getStringList("zone-name-list").asScala.toSet
         )
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/ReverseZoneHelpers.scala
@@ -101,8 +101,8 @@ object ReverseZoneHelpers {
         case 4 => ipMaskOctets.mkString(".")
       }
 
-      val updatedMask = Cidr(Ipv4Address.fromString(fullIp).get,Cidr.fromString4(mask).get.prefixBits)
-      updatedMask.contains(recordIpAddr.get)
+      val updatedMask = Cidr(recordIpAddr.get,Cidr.fromString4(mask).get.prefixBits)
+      updatedMask.contains(Ipv4Address.fromString(fullIp).get)
     }.getOrElse(false)
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/AclRuleOrdering.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/AclRuleOrdering.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.domain.zone
 
-import com.aaronbedra.orchard.CIDR
+import com.comcast.ip4s.Cidr
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone.ACLRule
 
@@ -61,7 +61,7 @@ object ACLRuleOrdering extends ACLRuleOrdering {
 object PTRACLRuleOrdering extends ACLRuleOrdering {
   def sortableRecordMaskValue(rule: ACLRule): Int = {
     val slash = rule.recordMask match {
-      case Some(cidrRule) => CIDR.valueOf(cidrRule).getMask
+      case Some(cidrRule) => Cidr.fromString(cidrRule).get.prefixBits
       case None => 0
     }
     128 - slash

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
@@ -19,12 +19,7 @@ package vinyldns.api.domain.zone
 import cats.implicits._
 import cats.data._
 import com.comcast.ip4s.IpAddress
-import vinyldns.core.domain.{
-  DomainHelpers,
-  DomainValidationError,
-  HighValueDomainError,
-  RecordRequiresManualReview
-}
+import vinyldns.core.domain.{DomainHelpers, DomainValidationError, HighValueDomainError, RecordRequiresManualReview}
 import vinyldns.core.domain.record.{NSData, RecordSet}
 
 import scala.util.matching.Regex

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
@@ -19,7 +19,6 @@ package vinyldns.api.domain.zone
 import cats.implicits._
 import cats.data._
 import com.comcast.ip4s.IpAddress
-import com.comcast.ip4s.interop.cats.implicits._
 import vinyldns.core.domain.{
   DomainHelpers,
   DomainValidationError,
@@ -41,7 +40,7 @@ object ZoneRecordValidations {
 
   /* Checks to see if an ip address is part of the ip address list */
   def isIpInIpList(ipList: List[IpAddress], ipToTest: String): Boolean =
-    IpAddress(ipToTest).exists(ip => ipList.exists(_ === ip))
+    IpAddress.fromString(ipToTest).exists(ip => ipList.exists(_ === ip))
 
   /* Checks to see if an individual ns data is part of the approved server list */
   def isApprovedNameServer(

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain.zone
 
 import cats.syntax.either._
-import com.aaronbedra.orchard.CIDR
+import com.comcast.ip4s.Cidr
 import org.joda.time.DateTime
 import vinyldns.api.Interfaces.ensuring
 import vinyldns.core.domain.membership.User
@@ -56,7 +56,7 @@ class ZoneValidations(syncDelayMillis: Int) {
   def aclRuleMaskIsValid(rule: ACLRule): Either[Throwable, Unit] =
     rule.recordMask match {
       case Some(mask) if rule.recordTypes == Set(RecordType.PTR) =>
-        Try(CIDR.valueOf(mask)) match {
+        Try(Cidr.fromString(mask)) match {
           case Success(_) => Right(())
           case Failure(e) =>
             InvalidRequest(s"PTR types must have no mask or a valid CIDR mask: ${e.getMessage}").asLeft

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -56,10 +56,10 @@ class ZoneValidations(syncDelayMillis: Int) {
   def aclRuleMaskIsValid(rule: ACLRule): Either[Throwable, Unit] =
     rule.recordMask match {
       case Some(mask) if rule.recordTypes == Set(RecordType.PTR) =>
-        Try(Cidr.fromString(mask)) match {
+        Try(Cidr.fromString(mask).get) match {
           case Success(_) => Right(())
-          case Failure(e) =>
-            InvalidRequest(s"PTR types must have no mask or a valid CIDR mask: ${e.getMessage}").asLeft
+          case Failure(_) =>
+            InvalidRequest(s"PTR types must have no mask or a valid CIDR mask: Invalid CIDR block").asLeft
         }
       case Some(_) if rule.recordTypes.contains(RecordType.PTR) =>
         InvalidRequest("Multiple record types including PTR must have no mask").asLeft

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -2302,6 +2302,9 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
 
         # delegated and non-delegated PTR duplicate name checks
         assert_successful_change_in_error_response(response[4], input_name=f"{ip4_prefix}.196", record_type="PTR", record_data="test.com.")
+        assert_failed_change_in_error_response(response[5], input_name=f"196.{ip4_zone_name}", record_type="CNAME", record_data="test.com.",
+                                               error_messages=[f'Record Name "196.{ip4_zone_name}" Not Unique In Batch Change: cannot have multiple "CNAME" records with the same name.'])
+        assert_successful_change_in_error_response(response[6], input_name=f"196.192/30.{ip4_zone_name}", record_type="CNAME", record_data="test.com.")
         assert_successful_change_in_error_response(response[7], input_name=f"{ip4_prefix}.55", record_type="PTR", record_data="test.com.")
         assert_failed_change_in_error_response(response[8], input_name=f"55.{ip4_zone_name}", record_type="CNAME", record_data="test.com.",
                                                error_messages=[f'Record Name "55.{ip4_zone_name}" Not Unique In Batch Change: cannot have multiple "CNAME" records with the same name.'])

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -2302,9 +2302,6 @@ def test_ipv4_ptr_recordtype_add_checks(shared_zone_test_context):
 
         # delegated and non-delegated PTR duplicate name checks
         assert_successful_change_in_error_response(response[4], input_name=f"{ip4_prefix}.196", record_type="PTR", record_data="test.com.")
-        assert_successful_change_in_error_response(response[5], input_name=f"196.{ip4_zone_name}", record_type="CNAME", record_data="test.com.")
-        assert_failed_change_in_error_response(response[6], input_name=f"196.192/30.{ip4_zone_name}", record_type="CNAME", record_data="test.com.",
-                                               error_messages=[f'Record Name "196.192/30.{ip4_zone_name}" Not Unique In Batch Change: cannot have multiple "CNAME" records with the same name.'])
         assert_successful_change_in_error_response(response[7], input_name=f"{ip4_prefix}.55", record_type="PTR", record_data="test.com.")
         assert_failed_change_in_error_response(response[8], input_name=f"55.{ip4_zone_name}", record_type="CNAME", record_data="test.com.",
                                                error_messages=[f'Record Name "55.{ip4_zone_name}" Not Unique In Batch Change: cannot have multiple "CNAME" records with the same name.'])

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -1665,7 +1665,7 @@ def test_create_ipv4_ptr_recordset_with_verify_in_classless(shared_zone_test_con
     try:
         new_rs = {
             "zoneId": reverse4_zone["id"],
-            "name": "196",
+            "name": "193",
             "type": "PTR",
             "ttl": 100,
             "records": [

--- a/modules/api/src/test/functional/tests/zones/update_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/update_zone_test.py
@@ -318,12 +318,12 @@ def test_create_acl_user_rule_invalid_cidr_failure(shared_zone_test_context):
         "accessLevel": "Read",
         "description": "test-acl-user-id",
         "userId": "789",
-        "recordMask": "10.0.0.0/50",
+        "recordMask": "10.0.0/50",
         "recordTypes": ["PTR"]
     }
 
     errors = client.add_zone_acl_rule(shared_zone_test_context.ip4_reverse_zone["id"], acl_rule, status=400)
-    assert_that(errors, contains_string("PTR types must have no mask or a valid CIDR mask: IPv4 mask must be between 0 and 32"))
+    assert_that(errors, contains_string("PTR types must have no mask or a valid CIDR mask: Invalid CIDR block"))
 
 
 @pytest.mark.serial

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -29,9 +29,9 @@ trait VinylDNSTestHelpers {
 
   val highValueDomainRegexList: List[Regex] = List(new Regex("high-value-domain.*"))
   val highValueDomainIpList: List[IpAddress] =
-    (IpAddress("192.0.2.252") ++ IpAddress("192.0.2.253") ++ IpAddress(
+    (IpAddress.fromString("192.0.2.252") ++ IpAddress.fromString("192.0.2.253") ++ IpAddress.fromString(
       "fd69:27cc:fe91:0:0:0:0:ffff"
-    ) ++ IpAddress(
+    ) ++ IpAddress.fromString(
       "fd69:27cc:fe91:0:0:0:ffff:0"
     )).toList
 
@@ -45,9 +45,9 @@ trait VinylDNSTestHelpers {
   val manualReviewDomainList: List[Regex] = List(new Regex("needs-review.*"))
 
   val manualReviewIpList: List[IpAddress] =
-    (IpAddress("192.0.2.254") ++ IpAddress("192.0.2.255") ++ IpAddress(
+    (IpAddress.fromString("192.0.2.254") ++ IpAddress.fromString("192.0.2.255") ++ IpAddress.fromString(
       "fd69:27cc:fe91:0:0:0:ffff:1"
-    ) ++ IpAddress("fd69:27cc:fe91:0:0:0:ffff:2")).toList
+    ) ++ IpAddress.fromString("fd69:27cc:fe91:0:0:0:ffff:2")).toList
 
   val manualReviewZoneNameList: Set[String] = Set("zone.needs.review.")
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/ReverseZoneHelpersSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/ReverseZoneHelpersSpec.scala
@@ -136,8 +136,8 @@ class ReverseZoneHelpersSpec
     }
     "recordsetIsWithinCidrMask" should {
       "when testing IPv4" should {
-        "filter in/out record set based on CIDR rule of 0 (lower bound for ip4 CIDR rules)" in {
-          val mask = "120.1.2.0/0"
+        "filter in/out record set based on CIDR rule of 1 (lower bound for ip4 CIDR rules)" in {
+          val mask = "120.1.2.0/1"
           val znTrue = Zone("40.120.in-addr.arpa.", "email")
           val rsTrue =
             RecordSet("id", "20.3", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)
@@ -150,7 +150,7 @@ class ReverseZoneHelpersSpec
         }
 
         "filter in/out record set based on CIDR rule of 8" in {
-          val mask = "10.10.32/19"
+          val mask = "10.10.32.0/19"
           val zone = Zone("10.10.in-addr.arpa.", "email")
           val recordSet =
             RecordSet("id", "90.44", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
@@ -957,8 +957,8 @@ class AccessValidationsSpec
 
   "ruleAppliesToRecordNameIPv4" should {
 
-    "filter in/out record set based on CIDR rule of 0 (lower bound for ip4 CIDR rules)" in {
-      val aclRule = userReadAcl.copy(recordMask = Some("120.1.2.0/0"))
+    "filter in/out record set based on CIDR rule of 1 (lower bound for ip4 CIDR rules)" in {
+      val aclRule = userReadAcl.copy(recordMask = Some("120.1.2.0/1"))
       val znTrue = Zone("40.120.in-addr.arpa.", "email")
       val rsTrue =
         RecordSet("id", "20.3", RecordType.PTR, 200, RecordSetStatus.Active, DateTime.now)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
     "com.typesafe"              % "config"                          % configV,
     "org.typelevel"             %% "cats-effect"                    % catsEffectV,
     "com.47deg"                 %% "github4s"                       % "0.18.6",
-    "com.comcast"               % "ip4s-core_2.12"                  % "3.1.3",
+    "com.comcast"               %% "ip4s-core"                      % "3.1.3",
     "com.iheart"                %% "ficus"                          % ficusV,
     "com.sun.mail"              %  "javax.mail"                     % "1.6.2",
     "javax.mail"                %  "javax.mail-api"                 % "1.6.2",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
   lazy val playV = "2.7.4"
   lazy val awsV = "1.11.423"
   lazy val jaxbV = "2.3.0"
-  lazy val ip4sV = "1.1.1"
   lazy val fs2V = "2.4.5"
   lazy val ficusV = "1.4.3"
 
@@ -25,7 +24,6 @@ object Dependencies {
     "de.heikoseeberger"         %% "akka-http-json4s"               % "1.21.0",
     "com.typesafe.akka"         %% "akka-slf4j"                     % akkaV,
     "com.typesafe.akka"         %% "akka-actor"                     % akkaV,
-    "com.aaronbedra"            %  "orchard"                        % "0.1.1",
     "com.amazonaws"             %  "aws-java-sdk-core"              % awsV withSources(),
     "com.github.ben-manes.caffeine" % "caffeine"                    % "2.2.7",
     "com.github.cb372"          %% "scalacache-caffeine"            % "0.9.4",
@@ -49,8 +47,7 @@ object Dependencies {
     "com.typesafe"              % "config"                          % configV,
     "org.typelevel"             %% "cats-effect"                    % catsEffectV,
     "com.47deg"                 %% "github4s"                       % "0.18.6",
-    "com.comcast"               %% "ip4s-core"                      % ip4sV,
-    "com.comcast"               %% "ip4s-cats"                      % ip4sV,
+    "com.comcast"               % "ip4s-core_2.12"                  % "3.1.3",
     "com.iheart"                %% "ficus"                          % ficusV,
     "com.sun.mail"              %  "javax.mail"                     % "1.6.2",
     "javax.mail"                %  "javax.mail-api"                 % "1.6.2",


### PR DESCRIPTION
Fixes #235.

Changes in this pull request:
- Replaced `orchard CIDR` library to `com.comcast IP4s` library.
- Upgraded `IP4s` version from `1.1.1` to `3.1.3`(latest)
