### PR TITLE
Replace await with IO

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -550,25 +550,23 @@ class RecordSetServiceIntegrationSpec
     }
 
     "fail deleting for user not in record owner group in shared zone" in {
-      val result = leftResultOf(
+      val result =
         testRecordSetService
           .deleteRecordSet(sharedTestRecord.id, sharedTestRecord.zoneId, dummyAuth)
-          .value
-      )
+          .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe a[NotAuthorizedError]
     }
 
     "fail deleting for user in record owner group in non-shared zone" in {
-      val result = leftResultOf(
+      val result =
         testRecordSetService
           .deleteRecordSet(
             testOwnerGroupRecordInNormalZone.id,
             testOwnerGroupRecordInNormalZone.zoneId,
             auth2
           )
-          .value
-      )
+          .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe a[NotAuthorizedError]
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/auth/MembershipAuthPrincipalProviderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/auth/MembershipAuthPrincipalProviderSpec.scala
@@ -21,17 +21,14 @@ import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import vinyldns.api.ResultHelpers
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.domain.membership.{MembershipRepository, UserRepository}
 import cats.effect._
-import vinyldns.core.domain.auth.AuthPrincipal
 
 class MembershipAuthPrincipalProviderSpec
     extends AnyWordSpec
     with Matchers
-    with MockitoSugar
-    with ResultHelpers {
+    with MockitoSugar {
 
   "MembershipAuthPrincipalProvider" should {
     "return the AuthPrincipal" in {
@@ -65,7 +62,7 @@ class MembershipAuthPrincipalProviderSpec
         .when(mockUserRepo)
         .getUserByAccessKey(any[String])
 
-      val result = await[Option[AuthPrincipal]](underTest.getAuthPrincipal("None"))
+      val result = underTest.getAuthPrincipal("None").unsafeRunSync()
       result shouldBe None
     }
     "return an empty list of groups if there are no matching groups" in {
@@ -83,7 +80,7 @@ class MembershipAuthPrincipalProviderSpec
         .when(mockMembershipRepo)
         .getGroupsForUser(any[String])
 
-      val result = await[Option[AuthPrincipal]](underTest.getAuthPrincipal(accessKey))
+      val result = underTest.getAuthPrincipal(accessKey).unsafeRunSync()
       result.map { authPrincipal =>
         authPrincipal.signedInUser shouldBe okUser
         authPrincipal.memberGroupIds shouldBe Seq()

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -554,7 +554,7 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
           singleChangesOneDelete,
           approvalStatus = BatchChangeApprovalStatus.AutoApproved
         )
-      val result = rightResultOf(
+      val result =
         underTest
           .sendBatchForProcessing(
             batchWithBadChange,
@@ -562,8 +562,7 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
             ChangeForValidationMap(changeForValidationOneDelete.map(_.validNel), existingRecordSets),
             None
           )
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       val returnedBatch = result.batchChange
 
@@ -576,7 +575,7 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
 
       // check the update has been made in the DB
       val savedBatch: Option[BatchChange] =
-        await(batchChangeRepo.getBatchChange(batchWithBadChange.id))
+        batchChangeRepo.getBatchChange(batchWithBadChange.id).unsafeRunSync()
       savedBatch shouldBe Some(returnedBatch)
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -26,7 +26,6 @@ import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import vinyldns.api.ValidatedBatchMatcherImprovements.containChangeForValidation
-import vinyldns.api._
 import vinyldns.api.domain.auth.AuthPrincipalProvider
 import vinyldns.api.domain.batch.BatchChangeInterfaces.{BatchResult, _}
 import vinyldns.api.domain.batch.BatchTransformations._
@@ -58,7 +57,6 @@ class BatchChangeServiceSpec
     extends AnyWordSpec
     with Matchers
     with MockitoSugar
-    with CatsHelpers
     with BeforeAndAfterEach
     with EitherMatchers
     with EitherValues
@@ -457,7 +455,7 @@ class BatchChangeServiceSpec
     "succeed if all inputs are good" in {
       val input = BatchChangeInput(None, List(apexAddA, nonApexAddA))
 
-      val result = rightResultOf(underTest.applyBatchChange(input, auth, true).value)
+      val result = underTest.applyBatchChange(input, auth, true).value.unsafeRunSync().toOption.get
 
       result.changes.length shouldBe 2
     }
@@ -487,7 +485,7 @@ class BatchChangeServiceSpec
 
       val input = BatchChangeInput(None, List(ptr), Some(authGrp.id))
 
-      val result = rightResultOf(underTest.applyBatchChange(input, auth, false).value)
+      val result = underTest.applyBatchChange(input, auth, false).value.unsafeRunSync().toOption.get
 
       result.changes.length shouldBe 1
       result.changes.head.zoneId shouldBe Some(ipv6PTR17Zone.id)
@@ -518,7 +516,7 @@ class BatchChangeServiceSpec
 
       val input = BatchChangeInput(None, List(ptr), Some(authGrp.id))
 
-      val result = rightResultOf(underTest.applyBatchChange(input, auth, false).value)
+      val result = underTest.applyBatchChange(input, auth, false).value.unsafeRunSync().toOption.get
 
       result.changes.length shouldBe 1
       result.changes.head.zoneId shouldBe Some(ipv6PTR16Zone.id)
@@ -526,7 +524,7 @@ class BatchChangeServiceSpec
 
     "fail if conversion cannot process" in {
       val input = BatchChangeInput(Some("conversionError"), List(apexAddA, nonApexAddA))
-      val result = leftResultOf(underTest.applyBatchChange(input, auth, true).value)
+      val result = underTest.applyBatchChange(input, auth, true).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe an[BatchConversionError]
     }
@@ -534,7 +532,7 @@ class BatchChangeServiceSpec
     "fail with GroupDoesNotExist if owner group ID is provided for a non-existent group" in {
       val ownerGroupId = "non-existent-group-id"
       val input = BatchChangeInput(None, List(apexAddA), Some(ownerGroupId))
-      val result = leftResultOf(underTest.applyBatchChange(input, auth, true).value)
+      val result = underTest.applyBatchChange(input, auth, true).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe InvalidBatchChangeInput(List(GroupDoesNotExist(ownerGroupId)))
     }
@@ -542,7 +540,7 @@ class BatchChangeServiceSpec
     "fail with UserDoesNotBelongToOwnerGroup if normal user does not belong to group specified by owner group ID" in {
       val ownerGroupId = "user-is-not-member"
       val input = BatchChangeInput(None, List(apexAddA), Some(ownerGroupId))
-      val result = leftResultOf(underTest.applyBatchChange(input, notAuth, true).value)
+      val result = underTest.applyBatchChange(input, notAuth, true).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe
         InvalidBatchChangeInput(
@@ -552,7 +550,7 @@ class BatchChangeServiceSpec
 
     "succeed if owner group ID is provided and user is a member of the group" in {
       val input = BatchChangeInput(None, List(apexAddA), Some(okGroup.id))
-      val result = rightResultOf(underTest.applyBatchChange(input, okAuth, true).value)
+      val result = underTest.applyBatchChange(input, okAuth, true).value.unsafeRunSync().toOption.get
 
       result.changes.length shouldBe 1
     }
@@ -561,11 +559,9 @@ class BatchChangeServiceSpec
       val ownerGroupId = Some("user-is-not-member")
       val input = BatchChangeInput(None, List(apexAddA), ownerGroupId)
       val result =
-        rightResultOf(
           underTest
             .applyBatchChange(input, AuthPrincipal(superUser, Seq(baseZone.adminGroupId)), true)
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
 
       result.changes.length shouldBe 1
     }
@@ -579,7 +575,7 @@ class BatchChangeServiceSpec
         AddChangeInput("non-apex.test.com.", RecordType.TXT, None, TXTData("hello"))
 
       val input = BatchChangeInput(None, List(noTtl, withTtl, noTtlDel, noTtlUpdate))
-      val result = rightResultOf(underTest.applyBatchChange(input, auth, true).value)
+      val result = underTest.applyBatchChange(input, auth, true).value.unsafeRunSync().toOption.get
 
       result.changes.length shouldBe 4
       result
@@ -607,15 +603,13 @@ class BatchChangeServiceSpec
       doReturn(IO.unit).when(mockNotifier).notify(any[Notification[_]])
 
       val result =
-        rightResultOf(
           underTest
             .rejectBatchChange(
               batchChange.id,
               supportUserAuth,
               RejectBatchChangeInput(Some("review comment"))
             )
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
 
       result.status shouldBe BatchChangeStatus.Rejected
       result.approvalStatus shouldBe BatchChangeApprovalStatus.ManuallyRejected
@@ -641,11 +635,9 @@ class BatchChangeServiceSpec
       val rejectAuth = AuthPrincipal(supportUser.copy(isTest = true), List())
 
       val result =
-        rightResultOf(
           underTestManualEnabled
             .rejectBatchChange(batchChange.id, rejectAuth, RejectBatchChangeInput(Some("bad")))
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
 
       result.status shouldBe BatchChangeStatus.Rejected
     }
@@ -663,11 +655,9 @@ class BatchChangeServiceSpec
       val rejectAuth = AuthPrincipal(supportUser.copy(isTest = true), List())
 
       val result =
-        leftResultOf(
           underTestManualEnabled
             .rejectBatchChange(batchChange.id, rejectAuth, RejectBatchChangeInput(Some("bad")))
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -684,11 +674,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
           underTest
             .rejectBatchChange(batchChange.id, supportUserAuth, RejectBatchChangeInput())
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe BatchChangeNotPendingReview(batchChange.id)
     }
@@ -706,9 +694,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
-          underTest.rejectBatchChange(batchChange.id, auth, RejectBatchChangeInput()).value
-        )
+          underTest.rejectBatchChange(batchChange.id, auth, RejectBatchChangeInput()).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -726,9 +712,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
-          underTest.rejectBatchChange(batchChange.id, auth, RejectBatchChangeInput()).value
-        )
+          underTest.rejectBatchChange(batchChange.id, auth, RejectBatchChangeInput()).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -748,15 +732,13 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeNeedsApproval)
 
       val result =
-        rightResultOf(
           underTestManualEnabled
             .approveBatchChange(
               batchChangeNeedsApproval.id,
               supportUserAuth,
               ApproveBatchChangeInput(Some("reviewed!"))
             )
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
 
       result.userId shouldBe batchChangeNeedsApproval.userId
       result.userName shouldBe batchChangeNeedsApproval.userName
@@ -776,15 +758,13 @@ class BatchChangeServiceSpec
       val auth = AuthPrincipal(supportUser.copy(isTest = true), List())
 
       val result =
-        leftResultOf(
           underTestManualEnabled
             .approveBatchChange(
               batchChangeNeedsApproval.id,
               auth,
               ApproveBatchChangeInput(Some("reviewed!"))
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChangeNeedsApproval.id)
     }
@@ -794,11 +774,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
           underTest
             .approveBatchChange(batchChange.id, supportUserAuth, ApproveBatchChangeInput())
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe BatchChangeNotPendingReview(batchChange.id)
     }
@@ -807,11 +785,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeNeedsApproval)
 
       val result =
-        leftResultOf(
           underTest
             .approveBatchChange(batchChangeNeedsApproval.id, auth, ApproveBatchChangeInput())
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChangeNeedsApproval.id)
     }
@@ -822,9 +798,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
-          underTest.approveBatchChange(batchChange.id, auth, ApproveBatchChangeInput()).value
-        )
+          underTest.approveBatchChange(batchChange.id, auth, ApproveBatchChangeInput()).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -842,11 +816,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
           underTest
             .approveBatchChange(batchChange.id, superUserAuth, ApproveBatchChangeInput())
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe BatchRequesterNotFound("someOtherUserId", "someUn")
     }
@@ -866,11 +838,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        rightResultOf(
           underTest
             .cancelBatchChange(batchChange.id, auth)
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
 
       result.status shouldBe BatchChangeStatus.Cancelled
       result.approvalStatus shouldBe BatchChangeApprovalStatus.Cancelled
@@ -891,7 +861,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(underTest.cancelBatchChange(batchChange.id, supportUserAuth).value)
+        underTest.cancelBatchChange(batchChange.id, supportUserAuth).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -909,11 +879,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
           underTest
             .cancelBatchChange(batchChange.id, auth)
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe BatchChangeNotPendingReview(batchChange.id)
     }
@@ -931,11 +899,9 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChange)
 
       val result =
-        leftResultOf(
           underTest
             .cancelBatchChange(batchChange.id, supportUserAuth)
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe BatchChangeNotPendingReview(batchChange.id)
     }
@@ -954,13 +920,13 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.getBatchChange(batchChange.id, auth).value)
+      val result = underTest.getBatchChange(batchChange.id, auth).value.unsafeRunSync().toOption.get
 
       result shouldBe BatchChangeInfo(batchChange)
     }
 
     "Fail if batchChange id does not exist" in {
-      val result = leftResultOf(underTest.getBatchChange("badId", auth).value)
+      val result = underTest.getBatchChange("badId", auth).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe BatchChangeNotFound("badId")
     }
@@ -976,7 +942,7 @@ class BatchChangeServiceSpec
       )
       batchChangeRepo.save(batchChange)
 
-      val result = leftResultOf(underTest.getBatchChange(batchChange.id, notAuth).value)
+      val result = underTest.getBatchChange(batchChange.id, notAuth).value.unsafeRunSync().swap.toOption.get
 
       result shouldBe UserNotAuthorizedError(batchChange.id)
     }
@@ -994,7 +960,7 @@ class BatchChangeServiceSpec
 
       val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSuper = true))
 
-      val result = rightResultOf(underTest.getBatchChange(batchChange.id, authSuper).value)
+      val result = underTest.getBatchChange(batchChange.id, authSuper).value.unsafeRunSync().toOption.get
 
       result shouldBe BatchChangeInfo(batchChange)
     }
@@ -1012,7 +978,7 @@ class BatchChangeServiceSpec
 
       val authSuper = notAuth.copy(signedInUser = notAuth.signedInUser.copy(isSupport = true))
 
-      val result = rightResultOf(underTest.getBatchChange(batchChange.id, authSuper).value)
+      val result = underTest.getBatchChange(batchChange.id, authSuper).value.unsafeRunSync().toOption.get
 
       result shouldBe BatchChangeInfo(batchChange)
     }
@@ -1030,7 +996,7 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.getBatchChange(batchChange.id, auth).value)
+      val result = underTest.getBatchChange(batchChange.id, auth).value.unsafeRunSync().toOption.get
       result shouldBe BatchChangeInfo(batchChange, Some(okGroup.name))
     }
 
@@ -1047,7 +1013,7 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.getBatchChange(batchChange.id, auth).value)
+      val result = underTest.getBatchChange(batchChange.id, auth).value.unsafeRunSync().toOption.get
       result shouldBe BatchChangeInfo(batchChange)
     }
 
@@ -1067,7 +1033,7 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.getBatchChange(batchChange.id, auth).value)
+      val result = underTest.getBatchChange(batchChange.id, auth).value.unsafeRunSync().toOption.get
       result shouldBe BatchChangeInfo(batchChange, Some(okGroup.name), Some(superUser.userName))
     }
   }
@@ -1086,7 +1052,7 @@ class BatchChangeServiceSpec
         error
       )
       val zoneMap = ExistingZones(Set(apexZone, baseZone, ptrZone, delegatedPTRZone, ipv6PTRZone))
-      val result = await(underTest.getExistingRecordSets(in, zoneMap))
+      val result = underTest.getExistingRecordSets(in, zoneMap).unsafeRunSync()
 
       val expected =
         List(existingApex, existingNonApex, existingPtr, existingPtrDelegated, existingPtrV6)
@@ -1103,7 +1069,7 @@ class BatchChangeServiceSpec
         error
       )
       val zoneMap = ExistingZones(Set(apexZone, baseZone, ptrZone, ipv6PTRZone))
-      val result = await(underTest.getExistingRecordSets(in, zoneMap))
+      val result = underTest.getExistingRecordSets(in, zoneMap).unsafeRunSync()
 
       val expected =
         List(existingApex, existingNonApex, existingPtr, existingPtrV6)
@@ -1113,7 +1079,7 @@ class BatchChangeServiceSpec
     "not fail if gets all lefts" in {
       val errors = List(error)
       val zoneMap = ExistingZones(Set(apexZone, baseZone, ptrZone, delegatedPTRZone, ipv6PTRZone))
-      val result = await(underTest.getExistingRecordSets(errors, zoneMap))
+      val result = underTest.getExistingRecordSets(errors, zoneMap).unsafeRunSync()
 
       result.recordSets.length shouldBe 0
     }
@@ -1122,42 +1088,42 @@ class BatchChangeServiceSpec
   "getZonesForRequest" should {
     "return names for the apex and base zones if they both exist" in {
       val underTestBaseApexZoneList: ExistingZones =
-        await(underTest.getZonesForRequest(List(apexAddA.validNel)))
+        underTest.getZonesForRequest(List(apexAddA.validNel)).unsafeRunSync()
 
       (underTestBaseApexZoneList.zones should contain).allOf(apexZone, baseZone)
     }
 
     "return only the apex zone if only the apex zone exists or A or AAAA records" in {
       val underTestOnlyApexZoneList: ExistingZones =
-        await(underTest.getZonesForRequest(List(onlyApexAddA.validNel)))
+        underTest.getZonesForRequest(List(onlyApexAddA.validNel)).unsafeRunSync()
 
       (underTestOnlyApexZoneList.zones should contain).only(onlyApexZone)
     }
 
     "return only the base zone if only the base zone exists" in {
       val underTestOnlyBaseZoneList: ExistingZones =
-        await(underTest.getZonesForRequest(List(onlyBaseAddAAAA.validNel)))
+        underTest.getZonesForRequest(List(onlyBaseAddAAAA.validNel)).unsafeRunSync()
 
       (underTestOnlyBaseZoneList.zones should contain).only(onlyBaseZone)
     }
 
     "return no zones if neither the apex nor base zone exist" in {
       val underTestOnlyNoZonesList: ExistingZones =
-        await(underTest.getZonesForRequest(List(noZoneAddA.validNel)))
+        underTest.getZonesForRequest(List(noZoneAddA.validNel)).unsafeRunSync()
 
       underTestOnlyNoZonesList.zones shouldBe Set()
     }
 
     "return all possible zones for a dotted host" in {
       val underTestZonesList: ExistingZones =
-        await(underTest.getZonesForRequest(List(dottedAddA.validNel)))
+        underTest.getZonesForRequest(List(dottedAddA.validNel)).unsafeRunSync()
 
       (underTestZonesList.zones should contain).allOf(apexZone, baseZone)
     }
 
     "return all possible zones given an IPv4 PTR" in {
       val underTestPTRZonesList: ExistingZones =
-        await(underTest.getZonesForRequest(List(ptrAdd.validNel)))
+        underTest.getZonesForRequest(List(ptrAdd.validNel)).unsafeRunSync()
 
       (underTestPTRZonesList.zones should contain).allOf(ptrZone, delegatedPTRZone)
     }
@@ -1197,7 +1163,7 @@ class BatchChangeServiceSpec
       )
 
       val ptr = AddChangeInput(ip, RecordType.PTR, ttl, PTRData(Fqdn("ptr."))).validNel
-      val underTestPTRZonesList: ExistingZones = await(underTest.getZonesForRequest(List(ptr)))
+      val underTestPTRZonesList: ExistingZones = underTest.getZonesForRequest(List(ptr)).unsafeRunSync()
 
       val zoneNames = underTestPTRZonesList.zones.map(_.name)
       zoneNames should contain theSameElementsAs possibleZones
@@ -1223,7 +1189,7 @@ class BatchChangeServiceSpec
 
       val ip = "2001:0db8:0000:0000:0000:ff00:0042:8329"
       val ptr = AddChangeInput(ip, RecordType.PTR, ttl, PTRData(Fqdn("ptr."))).validNel
-      val underTestPTRZonesList: ExistingZones = await(underTest.getZonesForRequest(List(ptr)))
+      val underTestPTRZonesList: ExistingZones = underTest.getZonesForRequest(List(ptr)).unsafeRunSync()
 
       val zoneNames = underTestPTRZonesList.zones.map(_.name)
       zoneNames shouldBe Set("0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.")
@@ -1272,7 +1238,7 @@ class BatchChangeServiceSpec
         AddChangeInput(v6Name, RecordType.PTR, ttl, PTRData(Fqdn("ptr."))).validNel
       }
 
-      val underTestPTRZonesList: ExistingZones = await(underTest.getZonesForRequest(ptrs))
+      val underTestPTRZonesList: ExistingZones = underTest.getZonesForRequest(ptrs).unsafeRunSync()
 
       val zoneNames = underTestPTRZonesList.zones.map(_.name)
       zoneNames should contain theSameElementsAs (possibleZones1 ++ possibleZones2)
@@ -1280,7 +1246,7 @@ class BatchChangeServiceSpec
 
     "return a set of distinct zones, given duplicates" in {
       val underTestDistinctZonesList: ExistingZones =
-        await(underTest.getZonesForRequest(List(cnameReverseAdd.validNel, ptrAdd.validNel)))
+        underTest.getZonesForRequest(List(cnameReverseAdd.validNel, ptrAdd.validNel)).unsafeRunSync()
 
       underTestDistinctZonesList.zones.count(_.id == "nonDelegatedPTR") shouldBe 1
     }
@@ -2031,7 +1997,7 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value)
+      val result = underTest.listBatchChangeSummaries(auth, maxItems = 100).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2070,7 +2036,7 @@ class BatchChangeServiceSpec
       )
       batchChangeRepo.save(batchChangeTwo)
 
-      val result = rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value)
+      val result = underTest.listBatchChangeSummaries(auth, maxItems = 100).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2104,7 +2070,7 @@ class BatchChangeServiceSpec
       )
       batchChangeRepo.save(batchChangeTwo)
 
-      val result = rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 1).value)
+      val result = underTest.listBatchChangeSummaries(auth, maxItems = 1).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 1
       result.nextId shouldBe Some(1)
@@ -2137,14 +2103,13 @@ class BatchChangeServiceSpec
       )
       batchChangeRepo.save(batchChangeTwo)
 
-      val result = rightResultOf(
+      val result =
         underTest
           .listBatchChangeSummaries(
             auth,
             approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
           )
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2179,7 +2144,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeTwo)
 
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(auth, startFrom = Some(1)).value)
+        underTest.listBatchChangeSummaries(auth, startFrom = Some(1)).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2213,7 +2178,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeUserTwo)
 
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value).batchChanges
+        underTest.listBatchChangeSummaries(auth, maxItems = 100).value.unsafeRunSync().toOption.get.batchChanges
 
       result.length shouldBe 1
       result(0).createdTimestamp shouldBe batchChangeUserOne.createdTimestamp
@@ -2242,7 +2207,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeUserTwo)
 
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(auth, ignoreAccess = true).value).batchChanges
+        underTest.listBatchChangeSummaries(auth, ignoreAccess = true).value.unsafeRunSync().toOption.get.batchChanges
 
       result.length shouldBe 1
       result(0).createdTimestamp shouldBe batchChangeUserOne.createdTimestamp
@@ -2271,7 +2236,7 @@ class BatchChangeServiceSpec
       batchChangeRepo.save(batchChangeUserTwo)
 
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(superUserAuth, ignoreAccess = true).value)
+        underTest.listBatchChangeSummaries(superUserAuth, ignoreAccess = true).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2285,7 +2250,7 @@ class BatchChangeServiceSpec
 
     "return an empty list of batchChangeSummaries if none exist" in {
       val result =
-        rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value).batchChanges
+        underTest.listBatchChangeSummaries(auth, maxItems = 100).value.unsafeRunSync().toOption.get.batchChanges
 
       result.length shouldBe 0
     }
@@ -2303,7 +2268,7 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value)
+      val result = underTest.listBatchChangeSummaries(auth, maxItems = 100).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2328,7 +2293,7 @@ class BatchChangeServiceSpec
         )
       batchChangeRepo.save(batchChange)
 
-      val result = rightResultOf(underTest.listBatchChangeSummaries(auth, maxItems = 100).value)
+      val result = underTest.listBatchChangeSummaries(auth, maxItems = 100).value.unsafeRunSync().toOption.get
 
       result.maxItems shouldBe 100
       result.nextId shouldBe None
@@ -2343,29 +2308,29 @@ class BatchChangeServiceSpec
 
   "getOwnerGroup" should {
     "return None if owner group ID is None" in {
-      rightResultOf(underTest.getOwnerGroup(None).value) shouldBe None
+      underTest.getOwnerGroup(None).value.unsafeRunSync().toOption.get shouldBe None
     }
 
     "return None if group does not exist for owner group ID" in {
-      rightResultOf(underTest.getOwnerGroup(Some("non-existent-group-id")).value) shouldBe None
+      underTest.getOwnerGroup(Some("non-existent-group-id")).value.unsafeRunSync().toOption.get shouldBe None
     }
 
     "return the group if the group exists for the owner group ID" in {
-      rightResultOf(underTest.getOwnerGroup(Some(okGroup.id)).value) shouldBe Some(okGroup)
+      underTest.getOwnerGroup(Some(okGroup.id)).value.unsafeRunSync().toOption.get shouldBe Some(okGroup)
     }
   }
 
   "getReviewer" should {
     "return None if reviewer ID is None" in {
-      rightResultOf(underTest.getReviewer(None).value) shouldBe None
+      underTest.getReviewer(None).value.unsafeRunSync().toOption.get shouldBe None
     }
 
     "return None if reviewer does not exist for the given reviewer ID" in {
-      rightResultOf(underTest.getReviewer(Some("non-existent-user-id")).value) shouldBe None
+      underTest.getReviewer(Some("non-existent-user-id")).value.unsafeRunSync().toOption.get shouldBe None
     }
 
     "return the reviewer if the reviewer exists for the given reviewer ID" in {
-      rightResultOf(underTest.getReviewer(Some(superUser.id)).value) shouldBe Some(superUser)
+      underTest.getReviewer(Some(superUser.id)).value.unsafeRunSync().toOption.get shouldBe Some(superUser)
     }
   }
 
@@ -2381,7 +2346,7 @@ class BatchChangeServiceSpec
           approvalStatus = BatchChangeApprovalStatus.AutoApproved
         )
 
-      val result = rightResultOf(
+      val result =
         underTestManualEnabled
           .convertOrSave(
             batchChange,
@@ -2389,8 +2354,8 @@ class BatchChangeServiceSpec
             ChangeForValidationMap(List(), ExistingRecordSets(List())),
             None
           )
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
+
       result.reviewComment shouldBe Some("batchSentToConverter")
     }
     "not send to the converter, save the change if PendingReview and MA enabled" in {
@@ -2404,7 +2369,7 @@ class BatchChangeServiceSpec
           approvalStatus = BatchChangeApprovalStatus.PendingReview
         )
 
-      val result = rightResultOf(
+      val result =
         underTestManualEnabled
           .convertOrSave(
             batchChange,
@@ -2412,8 +2377,7 @@ class BatchChangeServiceSpec
             ChangeForValidationMap(List(), ExistingRecordSets(List())),
             None
           )
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       // not sent to converter
       result.reviewComment shouldBe None
@@ -2431,7 +2395,7 @@ class BatchChangeServiceSpec
           approvalStatus = BatchChangeApprovalStatus.PendingReview
         )
 
-      val result = leftResultOf(
+      val result =
         underTest
           .convertOrSave(
             batchChange,
@@ -2439,8 +2403,7 @@ class BatchChangeServiceSpec
             ChangeForValidationMap(List(), ExistingRecordSets(List())),
             None
           )
-          .value
-      )
+          .value.unsafeRunSync().swap.toOption.get
 
       result shouldBe an[UnknownConversionError]
     }
@@ -2455,7 +2418,7 @@ class BatchChangeServiceSpec
           approvalStatus = BatchChangeApprovalStatus.ManuallyApproved
         )
 
-      val result = leftResultOf(
+      val result =
         underTest
           .convertOrSave(
             batchChange,
@@ -2463,8 +2426,8 @@ class BatchChangeServiceSpec
             ChangeForValidationMap(List(), ExistingRecordSets(List())),
             None
           )
-          .value
-      )
+          .value.unsafeRunSync().swap.toOption.get
+
       result shouldBe an[UnknownConversionError]
     }
   }
@@ -2528,7 +2491,7 @@ class BatchChangeServiceSpec
     "combine gets for each valid record" in {
       val in = List(apexAddForVal.validNel, error)
 
-      val result = rightResultOf(underTest.getGroupIdsFromUnauthorizedErrors(in).value)
+      val result = underTest.getGroupIdsFromUnauthorizedErrors(in).value.unsafeRunSync().toOption.get
 
       result shouldBe Set(okGroup)
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -275,7 +275,7 @@ class MembershipServiceSpec
           .when(underTest)
           .groupValidation(groupInfo.copy(name = "", email = ""))
 
-        val error = leftResultOf(underTest.createGroup(groupInfo.copy(name = "", email = ""), okAuth).value)
+        val error = underTest.createGroup(groupInfo.copy(name = "", email = ""), okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[GroupValidationError]
 
         verify(mockGroupRepo, never()).save(any[DB], any[Group])
@@ -412,7 +412,7 @@ class MembershipServiceSpec
           .when(underTest)
           .groupValidation(existingGroup.copy(name = "", email = ""))
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -423,8 +423,8 @@ class MembershipServiceSpec
               updatedInfo.adminUserIds,
               okAuth
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe a[GroupValidationError]
       }
 
@@ -641,7 +641,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(listOfDummyGroups.toSet))
           .when(mockGroupRepo)
           .getGroups(any[Set[String]])
-        val result: ListMyGroupsResponse = rightResultOf(
+        val result: ListMyGroupsResponse =
           underTest
             .listMyGroups(
               groupNameFilter = Some("Name-Dummy01"),
@@ -650,8 +650,8 @@ class MembershipServiceSpec
               listOfDummyGroupsAuth,
               false
             )
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
+
         result shouldBe ListMyGroupsResponse(
           groups = listOfDummyGroupInfo.slice(10, 20),
           groupNameFilter = Some("Name-Dummy01"),
@@ -794,7 +794,7 @@ class MembershipServiceSpec
           listOfDummyGroupChanges.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))).take(1).head
 
         val result: GroupChangeInfo =
-          rightResultOf(underTest.getGroupChange(dummyGroup.id, dummyAuth).value)
+          underTest.getGroupChange(dummyGroup.id, dummyAuth).value.unsafeRunSync().toOption.get
         result shouldBe expected
       }
 
@@ -813,7 +813,7 @@ class MembershipServiceSpec
           listOfDummyGroupChanges.map(change => GroupChangeInfo.apply(change.copy(userName = userMap.get(change.userId)))).take(1).head
 
         val result: GroupChangeInfo =
-          rightResultOf(underTest.getGroupChange(dummyGroup.id, okAuth).value)
+          underTest.getGroupChange(dummyGroup.id, okAuth).value.unsafeRunSync().toOption.get
         result shouldBe expected
       }
 
@@ -826,7 +826,7 @@ class MembershipServiceSpec
           .when(mockUserRepo)
           .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
-        val result = leftResultOf(underTest.getGroupChange(dummyGroup.id, okAuth).value)
+        val result = underTest.getGroupChange(dummyGroup.id, okAuth).value.unsafeRunSync().swap.toOption.get
         result shouldBe a[InvalidGroupRequestError]
       }
     }
@@ -886,7 +886,7 @@ class MembershipServiceSpec
     "determine group difference" should {
       "return difference between two groups" in {
         val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate, okGroupChange.copy(changeType = GroupChangeType.Delete))
-        val result: Seq[String] = rightResultOf(underTest.determineGroupDifference(groupChange).value)
+        val result: Seq[String] = underTest.determineGroupDifference(groupChange).value.unsafeRunSync().toOption.get
         // Newly created group's change message
         result(0) shouldBe "Group Created."
         // Updated group's change message

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.BeforeAndAfterEach
 import vinyldns.api.Interfaces._
-import vinyldns.api.ResultHelpers
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.zone.ZoneRepository
 import cats.effect._
@@ -41,7 +40,6 @@ class MembershipServiceSpec
     with Matchers
     with MockitoSugar
     with BeforeAndAfterEach
-    with ResultHelpers
     with EitherMatchers {
 
   private val mockGroupRepo = mock[GroupRepository]
@@ -122,7 +120,7 @@ class MembershipServiceSpec
           .saveMembers(any[DB], anyString, any[Set[String]], isAdmin = anyBoolean)
         doReturn(IO.pure(okGroupChange)).when(mockGroupChangeRepo).save(any[DB], any[GroupChange])
 
-        val result: Group = rightResultOf(underTest.createGroup(groupInfo, okAuth).value)
+        val result: Group = underTest.createGroup(groupInfo, okAuth).value.unsafeRunSync().toOption.get
         result shouldBe groupInfo
 
         val groupCaptor = ArgumentCaptor.forClass(classOf[Group])
@@ -149,7 +147,7 @@ class MembershipServiceSpec
           .saveMembers(any[DB], anyString, any[Set[String]], isAdmin = anyBoolean)
         doReturn(IO.pure(okGroupChange)).when(mockGroupChangeRepo).save(any[DB], any[GroupChange])
 
-        val result: Group = rightResultOf(underTest.createGroup(groupInfo, okAuth).value)
+        val result: Group = underTest.createGroup(groupInfo, okAuth).value.unsafeRunSync().toOption.get
         result shouldBe groupInfo
 
         val groupChangeCaptor = ArgumentCaptor.forClass(classOf[GroupChange])
@@ -178,7 +176,7 @@ class MembershipServiceSpec
         ).thenReturn(IO.pure(expectedMembersAdded))
         doReturn(IO.pure(okGroupChange)).when(mockGroupChangeRepo).save(any[DB], any[GroupChange])
 
-        val result: Group = rightResultOf(underTest.createGroup(info, okAuth).value)
+        val result: Group = underTest.createGroup(info, okAuth).value.unsafeRunSync().toOption.get
         result shouldBe info
 
         val memberIdCaptor = ArgumentCaptor.forClass(classOf[Set[String]])
@@ -204,7 +202,7 @@ class MembershipServiceSpec
           .saveMembers(any[DB], anyString, any[Set[String]], isAdmin = anyBoolean)
         doReturn(IO.pure(okGroupChange)).when(mockGroupChangeRepo).save(any[DB], any[GroupChange])
 
-        val result: Group = rightResultOf(underTest.createGroup(info, okAuth).value)
+        val result: Group = underTest.createGroup(info, okAuth).value.unsafeRunSync().toOption.get
         result.memberIds should contain(okAuth.userId)
       }
 
@@ -214,7 +212,7 @@ class MembershipServiceSpec
           .when(underTest)
           .groupWithSameNameDoesNotExist(groupInfo.name)
 
-        val error = leftResultOf(underTest.createGroup(groupInfo, okAuth).value)
+        val error = underTest.createGroup(groupInfo, okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[GroupAlreadyExistsError]
 
         verify(mockGroupRepo, never()).save(any[DB], any[Group])
@@ -229,7 +227,7 @@ class MembershipServiceSpec
           .when(underTest)
           .usersExist(groupInfo.memberIds)
 
-        val error = leftResultOf(underTest.createGroup(groupInfo, okAuth).value)
+        val error = underTest.createGroup(groupInfo, okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[UserNotFoundError]
 
         verify(mockGroupRepo, never()).save(any[DB], any[Group])
@@ -244,7 +242,7 @@ class MembershipServiceSpec
         doReturn(IO.raiseError(new RuntimeException("fail"))).when(mockGroupRepo).save(any[DB], any[Group])
         doReturn(IO.pure(okGroupChange)).when(mockGroupChangeRepo).save(any[DB], any[GroupChange])
 
-        val error = leftResultOf(underTest.createGroup(groupInfo, okAuth).value)
+        val error = underTest.createGroup(groupInfo, okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[RuntimeException]
 
         verify(mockMembershipRepo, never())
@@ -261,7 +259,7 @@ class MembershipServiceSpec
           .saveMembers(any[DB], anyString, any[Set[String]], isAdmin = anyBoolean)
         doReturn(IO.pure(okGroupChange)).when(mockGroupChangeRepo).save(any[DB], any[GroupChange])
 
-        val error = leftResultOf(underTest.createGroup(groupInfo, okAuth).value)
+        val error = underTest.createGroup(groupInfo, okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[RuntimeException]
       }
     }
@@ -284,7 +282,6 @@ class MembershipServiceSpec
           .when(mockGroupChangeRepo)
           .save(any[DB], any[GroupChange])
 
-        awaitResultOf(
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -295,8 +292,7 @@ class MembershipServiceSpec
               updatedInfo.adminUserIds,
               okAuth
             )
-            .value
-        )
+            .value.unsafeRunSync()
 
         val groupCaptor = ArgumentCaptor.forClass(classOf[Group])
         val addedMemberCaptor = ArgumentCaptor.forClass(classOf[Set[String]])
@@ -346,7 +342,7 @@ class MembershipServiceSpec
       "return an error if the user is not an admin" in {
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -357,8 +353,7 @@ class MembershipServiceSpec
               updatedInfo.adminUserIds,
               dummyAuth
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
         error shouldBe a[NotAuthorizedError]
       }
@@ -372,7 +367,7 @@ class MembershipServiceSpec
           .when(underTest)
           .differentGroupWithSameNameDoesNotExist(updatedInfo.name, existingGroup.id)
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -383,15 +378,15 @@ class MembershipServiceSpec
               updatedInfo.adminUserIds,
               okAuth
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe a[GroupAlreadyExistsError]
       }
 
       "return an error if the group is not found" in {
         doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(existingGroup.id)
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -402,8 +397,8 @@ class MembershipServiceSpec
               updatedInfo.adminUserIds,
               okAuth
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe a[GroupNotFoundError]
       }
 
@@ -418,7 +413,7 @@ class MembershipServiceSpec
           .when(underTest)
           .usersExist(any[Set[String]])
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -429,8 +424,8 @@ class MembershipServiceSpec
               updatedInfo.adminUserIds,
               okAuth
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe a[UserNotFoundError]
       }
 
@@ -439,7 +434,7 @@ class MembershipServiceSpec
           .when(mockGroupRepo)
           .getGroup(existingGroup.id)
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateGroup(
               updatedInfo.id,
@@ -450,8 +445,8 @@ class MembershipServiceSpec
               Set(),
               okAuth
             )
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe an[InvalidGroupError]
       }
     }
@@ -474,7 +469,7 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getFirstOwnedZoneAclGroupId(anyString())
 
-        val result: Group = rightResultOf(underTest.deleteGroup("ok", okAuth).value)
+        val result: Group = underTest.deleteGroup("ok", okAuth).value.unsafeRunSync().toOption.get
         result shouldBe okGroup.copy(status = GroupStatus.Deleted)
 
         val groupCaptor = ArgumentCaptor.forClass(classOf[Group])
@@ -495,7 +490,7 @@ class MembershipServiceSpec
       "return an error if the user is not an admin" in {
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
 
-        val error = leftResultOf(underTest.deleteGroup("ok", dummyAuth).value)
+        val error = underTest.deleteGroup("ok", dummyAuth).value.unsafeRunSync().swap.toOption.get
 
         error shouldBe a[NotAuthorizedError]
       }
@@ -504,7 +499,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(anyString)
         doReturn(IO.pure(List())).when(mockZoneRepo).getZonesByAdminGroupId(anyString)
 
-        val error = leftResultOf(underTest.deleteGroup("ok", okAuth).value)
+        val error = underTest.deleteGroup("ok", okAuth).value.unsafeRunSync().swap.toOption.get
 
         error shouldBe a[GroupNotFoundError]
       }
@@ -515,7 +510,7 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getZonesByAdminGroupId(anyString)
 
-        val error = leftResultOf(underTest.deleteGroup("ok", okAuth).value)
+        val error = underTest.deleteGroup("ok", okAuth).value.unsafeRunSync().swap.toOption.get
 
         error shouldBe an[InvalidGroupRequestError]
       }
@@ -525,7 +520,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(Some("somerecordsetid")))
           .when(mockRecordSetRepo)
           .getFirstOwnedRecordByGroup(anyString())
-        val error = leftResultOf(underTest.deleteGroup("ok", okAuth).value)
+        val error = underTest.deleteGroup("ok", okAuth).value.unsafeRunSync().swap.toOption.get
 
         error shouldBe an[InvalidGroupRequestError]
       }
@@ -535,7 +530,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(Some("someId")))
           .when(mockZoneRepo)
           .getFirstOwnedZoneAclGroupId(anyString())
-        val error = leftResultOf(underTest.deleteGroup("ok", okAuth).value)
+        val error = underTest.deleteGroup("ok", okAuth).value.unsafeRunSync().swap.toOption.get
 
         error shouldBe an[InvalidGroupRequestError]
       }
@@ -545,13 +540,13 @@ class MembershipServiceSpec
     "get a group" should {
       "return the group" in {
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroup(anyString)
-        val result: Group = rightResultOf(underTest.getGroup(okGroup.id, okAuth).value)
+        val result: Group = underTest.getGroup(okGroup.id, okAuth).value.unsafeRunSync().toOption.get
         result shouldBe okGroup
       }
 
       "return an error if the group is not found" in {
         doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(anyString)
-        val error = leftResultOf(underTest.getGroup("notfound", okAuth).value)
+        val error = underTest.getGroup("notfound", okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[GroupNotFoundError]
       }
     }
@@ -562,7 +557,7 @@ class MembershipServiceSpec
           .when(mockGroupRepo)
           .getGroups(any[Set[String]])
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, listOfDummyGroupsAuth, false).value)
+          underTest.listMyGroups(None, None, 100, listOfDummyGroupsAuth, false).value.unsafeRunSync().toOption.get
         verify(mockGroupRepo, never()).getAllGroups()
         result shouldBe ListMyGroupsResponse(
           groups = listOfDummyGroupInfo.take(100),
@@ -577,7 +572,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(listOfDummyGroups.toSet))
           .when(mockGroupRepo)
           .getGroups(any[Set[String]])
-        val result: ListMyGroupsResponse = rightResultOf(
+        val result: ListMyGroupsResponse =
           underTest
             .listMyGroups(
               groupNameFilter = Some("name-dummy01"),
@@ -586,8 +581,8 @@ class MembershipServiceSpec
               listOfDummyGroupsAuth,
               false
             )
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
+
         result shouldBe ListMyGroupsResponse(
           groups = listOfDummyGroupInfo.slice(10, 20),
           groupNameFilter = Some("name-dummy01"),
@@ -601,7 +596,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(listOfDummyGroups.toSet))
           .when(mockGroupRepo)
           .getGroups(any[Set[String]])
-        val result: ListMyGroupsResponse = rightResultOf(
+        val result: ListMyGroupsResponse =
           underTest
             .listMyGroups(
               groupNameFilter = None,
@@ -610,8 +605,8 @@ class MembershipServiceSpec
               listOfDummyGroupsAuth,
               ignoreAccess = false
             )
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
+
         result shouldBe ListMyGroupsResponse(
           groups = listOfDummyGroupInfo.slice(100, 200),
           groupNameFilter = None,
@@ -625,7 +620,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(listOfDummyGroups.toSet))
           .when(mockGroupRepo)
           .getGroups(any[Set[String]])
-        val result: ListMyGroupsResponse = rightResultOf(
+        val result: ListMyGroupsResponse =
           underTest
             .listMyGroups(
               groupNameFilter = None,
@@ -634,8 +629,8 @@ class MembershipServiceSpec
               listOfDummyGroupsAuth,
               ignoreAccess = false
             )
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
+
         result shouldBe ListMyGroupsResponse(
           groups = listOfDummyGroupInfo.slice(0, 10),
           groupNameFilter = None,
@@ -648,13 +643,13 @@ class MembershipServiceSpec
       "return an empty set if the user is not a member of any groups" in {
         doReturn(IO.pure(Set())).when(mockGroupRepo).getGroups(any[Set[String]])
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, notAuth, false).value)
+          underTest.listMyGroups(None, None, 100, notAuth, false).value.unsafeRunSync().toOption.get
         result shouldBe ListMyGroupsResponse(Seq(), None, None, None, 100, false)
       }
       "return all groups from the database if ignoreAccess is true" in {
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, notAuth, true).value)
+          underTest.listMyGroups(None, None, 100, notAuth, true).value.unsafeRunSync().toOption.get
         verify(mockGroupRepo).getAllGroups()
         result.groups should contain theSameElementsAs Seq(
           GroupInfo(dummyGroup),
@@ -664,7 +659,7 @@ class MembershipServiceSpec
       "return all groups from the database for super users even if ignoreAccess is false" in {
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, superUserAuth, false).value)
+          underTest.listMyGroups(None, None, 100, superUserAuth, false).value.unsafeRunSync().toOption.get
         verify(mockGroupRepo).getAllGroups()
         result.groups should contain theSameElementsAs Seq(
           GroupInfo(dummyGroup),
@@ -674,7 +669,7 @@ class MembershipServiceSpec
       "return all groups from the database for super users if ignoreAccess is true" in {
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, superUserAuth, true).value)
+          underTest.listMyGroups(None, None, 100, superUserAuth, true).value.unsafeRunSync().toOption.get
         verify(mockGroupRepo).getAllGroups()
         result.groups should contain theSameElementsAs Seq(
           GroupInfo(dummyGroup),
@@ -685,7 +680,7 @@ class MembershipServiceSpec
         val supportAuth = AuthPrincipal(okUser.copy(isSupport = true), Seq())
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, supportAuth, false).value)
+          underTest.listMyGroups(None, None, 100, supportAuth, false).value.unsafeRunSync().toOption.get
         verify(mockGroupRepo).getAllGroups()
         result.groups should contain theSameElementsAs Seq(
           GroupInfo(dummyGroup),
@@ -696,7 +691,7 @@ class MembershipServiceSpec
         val supportAuth = AuthPrincipal(okUser.copy(isSupport = true), Seq())
         doReturn(IO.pure(Set(okGroup, dummyGroup))).when(mockGroupRepo).getAllGroups()
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, supportAuth, true).value)
+          underTest.listMyGroups(None, None, 100, supportAuth, true).value.unsafeRunSync().toOption.get
         verify(mockGroupRepo).getAllGroups()
         result.groups should contain theSameElementsAs Seq(
           GroupInfo(dummyGroup),
@@ -709,7 +704,7 @@ class MembershipServiceSpec
           .when(mockGroupRepo)
           .getGroups(any[Set[String]])
         val result: ListMyGroupsResponse =
-          rightResultOf(underTest.listMyGroups(None, None, 100, deletedGroupAuth, false).value)
+          underTest.listMyGroups(None, None, 100, deletedGroupAuth, false).value.unsafeRunSync().toOption.get
         result shouldBe ListMyGroupsResponse(Seq(), None, None, None, 100, false)
       }
     }
@@ -728,7 +723,7 @@ class MembershipServiceSpec
           listOfDummyGroupChanges.map(GroupChangeInfo.apply).take(100)
 
         val result: ListGroupChangesResponse =
-          rightResultOf(underTest.getGroupActivity(dummyGroup.id, None, 100, dummyAuth).value)
+          underTest.getGroupActivity(dummyGroup.id, None, 100, dummyAuth).value.unsafeRunSync().toOption.get
         result.changes should contain theSameElementsAs expected
         result.maxItems shouldBe 100
         result.nextId shouldBe Some(listOfDummyGroupChanges(100).id)
@@ -748,7 +743,7 @@ class MembershipServiceSpec
         listOfDummyGroupChanges.map(GroupChangeInfo.apply).take(100)
 
       val result: ListGroupChangesResponse =
-        rightResultOf(underTest.getGroupActivity(dummyGroup.id, None, 100, okAuth).value)
+        underTest.getGroupActivity(dummyGroup.id, None, 100, okAuth).value.unsafeRunSync().toOption.get
       result.changes should contain theSameElementsAs expected
       result.maxItems shouldBe 100
       result.nextId shouldBe Some(listOfDummyGroupChanges(100).id)
@@ -769,7 +764,7 @@ class MembershipServiceSpec
           .getUsers(testGroup.adminUserIds, None, None)
 
         val result: ListAdminsResponse =
-          rightResultOf(underTest.listAdmins(testGroup.id, okAuth).value)
+          underTest.listAdmins(testGroup.id, okAuth).value.unsafeRunSync().toOption.get
         result.admins should contain theSameElementsAs expectedAdmins
       }
 
@@ -785,7 +780,7 @@ class MembershipServiceSpec
           .getUsers(testGroup.adminUserIds, None, None)
 
         val result: ListAdminsResponse =
-          rightResultOf(underTest.listAdmins(testGroup.id, dummyAuth).value)
+          underTest.listAdmins(testGroup.id, dummyAuth).value.unsafeRunSync().toOption.get
         result.admins should contain theSameElementsAs expectedAdmins
       }
     }
@@ -806,7 +801,7 @@ class MembershipServiceSpec
           .getUsers(testGroup.memberIds, None, Some(100))
 
         val result: ListMembersResponse =
-          rightResultOf(underTest.listMembers(testGroup.id, None, 100, testAuth).value)
+          underTest.listMembers(testGroup.id, None, 100, testAuth).value.unsafeRunSync().toOption.get
 
         result.members should contain theSameElementsAs expectedMembers
         result.nextId shouldBe testListUsersResult.lastEvaluatedId
@@ -831,7 +826,7 @@ class MembershipServiceSpec
           .getUsers(testGroup.memberIds, None, Some(100))
 
         val result: ListMembersResponse =
-          rightResultOf(underTest.listMembers(testGroup.id, None, 100, supportAuth).value)
+          underTest.listMembers(testGroup.id, None, 100, supportAuth).value.unsafeRunSync().toOption.get
 
         result.members should contain theSameElementsAs expectedMembers
         result.nextId shouldBe testListUsersResult.lastEvaluatedId
@@ -852,7 +847,7 @@ class MembershipServiceSpec
           .getUsers(testGroup.memberIds, None, Some(100))
 
         val result: ListMembersResponse =
-          rightResultOf(underTest.listMembers(testGroup.id, None, 100, dummyAuth).value)
+          underTest.listMembers(testGroup.id, None, 100, dummyAuth).value.unsafeRunSync().toOption.get
 
         result.members should contain theSameElementsAs expectedMembers
         result.nextId shouldBe testListUsersResult.lastEvaluatedId
@@ -865,21 +860,21 @@ class MembershipServiceSpec
       "return true when a group with the same name does not exist" in {
         doReturn(IO.pure(None)).when(mockGroupRepo).getGroupByName("foo")
 
-        val result = awaitResultOf(underTest.groupWithSameNameDoesNotExist("foo").value)
+        val result = underTest.groupWithSameNameDoesNotExist("foo").value.unsafeRunSync()
         result should be(right)
       }
 
       "return a GroupAlreadyExistsError if a group with the same name already exists" in {
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroupByName("foo")
 
-        val result = leftResultOf(underTest.groupWithSameNameDoesNotExist("foo").value)
+        val result = underTest.groupWithSameNameDoesNotExist("foo").value.unsafeRunSync().swap.toOption.get
         result shouldBe a[GroupAlreadyExistsError]
       }
 
       "return true if a group with the same name exists but is deleted" in {
         doReturn(IO.pure(Some(deletedGroup))).when(mockGroupRepo).getGroupByName("foo")
 
-        val result = awaitResultOf(underTest.groupWithSameNameDoesNotExist("foo").value)
+        val result = underTest.groupWithSameNameDoesNotExist("foo").value.unsafeRunSync()
         result should be(right)
       }
     }
@@ -890,7 +885,7 @@ class MembershipServiceSpec
           .when(mockUserRepo)
           .getUsers(okGroup.memberIds, None, None)
 
-        val result = awaitResultOf(underTest.usersExist(okGroup.memberIds).value)
+        val result = underTest.usersExist(okGroup.memberIds).value.unsafeRunSync()
         result should be(right)
       }
 
@@ -899,7 +894,7 @@ class MembershipServiceSpec
           .when(mockUserRepo)
           .getUsers(Set(okUser.id, dummyUser.id), None, None)
 
-        val result = leftResultOf(underTest.usersExist(Set(okUser.id, dummyUser.id)).value)
+        val result = underTest.usersExist(Set(okUser.id, dummyUser.id)).value.unsafeRunSync().swap.toOption.get
         result shouldBe a[UserNotFoundError]
       }
     }
@@ -911,7 +906,7 @@ class MembershipServiceSpec
         doReturn(IO.pure(Some(existingGroup))).when(mockGroupRepo).getGroupByName("foo")
 
         val error =
-          leftResultOf(underTest.differentGroupWithSameNameDoesNotExist("foo", "bar").value)
+          underTest.differentGroupWithSameNameDoesNotExist("foo", "bar").value.unsafeRunSync().swap.toOption.get
         error shouldBe a[GroupAlreadyExistsError]
       }
 
@@ -919,9 +914,8 @@ class MembershipServiceSpec
 
         doReturn(IO.pure(Some(okGroup))).when(mockGroupRepo).getGroupByName(okGroup.name)
 
-        val result = awaitResultOf(
-          underTest.differentGroupWithSameNameDoesNotExist(okGroup.name, okGroup.id).value
-        )
+        val result =
+          underTest.differentGroupWithSameNameDoesNotExist(okGroup.name, okGroup.id).value.unsafeRunSync()
         result should be(right)
       }
 
@@ -932,9 +926,8 @@ class MembershipServiceSpec
           .when(mockGroupRepo)
           .getGroupByName(okGroup.name)
 
-        val result = awaitResultOf(
-          underTest.differentGroupWithSameNameDoesNotExist(okGroup.name, okGroup.id).value
-        )
+        val result =
+          underTest.differentGroupWithSameNameDoesNotExist(okGroup.name, okGroup.id).value.unsafeRunSync()
         result should be(right)
       }
     }
@@ -943,7 +936,7 @@ class MembershipServiceSpec
       "return true when a group for deletion is not the admin of a zone" in {
         doReturn(IO.pure(List())).when(mockZoneRepo).getZonesByAdminGroupId(okGroup.id)
 
-        val result = awaitResultOf(underTest.isNotZoneAdmin(okGroup).value)
+        val result = underTest.isNotZoneAdmin(okGroup).value.unsafeRunSync()
         result should be(right)
       }
 
@@ -952,7 +945,7 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getZonesByAdminGroupId(okGroup.id)
 
-        val error = leftResultOf(underTest.isNotZoneAdmin(okGroup).value)
+        val error = underTest.isNotZoneAdmin(okGroup).value.unsafeRunSync().swap.toOption.get
         error shouldBe an[InvalidGroupRequestError]
       }
     }
@@ -961,7 +954,7 @@ class MembershipServiceSpec
       "return true when a group for deletion is not the admin of a zone" in {
         doReturn(IO.pure(None)).when(mockRecordSetRepo).getFirstOwnedRecordByGroup(okGroup.id)
 
-        val result = awaitResultOf(underTest.isNotRecordOwnerGroup(okGroup).value)
+        val result = underTest.isNotRecordOwnerGroup(okGroup).value.unsafeRunSync()
         result should be(right)
       }
 
@@ -970,7 +963,7 @@ class MembershipServiceSpec
           .when(mockRecordSetRepo)
           .getFirstOwnedRecordByGroup(okGroup.id)
 
-        val error = leftResultOf(underTest.isNotRecordOwnerGroup(okGroup).value)
+        val error = underTest.isNotRecordOwnerGroup(okGroup).value.unsafeRunSync().swap.toOption.get
         error shouldBe an[InvalidGroupRequestError]
       }
     }
@@ -979,7 +972,7 @@ class MembershipServiceSpec
       "return successfully when a groupId is not in any zone ACL" in {
         doReturn(IO.pure(None)).when(mockZoneRepo).getFirstOwnedZoneAclGroupId(okGroup.id)
 
-        val result = awaitResultOf(underTest.isNotInZoneAclRule(okGroup).value)
+        val result = underTest.isNotInZoneAclRule(okGroup).value.unsafeRunSync()
         result should be(right)
       }
 
@@ -988,7 +981,7 @@ class MembershipServiceSpec
           .when(mockZoneRepo)
           .getFirstOwnedZoneAclGroupId(okGroup.id)
 
-        val error = leftResultOf(underTest.isNotInZoneAclRule(okGroup).value)
+        val error = underTest.isNotInZoneAclRule(okGroup).value.unsafeRunSync().swap.toOption.get
         error shouldBe an[InvalidGroupRequestError]
       }
     }
@@ -1031,11 +1024,10 @@ class MembershipServiceSpec
       }
 
       "return an error if the signed in user is not a super user" in {
-        val error = leftResultOf(
+        val error =
           underTest
             .updateUserLockStatus(okUser.id, LockStatus.Locked, dummyAuth)
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
 
         error shouldBe a[NotAuthorizedError]
       }
@@ -1045,22 +1037,22 @@ class MembershipServiceSpec
           signedInUser = dummyAuth.signedInUser.copy(isSupport = true),
           memberGroupIds = Seq.empty
         )
-        val error = leftResultOf(
+        val error =
           underTest
             .updateUserLockStatus(okUser.id, LockStatus.Locked, supportAuth)
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe a[NotAuthorizedError]
       }
 
       "return an error if the requested user is not found" in {
         doReturn(IO.pure(None)).when(mockUserRepo).getUser(okUser.id)
 
-        val error = leftResultOf(
+        val error =
           underTest
             .updateUserLockStatus(okUser.id, LockStatus.Locked, superUserAuth)
-            .value
-        )
+            .value.unsafeRunSync().swap.toOption.get
+
         error shouldBe a[UserNotFoundError]
       }
     }
@@ -1068,13 +1060,13 @@ class MembershipServiceSpec
     "get user" should {
       "return the user" in {
         doReturn(IO.pure(Some(okUser))).when(mockUserRepo).getUserByIdOrName(anyString)
-        val result: User = rightResultOf(underTest.getUser(okUser.id, okAuth).value)
+        val result: User = underTest.getUser(okUser.id, okAuth).value.unsafeRunSync().toOption.get
         result shouldBe okUser
       }
 
       "return an error if the user is not found" in {
         doReturn(IO.pure(None)).when(mockUserRepo).getUserByIdOrName(anyString)
-        val error = leftResultOf(underTest.getUser("notfound", okAuth).value)
+        val error = underTest.getUser("notfound", okAuth).value.unsafeRunSync().swap.toOption.get
         error shouldBe a[UserNotFoundError]
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -288,7 +288,7 @@ class RecordSetServiceSpec
         .when(mockUserRepo)
         .getUsers(Set.empty, None, None)
 
-      val result = leftResultOf(underTestWithEmptyDottedHostsConfig.addRecordSet(record, okAuth).value)
+      val result = underTestWithEmptyDottedHostsConfig.addRecordSet(record, okAuth).value.unsafeRunSync().swap.toOption.get
       result shouldBe an[InvalidRequest]
     }
     "fail if the record is relative with trailing dot" in {
@@ -585,9 +585,8 @@ class RecordSetServiceSpec
       .getUsers(dummyGroup.memberIds, None, None)
 
     // passes as all three properties within dotted hosts config (allowed zones, users and record types) are satisfied
-    val result: RecordSetChange = rightResultOf(
-      underTest.addRecordSet(record, xyzAuth).map(_.asInstanceOf[RecordSetChange]).value
-    )
+    val result: RecordSetChange =
+      underTest.addRecordSet(record, xyzAuth).map(_.asInstanceOf[RecordSetChange]).value.unsafeRunSync().toOption.get
 
     result.recordSet.name shouldBe record.name
   }
@@ -629,9 +628,8 @@ class RecordSetServiceSpec
       .getUsers(xyzGroup.memberIds, None, None)
 
     // passes as all three properties within dotted hosts config (allowed zones, users and record types) are satisfied
-    val result: RecordSetChange = rightResultOf(
-      underTest.addRecordSet(record, xyzAuth).map(_.asInstanceOf[RecordSetChange]).value
-    )
+    val result: RecordSetChange =
+      underTest.addRecordSet(record, xyzAuth).map(_.asInstanceOf[RecordSetChange]).value.unsafeRunSync().toOption.get
 
     result.recordSet.name shouldBe record.name
   }
@@ -673,7 +671,7 @@ class RecordSetServiceSpec
       .getUsers(xyzGroup.memberIds, None, None)
 
     // fails as dotted host record name has dot at the end and is not an apex record
-    val result = leftResultOf(underTest.addRecordSet(record, xyzAuth).value)
+    val result = underTest.addRecordSet(record, xyzAuth).value.unsafeRunSync().swap.toOption.get
     result shouldBe an[InvalidRequest]
   }
   "fail if the record is dotted and zone, user, record type is allowed but number of dots allowed in config is 0" in {
@@ -714,7 +712,7 @@ class RecordSetServiceSpec
       .getUsers(dummyGroup.memberIds, None, None)
 
     // fails as no.of.dots allowed for the zone in the config is 0
-    val result = leftResultOf(underTest.addRecordSet(record, xyzAuth).value)
+    val result = underTest.addRecordSet(record, xyzAuth).value.unsafeRunSync().swap.toOption.get
     result shouldBe an[InvalidRequest]
   }
   "fail if the record is dotted and user, record type is in allowed dotted hosts config except zone" in {
@@ -750,7 +748,7 @@ class RecordSetServiceSpec
       .getUsers(Set.empty, None, None)
 
     // fails as only two properties within dotted hosts config (users and record types) are satisfied while zone is not allowed
-    val result = leftResultOf(underTest.addRecordSet(record, okAuth).value)
+    val result = underTest.addRecordSet(record, okAuth).value.unsafeRunSync().swap.toOption.get
     result shouldBe an[InvalidRequest]
   }
   "fail if the record is dotted and zone, record type is in allowed dotted hosts config except user" in {
@@ -791,7 +789,7 @@ class RecordSetServiceSpec
       .getUsers(dummyGroup.memberIds, None, None)
 
     // fails as only two properties within dotted hosts config (zones and record types) are satisfied while user is not allowed
-    val result = leftResultOf(underTest.addRecordSet(record, abcAuth).value)
+    val result = underTest.addRecordSet(record, abcAuth).value.unsafeRunSync().swap.toOption.get
     result shouldBe an[InvalidRequest]
   }
   "fail if the record is dotted and zone, user is in allowed dotted hosts config except record type" in {
@@ -834,7 +832,7 @@ class RecordSetServiceSpec
       .getUsers(dummyGroup.memberIds, None, None)
 
     // fails as only two properties within dotted hosts config (zone and user) are satisfied while record type is not allowed
-    val result = leftResultOf(underTest.addRecordSet(record, xyzAuth).value)
+    val result = underTest.addRecordSet(record, xyzAuth).value.unsafeRunSync().swap.toOption.get
     result shouldBe an[InvalidRequest]
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -24,7 +24,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.BeforeAndAfterEach
 import vinyldns.core.domain.record._
-import vinyldns.api.ResultHelpers
 import cats.effect._
 import org.mockito.Matchers.any
 import vinyldns.core.domain.Fqdn
@@ -39,7 +38,6 @@ class ZoneConnectionValidatorSpec
     with Matchers
     with MockitoSugar
     with BeforeAndAfterEach
-    with ResultHelpers
     with EitherMatchers
     with EitherValues {
 
@@ -152,7 +150,7 @@ class ZoneConnectionValidatorSpec
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])
       doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
 
-      val result = awaitResultOf(underTest.validateZoneConnections(testZone).value)
+      val result = underTest.validateZoneConnections(testZone).value.unsafeRunSync()
       result should be(right)
     }
 
@@ -164,7 +162,7 @@ class ZoneConnectionValidatorSpec
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])
       doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
 
-      val result = leftResultOf(underTest.validateZoneConnections(testZone).value)
+      val result = underTest.validateZoneConnections(testZone).value.unsafeRunSync().swap.toOption.get
       result shouldBe ZoneValidationFailed(
         testZone,
         List(s"Name Server not.approved. is not an approved name server."),
@@ -181,7 +179,7 @@ class ZoneConnectionValidatorSpec
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])
       doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
 
-      val result = leftResultOf(underTest.validateZoneConnections(testZone).value)
+      val result = underTest.validateZoneConnections(testZone).value.unsafeRunSync().swap.toOption.get
       result shouldBe a[ZoneValidationFailed]
       result shouldBe ZoneValidationFailed(
         testZone,
@@ -202,7 +200,7 @@ class ZoneConnectionValidatorSpec
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])
       doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
 
-      val result = leftResultOf(underTest.validateZoneConnections(badZone).value)
+      val result = underTest.validateZoneConnections(badZone).value.unsafeRunSync().swap.toOption.get
       result shouldBe a[ConnectionFailed]
     }
 
@@ -219,7 +217,7 @@ class ZoneConnectionValidatorSpec
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])
       doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
 
-      val result = leftResultOf(underTest.validateZoneConnections(badZone).value)
+      val result = underTest.validateZoneConnections(badZone).value.unsafeRunSync().swap.toOption.get
       result shouldBe a[ConnectionFailed]
       result.getMessage should include("transfer connection failure!")
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import cats.implicits._
 import vinyldns.api.Interfaces._
-import vinyldns.api.ResultHelpers
 import cats.effect._
 import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import vinyldns.api.domain.access.AccessValidations
@@ -37,13 +36,10 @@ import vinyldns.core.TestZoneData._
 import vinyldns.core.crypto.NoOpCrypto
 import vinyldns.core.domain.backend.BackendResolver
 
-import scala.concurrent.duration._
-
 class ZoneServiceSpec
     extends AnyWordSpec
     with Matchers
     with MockitoSugar
-    with ResultHelpers
     with BeforeAndAfterEach
     with EitherValues {
 
@@ -109,9 +105,8 @@ class ZoneServiceSpec
     "return an appropriate zone change response" in {
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
 
-      val resultChange: ZoneChange = rightResultOf(
-        underTest.connectToZone(createZoneAuthorized, okAuth).map(_.asInstanceOf[ZoneChange]).value
-      )
+      val resultChange: ZoneChange =
+        underTest.connectToZone(createZoneAuthorized, okAuth).map(_.asInstanceOf[ZoneChange]).value.unsafeRunSync().toOption.get
 
       resultChange.changeType shouldBe ZoneChangeType.Create
       Option(resultChange.created) shouldBe defined
@@ -131,12 +126,11 @@ class ZoneServiceSpec
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
 
       val nonTestUser = okAuth.copy(signedInUser = okAuth.signedInUser.copy(isTest = false))
-      val resultChange: ZoneChange = rightResultOf(
+      val resultChange: ZoneChange =
         underTest
           .connectToZone(createZoneAuthorized, nonTestUser)
           .map(_.asInstanceOf[ZoneChange])
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       resultChange.zone.isTest shouldBe false
     }
@@ -146,12 +140,11 @@ class ZoneServiceSpec
 
       val testUser = okAuth.copy(signedInUser = okAuth.signedInUser.copy(isTest = true))
       testUser.isTestUser shouldBe true
-      val resultChange: ZoneChange = rightResultOf(
+      val resultChange: ZoneChange =
         underTest
           .connectToZone(createZoneAuthorized, testUser)
           .map(_.asInstanceOf[ZoneChange])
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       resultChange.zone.isTest shouldBe true
     }
@@ -159,7 +152,7 @@ class ZoneServiceSpec
     "return a ZoneAlreadyExists error if the zone exists" in {
       doReturn(IO.pure(Some(okZone))).when(mockZoneRepo).getZoneByName(anyString)
 
-      val error = leftResultOf(underTest.connectToZone(createZoneAuthorized, okAuth).value)
+      val error = underTest.connectToZone(createZoneAuthorized, okAuth).value.unsafeRunSync().swap.toOption.get
 
       error shouldBe a[ZoneAlreadyExistsError]
     }
@@ -168,7 +161,7 @@ class ZoneServiceSpec
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
       doReturn(IO.pure(None)).when(mockGroupRepo).getGroup(anyString)
 
-      val error = leftResultOf(underTest.connectToZone(createZoneAuthorized, okAuth).value)
+      val error = underTest.connectToZone(createZoneAuthorized, okAuth).value.unsafeRunSync().swap.toOption.get
 
       error shouldBe an[InvalidGroupError]
     }
@@ -176,9 +169,9 @@ class ZoneServiceSpec
     "allow the zone to be created if it exists and the zone is deleted" in {
       doReturn(IO.pure(Some(zoneDeleted))).when(mockZoneRepo).getZoneByName(anyString)
 
-      val resultChange: ZoneChange = rightResultOf(
-        underTest.connectToZone(createZoneAuthorized, okAuth).map(_.asInstanceOf[ZoneChange]).value
-      )
+      val resultChange: ZoneChange =
+        underTest.connectToZone(createZoneAuthorized, okAuth).map(_.asInstanceOf[ZoneChange]).value.unsafeRunSync().toOption.get
+
       resultChange.changeType shouldBe ZoneChangeType.Create
     }
 
@@ -186,7 +179,7 @@ class ZoneServiceSpec
       val badAcl = ACLRule(baseAclRuleInfo.copy(recordMask = Some("x{5,-3}")))
       val newZone = createZoneAuthorized.copy(acl = ZoneACL(Set(badAcl)))
 
-      val error = leftResultOf(underTest.connectToZone(newZone, okAuth).value)
+      val error = underTest.connectToZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]
     }
 
@@ -194,9 +187,8 @@ class ZoneServiceSpec
       val newZone = createZoneAuthorized.copy(shared = true)
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
 
-      val resultZone = rightResultOf(
-        underTest.connectToZone(newZone, superUserAuth).map(_.asInstanceOf[ZoneChange]).value
-      ).zone
+      val resultZone =
+        underTest.connectToZone(newZone, superUserAuth).map(_.asInstanceOf[ZoneChange]).value.unsafeRunSync().toOption.get.zone
 
       Option(resultZone.id) should not be None
       resultZone.email shouldBe okZone.email
@@ -210,12 +202,11 @@ class ZoneServiceSpec
       val newZone = createZoneAuthorized.copy(shared = true)
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
 
-      val resultZone = rightResultOf(
+      val resultZone =
         underTest
           .connectToZone(newZone, supportUserAuth)
           .map(_.asInstanceOf[ZoneChange])
-          .value
-      ).zone
+          .value.unsafeRunSync().toOption.get.zone
 
       Option(resultZone.id) should not be None
       resultZone.email shouldBe okZone.email
@@ -229,14 +220,14 @@ class ZoneServiceSpec
       val newZone = createZoneAuthorized.copy(shared = true)
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName(anyString)
 
-      val error = leftResultOf(underTest.connectToZone(newZone, okAuth).value)
+      val error = underTest.connectToZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
     "return an InvalidRequest if zone has a specified backend ID that is invalid" in {
       val newZone = createZoneAuthorized.copy(backendId = Some("badId"))
 
-      val error = leftResultOf(underTest.connectToZone(newZone, okAuth).value)
+      val error = underTest.connectToZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]
     }
   }
@@ -248,13 +239,11 @@ class ZoneServiceSpec
       val doubleAuth = AuthPrincipal(TestDataLoader.okUser, Seq(twoUserGroup.id, okGroup.id))
       val updateZoneInput = updateZoneAuthorized.copy(adminGroupId = twoUserGroup.id)
 
-      val resultChange: ZoneChange = rightResultOf(
+      val resultChange: ZoneChange =
         underTest
           .updateZone(updateZoneInput, doubleAuth)
           .map(_.asInstanceOf[ZoneChange])
-          .value,
-        duration = 2.seconds
-      )
+          .value.unsafeRunSync().toOption.get
 
       resultChange.zone.id shouldBe okZone.id
       resultChange.changeType shouldBe ZoneChangeType.Update
@@ -272,12 +261,11 @@ class ZoneServiceSpec
       val doubleAuth = AuthPrincipal(TestDataLoader.okUser, Seq(okGroup.id, okGroup.id))
 
       val resultChange: ZoneChange =
-        rightResultOf(
           underTest
             .updateZone(newZone, doubleAuth)
             .map(_.asInstanceOf[ZoneChange])
-            .value
-        )
+            .value.unsafeRunSync().toOption.get
+
       resultChange.zone.id shouldBe oldZone.id
       resultChange.zone.connection shouldBe oldZone.connection
     }
@@ -288,7 +276,7 @@ class ZoneServiceSpec
       val newZone =
         updateZoneAuthorized.copy(connection = Some(badConnection), adminGroupId = okGroup.id)
 
-      val error = leftResultOf(underTest.updateZone(newZone, okAuth).value)
+      val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[ConnectionFailed]
     }
 
@@ -297,7 +285,7 @@ class ZoneServiceSpec
 
       val noAuth = AuthPrincipal(TestDataLoader.okUser, Seq())
 
-      val error = leftResultOf(underTest.updateZone(updateZoneAuthorized, noAuth).value)
+      val error = underTest.updateZone(updateZoneAuthorized, noAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -307,7 +295,7 @@ class ZoneServiceSpec
       val badAcl = ACLRule(baseAclRuleInfo.copy(recordMask = Some("x{5,-3}")))
       val newZone = updateZoneAuthorized.copy(acl = ZoneACL(Set(badAcl)))
 
-      val error = leftResultOf(underTest.updateZone(newZone, okAuth).value)
+      val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]
     }
 
@@ -317,11 +305,11 @@ class ZoneServiceSpec
         .when(mockZoneRepo)
         .getZone(newZone.id)
 
-      val result = rightResultOf(
+      val result =
         underTest
           .updateZone(newZone, AuthPrincipal(superUser, List.empty))
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
+
       result shouldBe a[ZoneChange]
     }
 
@@ -331,11 +319,11 @@ class ZoneServiceSpec
         .when(mockZoneRepo)
         .getZone(newZone.id)
 
-      val result = rightResultOf(
+      val result =
         underTest
           .updateZone(newZone, supportUserAuth)
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
+
       result shouldBe a[ZoneChange]
     }
 
@@ -346,7 +334,7 @@ class ZoneServiceSpec
         .when(mockZoneRepo)
         .getZone(newZone.id)
 
-      val error = leftResultOf(underTest.updateZone(newZone, okAuth).value)
+      val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -356,13 +344,13 @@ class ZoneServiceSpec
         .when(mockZoneRepo)
         .getZone(newZone.id)
 
-      val result = rightResultOf(underTest.updateZone(newZone, okAuth).value)
+      val result = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().toOption.get
       result shouldBe a[ZoneChange]
     }
     "return an InvalidRequest if zone has a specified backend ID that is invalid" in {
       val newZone = updateZoneAuthorized.copy(backendId = Some("badId"))
 
-      val error = leftResultOf(underTest.updateZone(newZone, okAuth).value)
+      val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]
     }
   }
@@ -372,7 +360,7 @@ class ZoneServiceSpec
       doReturn(IO.pure(Some(okZone))).when(mockZoneRepo).getZone(anyString)
 
       val resultChange: ZoneChange =
-        rightResultOf(underTest.deleteZone(okZone.id, okAuth).map(_.asInstanceOf[ZoneChange]).value)
+        underTest.deleteZone(okZone.id, okAuth).map(_.asInstanceOf[ZoneChange]).value.unsafeRunSync().toOption.get
 
       resultChange.zone.id shouldBe okZone.id
       resultChange.changeType shouldBe ZoneChangeType.Delete
@@ -383,7 +371,7 @@ class ZoneServiceSpec
 
       val noAuth = AuthPrincipal(TestDataLoader.okUser, Seq())
 
-      val error = leftResultOf(underTest.deleteZone(okZone.id, noAuth).value)
+      val error = underTest.deleteZone(okZone.id, noAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
   }
@@ -393,7 +381,7 @@ class ZoneServiceSpec
       doReturn(IO.pure(Some(okZone))).when(mockZoneRepo).getZone(anyString)
 
       val resultChange: ZoneChange =
-        rightResultOf(underTest.syncZone(okZone.id, okAuth).map(_.asInstanceOf[ZoneChange]).value)
+        underTest.syncZone(okZone.id, okAuth).map(_.asInstanceOf[ZoneChange]).value.unsafeRunSync().toOption.get
 
       resultChange.zone.id shouldBe okZone.id
       resultChange.changeType shouldBe ZoneChangeType.Sync
@@ -405,7 +393,7 @@ class ZoneServiceSpec
 
       val noAuth = AuthPrincipal(TestDataLoader.okUser, Seq())
 
-      val error = leftResultOf(underTest.syncZone(okZone.id, noAuth).value)
+      val error = underTest.syncZone(okZone.id, noAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
   }
@@ -414,7 +402,7 @@ class ZoneServiceSpec
     "fail with no zone returned" in {
       doReturn(IO.pure(None)).when(mockZoneRepo).getZone("notAZoneId")
 
-      val error = leftResultOf(underTest.getZone("notAZoneId", okAuth).value)
+      val error = underTest.getZone("notAZoneId", okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[ZoneNotFoundError]
     }
 
@@ -423,7 +411,7 @@ class ZoneServiceSpec
 
       val noAuth = AuthPrincipal(TestDataLoader.okUser, Seq())
 
-      val error = leftResultOf(underTest.getZone(okZone.id, noAuth).value)
+      val error = underTest.getZone(okZone.id, noAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -471,7 +459,7 @@ class ZoneServiceSpec
         goodGroup.name,
         AccessLevel.Delete
       )
-      val result: ZoneInfo = rightResultOf(underTest.getZone(zoneWithRules.id, abcAuth).value)
+      val result: ZoneInfo = underTest.getZone(zoneWithRules.id, abcAuth).value.unsafeRunSync().toOption.get
       result shouldBe expectedZoneInfo
     }
 
@@ -485,14 +473,14 @@ class ZoneServiceSpec
 
       val expectedZoneInfo =
         ZoneInfo(abcZone, ZoneACLInfo(Set()), "Unknown group name", AccessLevel.Delete)
-      val result: ZoneInfo = rightResultOf(underTest.getZone(abcZone.id, abcAuth).value)
+      val result: ZoneInfo = underTest.getZone(abcZone.id, abcAuth).value.unsafeRunSync().toOption.get
       result shouldBe expectedZoneInfo
     }
 
     "return a zone by name with failure when no zone is found" in {
       doReturn(IO.pure(None)).when(mockZoneRepo).getZoneByName("someZoneName.")
 
-      val error = leftResultOf(underTest.getZoneByName("someZoneName", okAuth).value)
+      val error = underTest.getZoneByName("someZoneName", okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[ZoneNotFoundError]
     }
 
@@ -518,7 +506,7 @@ class ZoneServiceSpec
         .listZones(abcAuth, None, None, 100, false)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
-      val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
+      val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
       result.zones shouldBe List()
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
@@ -535,7 +523,7 @@ class ZoneServiceSpec
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
 
-      val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
+      val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary)
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
@@ -553,7 +541,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
 
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, ignoreAccess = true).value)
+        underTest.listZones(abcAuth, ignoreAccess = true).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
@@ -568,7 +556,7 @@ class ZoneServiceSpec
         .listZones(abcAuth, None, None, 100, false)
       doReturn(IO.pure(Set(okGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
-      val result: ListZonesResponse = rightResultOf(underTest.listZones(abcAuth).value)
+      val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
       val expectedZones =
         List(abcZoneSummary, xyzZoneSummary).map(_.copy(adminGroupName = "Unknown group name"))
       result.zones shouldBe expectedZones
@@ -595,7 +583,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
 
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, maxItems = 2).value)
+        underTest.listZones(abcAuth, maxItems = 2).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
       result.maxItems shouldBe 2
       result.startFrom shouldBe None
@@ -621,7 +609,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
 
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, nameFilter = Some("foo"), maxItems = 2).value)
+        underTest.listZones(abcAuth, nameFilter = Some("foo"), maxItems = 2).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
       result.nameFilter shouldBe Some("foo")
       result.nextId shouldBe Some("zone2.")
@@ -645,7 +633,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
 
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value)
+        underTest.listZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
       result.startFrom shouldBe Some("zone4.")
     }
@@ -668,7 +656,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
 
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value)
+        underTest.listZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary, xyzZoneSummary)
       result.nextId shouldBe Some("zone6.")
     }
@@ -684,7 +672,7 @@ class ZoneServiceSpec
         .listZoneChanges(okZone.id, startFrom = None, maxItems = 100)
 
       val result: ListZoneChangesResponse =
-        rightResultOf(underTest.listZoneChanges(okZone.id, okAuth).value)
+        underTest.listZoneChanges(okZone.id, okAuth).value.unsafeRunSync().toOption.get
 
       result.zoneChanges shouldBe List(zoneUpdate, zoneCreate)
       result.zoneId shouldBe okZone.id
@@ -699,7 +687,7 @@ class ZoneServiceSpec
         .listZoneChanges(okZone.id, startFrom = None, maxItems = 100)
 
       val result: ListZoneChangesResponse =
-        rightResultOf(underTest.listZoneChanges(okZone.id, okAuth).value)
+        underTest.listZoneChanges(okZone.id, okAuth).value.unsafeRunSync().toOption.get
 
       result.zoneChanges shouldBe empty
       result.zoneId shouldBe okZone.id
@@ -710,7 +698,7 @@ class ZoneServiceSpec
         .when(mockZoneRepo)
         .getZone(zoneNotAuthorized.id)
 
-      val error = leftResultOf(underTest.listZoneChanges(zoneNotAuthorized.id, okAuth).value)
+      val error = underTest.listZoneChanges(zoneNotAuthorized.id, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -725,7 +713,7 @@ class ZoneServiceSpec
         .listZoneChanges(zoneId = okZone.id, startFrom = None, maxItems = 100)
 
       val result: ListZoneChangesResponse =
-        rightResultOf(underTest.listZoneChanges(okZone.id, okAuth).value)
+        underTest.listZoneChanges(okZone.id, okAuth).value.unsafeRunSync().toOption.get
 
       result.zoneChanges.head shouldBe zoneUpdate
       result.zoneChanges(1) shouldBe zoneCreate
@@ -737,19 +725,18 @@ class ZoneServiceSpec
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(anyString)
 
       val error =
-        leftResultOf(underTest.addACLRule(zoneNotAuthorized.id, baseAclRuleInfo, okAuth).value)
+        underTest.addACLRule(zoneNotAuthorized.id, baseAclRuleInfo, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
     "generate a zone update if the request is valid" in {
       doReturn(IO.pure(Some(okZone))).when(mockZoneRepo).getZone(anyString)
 
-      val result: ZoneChange = rightResultOf(
+      val result: ZoneChange =
         underTest
           .addACLRule(okZone.id, userAclRuleInfo, okAuth)
           .map(_.asInstanceOf[ZoneChange])
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       result.changeType shouldBe ZoneChangeType.Update
       result.zone.acl.rules.size shouldBe 1
@@ -761,7 +748,7 @@ class ZoneServiceSpec
 
       val invalidRegexMaskRuleInfo = baseAclRuleInfo.copy(recordMask = Some("x{5,-3}"))
       val error =
-        leftResultOf(underTest.addACLRule(okZone.id, invalidRegexMaskRuleInfo, okAuth).value)
+        underTest.addACLRule(okZone.id, invalidRegexMaskRuleInfo, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]
     }
   }
@@ -771,7 +758,7 @@ class ZoneServiceSpec
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(anyString)
 
       val error =
-        leftResultOf(underTest.deleteACLRule(zoneNotAuthorized.id, baseAclRuleInfo, okAuth).value)
+        underTest.deleteACLRule(zoneNotAuthorized.id, baseAclRuleInfo, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[NotAuthorizedError]
     }
 
@@ -780,12 +767,11 @@ class ZoneServiceSpec
       val zone = okZone.copy(acl = acl)
       doReturn(IO.pure(Some(zone))).when(mockZoneRepo).getZone(anyString)
 
-      val result: ZoneChange = rightResultOf(
+      val result: ZoneChange =
         underTest
           .deleteACLRule(zone.id, userAclRuleInfo, okAuth)
           .map(_.asInstanceOf[ZoneChange])
-          .value
-      )
+          .value.unsafeRunSync().toOption.get
 
       result.changeType shouldBe ZoneChangeType.Update
       result.zone.acl.rules.size shouldBe 0

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -561,7 +561,7 @@ class ZoneServiceSpec
 
       // When searchByAdminGroup is true, zones are filtered by admin group name given in nameFilter
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, Some("abcGroup"), None, 100, searchByAdminGroup = true, ignoreAccess = true).value)
+        underTest.listZones(abcAuth, Some("abcGroup"), None, 100, searchByAdminGroup = true, ignoreAccess = true).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary)
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
@@ -580,7 +580,7 @@ class ZoneServiceSpec
 
       // When searchByAdminGroup is false, zone name given in nameFilter is returned
       val result: ListZonesResponse =
-        rightResultOf(underTest.listZones(abcAuth, Some("abcZone"), None, 100, searchByAdminGroup = false, ignoreAccess = true).value)
+        underTest.listZones(abcAuth, Some("abcZone"), None, 100, searchByAdminGroup = false, ignoreAccess = true).value.unsafeRunSync().toOption.get
       result.zones shouldBe List(abcZoneSummary)
       result.maxItems shouldBe 100
       result.startFrom shouldBe None

--- a/modules/api/src/test/scala/vinyldns/api/engine/BatchChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/BatchChangeHandlerSpec.scala
@@ -23,7 +23,6 @@ import org.mockito.Mockito.{doReturn, verify}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-import vinyldns.api.CatsHelpers
 import vinyldns.api.repository.InMemoryBatchChangeRepository
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record._
@@ -34,8 +33,7 @@ import scala.concurrent.ExecutionContext
 class BatchChangeHandlerSpec
     extends AnyWordSpec
     with MockitoSugar
-    with BeforeAndAfterEach
-    with CatsHelpers {
+    with BeforeAndAfterEach {
 
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
   implicit val contextShift: ContextShift[IO] = IO.contextShift(ec)
@@ -76,7 +74,7 @@ class BatchChangeHandlerSpec
   "notify on batch change complete" in {
     doReturn(IO.unit).when(mockNotifier).notify(any[Notification[_]])
 
-    await(batchRepo.save(completedBatchChange))
+    batchRepo.save(completedBatchChange).unsafeRunSync()
 
     BatchChangeHandler
       .process(batchRepo, notifiers, BatchChangeCommand(completedBatchChange.id))
@@ -91,7 +89,7 @@ class BatchChangeHandlerSpec
     val partiallyFailedBatchChange =
       completedBatchChange.copy(changes = List(addChange.copy(status = SingleChangeStatus.Failed)))
 
-    await(batchRepo.save(partiallyFailedBatchChange))
+    batchRepo.save(partiallyFailedBatchChange).unsafeRunSync()
 
     BatchChangeHandler
       .process(batchRepo, notifiers, BatchChangeCommand(partiallyFailedBatchChange.id))

--- a/modules/api/src/test/scala/vinyldns/api/engine/RecordSetChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/RecordSetChangeHandlerSpec.scala
@@ -28,7 +28,6 @@ import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import vinyldns.api.backend.dns.DnsProtocol.{NotAuthorized, TryAgain}
 import vinyldns.api.engine.RecordSetChangeHandler.{AlreadyApplied, ReadyToApply, Requeue}
 import vinyldns.api.repository.InMemoryBatchChangeRepository
-import vinyldns.api.CatsHelpers
 import vinyldns.core.domain.batch.{BatchChange, BatchChangeApprovalStatus, SingleAddChange, SingleChangeStatus}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.{ChangeSet, RecordChangeRepository, RecordSetRepository, _}
@@ -45,7 +44,6 @@ class RecordSetChangeHandlerSpec
     with Matchers
     with MockitoSugar
     with BeforeAndAfterEach
-    with CatsHelpers
     with EitherValues
     with TransactionProvider {
 
@@ -115,7 +113,7 @@ class RecordSetChangeHandlerSpec
     batchRepo.clear()
 
     // seed the linked batch change in the DB
-    await(batchRepo.save(batchChange))
+    batchRepo.save(batchChange).unsafeRunSync()
 
     doReturn(IO.pure(Nil))
       .when(mockRsRepo)
@@ -150,7 +148,7 @@ class RecordSetChangeHandlerSpec
       savedCs.status shouldBe ChangeSetStatus.Complete
       savedCs.changes.head.status shouldBe RecordSetChangeStatus.Complete
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Complete,
@@ -195,7 +193,7 @@ class RecordSetChangeHandlerSpec
       verify(mockBackend).applyChange(rsChange)
       verify(mockBackend, times(2)).resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Complete,
@@ -245,7 +243,7 @@ class RecordSetChangeHandlerSpec
       // make sure we only called resolve once when validating, ensures that verify was not called
       verify(mockBackend, times(1)).resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Failed,
@@ -291,7 +289,7 @@ class RecordSetChangeHandlerSpec
       // we will retry the verify 3 times based on the mock setup
       verify(mockBackend, times(2)).resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Failed,
@@ -347,7 +345,7 @@ class RecordSetChangeHandlerSpec
       verify(mockBackend, never()).applyChange(rsChange)
       verify(mockBackend, times(1)).resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Failed,
@@ -390,7 +388,7 @@ class RecordSetChangeHandlerSpec
       verify(mockBackend, times(1)).applyChange(rsChange)
       verify(mockBackend, times(1)).resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Failed,
@@ -445,7 +443,7 @@ class RecordSetChangeHandlerSpec
       // make sure we never called resolve, as we skip validate step and verify
       verify(mockBackend, never).resolve(rs.name, rsChange.zone.name, rs.typ)
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Complete,
@@ -599,7 +597,7 @@ class RecordSetChangeHandlerSpec
       savedCs.status shouldBe ChangeSetStatus.Complete
       savedCs.changes.head.status shouldBe RecordSetChangeStatus.Complete
 
-      val batchChangeUpdates = await(batchRepo.getBatchChange(batchChange.id))
+      val batchChangeUpdates = batchRepo.getBatchChange(batchChange.id).unsafeRunSync()
       val updatedSingleChanges = completeCreateAAAASingleChanges.map { ch =>
         ch.copy(
           status = SingleChangeStatus.Complete,


### PR DESCRIPTION
Fixes #464 

Changes in this pull request:
- Replaced `await` and other related functions present in `CatsHelpers.scala` and `ResultHelpers.scala` which is not necessary with cats `IO` library as we switched over.
