### PR TITLE
Remove 'Complete' zone change status

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -124,7 +124,7 @@ class ZoneRoutingSpec
       ("status" -> "invalidStatus") ~~
       ("adminGroupId" -> "admin-group-id")
 
-  private val zoneCreate = ZoneChange(ok, "ok", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val zoneCreate = ZoneChange(ok, "ok", ZoneChangeType.Create, ZoneChangeStatus.Synced)
   private val listZoneChangeResponse = ListZoneChangesResponse(
     ok.id,
     List(zoneCreate, zoneUpdate),
@@ -157,7 +157,7 @@ class ZoneRoutingSpec
         case ok.email | connectionOk.email | trailingDot.email | "invalid-zone-status@test.com" =>
           Right(
             zoneCreate.copy(
-              status = ZoneChangeStatus.Complete,
+              status = ZoneChangeStatus.Synced,
               zone = Zone(createZoneInput, false).copy(status = ZoneStatus.Active)
             )
           )
@@ -183,7 +183,7 @@ class ZoneRoutingSpec
         case ok.email | connectionOk.email =>
           Right(
             zoneUpdate.copy(
-              status = ZoneChangeStatus.Complete,
+              status = ZoneChangeStatus.Synced,
               zone = Zone(updateZoneInput, zoneUpdate.zone).copy(status = ZoneStatus.Active)
             )
           )
@@ -208,7 +208,7 @@ class ZoneRoutingSpec
         case notFound.id => Left(ZoneNotFoundError(s"$zoneId"))
         case notAuthorized.id => Left(NotAuthorizedError(s"$zoneId"))
         case ok.id | connectionOk.id =>
-          Right(ZoneChange(ok, "ok", ZoneChangeType.Delete, ZoneChangeStatus.Complete))
+          Right(ZoneChange(ok, "ok", ZoneChangeType.Delete, ZoneChangeStatus.Synced))
         case error.id => Left(new RuntimeException("fail"))
         case zone1.id => Left(ZoneUnavailableError(zoneId))
       }
@@ -372,7 +372,7 @@ class ZoneRoutingSpec
                 authPrincipal,
                 NoOpCrypto.instance
               )
-              .copy(status = ZoneChangeStatus.Complete)
+              .copy(status = ZoneChangeStatus.Synced)
           )
         case error.id => Left(new RuntimeException("fail"))
       }
@@ -397,7 +397,7 @@ class ZoneRoutingSpec
                 authPrincipal,
                 NoOpCrypto.instance
               )
-              .copy(status = ZoneChangeStatus.Complete)
+              .copy(status = ZoneChangeStatus.Synced)
           )
         case error.id => Left(new RuntimeException("fail"))
       }

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChange.scala
@@ -22,7 +22,7 @@ import org.joda.time.DateTime
 
 object ZoneChangeStatus extends Enumeration {
   type ZoneChangeStatus = Value
-  val Pending, Complete, Failed, Synced = Value
+  val Pending, Failed, Synced = Value
 }
 
 object ZoneChangeType extends Enumeration {

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -79,11 +79,11 @@ object TestZoneData {
     okZone,
     "ok",
     ZoneChangeType.Create,
-    ZoneChangeStatus.Complete,
+    ZoneChangeStatus.Synced,
     created = DateTime.now.minus(1000)
   )
 
-  val zoneUpdate: ZoneChange = zoneChangePending.copy(status = ZoneChangeStatus.Complete)
+  val zoneUpdate: ZoneChange = zoneChangePending.copy(status = ZoneChangeStatus.Synced)
 
   def makeTestPendingZoneChange(zone: Zone): ZoneChange =
     ZoneChange(zone, "userId", ZoneChangeType.Update, ZoneChangeStatus.Pending)

--- a/modules/core/src/test/scala/vinyldns/core/domain/zone/ZoneChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/zone/ZoneChangeSpec.scala
@@ -26,7 +26,7 @@ class ZoneChangeSpec extends AnyWordSpec with Matchers {
     Zone("test", "test"),
     "ok",
     ZoneChangeType.Create,
-    ZoneChangeStatus.Complete,
+    ZoneChangeStatus.Synced,
     created = DateTime.now.minus(1000)
   )
 

--- a/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
@@ -74,7 +74,7 @@ class ProtobufConversionsSpec
     zone,
     "system",
     ZoneChangeType.Update,
-    ZoneChangeStatus.Complete,
+    ZoneChangeStatus.Synced,
     DateTime.now,
     Some("hello")
   )


### PR DESCRIPTION
Fixes #618 

Changes in this pull request:
- Remove the zone change status `Complete` and it's occurrences since it is not being used anywhere other than tests.
