### PR TITLE
Remove keys from User by overriding 'toString'

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -94,7 +94,13 @@ class MembershipValidationsSpec
         val nonSuperAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, nonSuperAuth) should be(right)
       }
+    }
 
+    "User toString" should {
+      "not display access and secret keys" in {
+        val userString = s"""User: [id="ok"; userName="ok"; firstName="Some(ok)"; lastName="Some(ok)"; email="Some(test@test.com)"; created="${okUser.created}"; isSuper="false"; isSupport="false"; isTest="false"; lockStatus="Unlocked"; ]"""
+        okUser.toString shouldBe userString
+      }
     }
   }
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -51,6 +51,23 @@ final case class User(
 
   def withEncryptedSecretKey(cryptoAlgebra: CryptoAlgebra): User =
     copy(secretKey = cryptoAlgebra.encrypt(secretKey))
+
+  override def toString: String = {
+    val sb = new StringBuilder
+    sb.append("User: [")
+    sb.append("id=\"").append(id).append("\"; ")
+    sb.append("userName=\"").append(userName).append("\"; ")
+    sb.append("firstName=\"").append(firstName.toString).append("\"; ")
+    sb.append("lastName=\"").append(lastName.toString).append("\"; ")
+    sb.append("email=\"").append(email.toString).append("\"; ")
+    sb.append("created=\"").append(created).append("\"; ")
+    sb.append("isSuper=\"").append(isSuper).append("\"; ")
+    sb.append("isSupport=\"").append(isSupport).append("\"; ")
+    sb.append("isTest=\"").append(isTest).append("\"; ")
+    sb.append("lockStatus=\"").append(lockStatus.toString).append("\"; ")
+    sb.append("]")
+    sb.toString
+  }
 }
 
 object User {

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -160,7 +160,7 @@ trait TestApplicationData { this: Mockito =>
       | "oldGroup": {},
       | "id": "b6018a9b-c893-40e9-aa25-4ccfee460c18",
       | "created": "2022-07-22T08:19:22Z",
-      | "userName": "$frodoUser",
+      | "userName": "${frodoUser.userName}",
       | "groupChangeMessage": ""
       | }
     """.stripMargin)
@@ -180,7 +180,7 @@ trait TestApplicationData { this: Mockito =>
        | "oldGroup": {},
        | "id": "b6018a9b-c893-40e9-aa25-4ccfee460c18",
        | "created": "2022-07-22T08:19:22Z",
-       | "userName": "$frodoUser",
+       | "userName": "${frodoUser.userName}",
        | "groupChangeMessage": ""
        | }],
        | "maxItems": 100


### PR DESCRIPTION
Fixes #444 

Changes in this pull request:
- Excluded access and secret keys to prevent accidental logging of sensitive info by overriding `toString` in User, and validated that it doesn't show up in any log statements.
