### PR TITLE
Override ZoneConnection toString

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -245,8 +245,8 @@ class ZoneConnectionValidatorSpec
     "Zone Connection toString" should {
       "not display key and algorithm" in {
         zc.toString shouldBe "ZoneConnection: [name=\"zc.\"; keyName=\"zc.\"; primaryServer=\"10.1.1.1\"; ]"
-
-        // verify the same while displaying connection and transferConnection in Zone
+      }
+      "not display key and algorithm while displaying connection and transferConnection of a Zone" in {
         val zoneString = s"""Zone: [id="${testZone.id}"; name="vinyldns."; account="system"; adminGroupId="system"; status="Active"; shared="false"; connection="Some(ZoneConnection: [name="vinyldns."; keyName="vinyldns."; primaryServer="10.1.1.1"; ])"; transferConnection="Some(ZoneConnection: [name="vinyldns."; keyName="vinyldns."; primaryServer="10.1.1.1"; ])"; reverse="false"; isTest="false"; created="${testZone.created}"; ]"""
         testZone.toString shouldBe zoneString
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -241,5 +241,15 @@ class ZoneConnectionValidatorSpec
         underTest.isValidBackendId(Some("bad")) shouldBe left
       }
     }
+
+    "Zone Connection toString" should {
+      "not display key and algorithm" in {
+        zc.toString shouldBe "ZoneConnection: [name=\"zc.\"; keyName=\"zc.\"; primaryServer=\"10.1.1.1\"; ]"
+
+        // verify the same while displaying connection and transferConnection in Zone
+        val zoneString = s"""Zone: [id="${testZone.id}"; name="vinyldns."; account="system"; adminGroupId="system"; status="Active"; shared="false"; connection="Some(ZoneConnection: [name="vinyldns."; keyName="vinyldns."; primaryServer="10.1.1.1"; ])"; transferConnection="Some(ZoneConnection: [name="vinyldns."; keyName="vinyldns."; primaryServer="10.1.1.1"; ])"; reverse="false"; isTest="false"; created="${testZone.created}"; ]"""
+        testZone.toString shouldBe zoneString
+      }
+    }
   }
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
@@ -188,6 +188,16 @@ case class ZoneConnection(
 
   def decrypted(crypto: CryptoAlgebra): ZoneConnection =
     copy(key = crypto.decrypt(key))
+
+  override def toString: String = {
+    val sb = new StringBuilder
+    sb.append("ZoneConnection: [")
+    sb.append("name=\"").append(name).append("\"; ")
+    sb.append("keyName=\"").append(keyName).append("\"; ")
+    sb.append("primaryServer=\"").append(primaryServer).append("\"; ")
+    sb.append("]")
+    sb.toString
+  }
 }
 
 final case class LegacyDnsBackend(


### PR DESCRIPTION
Fixes #408 

Changes in this pull request:
- Excluded zone connection key and algorithm to prevent accidental logging of sensitive info by overriding `toString` in ZoneConnection. Validated that it doesn't show up in any log statements and also that Zone `toString` has the zone connection in this format.