### PR TITLE
Correctly handle SPF record data 

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsConversions.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsConversions.scala
@@ -278,7 +278,7 @@ trait DnsConversions {
 
   def fromSPFRecord(r: DNS.SPFRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
     fromDnsRecord(r, zoneName, zoneId) { data =>
-      List(SPFData(data.getStrings.asScala.mkString(",")))
+      List(SPFData(data.getStrings.asScala.mkString))
     }
 
   def fromSRVRecord(r: DNS.SRVRecord, zoneName: DNS.Name, zoneId: String): RecordSet =
@@ -393,7 +393,8 @@ trait DnsConversions {
           new DNS.SSHFPRecord(recordName, DNS.DClass.IN, ttl, algorithm, typ, Hex.decodeHex(fingerprint.toCharArray()))
 
         case SPFData(text) =>
-          new DNS.SPFRecord(recordName, DNS.DClass.IN, ttl, text)
+          val texts = text.grouped(255).toList
+          new DNS.SPFRecord(recordName, DNS.DClass.IN, ttl, texts.asJava)
 
         case TXTData(text) =>
           val texts = text.grouped(255).toList

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -1554,6 +1554,29 @@ def test_create_long_txt_record_succeeds(shared_zone_test_context):
             pass
 
 
+def test_create_long_spf_record_succeeds(shared_zone_test_context):
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    zone = shared_zone_test_context.system_test_zone
+
+    # Anything larger than 255 will test the limits of SPF, 4000 is the value used by R53
+    # (https://aws.amazon.com/premiumsupport/knowledge-center/route-53-configure-long-spf-txt-records/)
+    record_data = "a" * 4000
+    long_spf_rs = create_recordset(zone, "long-spf-record", "SPF", [{"text": record_data}])
+
+    try:
+        rs_create = client.create_recordset(long_spf_rs, status=202)
+        rs = client.wait_until_recordset_change_status(rs_create, "Complete")["recordSet"]
+        assert_that(rs["records"][0]["text"], is_(record_data))
+    finally:
+        try:
+            delete_result = client.delete_recordset(rs["zoneId"], rs["id"], status=202)
+            client.wait_until_recordset_change_status(delete_result, "Complete")
+        except Exception:
+            traceback.print_exc()
+            pass
+
+
 def test_txt_dotted_host_create_succeeds(shared_zone_test_context):
     """
     Tests that a TXT dotted host recordset create succeeds

--- a/modules/api/src/test/scala/vinyldns/api/backend/dns/DnsConversionsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/dns/DnsConversionsSpec.scala
@@ -398,9 +398,9 @@ class DnsConversionsSpec
       verifyMatch(result, testLongTXT)
     }
 
-    "fail to convert a bad SPF record set" in {
-      val result = toDnsRRset(testLongSPF, testZoneName).left.value
-      result shouldBe a[java.lang.IllegalArgumentException]
+    "convert long SPF record set" in {
+      val result = toDnsRRset(testLongSPF, testZoneName).right.value
+      verifyMatch(result, testLongSPF)
     }
   }
 
@@ -513,6 +513,9 @@ class DnsConversionsSpec
     }
     "convert to/from RecordType TXT long TXT record data" in {
       verifyMatch(testLongTXT, roundTrip(testLongTXT))
+    }
+    "convert to/from RecordType SPF long SPF record data" in {
+      verifyMatch(testLongSPF, roundTrip(testLongSPF))
     }
   }
 


### PR DESCRIPTION
Fixes #570 

Changes in this pull request:
- Made changes similar to the PR: #568 which fixes a similar issue for TXT records. Group SPF record data as a list of 255 character length strings.
