### PR TITLE
Remove portal logs from browser console

### DIFF
--- a/modules/portal/public/app.js
+++ b/modules/portal/public/app.js
@@ -13,7 +13,7 @@ angular.module('vinyldns', [
             });
         $animateProvider
             .classNameFilter(/toshow/);
-        //turning off $log
+        // turning off $log. Change to true for local development and testing
         $logProvider.debugEnabled(false);
     })
     .controller('AppController', function ($scope, $timeout, profileService, utilityService) {

--- a/modules/portal/public/lib/controllers/controller.groups.js
+++ b/modules/portal/public/lib/controllers/controller.groups.js
@@ -68,10 +68,10 @@ angular.module('controller.groups', []).controller('GroupsController', function 
         //prevent user executing service call multiple times
         //if true prevent, if false allow for execution of rest of code
         //ng-href='/groups'
-        $log.log('createGroup::called', $scope.data);
+        $log.debug('createGroup::called', $scope.data);
 
         if ($scope.processing) {
-            $log.log('createGroup::processing is true; exiting');
+            $log.debug('createGroup::processing is true; exiting');
             return;
         }
         //flag to prevent multiple clicks until previous promise has resolved.
@@ -116,7 +116,7 @@ angular.module('controller.groups', []).controller('GroupsController', function 
 
     $scope.refresh = function () {
         function success(result) {
-            $log.log('getGroups:refresh-success', result);
+            $log.debug('getGroups:refresh-success', result);
             //update groups
             $scope.groups.items = result.groups;
             $scope.groupsLoaded = true;
@@ -149,7 +149,7 @@ angular.module('controller.groups', []).controller('GroupsController', function 
 
     function getGroups() {
         function success(response) {
-            $log.log('groupsService::getGroups-success');
+            $log.debug('groupsService::getGroups-success');
             return response.data;
         }
 
@@ -163,7 +163,7 @@ angular.module('controller.groups', []).controller('GroupsController', function 
 
     function getGroupsAbridged() {
         function success(response) {
-            $log.log('groupsService::getGroups-success');
+            $log.debug('groupsService::getGroups-success');
             return response.data;
         }
 
@@ -202,10 +202,10 @@ angular.module('controller.groups', []).controller('GroupsController', function 
         //prevent user executing service call multiple times
         //if true prevent, if false allow for execution of rest of code
         //ng-href='/groups'
-        $log.log('updateGroup::called', $scope.data);
+        $log.debug('updateGroup::called', $scope.data);
 
         if ($scope.processing) {
-            $log.log('updateGroup::processing is true; exiting');
+            $log.debug('updateGroup::processing is true; exiting');
             return;
         }
         //flag to prevent multiple clicks until previous promise has resolved.
@@ -268,7 +268,7 @@ angular.module('controller.groups', []).controller('GroupsController', function 
             //update user profile data
             //make user profile available to page
             $scope.profile = results.data;
-            $log.log($scope.profile);
+            $log.debug($scope.profile);
             //load data in grid
             $scope.refresh();
         }

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -195,7 +195,7 @@ angular.module('controller.manageZones', [])
             if ($scope.currentAclRule.priority == 'User') {
                 profileService.getUserDataByUsername($scope.currentAclRule.userName)
                     .then(function (profile) {
-                        $log.log('profileService::getUserDataByUsername-success');
+                        $log.debug('profileService::getUserDataByUsername-success');
                         $scope.currentAclRule.userId = profile.data.id;
                         $scope.postUserLookup(type);
                     })
@@ -269,7 +269,7 @@ angular.module('controller.manageZones', [])
 
     $scope.refreshZone = function() {
         function success(response) {
-            $log.log('recordsService::getZone-success');
+            $log.debug('recordsService::getZone-success');
             $scope.zoneInfo = response.data.zone;
             $scope.updateZoneInfo = angular.copy($scope.zoneInfo);
             $scope.updateZoneInfo.hiddenKey = '';

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -29,7 +29,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
 
     $scope.getGroupMemberList = function(groupId) {
         function success(response) {
-            $log.log('groupsService::getGroupMemberList-success');
+            $log.debug('groupsService::getGroupMemberList-success');
             return response.data;
         }
         return groupsService
@@ -42,7 +42,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
 
     $scope.getGroup = function(groupId) {
         function success(response) {
-            $log.log('groupsService::getGroup-success');
+            $log.debug('groupsService::getGroup-success');
             return response.data;
         }
         return groupsService
@@ -71,7 +71,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
     };
 
     $scope.addMember = function() {
-        $log.log('addGroupMember::newMemberData', $scope.newMemberData);
+        $log.debug('addGroupMember::newMemberData', $scope.newMemberData);
         function lookupAccountSuccess(response) {
             if (response.data) {
                 $scope.membership.group.members.push({ id: response.data.id });
@@ -110,7 +110,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
             return user.id != memberId;
         };
 
-        $log.log('removing group member ' + memberId + ' from group ' + $scope.membership.group.id);
+        $log.debug('removing group member ' + memberId + ' from group ' + $scope.membership.group.id);
 
         $scope.membership.group.admins = $scope.membership.group.admins.filter(keepUser);
         $scope.membership.group.members = $scope.membership.group.members.filter(keepUser);
@@ -138,13 +138,13 @@ angular.module('controller.membership', []).controller('MembershipController', f
             return user.id != member.id;
         };
 
-        $log.log('toggleAdmin::toggled for member', member);
+        $log.debug('toggleAdmin::toggled for member', member);
 
         if(member.isAdmin) {
-            $log.log('toggleAdmin::toggled making an admin');
+            $log.debug('toggleAdmin::toggled making an admin');
             $scope.membership.group.admins.push({ id: member.id });
         } else {
-            $log.log('toggleAdmin::toggled removing as admin');
+            $log.debug('toggleAdmin::toggled removing as admin');
             $scope.membership.group.admins = $scope.membership.group.admins.filter(keepUser);
         }
 
@@ -170,14 +170,14 @@ angular.module('controller.membership', []).controller('MembershipController', f
     $scope.getGroupInfo = function (id) {
         //store group membership
         function getGroupSuccess(result) {
-            $log.log('refresh::getGroupSuccess-success', result);
+            $log.debug('refresh::getGroupSuccess-success', result);
             //update groups
             $scope.membership.group = result;
 
             determineAdmin();
 
             function getGroupMemberListSuccess(result) {
-                $log.log('refresh::getGroupMemberList-success', result);
+                $log.debug('refresh::getGroupMemberList-success', result);
                 //update groups
                 $scope.membership.members = result.members;
                 $scope.membershipLoaded = true;
@@ -201,7 +201,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
     $scope.refresh = function () {
         var id = $location.absUrl().toString();
         id = id.substring(id.lastIndexOf('/') + 1);
-        $log.log('loading group with id ', id);
+        $log.debug('loading group with id ', id);
 
         $scope.isGroupAdmin = false;
 

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -401,7 +401,7 @@ angular.module('controller.records', [])
 
     $scope.refreshZone = function() {
         function success(response) {
-            $log.log('recordsService::getZone-success');
+            $log.debug('recordsService::getZone-success');
             $scope.zoneInfo = response.data.zone;
             // Get current user's groups and determine if they're an admin of this zone
             getMembership()
@@ -416,7 +416,7 @@ angular.module('controller.records', [])
 
     $scope.syncZone = function() {
         function success(response) {
-            $log.log('recordsService::syncZone-success');
+            $log.debug('recordsService::syncZone-success');
             location.reload();
         }
         return recordsService
@@ -429,7 +429,7 @@ angular.module('controller.records', [])
 
     $scope.refreshRecordChangesPreview = function() {
         function success(response) {
-            $log.log('recordsService::getRecordSetChanges-success');
+            $log.debug('recordsService::getRecordSetChanges-success');
             var newChanges = [];
             angular.forEach(response.data.recordSetChanges, function(change) {
                 newChanges.push(change);
@@ -447,7 +447,7 @@ angular.module('controller.records', [])
     $scope.refreshRecordChanges = function() {
         changePaging = pagingService.resetPaging(changePaging);
         function success(response) {
-            $log.log('recordsService::getRecordSetChanges-success');
+            $log.debug('recordsService::getRecordSetChanges-success');
             changePaging.next = response.data.nextId;
             updateChangeDisplay(response.data.recordSetChanges)
         }
@@ -470,7 +470,7 @@ angular.module('controller.records', [])
     $scope.refreshRecords = function() {
         recordsPaging = pagingService.resetPaging(recordsPaging);
         function success(response) {
-            $log.log('recordsService::listRecordSetsByZone-success ('+ response.data.recordSets.length +' records)');
+            $log.debug('recordsService::listRecordSetsByZone-success ('+ response.data.recordSets.length +' records)');
             recordsPaging.next = response.data.nextId;
             updateRecordDisplay(response.data.recordSets);
         }
@@ -608,7 +608,7 @@ angular.module('controller.records', [])
     function profileSuccess(results) {
         if (results.data) {
             $scope.profile = results.data;
-            $log.log('profileService::getAuthenticatedUserData-success');
+            $log.debug('profileService::getAuthenticatedUserData-success');
         }
     }
 

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -70,7 +70,7 @@ angular.module('controller.zones', [])
     });
 
     $scope.canAccessGroup = function(groupId) {
-         return $scope.myGroupIds !== "undefined" &&  $scope.myGroupIds.indexOf(groupId) > -1;
+         return $scope.myGroupIds !== undefined &&  $scope.myGroupIds.indexOf(groupId) > -1;
     };
 
     $scope.canAccessZone = function(accessLevel) {
@@ -89,7 +89,7 @@ angular.module('controller.zones', [])
         zonesService
             .getZones(zonesPaging.maxItems, undefined, $scope.query)
             .then(function (response) {
-                $log.log('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
+                $log.debug('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 zonesPaging.next = response.data.nextId;
                 updateZoneDisplay(response.data.zones);
                 if (!$scope.query.length) {
@@ -103,7 +103,7 @@ angular.module('controller.zones', [])
         zonesService
             .getZones(zonesPaging.maxItems, undefined, $scope.query, true)
             .then(function (response) {
-                $log.log('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
+                $log.debug('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 allZonesPaging.next = response.data.nextId;
                 updateAllZonesDisplay(response.data.zones);
             })
@@ -116,7 +116,7 @@ angular.module('controller.zones', [])
         $scope.zones = zones;
         $scope.myZoneIds = zones.map(function(zone) {return zone['id']});
         $scope.zonesLoaded = true;
-        $log.log("Displaying my zones: ", $scope.zones);
+        $log.debug("Displaying my zones: ", $scope.zones);
         if($scope.zones.length > 0) {
             $("td.dataTables_empty").hide();
         } else {
@@ -127,7 +127,7 @@ angular.module('controller.zones', [])
     function updateAllZonesDisplay (zones) {
         $scope.allZones = zones;
         $scope.allZonesLoaded = true;
-        $log.log("Displaying all zones: ", $scope.allZones);
+        $log.debug("Displaying all zones: ", $scope.allZones);
         if($scope.allZones.length > 0) {
             $("td.dataTables_empty").hide();
         } else {
@@ -139,7 +139,7 @@ angular.module('controller.zones', [])
 
     $scope.addZoneConnection = function () {
         if ($scope.processing) {
-            $log.log('zoneConnection::processing is true; exiting');
+            $log.debug('zoneConnection::processing is true; exiting');
             return;
         }
 

--- a/modules/portal/public/lib/services/utility/service.utility.js
+++ b/modules/portal/public/lib/services/utility/service.utility.js
@@ -39,7 +39,7 @@ angular.module('service.utility', [])
             msg += stripQuotes(error.data);
         }
 
-        $log.log(type, error);
+        $log.debug(type, error);
         return {
             type: "danger", content: msg
         };
@@ -47,7 +47,7 @@ angular.module('service.utility', [])
 
     this.success = function(message, response, type) {
         var msg = "HTTP " + response.status + " (" + response.statusText + "): " + message;
-        $log.log(type, response);
+        $log.debug(type, response);
         return {
             type: "success", content: msg
         };

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -40,7 +40,7 @@ angular.module('service.zones', [])
 
         this.sendZone = function (payload) {
             var sanitizedPayload = this.sanitizeConnections(payload);
-            $log.info("service.zones: sending zone", sanitizedPayload);
+            $log.debug("service.zones: sending zone", sanitizedPayload);
             return $http.post("/api/zones", sanitizedPayload, {headers: utilityService.getCsrfHeader()});
         };
 
@@ -50,7 +50,7 @@ angular.module('service.zones', [])
 
         this.updateZone = function (id, payload) {
             var sanitizedPayload = this.sanitizeConnections(payload);
-            $log.info("service.zones: updating zone", sanitizedPayload);
+            $log.debug("service.zones: updating zone", sanitizedPayload);
             return $http.put("/api/zones/"+id, sanitizedPayload, {headers: utilityService.getCsrfHeader()});
         };
 


### PR DESCRIPTION
Fixes #1176 

Changes in this pull request:
-  Replaced `$log.log` with `$log.debug` to make use of the `$logProvider.debugEnabled()` method to disable portal logs in production and other environments.