### PR TITLE
PR #1116 Bug Fix

### DIFF
--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -104,7 +104,7 @@ a.action-link {
     top: 3px;
     left: 50%;
     width: 40%;
-    z-index: 100;
+    z-index: 2000;
 }
 
 .dns-connection-form {


### PR DESCRIPTION
Fixes #1116 

Changes in this pull request:
- There was a bug in the PR #1116. The error message displayed in the `alert box` popup was hidden behind the `navbar` due to the `z-index`. Made the required change to fix the bug.