### PR TITLE
Allow dotted hosts creation using config

### DIFF
--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -163,7 +163,7 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
-  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  # approved zones, individual users, users in groups, record types and no.of.dots that are allowed for dotted hosts
   dotted-hosts = {
     # for local testing
     allowed-settings = [

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -169,18 +169,18 @@ vinyldns {
     allowed-settings = [
       {
       zone = "*mmy."
-      allowed-user-list = ["testuser"]
-      allowed-group-list = ["dummy-group"]
-      allowed-record-type = ["AAAA"]
-      allowed-dots-limit = 3
+      user-list = ["testuser"]
+      group-list = ["dummy-group"]
+      record-types = ["AAAA"]
+      dots-limit = 3
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
       zone = "parent.com."
-      allowed-user-list = ["professor", "testuser"]
-      allowed-group-list = ["testing-group"]
-      allowed-record-type = ["A", "CNAME"]
-      allowed-dots-limit = 3
+      user-list = ["professor", "testuser"]
+      group-list = ["testing-group"]
+      record-types = ["A", "CNAME"]
+      dots-limit = 3
       }
     ]
   }

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -168,7 +168,7 @@ vinyldns {
     # for local testing
     allowed-settings = [
       {
-      zone = "dummy."
+      zone = "*mmy."
       allowed-user-list = ["testuser"]
       allowed-group-list = ["dummy-group"]
       allowed-record-type = ["AAAA"]
@@ -176,7 +176,7 @@ vinyldns {
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
-      zone = "*ent.com."
+      zone = "parent.com."
       allowed-user-list = ["professor", "testuser"]
       allowed-group-list = ["testing-group"]
       allowed-record-type = ["A", "CNAME"]

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -163,6 +163,28 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
+  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  dotted-hosts = {
+    # for local testing
+    allowed-settings = [
+      {
+      type = "auth-configs"
+      zone = "dummy."
+      allowed-user-list = ["testuser"]
+      allowed-group-list = ["dummy-group"]
+      allowed-record-type = ["AAAA"]
+      },
+      {
+      # for wildcard zones. Settings will be applied to all matching zones
+      type = "auth-configs"
+      zone = "*ent.com."
+      allowed-user-list = ["professor", "testuser"]
+      allowed-group-list = ["testing-group"]
+      allowed-record-type = ["A", "CNAME"]
+      }
+    ]
+  }
+
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production
   crypto {
     type = "vinyldns.core.crypto.NoOpCrypto"

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -172,6 +172,7 @@ vinyldns {
       allowed-user-list = ["testuser"]
       allowed-group-list = ["dummy-group"]
       allowed-record-type = ["AAAA"]
+      allowed-dots-limit = 3
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
@@ -179,6 +180,7 @@ vinyldns {
       allowed-user-list = ["professor", "testuser"]
       allowed-group-list = ["testing-group"]
       allowed-record-type = ["A", "CNAME"]
+      allowed-dots-limit = 3
       }
     ]
   }

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -168,7 +168,6 @@ vinyldns {
     # for local testing
     allowed-settings = [
       {
-      type = "auth-configs"
       zone = "dummy."
       allowed-user-list = ["testuser"]
       allowed-group-list = ["dummy-group"]
@@ -176,7 +175,6 @@ vinyldns {
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
-      type = "auth-configs"
       zone = "*ent.com."
       allowed-user-list = ["professor", "testuser"]
       allowed-group-list = ["testing-group"]

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -391,7 +391,7 @@ class RecordSetServiceIntegrationSpec
         .name shouldBe "test.dotted"
     }
 
-    "fail creating dotted record if it satisfies all dotted hosts config except allowed-dots-limit for the zone" in {
+    "fail creating dotted record if it satisfies all dotted hosts config except dots-limit for the zone" in {
       val newRecord = RecordSet(
         dummyZone.id,
         "test.dotted.more.dots.than.allowed",

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -32,7 +32,6 @@ import vinyldns.api.domain.access.AccessValidations
 import vinyldns.api.domain.zone._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.mysql.TransactionProvider
-import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData.testConnection
 import vinyldns.core.domain.{Fqdn, HighValueDomainError}
 import vinyldns.core.domain.auth.AuthPrincipal
@@ -64,13 +63,16 @@ class RecordSetServiceIntegrationSpec
   private var testRecordSetService: RecordSetServiceAlgebra = _
 
   private val user = User("live-test-user", "key", "secret")
+  private val testUser = User("testuser", "key", "secret")
   private val user2 = User("shared-record-test-user", "key-shared", "secret-shared")
   private val group = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id))
+  private val dummyGroup = Group(s"dummy-group", "test@test.com", adminUserIds = Set(testUser.id))
   private val group2 = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id, user2.id))
   private val sharedGroup =
     Group(s"test-shared-group", "test@test.com", adminUserIds = Set(user.id, user2.id))
   private val auth = AuthPrincipal(user, Seq(group.id, sharedGroup.id))
   private val auth2 = AuthPrincipal(user2, Seq(sharedGroup.id, group2.id))
+  val dummyAuth: AuthPrincipal = AuthPrincipal(testUser, Seq(dummyGroup.id))
 
   private val zone = Zone(
     s"live-zone-test.",
@@ -167,6 +169,14 @@ class RecordSetServiceIntegrationSpec
     adminGroupId = group.id
   )
 
+  private val dummyZone = Zone(
+    s"dummy.",
+    "test@test.com",
+    status = ZoneStatus.Active,
+    connection = testConnection,
+    adminGroupId = dummyGroup.id
+  )
+
   private val highValueDomainRecord = RecordSet(
     zone.id,
     "high-value-domain-existing",
@@ -254,8 +264,8 @@ class RecordSetServiceIntegrationSpec
         groupRepo.save(db, group)
       }
 
-    List(group, group2, sharedGroup).traverse(g => saveGroupData(groupRepo, g).void).unsafeRunSync()
-    List(zone, zoneTestNameConflicts, zoneTestAddRecords, sharedZone)
+    List(group, group2, sharedGroup, dummyGroup).traverse(g => saveGroupData(groupRepo, g).void).unsafeRunSync()
+    List(zone, dummyZone, zoneTestNameConflicts, zoneTestAddRecords, sharedZone)
       .traverse(
         z => zoneRepo.save(z)
       )
@@ -337,6 +347,48 @@ class RecordSetServiceIntegrationSpec
         .asInstanceOf[RecordSetChange]
         .recordSet
         .name shouldBe "zone-test-add-records."
+    }
+
+    "create dotted record fails if it doesn't satisfy dotted hosts config" in {
+      val newRecord = RecordSet(
+        zoneTestAddRecords.id,
+        "test.dot",
+        A,
+        38400,
+        RecordSetStatus.Active,
+        DateTime.now,
+        None,
+        List(AData("10.1.1.1"))
+      )
+      val result =
+        testRecordSetService
+          .addRecordSet(newRecord, auth)
+          .value
+          .unsafeRunSync()
+      leftValue(result) shouldBe a[InvalidRequest]
+    }
+
+    "create dotted record succeeds if it satisfies all dotted hosts config" in {
+      val newRecord = RecordSet(
+        dummyZone.id,
+        "test.dotted",
+        AAAA,
+        38400,
+        RecordSetStatus.Active,
+        DateTime.now,
+        None,
+        List(AAAAData("fd69:27cc:fe91::60"))
+      )
+      // succeeds as zone, user and record type is allowed as defined in application.conf
+      val result =
+        testRecordSetService
+          .addRecordSet(newRecord, dummyAuth)
+          .value
+          .unsafeRunSync()
+      rightValue(result)
+        .asInstanceOf[RecordSetChange]
+        .recordSet
+        .name shouldBe "test.dotted"
     }
 
     "update apex A record and add trailing dot" in {

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -391,6 +391,28 @@ class RecordSetServiceIntegrationSpec
         .name shouldBe "test.dotted"
     }
 
+    "fail creating dotted record if it satisfies all dotted hosts config except allowed-dots-limit for the zone" in {
+      val newRecord = RecordSet(
+        dummyZone.id,
+        "test.dotted.more.dots.than.allowed",
+        AAAA,
+        38400,
+        RecordSetStatus.Active,
+        DateTime.now,
+        None,
+        List(AAAAData("fd69:27cc:fe91::60"))
+      )
+
+      // The number of dots allowed in the record name for this zone as defined in the config is 3.
+      // Creating with 4 dots results in an error
+      val result =
+        testRecordSetService
+          .addRecordSet(newRecord, dummyAuth)
+          .value
+          .unsafeRunSync()
+      leftValue(result) shouldBe a[InvalidRequest]
+    }
+
     "update apex A record and add trailing dot" in {
       val newRecord = apexTestRecordA.copy(ttl = 200)
       val result = testRecordSetService

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -300,6 +300,7 @@ class RecordSetServiceIntegrationSpec
       mockBackendResolver,
       false,
       vinyldnsConfig.highValueDomainConfig,
+      vinyldnsConfig.dottedHostsConfig,
       vinyldnsConfig.serverConfig.approvedNameServers,
       useRecordSetCache = true
     )

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -165,25 +165,27 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
-  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
-  dotted-hosts = {
-      zone-list = [
-      "dummy", # for local testing
-      "*ent.com" # for local testing with wildcard zones (allows parent.com and child.parent.com zones)
-      ]
-      allowed-user-list = [
-      "testuser",
-      "professor" # for local testing (username)
-      ]
-      allowed-group-list = [
-      "test-group",
-      "duGroup" # for local testing (group name)
-      ]
-      allowed-record-type = [
-      "A",
-      "CNAME" # for local testing
-      ]
-  }
+# approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+dotted-hosts = {
+  # for local testing
+  allowed-settings = [
+    {
+    type = "auth-configs"
+    zone = "dummy."
+    allowed-user-list = ["testuser"]
+    allowed-group-list = ["dummy-group"]
+    allowed-record-type = ["AAAA"]
+    },
+    {
+    # for wildcard zones. Settings will be applied to all matching zones
+    type = "auth-configs"
+    zone = "*ent.com."
+    allowed-user-list = ["professor", "testuser"]
+    allowed-group-list = ["testing-group"]
+    allowed-record-type = ["A", "CNAME"]
+    }
+  ]
+}
 
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production
   crypto {

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -167,7 +167,8 @@ vinyldns {
 
   # approved zones/domains that are allowed to create dotted hosts
   zone-list = [
-  "ok." # for local testing
+  "dummy.", # for local testing
+  "*en.", # for local testing with wildcard zones (allows 'open.' zone)
   ]
 
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -165,9 +165,17 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
-  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  # approved zones, individual users, users in groups, record types and no.of.dots that are allowed for dotted hosts
   dotted-hosts = {
-    allowed-settings = []
+    allowed-settings = [
+      {
+      zone = "zonenamehere."
+      user-list = []
+      group-list = []
+      record-types = []
+      dots-limit = 0
+      }
+    ]
   }
 
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -168,7 +168,7 @@ vinyldns {
   # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
       zone-list = [
-      "dummy.", # for local testing
+      "dummy", # for local testing
       "*ent.com" # for local testing with wildcard zones (allows parent.com and child.parent.com zones)
       ]
       allowed-user-list = [

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -165,6 +165,11 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
+  # approved zones/domains that are allowed to create dotted hosts
+  zone-list = [
+  "ok." # for local testing
+  ]
+
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production
   crypto {
     type = "vinyldns.core.crypto.NoOpCrypto"

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -165,14 +165,23 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
-  # approved zones/domains and users that are allowed to create dotted hosts
+  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
       zone-list = [
       "dummy.", # for local testing
-      "*ent.com", # for local testing with wildcard zones (allows parent.com and child.parent.com zone)
+      "*ent.com" # for local testing with wildcard zones (allows parent.com and child.parent.com zones)
       ]
       allowed-user-list = [
-      "testuser" # for local testing
+      "testuser",
+      "professor" # for local testing (username)
+      ]
+      allowed-group-list = [
+      "test-group",
+      "duGroup" # for local testing (group name)
+      ]
+      allowed-record-type = [
+      "A",
+      "CNAME" # for local testing
       ]
   }
 

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -168,7 +168,7 @@ vinyldns {
   # approved zones/domains that are allowed to create dotted hosts
   zone-list = [
   "dummy.", # for local testing
-  "*en.", # for local testing with wildcard zones (allows 'open.' zone)
+  "*ent.com", # for local testing with wildcard zones (allows parent.com and child.parent.com zone)
   ]
 
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -165,11 +165,16 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
-  # approved zones/domains that are allowed to create dotted hosts
-  zone-list = [
-  "dummy.", # for local testing
-  "*ent.com", # for local testing with wildcard zones (allows parent.com and child.parent.com zone)
-  ]
+  # approved zones/domains and users that are allowed to create dotted hosts
+  dotted-hosts = {
+      zone-list = [
+      "dummy.", # for local testing
+      "*ent.com", # for local testing with wildcard zones (allows parent.com and child.parent.com zone)
+      ]
+      allowed-user-list = [
+      "testuser" # for local testing
+      ]
+  }
 
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production
   crypto {

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -165,27 +165,10 @@ vinyldns {
     "ns1.parent.com4."
   ]
 
-# approved zones, individual users, users in groups and record types that are allowed for dotted hosts
-dotted-hosts = {
-  # for local testing
-  allowed-settings = [
-    {
-    type = "auth-configs"
-    zone = "dummy."
-    allowed-user-list = ["testuser"]
-    allowed-group-list = ["dummy-group"]
-    allowed-record-type = ["AAAA"]
-    },
-    {
-    # for wildcard zones. Settings will be applied to all matching zones
-    type = "auth-configs"
-    zone = "*ent.com."
-    allowed-user-list = ["professor", "testuser"]
-    allowed-group-list = ["testing-group"]
-    allowed-record-type = ["A", "CNAME"]
-    }
-  ]
-}
+  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  dotted-hosts = {
+    allowed-settings = []
+  }
 
   # Note: This MUST match the Portal or strange errors will ensue, NoOpCrypto should not be used for production
   crypto {

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -92,18 +92,16 @@ vinyldns {
 
   # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
-      zone-list = [
-      "parent.com*" # for local testing with wildcard zones (allows parent.com and child.parent.com zones)
-      ]
-      allowed-user-list = [
-      "ok" # for local testing (username)
-      ]
-      allowed-group-list = [
-      "dummy-group*" # for local testing (group name)
-      ]
-      allowed-record-type = [
-      "CNAME" # for local testing
-      ]
+    allowed-settings = [
+      {
+      # for wildcard zones. Settings will be applied to all matching zones
+      type = "auth-configs"
+      zone = "*ent.com*."
+      allowed-user-list = ["ok"]
+      allowed-group-list = ["dummy-group*"]
+      allowed-record-type = ["CNAME"]
+      }
+    ]
   }
 
   # color should be green or blue, used in order to do blue/green deployment

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -90,20 +90,19 @@ vinyldns {
     "ns1.parent.com."
   ]
 
-  # approved zones/domains and users that are allowed to create dotted hosts
+  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
       zone-list = [
-      "dummy.", # for local testing
-      "*ent.com", # for local testing with wildcard zones (allows parent.com and child.parent.com zone)
+      "parent.com*" # for local testing with wildcard zones (allows parent.com and child.parent.com zones)
       ]
       allowed-user-list = [
-      "testuser" # for local testing
+      "ok" # for local testing (username)
       ]
       allowed-group-list = [
-      "test-group" # for local testing
+      "dummy-group*" # for local testing (group name)
       ]
       allowed-record-type = [
-      "A" # for local testing
+      "CNAME" # for local testing
       ]
   }
 

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -100,6 +100,7 @@ vinyldns {
       allowed-user-list = ["ok"]
       allowed-group-list = ["dummy-group"]
       allowed-record-type = ["CNAME"]
+      allowed-dots-limit = 3
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
@@ -107,6 +108,7 @@ vinyldns {
       allowed-user-list = ["sharedZoneUser"]
       allowed-group-list = ["history-group1"]
       allowed-record-type = ["A"]
+      allowed-dots-limit = 3
       }
     ]
   }

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -97,18 +97,18 @@ vinyldns {
       {
       # for wildcard zones. Settings will be applied to all matching zones
       zone = "*ent.com*."
-      allowed-user-list = ["ok"]
-      allowed-group-list = ["dummy-group"]
-      allowed-record-type = ["CNAME"]
-      allowed-dots-limit = 3
+      user-list = ["ok"]
+      group-list = ["dummy-group"]
+      record-types = ["CNAME"]
+      dots-limit = 3
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
       zone = "dummy*."
-      allowed-user-list = ["sharedZoneUser"]
-      allowed-group-list = ["history-group1"]
-      allowed-record-type = ["A"]
-      allowed-dots-limit = 3
+      user-list = ["sharedZoneUser"]
+      group-list = ["history-group1"]
+      record-types = ["A"]
+      dots-limit = 3
       }
     ]
   }

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -90,7 +90,7 @@ vinyldns {
     "ns1.parent.com."
   ]
 
-  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  # approved zones, individual users, users in groups, record types and no.of.dots that are allowed for dotted hosts
   dotted-hosts = {
     # for local testing
     allowed-settings = [

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -99,6 +99,12 @@ vinyldns {
       allowed-user-list = [
       "testuser" # for local testing
       ]
+      allowed-group-list = [
+      "test-group" # for local testing
+      ]
+      allowed-record-type = [
+      "A" # for local testing
+      ]
   }
 
   # color should be green or blue, used in order to do blue/green deployment

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -90,10 +90,16 @@ vinyldns {
     "ns1.parent.com."
   ]
 
-  # approved zones/domains that are allowed to create dotted hosts
-  zone-list = [
-    "ok." # for local testing
-  ]
+  # approved zones/domains and users that are allowed to create dotted hosts
+  dotted-hosts = {
+      zone-list = [
+      "dummy.", # for local testing
+      "*ent.com", # for local testing with wildcard zones (allows parent.com and child.parent.com zone)
+      ]
+      allowed-user-list = [
+      "testuser" # for local testing
+      ]
+  }
 
   # color should be green or blue, used in order to do blue/green deployment
   color = "green"

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -96,7 +96,6 @@ vinyldns {
     allowed-settings = [
       {
       # for wildcard zones. Settings will be applied to all matching zones
-      type = "auth-configs"
       zone = "*ent.com*."
       allowed-user-list = ["ok"]
       allowed-group-list = ["dummy-group"]
@@ -104,7 +103,6 @@ vinyldns {
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
-      type = "auth-configs"
       zone = "dummy*."
       allowed-user-list = ["sharedZoneUser"]
       allowed-group-list = ["history-group1"]

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -93,22 +93,22 @@ vinyldns {
   # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
     allowed-settings = [
-        {
-        # for wildcard zones. Settings will be applied to all matching zones
-        type = "auth-configs"
-        zone = "*ent.com*."
-        allowed-user-list = ["ok"]
-        allowed-group-list = ["dummy-group"]
-        allowed-record-type = ["CNAME"]
-        },
-        {
-        # for wildcard zones. Settings will be applied to all matching zones
-        type = "auth-configs"
-        zone = "dummy*."
-        allowed-user-list = ["sharedZoneUser"]
-        allowed-group-list = ["history-group1"]
-        allowed-record-type = ["A"]
-        }
+      {
+      # for wildcard zones. Settings will be applied to all matching zones
+      type = "auth-configs"
+      zone = "*ent.com*."
+      allowed-user-list = ["ok"]
+      allowed-group-list = ["dummy-group"]
+      allowed-record-type = ["CNAME"]
+      },
+      {
+      # for wildcard zones. Settings will be applied to all matching zones
+      type = "auth-configs"
+      zone = "dummy*."
+      allowed-user-list = ["sharedZoneUser"]
+      allowed-group-list = ["history-group1"]
+      allowed-record-type = ["A"]
+      }
     ]
   }
 

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -92,6 +92,7 @@ vinyldns {
 
   # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
+    # for local testing
     allowed-settings = [
       {
       # for wildcard zones. Settings will be applied to all matching zones

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -90,6 +90,11 @@ vinyldns {
     "ns1.parent.com."
   ]
 
+  # approved zones/domains that are allowed to create dotted hosts
+  zone-list = [
+    "ok." # for local testing
+  ]
+
   # color should be green or blue, used in order to do blue/green deployment
   color = "green"
 

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -93,14 +93,22 @@ vinyldns {
   # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
   dotted-hosts = {
     allowed-settings = [
-      {
-      # for wildcard zones. Settings will be applied to all matching zones
-      type = "auth-configs"
-      zone = "*ent.com*."
-      allowed-user-list = ["ok"]
-      allowed-group-list = ["dummy-group*"]
-      allowed-record-type = ["CNAME"]
-      }
+        {
+        # for wildcard zones. Settings will be applied to all matching zones
+        type = "auth-configs"
+        zone = "*ent.com*."
+        allowed-user-list = ["ok"]
+        allowed-group-list = ["dummy-group"]
+        allowed-record-type = ["CNAME"]
+        },
+        {
+        # for wildcard zones. Settings will be applied to all matching zones
+        type = "auth-configs"
+        zone = "dummy*."
+        allowed-user-list = ["sharedZoneUser"]
+        allowed-group-list = ["history-group1"]
+        allowed-record-type = ["A"]
+        }
     ]
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -121,7 +121,8 @@ object Boot extends App {
         vinyldnsConfig.highValueDomainConfig,
         vinyldnsConfig.manualReviewConfig,
         vinyldnsConfig.batchChangeConfig,
-        vinyldnsConfig.scheduledChangesConfig
+        vinyldnsConfig.scheduledChangesConfig,
+        vinyldnsConfig.dottedHostsConfig
       )
       val membershipService = MembershipService(repositories)
 
@@ -139,6 +140,7 @@ object Boot extends App {
           backendResolver,
           vinyldnsConfig.serverConfig.validateRecordLookupAgainstDnsBackend,
           vinyldnsConfig.highValueDomainConfig,
+          vinyldnsConfig.dottedHostsConfig,
           vinyldnsConfig.serverConfig.approvedNameServers,
           vinyldnsConfig.serverConfig.useRecordSetCache
         )

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -121,8 +121,7 @@ object Boot extends App {
         vinyldnsConfig.highValueDomainConfig,
         vinyldnsConfig.manualReviewConfig,
         vinyldnsConfig.batchChangeConfig,
-        vinyldnsConfig.scheduledChangesConfig,
-        vinyldnsConfig.dottedHostsConfig
+        vinyldnsConfig.scheduledChangesConfig
       )
       val membershipService = MembershipService(repositories)
 
@@ -185,7 +184,8 @@ object Boot extends App {
         notifiers,
         vinyldnsConfig.scheduledChangesConfig.enabled,
         vinyldnsConfig.batchChangeConfig.v6DiscoveryNibbleBoundaries,
-        vinyldnsConfig.serverConfig.defaultTtl
+        vinyldnsConfig.serverConfig.defaultTtl,
+        vinyldnsConfig.dottedHostsConfig
       )
       val collectorRegistry = CollectorRegistry.defaultRegistry
       val vinyldnsService = new VinylDNSService(

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -184,8 +184,7 @@ object Boot extends App {
         notifiers,
         vinyldnsConfig.scheduledChangesConfig.enabled,
         vinyldnsConfig.batchChangeConfig.v6DiscoveryNibbleBoundaries,
-        vinyldnsConfig.serverConfig.defaultTtl,
-        vinyldnsConfig.dottedHostsConfig
+        vinyldnsConfig.serverConfig.defaultTtl
       )
       val collectorRegistry = CollectorRegistry.defaultRegistry
       val vinyldnsService = new VinylDNSService(

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -17,17 +17,16 @@
 package vinyldns.api.config
 
 import pureconfig.ConfigReader
+import pureconfig.generic.auto._
 
-final case class DottedHostsConfig(zoneList: List[String], allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String])
+sealed trait AuthMethod
+final case class AuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String]) extends AuthMethod
+final case class DottedHostsConfig(authMethods: List[AuthMethod])
+
 object DottedHostsConfig {
   implicit val configReader: ConfigReader[DottedHostsConfig] =
-    ConfigReader.forProduct4[DottedHostsConfig, List[String], List[String], List[String], List[String]](
-      "zone-list",
-      "allowed-user-list",
-      "allowed-group-list",
-      "allowed-record-type"
-    ){
-      case (zoneList, allowedUserList, allowedGroupList, allowedRecordType) =>
-        DottedHostsConfig(zoneList, allowedUserList, allowedGroupList, allowedRecordType)
-    }
+    ConfigReader.forProduct1[DottedHostsConfig, List[AuthMethod]](
+      "allowed-settings",
+    )(authMethods =>
+      DottedHostsConfig(authMethods))
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -18,11 +18,14 @@ package vinyldns.api.config
 
 import pureconfig.ConfigReader
 
-final case class DottedHostsConfig(zoneList: List[String])
+final case class DottedHostsConfig(zoneList: List[String], allowedUserList: List[String])
 object DottedHostsConfig {
   implicit val configReader: ConfigReader[DottedHostsConfig] =
-    ConfigReader.forProduct1[DottedHostsConfig, List[String]](
-      "zone-list"
-    )(zoneList =>
-      DottedHostsConfig(zoneList))
+    ConfigReader.forProduct2[DottedHostsConfig, List[String], List[String]](
+      "zone-list",
+      "allowed-user-list"
+    ){
+      case (zoneList, allowedUserList) =>
+        DottedHostsConfig(zoneList, allowedUserList)
+    }
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -18,14 +18,16 @@ package vinyldns.api.config
 
 import pureconfig.ConfigReader
 
-final case class DottedHostsConfig(zoneList: List[String], allowedUserList: List[String])
+final case class DottedHostsConfig(zoneList: List[String], allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String])
 object DottedHostsConfig {
   implicit val configReader: ConfigReader[DottedHostsConfig] =
-    ConfigReader.forProduct2[DottedHostsConfig, List[String], List[String]](
+    ConfigReader.forProduct4[DottedHostsConfig, List[String], List[String], List[String], List[String]](
       "zone-list",
-      "allowed-user-list"
+      "allowed-user-list",
+      "allowed-group-list",
+      "allowed-record-type"
     ){
-      case (zoneList, allowedUserList) =>
-        DottedHostsConfig(zoneList, allowedUserList)
+      case (zoneList, allowedUserList, allowedGroupList, allowedRecordType) =>
+        DottedHostsConfig(zoneList, allowedUserList, allowedGroupList, allowedRecordType)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -19,7 +19,7 @@ package vinyldns.api.config
 import pureconfig.ConfigReader
 import pureconfig.generic.auto._
 
-final case class ZoneAuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String], allowedDotsLimit: Int)
+final case class ZoneAuthConfigs(zone: String, userList: List[String], groupList: List[String], recordTypes: List[String], dotsLimit: Int)
 final case class DottedHostsConfig(zoneAuthConfigs: List[ZoneAuthConfigs])
 
 object DottedHostsConfig {

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -19,13 +19,13 @@ package vinyldns.api.config
 import pureconfig.ConfigReader
 import pureconfig.generic.auto._
 
-final case class AuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String], allowedDotsLimit: Int)
-final case class DottedHostsConfig(authConfigs: List[AuthConfigs])
+final case class ZoneAuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String], allowedDotsLimit: Int)
+final case class DottedHostsConfig(zoneAuthConfigs: List[ZoneAuthConfigs])
 
 object DottedHostsConfig {
   implicit val configReader: ConfigReader[DottedHostsConfig] =
-    ConfigReader.forProduct1[DottedHostsConfig, List[AuthConfigs]](
+    ConfigReader.forProduct1[DottedHostsConfig, List[ZoneAuthConfigs]](
       "allowed-settings",
-    )(authConfigs =>
-      DottedHostsConfig(authConfigs))
+    )(zoneAuthConfigs =>
+      DottedHostsConfig(zoneAuthConfigs))
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -19,14 +19,13 @@ package vinyldns.api.config
 import pureconfig.ConfigReader
 import pureconfig.generic.auto._
 
-sealed trait AuthMethod
-final case class AuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String]) extends AuthMethod
-final case class DottedHostsConfig(authMethods: List[AuthMethod])
+final case class AuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String])
+final case class DottedHostsConfig(authConfigs: List[AuthConfigs])
 
 object DottedHostsConfig {
   implicit val configReader: ConfigReader[DottedHostsConfig] =
-    ConfigReader.forProduct1[DottedHostsConfig, List[AuthMethod]](
+    ConfigReader.forProduct1[DottedHostsConfig, List[AuthConfigs]](
       "allowed-settings",
-    )(authMethods =>
-      DottedHostsConfig(authMethods))
+    )(authConfigs =>
+      DottedHostsConfig(authConfigs))
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.api.config
+
+import pureconfig.ConfigReader
+
+final case class DottedHostsConfig(zoneList: List[String])
+object DottedHostsConfig {
+  implicit val configReader: ConfigReader[DottedHostsConfig] =
+    ConfigReader.forProduct1[DottedHostsConfig, List[String]](
+      "zone-list"
+    )(zoneList =>
+      DottedHostsConfig(zoneList))
+}

--- a/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/DottedHostsConfig.scala
@@ -19,7 +19,7 @@ package vinyldns.api.config
 import pureconfig.ConfigReader
 import pureconfig.generic.auto._
 
-final case class AuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String])
+final case class AuthConfigs(zone: String, allowedUserList: List[String], allowedGroupList: List[String], allowedRecordType: List[String], allowedDotsLimit: Int)
 final case class DottedHostsConfig(authConfigs: List[AuthConfigs])
 
 object DottedHostsConfig {

--- a/modules/api/src/main/scala/vinyldns/api/config/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/VinylDNSConfig.scala
@@ -86,7 +86,7 @@ object VinylDNSConfig {
       serverConfig <- loadIO[ServerConfig](config, "vinyldns")
       batchChangeConfig <- loadIO[BatchChangeConfig](config, "vinyldns")
       backendConfigs <- loadIO[BackendConfigs](config, "vinyldns.backend")
-      dottedHostsConfig <- loadIO[DottedHostsConfig](config, "vinyldns")
+      dottedHostsConfig <- loadIO[DottedHostsConfig](config, "vinyldns.dotted-hosts")
       httpConfig <- loadIO[HttpConfig](config, "vinyldns.rest")
       hvdConfig <- loadIO[HighValueDomainConfig](config, "vinyldns.high-value-domains")
       scheduledChangesConfig <- loadIO[ScheduledChangesConfig](config, "vinyldns")

--- a/modules/api/src/main/scala/vinyldns/api/config/VinylDNSConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/VinylDNSConfig.scala
@@ -47,6 +47,7 @@ final case class VinylDNSConfig(
     notifierConfigs: List[NotifierConfig],
     dataStoreConfigs: List[DataStoreConfig],
     backendConfigs: BackendConfigs,
+    dottedHostsConfig: DottedHostsConfig,
     configuredDnsConnections: ConfiguredDnsConnections,
     apiMetricSettings: APIMetricsSettings,
     crypto: CryptoAlgebra,
@@ -85,6 +86,7 @@ object VinylDNSConfig {
       serverConfig <- loadIO[ServerConfig](config, "vinyldns")
       batchChangeConfig <- loadIO[BatchChangeConfig](config, "vinyldns")
       backendConfigs <- loadIO[BackendConfigs](config, "vinyldns.backend")
+      dottedHostsConfig <- loadIO[DottedHostsConfig](config, "vinyldns")
       httpConfig <- loadIO[HttpConfig](config, "vinyldns.rest")
       hvdConfig <- loadIO[HighValueDomainConfig](config, "vinyldns.high-value-domains")
       scheduledChangesConfig <- loadIO[ScheduledChangesConfig](config, "vinyldns")
@@ -110,6 +112,7 @@ object VinylDNSConfig {
       notifierConfigs,
       dataStoreConfigs,
       backendConfigs,
+      dottedHostsConfig,
       connections,
       metricSettings,
       crypto,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -211,8 +211,8 @@ class BatchChangeService(
     for{
       groupsInConfig <- groupRepository.getGroupsByName(groups.toSet)
       members = groupsInConfig.flatMap(x => x.memberIds)
-      usersList <- userRepository.getUsers(members, None, None)
-      users = usersList.users.map(x => x.userName)
+      usersList <- if(members.isEmpty) IO(Seq.empty) else userRepository.getUsers(members, None, None).map(x => x.users)
+      users = if(usersList.isEmpty) Seq.empty else usersList.map(x => x.userName)
       isPresent = users.contains(auth.signedInUser.userName)
     } yield isPresent
   }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -303,10 +303,10 @@ class BatchChangeValidations(
     val isDomainAllowed = dottedHostConfig.contains(change.zone.name)
 
     // Check if record set contains dot and if it is in zone which is allowed to have dotted records from dotted hosts config
-    if(change.recordName.contains(".") && isDomainAllowed) {
+    if((change.recordName.contains(".") || !zoneOrRecordDoesNotAlreadyExist) && isDomainAllowed && change.recordName != change.zone.name) {
       // If there is a zone or record already present which conflicts with the new dotted record, throw an error
       if (!zoneOrRecordDoesNotAlreadyExist || change.recordName == change.zone.name)
-        DottedHostError(change.recordName, change.inputChange.typ.toString).invalidNel
+        DottedHostError(change.recordName, change.zone.name).invalidNel
       else
         ().validNel
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -266,7 +266,7 @@ class RecordSetService(
     }
   }
 
-  // Check if user is allowed to create dotted hosts using the users present in dotted hosts config
+  // Check if user is allowed to create dotted hosts using the record types present in dotted hosts config
   def checkIfInAllowedRecordType(zone: Zone, config: DottedHostsConfig, rs: RecordSet): Boolean = {
     val configZones = config.authConfigs.map(x => x.zone)
     val zoneName = if(zone.name.takeRight(1) != ".") zone.name + "." else zone.name

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -253,8 +253,8 @@ class RecordSetService(
     for{
       groupsInConfig <- groupRepository.getGroupsByName(groups.toSet)
       members = groupsInConfig.flatMap(x => x.memberIds)
-      usersList <- userRepository.getUsers(members, None, None)
-      users = usersList.users.map(x => x.userName)
+      usersList <- if(members.isEmpty) IO(Seq.empty) else userRepository.getUsers(members, None, None).map(x => x.users)
+      users = if(usersList.isEmpty) Seq.empty else usersList.map(x => x.userName)
       isPresent = users.contains(auth.signedInUser.userName)
     } yield isPresent
   }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -130,7 +130,7 @@ class RecordSetService(
         allowedZoneList,
         isRecordTypeAndUserAllowed
       ).toResult
-      _ <- checkAllowedDots(allowedDotsLimit, rsForValidations, zone).toResult
+      _ <- if(allowedZoneList.contains(zone.name)) checkAllowedDots(allowedDotsLimit, rsForValidations, zone).toResult else ().toResult
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
 
@@ -167,6 +167,7 @@ class RecordSetService(
       isAllowedUser = isInAllowedUsers || isUserInAllowedGroups
       isRecordTypeAllowed = checkIfInAllowedRecordType(zone, dottedHostsConfig, rsForValidations)
       isRecordTypeAndUserAllowed = isAllowedUser && isRecordTypeAllowed
+      allowedDotsLimit = getAllowedDotsLimit(zone, dottedHostsConfig)
       recordFqdnDoesNotAlreadyExist <- recordFQDNDoesNotExist(rsForValidations, zone).toResult[Boolean]
       _ <- typeSpecificValidations(
         rsForValidations,
@@ -178,6 +179,7 @@ class RecordSetService(
         allowedZoneList,
         isRecordTypeAndUserAllowed,
       ).toResult
+      _ <- if(existing.name == rsForValidations.name) ().toResult else if(allowedZoneList.contains(zone.name)) checkAllowedDots(allowedDotsLimit, rsForValidations, zone).toResult else ().toResult
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -244,15 +244,10 @@ class RecordSetService(
     val dottedZoneConfig = configZones.filter(_.contains("*")).map(_.replace("*", "[A-Za-z0-9.]*"))
     val isContainWildcardZone = dottedZoneConfig.exists(x => zoneName.matches(x))
     val isContainNormalZone = configZones.contains(zoneName)
-    if(isContainWildcardZone || isContainNormalZone){
+    if(isContainNormalZone){
       val users = config.authConfigs.flatMap {
         x: AuthConfigs =>
-          if (x.zone.contains("*")) {
-            val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
-            if (zoneName.matches(wildcardZone)) x.allowedUserList else List.empty
-          } else {
-            if (x.zone == zoneName) x.allowedUserList else List.empty
-          }
+          if (x.zone == zoneName) x.allowedUserList else List.empty
       }
       if(users.contains(auth.signedInUser.userName)){
         true
@@ -261,7 +256,22 @@ class RecordSetService(
         false
       }
     }
-    else{
+    else if(isContainWildcardZone){
+      val users = config.authConfigs.flatMap {
+        x: AuthConfigs =>
+          if (x.zone.contains("*")) {
+            val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
+            if (zoneName.matches(wildcardZone)) x.allowedUserList else List.empty
+          } else List.empty
+      }
+      if(users.contains(auth.signedInUser.userName)){
+        true
+      }
+      else {
+        false
+      }
+    }
+    else {
       false
     }
   }
@@ -273,15 +283,10 @@ class RecordSetService(
     val dottedZoneConfig = configZones.filter(_.contains("*")).map(_.replace("*", "[A-Za-z0-9.]*"))
     val isContainWildcardZone = dottedZoneConfig.exists(x => zoneName.matches(x))
     val isContainNormalZone = configZones.contains(zoneName)
-    if(isContainWildcardZone || isContainNormalZone){
+    if(isContainNormalZone){
       val rType = config.authConfigs.flatMap {
         x: AuthConfigs =>
-          if (x.zone.contains("*")) {
-            val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
-            if (zoneName.matches(wildcardZone)) x.allowedRecordType else List.empty
-          } else {
-            if (x.zone == zoneName) x.allowedRecordType else List.empty
-          }
+          if (x.zone == zoneName) x.allowedRecordType else List.empty
       }
       if(rType.contains(rs.typ.toString)){
         true
@@ -290,7 +295,22 @@ class RecordSetService(
         false
       }
     }
-    else{
+    else if(isContainWildcardZone){
+      val rType = config.authConfigs.flatMap {
+        x: AuthConfigs =>
+          if (x.zone.contains("*")) {
+            val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
+            if (zoneName.matches(wildcardZone)) x.allowedRecordType else List.empty
+          } else List.empty
+      }
+      if(rType.contains(rs.typ.toString)){
+        true
+      }
+      else {
+        false
+      }
+    }
+    else {
       false
     }
   }
@@ -302,15 +322,19 @@ class RecordSetService(
     val dottedZoneConfig = configZones.filter(_.contains("*")).map(_.replace("*", "[A-Za-z0-9.]*"))
     val isContainWildcardZone = dottedZoneConfig.exists(x => zoneName.matches(x))
     val isContainNormalZone = configZones.contains(zoneName)
-    val groups = if(isContainWildcardZone || isContainNormalZone){
+    val groups = if(isContainNormalZone){
+      config.authConfigs.flatMap {
+        x: AuthConfigs =>
+          if (x.zone == zoneName) x.allowedGroupList else List.empty
+      }
+    }
+    else if(isContainWildcardZone){
       config.authConfigs.flatMap {
         x: AuthConfigs =>
           if (x.zone.contains("*")) {
             val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
             if (zoneName.matches(wildcardZone)) x.allowedGroupList else List.empty
-          } else {
-            if (x.zone == zoneName) x.allowedGroupList else List.empty
-          }
+          } else List.empty
       }
     }
     else {

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -252,10 +252,10 @@ class RecordSetService(
     val isContainWildcardZone = dottedZoneConfig.exists(x => zoneName.matches(x))
     val isContainNormalZone = configZones.contains(zoneName)
     if(isContainNormalZone){
-      config.zoneAuthConfigs.filter(x => x.zone == zoneName).head.allowedDotsLimit
+      config.zoneAuthConfigs.filter(x => x.zone == zoneName).head.dotsLimit
     }
     else if(isContainWildcardZone){
-      config.zoneAuthConfigs.filter(x => zoneName.matches(x.zone.replace("*", "[A-Za-z0-9.]*"))).head.allowedDotsLimit
+      config.zoneAuthConfigs.filter(x => zoneName.matches(x.zone.replace("*", "[A-Za-z0-9.]*"))).head.dotsLimit
     }
     else {
       0
@@ -272,7 +272,7 @@ class RecordSetService(
     if(isContainNormalZone){
       val users = config.zoneAuthConfigs.flatMap {
         x: ZoneAuthConfigs =>
-          if (x.zone == zoneName) x.allowedUserList else List.empty
+          if (x.zone == zoneName) x.userList else List.empty
       }
       if(users.contains(auth.signedInUser.userName)){
         true
@@ -286,7 +286,7 @@ class RecordSetService(
         x: ZoneAuthConfigs =>
           if (x.zone.contains("*")) {
             val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
-            if (zoneName.matches(wildcardZone)) x.allowedUserList else List.empty
+            if (zoneName.matches(wildcardZone)) x.userList else List.empty
           } else List.empty
       }
       if(users.contains(auth.signedInUser.userName)){
@@ -311,7 +311,7 @@ class RecordSetService(
     if(isContainNormalZone){
       val rType = config.zoneAuthConfigs.flatMap {
         x: ZoneAuthConfigs =>
-          if (x.zone == zoneName) x.allowedRecordType else List.empty
+          if (x.zone == zoneName) x.recordTypes else List.empty
       }
       if(rType.contains(rs.typ.toString)){
         true
@@ -325,7 +325,7 @@ class RecordSetService(
         x: ZoneAuthConfigs =>
           if (x.zone.contains("*")) {
             val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
-            if (zoneName.matches(wildcardZone)) x.allowedRecordType else List.empty
+            if (zoneName.matches(wildcardZone)) x.recordTypes else List.empty
           } else List.empty
       }
       if(rType.contains(rs.typ.toString)){
@@ -350,7 +350,7 @@ class RecordSetService(
     val groups = if(isContainNormalZone){
       config.zoneAuthConfigs.flatMap {
         x: ZoneAuthConfigs =>
-          if (x.zone == zoneName) x.allowedGroupList else List.empty
+          if (x.zone == zoneName) x.groupList else List.empty
       }
     }
     else if(isContainWildcardZone){
@@ -358,7 +358,7 @@ class RecordSetService(
         x: ZoneAuthConfigs =>
           if (x.zone.contains("*")) {
             val wildcardZone = x.zone.replace("*", "[A-Za-z0-9.]*")
-            if (zoneName.matches(wildcardZone)) x.allowedGroupList else List.empty
+            if (zoneName.matches(wildcardZone)) x.groupList else List.empty
           } else List.empty
       }
     }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -123,7 +123,7 @@ object RecordSetValidations {
     ensuring(
       InvalidRequest(
         s"Record with fqdn '${newRecordSet.name}.${zone.name}' cannot be created. " +
-          s"Please check if user has permission or if there's a zone/record that already exist and make the change there."
+          s"Please check if there's a record with the same fqdn and type already exist and make the change there."
       )
     )(
       (newRecordSet.name != zone.name || existingRecordSet.exists(_.name == newRecordSet.name)) && recordFqdnDoesNotExist && isRecordTypeAndUserAllowed

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -361,7 +361,7 @@ object RecordSetValidations {
     ensuring(
       InvalidRequest(
         s"RecordSet with name ${recordSet.name} has more dots than that is allowed in config for this zone " +
-          s"which is, 'allowed-dots-limit = $allowedDotsLimit'."
+          s"which is, 'dots-limit = $allowedDotsLimit'."
       )
     )(
       recordSet.name.count(_ == '.') <= allowedDotsLimit || (recordSet.name.count(_ == '.') == 1 &&

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -129,7 +129,7 @@ object RecordSetValidations {
     ensuring(
       InvalidRequest(
         s"Record with fqdn '${newRecordSet.name}.${zone.name}' cannot be created. " +
-          s"Please check if there's a record with the same fqdn and type already exist and make the change there."
+          s"Please check if a record with the same FQDN and type already exist and make the change there."
       )
     )(
       (newRecordSet.name != zone.name || existingRecordSet.exists(_.name == newRecordSet.name)) && recordFqdnDoesNotExist && isRecordTypeAndUserAllowed

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -365,6 +365,16 @@ object RecordSetValidations {
     )
   }
 
+  def isNotApexEndsWithDot(recordSet: RecordSet, zone: Zone): Either[Throwable, Unit] = {
+    ensuring(
+      InvalidRequest(
+        "RecordSet name cannot end with a dot, unless it's an apex record."
+      )
+    )(
+      recordSet.name.endsWith(zone.name) || !recordSet.name.endsWith(".")
+    )
+  }
+
   def canUseOwnerGroup(
       ownerGroupId: Option[String],
       group: Option[Group],

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -103,7 +103,7 @@ object RecordSetValidations {
     val isDomainAllowed = dottedHostConfig.contains(zone.name)
 
     // Check if record set contains dot and if it is in zone which is allowed to have dotted records from dotted hosts config
-    if(newRecordSet.name.contains(".") && isDomainAllowed) {
+    if((newRecordSet.name.contains(".") || !zoneOrRecordDoesNotAlreadyExist) && isDomainAllowed && newRecordSet.name != zone.name) {
       isDotted(newRecordSet, zone, existingRecordSet, zoneOrRecordDoesNotAlreadyExist)
     }
     else{
@@ -120,8 +120,8 @@ object RecordSetValidations {
   ): Either[Throwable, Unit] =
     ensuring(
       InvalidRequest(
-        s"Record with name ${newRecordSet.name} and type ${newRecordSet.typ} already exists. " +
-          s"Please check the record and zone that's already present and make the change there."
+        s"Record with fqdn '${newRecordSet.name}.${zone.name}' cannot be created. " +
+          s"Please check if there's a zone or record that already exist and make the change there."
       )
     )(
       (newRecordSet.name != zone.name || existingRecordSet.exists(_.name == newRecordSet.name)) && zoneOrRecordDoesNotAlreadyExist

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -352,6 +352,19 @@ object RecordSetValidations {
       .leftMap(errors => InvalidRequest(errors.toList.map(_.message).mkString(", ")))
   }
 
+  def checkAllowedDots(allowedDotsLimit: Int, recordSet: RecordSet, zone: Zone): Either[Throwable, Unit] = {
+    ensuring(
+      InvalidRequest(
+        s"RecordSet with name ${recordSet.name} has more dots than that is allowed in config for this zone " +
+          s"which is, 'allowed-dots-limit = $allowedDotsLimit'."
+      )
+    )(
+      recordSet.name.count(_ == '.') <= allowedDotsLimit || (recordSet.name.count(_ == '.') == 1 &&
+        recordSet.name.takeRight(1) == ".") || recordSet.name == zone.name ||
+        (recordSet.typ.toString == "PTR" || recordSet.typ.toString == "SRV" || recordSet.typ.toString == "TXT" || recordSet.typ.toString == "NAPTR")
+    )
+  }
+
   def canUseOwnerGroup(
       ownerGroupId: Option[String],
       group: Option[Group],

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -19,7 +19,7 @@ package vinyldns.api.domain.record
 import cats.syntax.either._
 import vinyldns.api.Interfaces._
 import vinyldns.api.backend.dns.DnsConversions
-import vinyldns.api.config.{DottedHostsConfig, HighValueDomainConfig}
+import vinyldns.api.config.HighValueDomainConfig
 import vinyldns.api.domain._
 import vinyldns.core.domain.DomainHelpers._
 import vinyldns.core.domain.record.RecordType._
@@ -96,11 +96,11 @@ object RecordSetValidations {
       zone: Zone,
       existingRecordSet: Option[RecordSet] = None,
       zoneOrRecordDoesNotAlreadyExist: Boolean,
-      dottedHostConfig: DottedHostsConfig
+      dottedHostConfig: Set[String]
   ): Either[Throwable, Unit] = {
 
     // Check if the zone of the record set is present in dotted hosts config list
-    val isDomainAllowed = dottedHostConfig.zoneList.contains(zone.name)
+    val isDomainAllowed = dottedHostConfig.contains(zone.name)
 
     // Check if record set contains dot and if it is in zone which is allowed to have dotted records from dotted hosts config
     if(newRecordSet.name.contains(".") && isDomainAllowed) {
@@ -150,7 +150,7 @@ object RecordSetValidations {
       existingRecordSet: Option[RecordSet],
       approvedNameServers: List[Regex],
       zoneOrRecordDoesNotAlreadyExist: Boolean = true,
-      dottedHostConfig: DottedHostsConfig
+      dottedHostConfig: Set[String]
   ): Either[Throwable, Unit] =
     newRecordSet.typ match {
       case CNAME => cnameValidations(newRecordSet, existingRecordsWithName, zone, existingRecordSet, zoneOrRecordDoesNotAlreadyExist, dottedHostConfig)
@@ -182,7 +182,7 @@ object RecordSetValidations {
       zone: Zone,
       existingRecordSet: Option[RecordSet] = None,
       zoneOrRecordDoesNotAlreadyExist: Boolean,
-      dottedHostConfig: DottedHostsConfig
+      dottedHostConfig: Set[String]
   ): Either[Throwable, Unit] = {
     // cannot create a cname record if a record with the same exists
     val noRecordWithName = {
@@ -225,7 +225,7 @@ object RecordSetValidations {
       existingRecordsWithName: List[RecordSet],
       zone: Zone,
       zoneOrRecordDoesNotAlreadyExist: Boolean,
-      dottedHostConfig: DottedHostsConfig
+      dottedHostConfig: Set[String]
   ): Either[Throwable, Unit] = {
     // see https://tools.ietf.org/html/rfc4035#section-2.4
     val nsChecks = existingRecordsWithName.find(_.typ == NS) match {
@@ -254,7 +254,7 @@ object RecordSetValidations {
       oldRecordSet: Option[RecordSet],
       approvedNameServers: List[Regex],
       zoneOrRecordDoesNotAlreadyExist: Boolean,
-      dottedHostConfig: DottedHostsConfig
+      dottedHostConfig: Set[String]
   ): Either[Throwable, Unit] = {
     // TODO kept consistency with old validation. Not sure why NS could be dotted in reverse specifically
     val isNotDottedHost = if (!zone.isReverse) checkForDot(newRecordSet, zone, None, zoneOrRecordDoesNotAlreadyExist, dottedHostConfig) else ().asRight
@@ -279,7 +279,7 @@ object RecordSetValidations {
     } yield ()
   }
 
-  def soaValidations(newRecordSet: RecordSet, zone: Zone, zoneOrRecordDoesNotAlreadyExist: Boolean, dottedHostConfig: DottedHostsConfig): Either[Throwable, Unit] =
+  def soaValidations(newRecordSet: RecordSet, zone: Zone, zoneOrRecordDoesNotAlreadyExist: Boolean, dottedHostConfig: Set[String]): Either[Throwable, Unit] =
     // TODO kept consistency with old validation. in theory if SOA always == zone name, no special case is needed here
     if (!zone.isReverse) checkForDot(newRecordSet, zone, None, zoneOrRecordDoesNotAlreadyExist, dottedHostConfig) else ().asRight
 

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -526,8 +526,8 @@ def test_create_dotted_a_record_not_apex_fails_when_dotted_hosts_config_not_sati
 
     zone_name = shared_zone_test_context.parent_zone["name"]
     error = client.create_recordset(dotted_host_a_record, status=422)
-    assert_that(error, is_("Record with name " + dotted_host_a_record["name"] + " and type A is a dotted host which "
-                                                                                "is not allowed in zone " + zone_name))
+    assert_that(error, is_("Record type is not allowed or the user is not authorized to create a dotted host in the "
+                           "zone '" + zone_name + "'"))
 
 
 def test_create_dotted_a_record_succeeds_if_all_dotted_hosts_config_satisfies(shared_zone_test_context):
@@ -627,8 +627,8 @@ def test_create_dotted_cname_record_fails_when_dotted_hosts_config_not_satisfied
     }
 
     error = client.create_recordset(dotted_host_cname_record, status=422)
-    assert_that(error,
-                is_(f'Record with name dot.ted and type CNAME is a dotted host which is not allowed in zone {zone["name"]}'))
+    assert_that(error, is_("Record type is not allowed or the user is not authorized to create a dotted host in the "
+                           "zone '" + zone["name"] + "'"))
 
 
 def test_create_dotted_cname_record_succeeds_if_all_dotted_hosts_config_satisfies(shared_zone_test_context):

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -562,7 +562,7 @@ def test_create_dotted_a_record_fails_if_all_dotted_hosts_config_not_satisfied(s
     Test that creating a A record set with dotted host record name fails
     Here the zone, user (in group) and record type is allowed.
     But the record name has more dots than the number of dots allowed for this zone. Hence the test fails
-    The 'allowed-dots-limit' config from dotted-hosts config is not satisfied. Config present in reference.conf
+    The 'dots-limit' config from dotted-hosts config is not satisfied. Config present in reference.conf
     """
     client = shared_zone_test_context.history_client
     zone = shared_zone_test_context.dummy_zone
@@ -576,7 +576,7 @@ def test_create_dotted_a_record_fails_if_all_dotted_hosts_config_not_satisfied(s
 
     error = client.create_recordset(dotted_host_a_record, status=422)
     assert_that(error, is_("RecordSet with name " + dotted_host_a_record["name"] + " has more dots than that is "
-                           "allowed in config for this zone which is, 'allowed-dots-limit = 3'."))
+                           "allowed in config for this zone which is, 'dots-limit = 3'."))
 
 
 def test_create_dotted_a_record_apex_succeeds(shared_zone_test_context):

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -530,7 +530,7 @@ def test_create_dotted_a_record_not_apex_fails_when_dotted_hosts_config_not_sati
                            "zone '" + zone_name + "'"))
 
 
-def test_create_dotted_a_record_succeeds_if_all_dotted_hosts_config_satisfies(shared_zone_test_context):
+def test_create_dotted_a_record_succeeds_if_all_dotted_hosts_config_satisfied(shared_zone_test_context):
     """
     Test that creating a A record set with dotted host record name succeeds
     Here the zone, user (in group) and record type is allowed. Hence the test succeeds
@@ -631,7 +631,7 @@ def test_create_dotted_cname_record_fails_when_dotted_hosts_config_not_satisfied
                            "zone '" + zone["name"] + "'"))
 
 
-def test_create_dotted_cname_record_succeeds_if_all_dotted_hosts_config_satisfies(shared_zone_test_context):
+def test_create_dotted_cname_record_succeeds_if_all_dotted_hosts_config_satisfied(shared_zone_test_context):
     """
     Test that creating a CNAME record set with dotted host record name succeeds.
     Here the zone, user (individual) and record type is allowed. Hence the test succeeds

--- a/modules/api/src/test/functional/tests/shared_zone_test_context.py
+++ b/modules/api/src/test/functional/tests/shared_zone_test_context.py
@@ -174,6 +174,15 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.dummy_group["id"],
                     "isTest": True,
+                    "acl": {
+                        "rules": [
+                            {
+                                "accessLevel": "Delete",
+                                "description": "some_test_rule",
+                                "userId": "history-id"
+                            }
+                        ]
+                    },
                     "connection": {
                         "name": "dummy.",
                         "keyName": VinylDNSTestContext.dns_key_name,

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -18,7 +18,7 @@ package vinyldns.api
 
 import com.comcast.ip4s.IpAddress
 import org.joda.time.DateTime
-import vinyldns.api.config.{AuthConfigs, BatchChangeConfig, DottedHostsConfig, HighValueDomainConfig, LimitsConfig, ManualReviewConfig, ScheduledChangesConfig}
+import vinyldns.api.config.{ZoneAuthConfigs, BatchChangeConfig, DottedHostsConfig, HighValueDomainConfig, LimitsConfig, ManualReviewConfig, ScheduledChangesConfig}
 import vinyldns.api.domain.batch.V6DiscoveryNibbleBoundaries
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone._
@@ -40,7 +40,7 @@ trait VinylDNSTestHelpers {
 
   val approvedNameServers: List[Regex] = List(new Regex("some.test.ns."))
 
-  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List(AuthConfigs("dotted.xyz.",List("xyz"),List("dummy"),List("CNAME"), 3), AuthConfigs("abc.zone.recordsets.",List("locked"),List("dummy"),List("CNAME"), 3), AuthConfigs("xyz.",List("super"),List("xyz"),List("CNAME"), 3)))
+  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List(ZoneAuthConfigs("dotted.xyz.",List("xyz"),List("dummy"),List("CNAME"), 3), ZoneAuthConfigs("abc.zone.recordsets.",List("locked"),List("dummy"),List("CNAME"), 3), ZoneAuthConfigs("xyz.",List("super"),List("xyz"),List("CNAME"), 3), ZoneAuthConfigs("dot.xyz.",List("super"),List("xyz"),List("CNAME"), 0)))
 
   val emptyDottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List.empty)
 

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -40,7 +40,7 @@ trait VinylDNSTestHelpers {
 
   val approvedNameServers: List[Regex] = List(new Regex("some.test.ns."))
 
-  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List("dotted.xyz"))
+  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List("dotted.xyz"), List("super"), List("dummy"), List("CNAME"))
 
   val defaultTtl: Long = 7200
 

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -42,6 +42,8 @@ trait VinylDNSTestHelpers {
 
   val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List(AuthConfigs("dotted.xyz.",List("xyz"),List("dummy"),List("CNAME")), AuthConfigs("abc.zone.recordsets.",List("locked"),List("dummy"),List("CNAME")), AuthConfigs("xyz.",List("super"),List("xyz"),List("CNAME"))))
 
+  val emptyDottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List.empty)
+
   val defaultTtl: Long = 7200
 
   val manualReviewDomainList: List[Regex] = List(new Regex("needs-review.*"))

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -40,7 +40,7 @@ trait VinylDNSTestHelpers {
 
   val approvedNameServers: List[Regex] = List(new Regex("some.test.ns."))
 
-  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List(AuthConfigs("dotted.xyz.",List("xyz"),List("dummy"),List("CNAME")), AuthConfigs("abc.zone.recordsets.",List("locked"),List("dummy"),List("CNAME")), AuthConfigs("xyz.",List("super"),List("xyz"),List("CNAME"))))
+  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List(AuthConfigs("dotted.xyz.",List("xyz"),List("dummy"),List("CNAME"), 3), AuthConfigs("abc.zone.recordsets.",List("locked"),List("dummy"),List("CNAME"), 3), AuthConfigs("xyz.",List("super"),List("xyz"),List("CNAME"), 3)))
 
   val emptyDottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List.empty)
 

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -18,7 +18,7 @@ package vinyldns.api
 
 import com.comcast.ip4s.IpAddress
 import org.joda.time.DateTime
-import vinyldns.api.config.{BatchChangeConfig, HighValueDomainConfig, LimitsConfig, ManualReviewConfig, ScheduledChangesConfig}
+import vinyldns.api.config.{BatchChangeConfig, DottedHostsConfig, HighValueDomainConfig, LimitsConfig, ManualReviewConfig, ScheduledChangesConfig}
 import vinyldns.api.domain.batch.V6DiscoveryNibbleBoundaries
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone._
@@ -39,6 +39,8 @@ trait VinylDNSTestHelpers {
     HighValueDomainConfig(highValueDomainRegexList, highValueDomainIpList)
 
   val approvedNameServers: List[Regex] = List(new Regex("some.test.ns."))
+
+  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List("dotted.xyz"))
 
   val defaultTtl: Long = 7200
 

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -18,7 +18,7 @@ package vinyldns.api
 
 import com.comcast.ip4s.IpAddress
 import org.joda.time.DateTime
-import vinyldns.api.config.{BatchChangeConfig, DottedHostsConfig, HighValueDomainConfig, LimitsConfig, ManualReviewConfig, ScheduledChangesConfig}
+import vinyldns.api.config.{AuthConfigs, BatchChangeConfig, DottedHostsConfig, HighValueDomainConfig, LimitsConfig, ManualReviewConfig, ScheduledChangesConfig}
 import vinyldns.api.domain.batch.V6DiscoveryNibbleBoundaries
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone._
@@ -40,7 +40,7 @@ trait VinylDNSTestHelpers {
 
   val approvedNameServers: List[Regex] = List(new Regex("some.test.ns."))
 
-  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List("dotted.xyz"), List("super"), List("dummy"), List("CNAME"))
+  val dottedHostsConfig: DottedHostsConfig = DottedHostsConfig(List(AuthConfigs("dotted.xyz.",List("xyz"),List("dummy"),List("CNAME")), AuthConfigs("abc.zone.recordsets.",List("locked"),List("dummy"),List("CNAME")), AuthConfigs("xyz.",List("super"),List("xyz"),List("CNAME"))))
 
   val defaultTtl: Long = 7200
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -55,7 +55,7 @@ import vinyldns.api.domain.access.AccessValidations
 import scala.concurrent.ExecutionContext
 
 class BatchChangeServiceSpec
-    extends AnyWordSpec
+  extends AnyWordSpec
     with Matchers
     with MockitoSugar
     with CatsHelpers
@@ -418,8 +418,7 @@ class BatchChangeServiceSpec
     mockNotifiers,
     false,
     defaultv6Discovery,
-    7200L,
-    VinylDNSTestHelpers.dottedHostsConfig
+    7200L
   )
 
   private val underTestManualEnabled = new BatchChangeService(
@@ -435,8 +434,7 @@ class BatchChangeServiceSpec
     mockNotifiers,
     false,
     defaultv6Discovery,
-    7200L,
-    VinylDNSTestHelpers.dottedHostsConfig
+    7200L
   )
 
   private val underTestScheduledEnabled = new BatchChangeService(
@@ -452,8 +450,7 @@ class BatchChangeServiceSpec
     mockNotifiers,
     true,
     defaultv6Discovery,
-    7200L,
-    VinylDNSTestHelpers.dottedHostsConfig
+    7200L
   )
 
   "applyBatchChange" should {
@@ -479,8 +476,7 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 17),
-        7200L,
-        VinylDNSTestHelpers.dottedHostsConfig
+        7200L
       )
       val ptr = AddChangeInput(
         "2001:0000:0000:0001:0000:ff00:0042:8329",
@@ -511,8 +507,7 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 16),
-        7200L,
-        VinylDNSTestHelpers.dottedHostsConfig
+        7200L
       )
       val ptr = AddChangeInput(
         "2001:0000:0000:0001:0000:ff00:0042:8329",
@@ -1182,8 +1177,7 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         defaultv6Discovery,
-        7200L,
-        VinylDNSTestHelpers.dottedHostsConfig
+        7200L
       )
 
       val ip = "2001:0db8:0000:0000:0000:ff00:0042:8329"
@@ -1224,8 +1218,7 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 16),
-        7200L,
-        VinylDNSTestHelpers.dottedHostsConfig
+        7200L
       )
 
       val ip = "2001:0db8:0000:0000:0000:ff00:0042:8329"
@@ -1251,8 +1244,7 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         defaultv6Discovery,
-        7200L,
-        VinylDNSTestHelpers.dottedHostsConfig
+        7200L
       )
 
       val ip1 = "::1"

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -418,7 +418,8 @@ class BatchChangeServiceSpec
     mockNotifiers,
     false,
     defaultv6Discovery,
-    7200L
+    7200L,
+    VinylDNSTestHelpers.dottedHostsConfig
   )
 
   private val underTestManualEnabled = new BatchChangeService(
@@ -434,7 +435,8 @@ class BatchChangeServiceSpec
     mockNotifiers,
     false,
     defaultv6Discovery,
-    7200L
+    7200L,
+    VinylDNSTestHelpers.dottedHostsConfig
   )
 
   private val underTestScheduledEnabled = new BatchChangeService(
@@ -450,7 +452,8 @@ class BatchChangeServiceSpec
     mockNotifiers,
     true,
     defaultv6Discovery,
-    7200L
+    7200L,
+    VinylDNSTestHelpers.dottedHostsConfig
   )
 
   "applyBatchChange" should {
@@ -476,7 +479,8 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 17),
-        7200L
+        7200L,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
       val ptr = AddChangeInput(
         "2001:0000:0000:0001:0000:ff00:0042:8329",
@@ -507,7 +511,8 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 16),
-        7200L
+        7200L,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
       val ptr = AddChangeInput(
         "2001:0000:0000:0001:0000:ff00:0042:8329",
@@ -1177,7 +1182,8 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         defaultv6Discovery,
-        7200L
+        7200L,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
       val ip = "2001:0db8:0000:0000:0000:ff00:0042:8329"
@@ -1218,7 +1224,8 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 16),
-        7200L
+        7200L,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
       val ip = "2001:0db8:0000:0000:0000:ff00:0042:8329"
@@ -1244,7 +1251,8 @@ class BatchChangeServiceSpec
         mockNotifiers,
         false,
         defaultv6Discovery,
-        7200L
+        7200L,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
       val ip1 = "::1"

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -821,7 +821,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -888,7 +890,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result.foreach(_ shouldBe valid)
@@ -930,7 +934,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result.foreach(_ shouldBe valid)
@@ -959,7 +965,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -992,7 +1000,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1034,7 +1044,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1086,7 +1098,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1126,7 +1140,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result.foreach(_ shouldBe valid)
@@ -1151,7 +1167,9 @@ class BatchChangeValidationsSpec
           false,
           None,
           true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+          false,
+          VinylDNSTestHelpers.dottedHostsConfig
         )
 
         result(0) should haveInvalid[DomainValidationError](
@@ -1170,7 +1188,9 @@ class BatchChangeValidationsSpec
           false,
           None,
           true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+          false,
+          VinylDNSTestHelpers.dottedHostsConfig
         )
 
       result(0) shouldBe valid
@@ -1188,7 +1208,9 @@ class BatchChangeValidationsSpec
           false,
           None,
           true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+          false,
+          VinylDNSTestHelpers.dottedHostsConfig
         )
         result(0) shouldBe valid
       }
@@ -1209,7 +1231,9 @@ class BatchChangeValidationsSpec
         false,
         None,
         true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+        false,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
       result(0) should haveInvalid[DomainValidationError](
@@ -1243,7 +1267,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1266,7 +1292,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1297,7 +1325,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1324,7 +1354,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1361,7 +1393,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1398,7 +1432,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1440,7 +1476,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1484,7 +1522,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result.map(_ shouldBe valid)
@@ -1505,7 +1545,9 @@ class BatchChangeValidationsSpec
         false,
         None,
         true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+        false,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
     result(0) shouldBe valid
@@ -1526,7 +1568,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1555,7 +1599,9 @@ class BatchChangeValidationsSpec
         false,
         None,
         true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+        false,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
     result(0) shouldBe valid
@@ -1573,7 +1619,9 @@ class BatchChangeValidationsSpec
           false,
           None,
           true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+          false,
+          VinylDNSTestHelpers.dottedHostsConfig
         )
 
       result(0) should haveInvalid[DomainValidationError](
@@ -1607,7 +1655,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1634,7 +1684,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1657,7 +1709,9 @@ class BatchChangeValidationsSpec
         false,
         None,
         true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+        false,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1689,7 +1743,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1713,7 +1769,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1737,7 +1795,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1770,7 +1830,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1795,7 +1857,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1865,7 +1929,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -1916,7 +1982,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result.map(_ shouldBe valid)
   }
@@ -1961,7 +2029,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result.map(_ shouldBe valid)
   }
@@ -1993,7 +2063,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result.map(_ shouldBe valid)
   }
@@ -2033,7 +2105,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2074,7 +2148,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result.map(_ shouldBe valid)
   }
@@ -2109,7 +2185,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result.map(_ shouldBe valid)
   }
@@ -2149,7 +2227,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result.map(_ shouldBe valid)
@@ -2265,7 +2345,9 @@ class BatchChangeValidationsSpec
         false,
         None,
         true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+        false,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
     result(0) should haveInvalid[DomainValidationError](RecordAlreadyExists("name-conflict."))
   }
@@ -2290,7 +2372,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result(0) shouldBe valid
   }
@@ -2323,7 +2407,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
     result(0) shouldBe valid
   }
@@ -2354,7 +2440,9 @@ class BatchChangeValidationsSpec
       false,
       Some("some-owner-group-id"),
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result.foreach(_ shouldBe valid)
@@ -2386,7 +2474,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2417,7 +2507,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) should
@@ -2443,7 +2535,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2459,7 +2553,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2495,7 +2591,9 @@ class BatchChangeValidationsSpec
       false,
       Some(okGroup.id),
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2542,7 +2640,9 @@ class BatchChangeValidationsSpec
       false,
       Some(okGroup.id),
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2603,7 +2703,9 @@ class BatchChangeValidationsSpec
         false,
         None,
         true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+        false,
+        VinylDNSTestHelpers.dottedHostsConfig
       )
 
     result(0) should haveInvalid[DomainValidationError](ZoneDiscoveryError("dotted.a.ok."))
@@ -2659,7 +2761,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid
@@ -2763,7 +2867,9 @@ class BatchChangeValidationsSpec
       false,
       None,
       true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+      false,
+      VinylDNSTestHelpers.dottedHostsConfig
     )
 
     result(0) shouldBe valid

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -819,7 +819,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -884,7 +886,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result.foreach(_ shouldBe valid)
@@ -924,7 +928,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result.foreach(_ shouldBe valid)
@@ -951,7 +957,9 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -982,7 +990,9 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1022,7 +1032,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1072,7 +1084,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1110,7 +1124,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result.foreach(_ shouldBe valid)
@@ -1133,7 +1149,9 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(newRecordSetList)),
           okAuth,
           false,
-          None
+          None,
+          true,
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
         )
 
         result(0) should haveInvalid[DomainValidationError](
@@ -1150,7 +1168,9 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           okAuth,
           false,
-          None
+          None,
+          true,
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
         )
 
       result(0) shouldBe valid
@@ -1166,7 +1186,9 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           okAuth,
           false,
-          None
+          None,
+          true,
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
         )
         result(0) shouldBe valid
       }
@@ -1185,7 +1207,9 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(input.validNel), ExistingRecordSets(existingRecordSetList)),
         okAuth,
         false,
-        None
+        None,
+        true,
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
       )
 
       result(0) should haveInvalid[DomainValidationError](
@@ -1217,7 +1241,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1238,7 +1264,9 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addCname.validNel), ExistingRecordSets(newRecordSetList)),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1267,7 +1295,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1292,7 +1322,9 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addCname.validNel), ExistingRecordSets(List(existingRecordPTR))),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1327,7 +1359,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1362,7 +1396,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1402,7 +1438,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1444,7 +1482,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result.map(_ shouldBe valid)
@@ -1463,7 +1503,9 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
         okAuth,
         false,
-        None
+        None,
+        true,
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
       )
 
     result(0) shouldBe valid
@@ -1482,7 +1524,9 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
       AuthPrincipal(superUser, Seq.empty),
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1509,7 +1553,9 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
         notAuth,
         false,
-        None
+        None,
+        true,
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
       )
 
     result(0) shouldBe valid
@@ -1525,7 +1571,9 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           notAuth,
           false,
-          None
+          None,
+          true,
+          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
         )
 
       result(0) should haveInvalid[DomainValidationError](
@@ -1557,7 +1605,9 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addCname.validNel, addPtr.validNel), ExistingRecordSets(List())),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1582,7 +1632,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1603,7 +1655,9 @@ class BatchChangeValidationsSpec
         ),
         okAuth,
         false,
-        None
+        None,
+        true,
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
       )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1633,7 +1687,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1655,7 +1711,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1677,7 +1735,9 @@ class BatchChangeValidationsSpec
       ),
       AuthPrincipal(superUser, Seq.empty),
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1708,7 +1768,9 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1731,7 +1793,9 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1799,7 +1863,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1848,7 +1914,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result.map(_ shouldBe valid)
   }
@@ -1891,7 +1959,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result.map(_ shouldBe valid)
   }
@@ -1921,7 +1991,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result.map(_ shouldBe valid)
   }
@@ -1959,7 +2031,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -1998,7 +2072,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result.map(_ shouldBe valid)
   }
@@ -2031,7 +2107,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result.map(_ shouldBe valid)
   }
@@ -2069,7 +2147,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result.map(_ shouldBe valid)
@@ -2183,7 +2263,9 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(addMX.validNel), ExistingRecordSets(List(existingMX))),
         okAuth,
         false,
-        None
+        None,
+        true,
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
       )
     result(0) should haveInvalid[DomainValidationError](RecordAlreadyExists("name-conflict."))
   }
@@ -2206,7 +2288,9 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addMx.validNel, addMx2.validNel), ExistingRecordSets(List())),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result(0) shouldBe valid
   }
@@ -2237,7 +2321,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
     result(0) shouldBe valid
   }
@@ -2266,7 +2352,9 @@ class BatchChangeValidationsSpec
       ),
       AuthPrincipal(okUser, Seq(abcGroup.id, okGroup.id)),
       false,
-      Some("some-owner-group-id")
+      Some("some-owner-group-id"),
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result.foreach(_ shouldBe valid)
@@ -2296,7 +2384,9 @@ class BatchChangeValidationsSpec
       ),
       AuthPrincipal(okUser, Seq(abcGroup.id, okGroup.id)),
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -2325,7 +2415,9 @@ class BatchChangeValidationsSpec
       ),
       dummyAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) should
@@ -2349,7 +2441,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -2363,7 +2457,9 @@ class BatchChangeValidationsSpec
       ),
       sharedAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -2397,7 +2493,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      Some(okGroup.id)
+      Some(okGroup.id),
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -2442,7 +2540,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      Some(okGroup.id)
+      Some(okGroup.id),
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -2501,7 +2601,9 @@ class BatchChangeValidationsSpec
         ),
         okAuth,
         false,
-        None
+        None,
+        true,
+        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
       )
 
     result(0) should haveInvalid[DomainValidationError](ZoneDiscoveryError("dotted.a.ok."))
@@ -2555,7 +2657,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid
@@ -2657,7 +2761,9 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None
+      None,
+      true,
+      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
     )
 
     result(0) shouldBe valid

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -41,7 +41,7 @@ import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone, ZoneStatus}
 import scala.util.Random
 
 class BatchChangeValidationsSpec
-    extends AnyPropSpec
+  extends AnyPropSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
     with EitherMatchers
@@ -192,9 +192,9 @@ class BatchChangeValidationsSpec
   )
 
   private def makeAddUpdateRecord(
-      recordName: String,
-      aData: AData = AData("1.2.3.4")
-  ): AddChangeForValidation =
+                                   recordName: String,
+                                   aData: AData = AData("1.2.3.4")
+                                 ): AddChangeForValidation =
     AddChangeForValidation(
       okZone,
       s"$recordName",
@@ -203,9 +203,9 @@ class BatchChangeValidationsSpec
     )
 
   private def makeDeleteUpdateDeleteRRSet(
-      recordName: String,
-      recordData: Option[RecordData] = None
-  ): DeleteRRSetChangeForValidation =
+                                           recordName: String,
+                                           recordData: Option[RecordData] = None
+                                         ): DeleteRRSetChangeForValidation =
     DeleteRRSetChangeForValidation(
       okZone,
       s"$recordName",
@@ -666,7 +666,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateAddChangeInput: should fail with InvalidIpv4Address
-      |if validateRecordData fails for an invalid ipv4 address""".stripMargin) {
+             |if validateRecordData fails for an invalid ipv4 address""".stripMargin) {
     val invalidIpv4 = "invalidIpv4:123"
     val change = AddChangeInput("test.comcast.com.", RecordType.A, ttl, AData(invalidIpv4))
     val result = validateAddChangeInput(change, false)
@@ -819,11 +819,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -888,11 +884,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result.foreach(_ shouldBe valid)
@@ -932,11 +924,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result.foreach(_ shouldBe valid)
@@ -963,11 +951,7 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -998,11 +982,7 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1042,11 +1022,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1069,7 +1045,7 @@ class BatchChangeValidationsSpec
 
   property(
     """validateChangesWithContext: should succeed for update in shared zone if user belongs to record
-             | owner group""".stripMargin
+      | owner group""".stripMargin
   ) {
     val existingRecord =
       sharedZoneRecord.copy(
@@ -1096,11 +1072,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1108,7 +1080,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should succeed adding a record
-      |if an existing CNAME with the same name exists but is being deleted""".stripMargin) {
+             |if an existing CNAME with the same name exists but is being deleted""".stripMargin) {
     val existingCname = rsOk.copy(name = "deleteRRSet", typ = RecordType.CNAME)
     val existingCname2 =
       existingCname.copy(name = "deleteRecord", records = List(CNAMEData(Fqdn("cname.data."))))
@@ -1138,11 +1110,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result.foreach(_ shouldBe valid)
@@ -1165,11 +1133,7 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(newRecordSetList)),
           okAuth,
           false,
-          None,
-          true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-          false,
-          VinylDNSTestHelpers.dottedHostsConfig
+          None
         )
 
         result(0) should haveInvalid[DomainValidationError](
@@ -1186,11 +1150,7 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           okAuth,
           false,
-          None,
-          true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-          false,
-          VinylDNSTestHelpers.dottedHostsConfig
+          None
         )
 
       result(0) shouldBe valid
@@ -1206,11 +1166,7 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           okAuth,
           false,
-          None,
-          true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-          false,
-          VinylDNSTestHelpers.dottedHostsConfig
+          None
         )
         result(0) shouldBe valid
       }
@@ -1229,11 +1185,7 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(input.validNel), ExistingRecordSets(existingRecordSetList)),
         okAuth,
         false,
-        None,
-        true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-        false,
-        VinylDNSTestHelpers.dottedHostsConfig
+        None
       )
 
       result(0) should haveInvalid[DomainValidationError](
@@ -1265,11 +1217,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1277,7 +1225,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should fail with CnameIsNotUniqueError
-      |if CNAME record name already exists""".stripMargin) {
+             |if CNAME record name already exists""".stripMargin) {
     val addCname = AddChangeForValidation(
       validZone,
       "existingCname",
@@ -1290,11 +1238,7 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addCname.validNel), ExistingRecordSets(newRecordSetList)),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1303,7 +1247,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should succeed for CNAME record
-      |if there's a duplicate PTR ipv4 record that is being deleted""".stripMargin) {
+             |if there's a duplicate PTR ipv4 record that is being deleted""".stripMargin) {
     val addCname = AddChangeForValidation(
       validIp4ReverseZone,
       "30",
@@ -1323,11 +1267,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1335,7 +1275,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should fail with CnameIsNotUniqueError for CNAME record
-      |if there's a duplicate PTR ipv6 record""".stripMargin) {
+             |if there's a duplicate PTR ipv6 record""".stripMargin) {
     val addCname = AddChangeForValidation(
       validZone,
       "0.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
@@ -1352,11 +1292,7 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addCname.validNel), ExistingRecordSets(List(existingRecordPTR))),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1365,7 +1301,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: CNAME record should pass
-      |if no other changes in batch change have same record name""".stripMargin) {
+             |if no other changes in batch change have same record name""".stripMargin) {
     val addA = AddChangeForValidation(
       okZone,
       "test",
@@ -1391,11 +1327,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1404,7 +1336,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: CNAME record should fail
-      |if another add change in batch change has the same record name""".stripMargin) {
+             |if another add change in batch change has the same record name""".stripMargin) {
     val addA = AddChangeForValidation(
       okZone,
       "test",
@@ -1430,11 +1362,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1448,7 +1376,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: both CNAME records should fail
-      |if there are duplicate CNAME add change inputs""".stripMargin) {
+             |if there are duplicate CNAME add change inputs""".stripMargin) {
     val addA = AddChangeForValidation(
       okZone,
       "test",
@@ -1474,11 +1402,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1494,7 +1418,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: both PTR records should succeed
-      |if there are duplicate PTR add change inputs""".stripMargin) {
+             |if there are duplicate PTR add change inputs""".stripMargin) {
     val addA = AddChangeForValidation(
       okZone,
       "test",
@@ -1520,18 +1444,14 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result.map(_ shouldBe valid)
   }
 
   property("""validateChangesWithContext: should succeed for AddChangeForValidation
-      |if user has group admin access""".stripMargin) {
+             |if user has group admin access""".stripMargin) {
     val addA = AddChangeForValidation(
       validZone,
       "valid",
@@ -1543,11 +1463,7 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
         okAuth,
         false,
-        None,
-        true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-        false,
-        VinylDNSTestHelpers.dottedHostsConfig
+        None
       )
 
     result(0) shouldBe valid
@@ -1566,11 +1482,7 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
       AuthPrincipal(superUser, Seq.empty),
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1597,11 +1509,7 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(addA.validNel), ExistingRecordSets(recordSetList)),
         notAuth,
         false,
-        None,
-        true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-        false,
-        VinylDNSTestHelpers.dottedHostsConfig
+        None
       )
 
     result(0) shouldBe valid
@@ -1617,11 +1525,7 @@ class BatchChangeValidationsSpec
           ChangeForValidationMap(List(input.validNel), ExistingRecordSets(recordSetList)),
           notAuth,
           false,
-          None,
-          true,
-          VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-          false,
-          VinylDNSTestHelpers.dottedHostsConfig
+          None
         )
 
       result(0) should haveInvalid[DomainValidationError](
@@ -1636,7 +1540,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should fail with RecordNameNotUniqueInBatch for PTR record
-      |if valid CNAME with same name exists in batch""".stripMargin) {
+             |if valid CNAME with same name exists in batch""".stripMargin) {
     val addCname = AddChangeForValidation(
       validZone,
       "existing",
@@ -1653,11 +1557,7 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addCname.validNel, addPtr.validNel), ExistingRecordSets(List())),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1682,11 +1582,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1707,11 +1603,7 @@ class BatchChangeValidationsSpec
         ),
         okAuth,
         false,
-        None,
-        true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-        false,
-        VinylDNSTestHelpers.dottedHostsConfig
+        None
       )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1723,7 +1615,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should succeed for DeleteChangeForValidation
-      |if record set status is Active""".stripMargin) {
+             |if record set status is Active""".stripMargin) {
     val deleteA = DeleteRRSetChangeForValidation(
       validZone,
       "Active-record-status",
@@ -1741,18 +1633,14 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
   }
 
   property("""validateChangesWithContext: should succeed for DeleteChangeForValidation
-      |if user has group admin access"""".stripMargin) {
+             |if user has group admin access"""".stripMargin) {
     val deleteA =
       DeleteRRSetChangeForValidation(
         validZone,
@@ -1767,18 +1655,14 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
   }
 
   property(""" validateChangesWithContext: should fail for DeleteChangeForValidation
-      | if user is superUser with no other access""".stripMargin) {
+             | if user is superUser with no other access""".stripMargin) {
     val deleteA =
       DeleteRRSetChangeForValidation(
         validZone,
@@ -1793,11 +1677,7 @@ class BatchChangeValidationsSpec
       ),
       AuthPrincipal(superUser, Seq.empty),
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1828,11 +1708,7 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1855,11 +1731,7 @@ class BatchChangeValidationsSpec
       ),
       notAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should haveInvalid[DomainValidationError](
@@ -1873,7 +1745,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateChangesWithContext: should properly process batch that contains
-      |a CNAME and different type record with the same name""".stripMargin) {
+             |a CNAME and different type record with the same name""".stripMargin) {
     val addDuplicateA = AddChangeForValidation(
       okZone,
       "test",
@@ -1927,11 +1799,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -1980,11 +1848,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result.map(_ shouldBe valid)
   }
@@ -2027,11 +1891,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result.map(_ shouldBe valid)
   }
@@ -2061,11 +1921,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result.map(_ shouldBe valid)
   }
@@ -2103,11 +1959,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -2146,11 +1998,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result.map(_ shouldBe valid)
   }
@@ -2183,11 +2031,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result.map(_ shouldBe valid)
   }
@@ -2225,11 +2069,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result.map(_ shouldBe valid)
@@ -2343,11 +2183,7 @@ class BatchChangeValidationsSpec
         ChangeForValidationMap(List(addMX.validNel), ExistingRecordSets(List(existingMX))),
         okAuth,
         false,
-        None,
-        true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-        false,
-        VinylDNSTestHelpers.dottedHostsConfig
+        None
       )
     result(0) should haveInvalid[DomainValidationError](RecordAlreadyExists("name-conflict."))
   }
@@ -2370,11 +2206,7 @@ class BatchChangeValidationsSpec
       ChangeForValidationMap(List(addMx.validNel, addMx2.validNel), ExistingRecordSets(List())),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result(0) shouldBe valid
   }
@@ -2405,11 +2237,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
     result(0) shouldBe valid
   }
@@ -2438,11 +2266,7 @@ class BatchChangeValidationsSpec
       ),
       AuthPrincipal(okUser, Seq(abcGroup.id, okGroup.id)),
       false,
-      Some("some-owner-group-id"),
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      Some("some-owner-group-id")
     )
 
     result.foreach(_ shouldBe valid)
@@ -2472,11 +2296,7 @@ class BatchChangeValidationsSpec
       ),
       AuthPrincipal(okUser, Seq(abcGroup.id, okGroup.id)),
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -2505,11 +2325,7 @@ class BatchChangeValidationsSpec
       ),
       dummyAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) should
@@ -2533,11 +2349,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -2551,11 +2363,7 @@ class BatchChangeValidationsSpec
       ),
       sharedAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -2589,11 +2397,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      Some(okGroup.id),
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      Some(okGroup.id)
     )
 
     result(0) shouldBe valid
@@ -2638,11 +2442,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      Some(okGroup.id),
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      Some(okGroup.id)
     )
 
     result(0) shouldBe valid
@@ -2656,7 +2456,7 @@ class BatchChangeValidationsSpec
 
   property(
     """validateChangesWithContext: should fail validateAddWithContext with
-             |ZoneDiscoveryError if new record is dotted host but not a TXT record type""".stripMargin
+      |ZoneDiscoveryError if new record is dotted host but not a TXT record type""".stripMargin
   ) {
     val addA = AddChangeForValidation(
       okZone,
@@ -2701,11 +2501,7 @@ class BatchChangeValidationsSpec
         ),
         okAuth,
         false,
-        None,
-        true,
-        VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-        false,
-        VinylDNSTestHelpers.dottedHostsConfig
+        None
       )
 
     result(0) should haveInvalid[DomainValidationError](ZoneDiscoveryError("dotted.a.ok."))
@@ -2759,11 +2555,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid
@@ -2865,11 +2657,7 @@ class BatchChangeValidationsSpec
       ),
       okAuth,
       false,
-      None,
-      true,
-      VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
-      false,
-      VinylDNSTestHelpers.dottedHostsConfig
+      None
     )
 
     result(0) shouldBe valid

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -83,6 +83,7 @@ class RecordSetServiceSpec
     mockBackendResolver,
     false,
     VinylDNSTestHelpers.highValueDomainConfig,
+    VinylDNSTestHelpers.dottedHostsConfig,
     VinylDNSTestHelpers.approvedNameServers,
     true
   )
@@ -101,6 +102,7 @@ class RecordSetServiceSpec
     mockBackendResolver,
     true,
     VinylDNSTestHelpers.highValueDomainConfig,
+    VinylDNSTestHelpers.dottedHostsConfig,
     VinylDNSTestHelpers.approvedNameServers,
     true
   )
@@ -165,6 +167,18 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, record.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name + "." + okZone.name))
 
       val result = leftResultOf(underTest.addRecordSet(record, okAuth).value)
       result shouldBe an[InvalidRequest]

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -128,21 +128,20 @@ class RecordSetServiceSpec
   )
 
   def getDottedHostsConfigGroupsAllowed(zone: Zone, config: DottedHostsConfig): List[String] = {
-    val configZones = config.authMethods.map {
-      case x: AuthConfigs => x.zone
-    }
+    val configZones = config.authConfigs.map(x => x.zone)
     val zoneName = if(zone.name.takeRight(1) != ".") zone.name + "." else zone.name
     val dottedZoneConfig = configZones.filter(_.contains("*")).map(_.replace("*", "[A-Za-z.]*"))
     val isContainWildcardZone = dottedZoneConfig.exists(x => zoneName.substring(0, zoneName.length - 1).matches(x))
     val isContainNormalZone = configZones.contains(zoneName)
     val groups = if (isContainWildcardZone || isContainNormalZone) {
-      config.authMethods.flatMap {
-        case x: AuthConfigs => if (x.zone.contains("*")) {
-          val wildcardZone = x.zone.replace("*", "[A-Za-z.]*")
-          if (zoneName.substring(0, zoneName.length - 1).matches(wildcardZone)) x.allowedGroupList else List.empty
-        } else {
-          if (x.zone == zoneName) x.allowedGroupList else List.empty
-        }
+      config.authConfigs.flatMap {
+        x: AuthConfigs =>
+          if (x.zone.contains("*")) {
+            val wildcardZone = x.zone.replace("*", "[A-Za-z.]*")
+            if (zoneName.substring(0, zoneName.length - 1).matches(wildcardZone)) x.allowedGroupList else List.empty
+          } else {
+            if (x.zone == zoneName) x.allowedGroupList else List.empty
+          }
       }
     }
     else {
@@ -151,9 +150,7 @@ class RecordSetServiceSpec
     groups
   }
 
-  val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authMethods.map {
-    case y:AuthConfigs => y.zone
-  }
+  val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authConfigs.map(x => x.zone)
 
   val dottedHostsConfigGroupsAllowed: List[String] = getDottedHostsConfigGroupsAllowed(okZone, VinylDNSTestHelpers.dottedHostsConfig)
 
@@ -563,9 +560,7 @@ class RecordSetServiceSpec
     val record =
       cname.copy(name = "new.name", zoneId = dottedZone.id, status = RecordSetStatus.Active)
 
-    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authMethods.map {
-      case y:AuthConfigs => y.zone
-    }
+    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authConfigs.map(x => x.zone)
 
     val dottedHostsConfigGroupsAllowed: List[String] = getDottedHostsConfigGroupsAllowed(dottedZone, VinylDNSTestHelpers.dottedHostsConfig)
 
@@ -609,9 +604,7 @@ class RecordSetServiceSpec
     val record =
       cname.copy(name = "new.name", zoneId = xyzZone.id, status = RecordSetStatus.Active)
 
-    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authMethods.map {
-      case y:AuthConfigs => y.zone
-    }
+    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authConfigs.map(x => x.zone)
 
     val dottedHostsConfigGroupsAllowed: List[String] = getDottedHostsConfigGroupsAllowed(xyzZone, VinylDNSTestHelpers.dottedHostsConfig)
 
@@ -691,9 +684,7 @@ class RecordSetServiceSpec
     val record =
       cname.copy(name = "new.name", zoneId = abcZone.id, status = RecordSetStatus.Active)
 
-    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authMethods.map {
-      case y:AuthConfigs => y.zone
-    }
+    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authConfigs.map(x => x.zone)
 
     val dottedHostsConfigGroupsAllowed: List[String] = getDottedHostsConfigGroupsAllowed(abcZone, VinylDNSTestHelpers.dottedHostsConfig)
 
@@ -734,7 +725,7 @@ class RecordSetServiceSpec
     val record =
       aaaa.copy(name = "new.name", zoneId = dottedZone.id, status = RecordSetStatus.Active)
 
-    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authMethods.map {
+    val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authConfigs.map {
       case y:AuthConfigs => y.zone
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -286,7 +286,7 @@ class RecordSetServiceSpec
         .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
       doReturn(IO.pure(Set()))
         .when(mockGroupRepo)
-        .getGroupsByName(Set.empty)
+        .getGroupsByName(dottedHostsConfigGroupsAllowed.toSet)
       doReturn(IO.pure(ListUsersResults(Seq(), None)))
         .when(mockUserRepo)
         .getUsers(Set.empty, None, None)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -132,6 +132,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange =
         rightResultOf(
@@ -197,6 +203,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result = leftResultOf(underTest.addRecordSet(record, okAuth).value)
       result shouldBe an[InvalidRequest]
@@ -226,6 +238,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result =
         leftResultOf(underTestWithDnsBackendValidations.addRecordSet(record, okAuth).value)
@@ -266,6 +284,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.addRecordSet(record, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -299,6 +323,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.addRecordSet(record, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -351,6 +381,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.addRecordSet(record, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -419,6 +455,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange =
         rightResultOf(
@@ -463,6 +505,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -514,6 +562,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -568,6 +622,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -605,6 +665,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -642,6 +708,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -792,6 +864,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result = rightResultOf(
         underTest.updateRecordSet(newRecord, auth).map(_.asInstanceOf[RecordSetChange]).value
@@ -836,6 +914,12 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Set()))
         .when(mockZoneRepo)
         .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(Set()))
+        .when(mockGroupRepo)
+        .getGroupsByName(VinylDNSTestHelpers.dottedHostsConfig.allowedGroupList.toSet)
+      doReturn(IO.pure(ListUsersResults(Seq(), None)))
+        .when(mockUserRepo)
+        .getUsers(Set.empty, None, None)
 
       val result = rightResultOf(
         underTest.updateRecordSet(newRecord, auth).map(_.asInstanceOf[RecordSetChange]).value

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -138,9 +138,9 @@ class RecordSetServiceSpec
         x: ZoneAuthConfigs =>
           if (x.zone.contains("*")) {
             val wildcardZone = x.zone.replace("*", "[A-Za-z.]*")
-            if (zoneName.substring(0, zoneName.length - 1).matches(wildcardZone)) x.allowedGroupList else List.empty
+            if (zoneName.substring(0, zoneName.length - 1).matches(wildcardZone)) x.groupList else List.empty
           } else {
-            if (x.zone == zoneName) x.allowedGroupList else List.empty
+            if (x.zone == zoneName) x.groupList else List.empty
           }
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -117,6 +117,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, record.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
 
       val result: RecordSetChange =
         rightResultOf(
@@ -157,7 +172,7 @@ class RecordSetServiceSpec
       val result = leftResultOf(underTest.addRecordSet(aaaa, okAuth).value)
       result shouldBe a[RecordSetAlreadyExists]
     }
-    "fail if the record is dotted" in {
+    "fail if the record is dotted and zone is not in the dotted hosts config allowed zones" in {
       val record =
         aaaa.copy(name = "new.name", zoneId = okZone.id, status = RecordSetStatus.Active)
 
@@ -179,6 +194,9 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByFQDNs(Set(record.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result = leftResultOf(underTest.addRecordSet(record, okAuth).value)
       result shouldBe an[InvalidRequest]
@@ -193,6 +211,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, record.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result =
         leftResultOf(underTestWithDnsBackendValidations.addRecordSet(record, okAuth).value)
@@ -218,6 +251,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, record.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result: RecordSetChange = rightResultOf(
         underTest.addRecordSet(record, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -236,6 +284,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, record.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(record.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result: RecordSetChange = rightResultOf(
         underTest.addRecordSet(record, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -273,6 +336,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Some(okGroup)))
         .when(mockGroupRepo)
         .getGroup(okGroup.id)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
 
       val result: RecordSetChange = rightResultOf(
         underTest.addRecordSet(record, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -326,6 +404,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, record.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(record.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(record.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
 
       val result: RecordSetChange =
         rightResultOf(
@@ -355,6 +448,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, newRecord.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -391,6 +499,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, newRecord.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -430,6 +553,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, newRecord.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -452,6 +590,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, newRecord.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -474,6 +627,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List()))
         .when(mockRecordRepo)
         .getRecordSetsByName(okZone.id, newRecord.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(newRecord.name.split('.').map(x => x + "." + okZone.name).toSet)
 
       val result: RecordSetChange = rightResultOf(
         underTest.updateRecordSet(newRecord, okAuth).map(_.asInstanceOf[RecordSetChange]).value
@@ -609,6 +777,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Some(oneUserDummyGroup)))
         .when(mockGroupRepo)
         .getGroup(oneUserDummyGroup.id)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
 
       val result = rightResultOf(
         underTest.updateRecordSet(newRecord, auth).map(_.asInstanceOf[RecordSetChange]).value
@@ -638,6 +821,21 @@ class RecordSetServiceSpec
       doReturn(IO.pure(List(oldRecord)))
         .when(mockRecordRepo)
         .getRecordSetsByName(zone.id, newRecord.name)
+      doReturn(IO.pure(Set(dottedZone)))
+        .when(mockZoneRepo)
+        .getZonesByNames(VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
+      doReturn(IO.pure(None))
+        .when(mockZoneRepo)
+        .getZoneByName(newRecord.name + "." + okZone.name)
+      doReturn(IO.pure(List()))
+        .when(mockRecordRepo)
+        .getRecordSetsByFQDNs(Set(newRecord.name + "." + okZone.name))
+      doReturn(IO.pure(Set()))
+        .when(mockZoneRepo)
+        .getZonesByFilters(Set.empty)
 
       val result = rightResultOf(
         underTest.updateRecordSet(newRecord, auth).map(_.asInstanceOf[RecordSetChange]).value

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -25,7 +25,6 @@ import vinyldns.core.domain.record.RecordType._
 import vinyldns.api.domain.zone.{InvalidGroupError, InvalidRequest, PendingUpdateError, RecordSetAlreadyExists, RecordSetValidation}
 import vinyldns.api.ResultHelpers
 import vinyldns.api.VinylDNSTestHelpers
-import vinyldns.api.config.AuthConfigs
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
 import vinyldns.core.TestMembershipData._
@@ -45,9 +44,7 @@ class RecordSetValidationsSpec
 
   import RecordSetValidations._
 
-  val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authMethods.map {
-    case y:AuthConfigs => y.zone
-  }
+  val dottedHostsConfigZonesAllowed: List[String] = VinylDNSTestHelpers.dottedHostsConfig.authConfigs.map(x => x.zone)
 
   "RecordSetValidations" should {
     "validRecordTypes" should {

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -197,12 +197,6 @@ class RecordSetValidationsSpec
         leftValue(isDotted(test, okZone, None, true, false)) shouldBe an[InvalidRequest]
       }
 
-      "return a failure for a dotted record name that matches the zone name" in {
-        val test = aaaa.copy(name = "ok.www.comcast.net")
-        val zone = okZone.copy(name = "ok.www.comcast.net")
-        leftValue(isDotted(test, zone, None, true, true)) shouldBe an[InvalidRequest]
-      }
-
       "return success for a dotted record if it does not already have a record or zone with same name and user is allowed" in {
         val test = aaaa.copy(name = "this.passes")
         isDotted(test, okZone, None, true, true) should be(right)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -189,19 +189,19 @@ class RecordSetValidationsSpec
         val dottedARecord = rsOk.copy(name = "this.is.a.failure.")
         "return a failure for any new record with dotted hosts in forward zones" in {
           leftValue(
-            typeSpecificValidations(dottedARecord, List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+            typeSpecificValidations(dottedARecord, List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false)
           ) shouldBe an[InvalidRequest]
         }
 
         "return a failure for any new record with dotted hosts in forward zones (CNAME)" in {
           leftValue(
-            typeSpecificValidations(dottedARecord.copy(typ = CNAME), List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+            typeSpecificValidations(dottedARecord.copy(typ = CNAME), List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false)
           ) shouldBe an[InvalidRequest]
         }
 
         "return a failure for any new record with dotted hosts in forward zones (NS)" in {
           leftValue(
-            typeSpecificValidations(dottedARecord.copy(typ = NS), List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
+            typeSpecificValidations(dottedARecord.copy(typ = NS), List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false)
           ) shouldBe an[InvalidRequest]
         }
 
@@ -213,7 +213,8 @@ class RecordSetValidationsSpec
             Some(dottedARecord.copy(ttl = 300)),
             Nil,
             true,
-            VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+            VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+            false
           ) should be(right)
         }
 
@@ -226,7 +227,8 @@ class RecordSetValidationsSpec
             Some(dottedCNAMERecord.copy(ttl = 300)),
             Nil,
             true,
-            VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+            VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+            false
           ) should be(right)
         }
 
@@ -240,7 +242,8 @@ class RecordSetValidationsSpec
               Some(dottedNSRecord.copy(ttl = 300)),
               Nil,
               true,
-              VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
+              VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet,
+              false
             )
           ) shouldBe an[InvalidRequest]
         }
@@ -251,35 +254,35 @@ class RecordSetValidationsSpec
           val test = srv.copy(name = "_sip._tcp.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
         "return success for an SRV record following convention without FQDN" in {
           val test = srv.copy(name = "_sip._tcp")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
         "return success for an SRV record following convention with a record name" in {
           val test = srv.copy(name = "_sip._tcp.foo.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
         "return success on a wildcard SRV that follows convention" in {
           val test = srv.copy(name = "*._tcp.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
         "return success on a wildcard in second position SRV that follows convention" in {
           val test = srv.copy(name = "_sip._*.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
       }
       "Skip dotted checks on NAPTR" should {
@@ -287,21 +290,21 @@ class RecordSetValidationsSpec
           val test = naptr.copy(name = "sub.naptr.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
         "return success for an NAPTR record without FQDN" in {
           val test = naptr.copy(name = "sub.naptr")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
         "return success on a wildcard NAPTR" in {
           val test = naptr.copy(name = "*.sub.naptr.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
       }
@@ -310,7 +313,7 @@ class RecordSetValidationsSpec
           val test = ptrIp4.copy(name = "10.1.2.")
           val zone = zoneIp4.copy(name = "198.in-addr.arpa.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
       }
       "Skip dotted checks on TXT" should {
@@ -318,7 +321,7 @@ class RecordSetValidationsSpec
           val test = txt.copy(name = "sub.txt.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
 
       }
@@ -335,7 +338,7 @@ class RecordSetValidationsSpec
             List(SOAData(Fqdn("something"), "other", 1, 2, 3, 5, 6))
           )
 
-          typeSpecificValidations(test, List(), zoneIp4, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+          typeSpecificValidations(test, List(), zoneIp4, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
         }
       }
     }
@@ -348,29 +351,29 @@ class RecordSetValidationsSpec
           records = List(NSData(Fqdn("some.test.ns.")))
         )
 
-        nsValidations(valid, okZone, None, List(new Regex(".*")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+        nsValidations(valid, okZone, None, List(new Regex(".*")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
       }
 
       "return an InvalidRequest if an NS record is '@'" in {
-        val error = leftValue(nsValidations(invalidNsApexRs, okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(nsValidations(invalidNsApexRs, okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if an NS record is the same as the zone" in {
         val invalid = invalidNsApexRs.copy(name = okZone.name)
-        val error = leftValue(nsValidations(invalid, okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(nsValidations(invalid, okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if the NS record being updated is '@'" in {
         val valid = invalidNsApexRs.copy(name = "this-is-not-origin-mate")
-        val error = leftValue(nsValidations(valid, okZone, Some(invalidNsApexRs), Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(nsValidations(valid, okZone, Some(invalidNsApexRs), Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if an NS record data is not in the approved server list" in {
         val ns = invalidNsApexRs.copy(records = List(NSData(Fqdn("not.approved."))))
-        val error = leftValue(nsValidations(ns, okZone, None, List(new Regex("not.*")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(nsValidations(ns, okZone, None, List(new Regex("not.*")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
     }
@@ -378,25 +381,25 @@ class RecordSetValidationsSpec
     "DSValidations" should {
       val matchingNs = ns.copy(zoneId = ds.zoneId, name = ds.name, ttl = ds.ttl)
       "return ok if the record is non-origin DS with matching NS" in {
-        dsValidations(ds, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+        dsValidations(ds, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
       }
       "return an InvalidRequest if a DS record is '@'" in {
         val apex = ds.copy(name = "@")
-        val error = leftValue(dsValidations(apex, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(dsValidations(apex, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a DS record is the same as the zone" in {
         val apex = ds.copy(name = okZone.name)
-        val error = leftValue(dsValidations(apex, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(dsValidations(apex, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if there is no NS matching the record" in {
-        val error = leftValue(dsValidations(ds, List(), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(dsValidations(ds, List(), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if the DS is dotted" in {
         val error =
-          leftValue(dsValidations(ds.copy(name = "test.dotted"), List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+          leftValue(dsValidations(ds.copy(name = "test.dotted"), List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
     }
@@ -404,51 +407,51 @@ class RecordSetValidationsSpec
     "CnameValidations" should {
       val invalidCnameApexRs: RecordSet = cname.copy(name = "@")
       "return a RecordSetAlreadyExistsError if a record with the same name exists and creating a cname" in {
-        val error = leftValue(cnameValidations(cname, List(aaaa), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(cnameValidations(cname, List(aaaa), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe a[RecordSetAlreadyExists]
       }
       "return ok if name is not '@'" in {
-        cnameValidations(cname, List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
+        cnameValidations(cname, List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(right)
       }
       "return an InvalidRequest if a cname record set name is '@'" in {
-        val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone, None,  true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone, None,  true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is same as zone" in {
         val invalid = invalidCnameApexRs.copy(name = okZone.name)
-        val error = leftValue(cnameValidations(invalid, List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(cnameValidations(invalid, List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is dotted" in {
-        val error = leftValue(cnameValidations(cname.copy(name = "dot.ted"), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(cnameValidations(cname.copy(name = "dot.ted"), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return ok if new recordset name does not contain dot" in {
-        cnameValidations(cname, List(), okZone, Some(cname.copy(name = "not-dotted")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(
+        cnameValidations(cname, List(), okZone, Some(cname.copy(name = "not-dotted")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(
           right
         )
       }
       "return ok if dotted host name doesn't change" in {
         val newRecord = cname.copy(name = "dot.ted", ttl = 500)
-        cnameValidations(newRecord, List(), okZone, Some(newRecord.copy(ttl = 300)), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(
+        cnameValidations(newRecord, List(), okZone, Some(newRecord.copy(ttl = 300)), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(
           right
         )
       }
       "return an InvalidRequest if a cname record set name is updated to '@'" in {
-        val error = leftValue(cnameValidations(cname.copy(name = "@"), List(), okZone, Some(cname), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(cnameValidations(cname.copy(name = "@"), List(), okZone, Some(cname), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if updated cname record set name is same as zone" in {
         val error =
-          leftValue(cnameValidations(cname.copy(name = okZone.name), List(), okZone, Some(cname), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+          leftValue(cnameValidations(cname.copy(name = okZone.name), List(), okZone, Some(cname), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[InvalidRequest]
       }
       "return an RecordSetValidation error if recordset data contain more than one sequential '.'" in {
-        val error = leftValue(cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record..zone")))), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
+        val error = leftValue(cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record..zone")))), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false))
         error shouldBe an[RecordSetValidation]
       }
       "return ok if recordset data does not contain sequential '.'" in {
-        cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record.zone")))), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(
+        cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record.zone")))), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet, false) should be(
           right
         )
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -189,19 +189,19 @@ class RecordSetValidationsSpec
         val dottedARecord = rsOk.copy(name = "this.is.a.failure.")
         "return a failure for any new record with dotted hosts in forward zones" in {
           leftValue(
-            typeSpecificValidations(dottedARecord, List(), okZone, None, Nil)
+            typeSpecificValidations(dottedARecord, List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
           ) shouldBe an[InvalidRequest]
         }
 
         "return a failure for any new record with dotted hosts in forward zones (CNAME)" in {
           leftValue(
-            typeSpecificValidations(dottedARecord.copy(typ = CNAME), List(), okZone, None, Nil)
+            typeSpecificValidations(dottedARecord.copy(typ = CNAME), List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
           ) shouldBe an[InvalidRequest]
         }
 
         "return a failure for any new record with dotted hosts in forward zones (NS)" in {
           leftValue(
-            typeSpecificValidations(dottedARecord.copy(typ = NS), List(), okZone, None, Nil)
+            typeSpecificValidations(dottedARecord.copy(typ = NS), List(), okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet)
           ) shouldBe an[InvalidRequest]
         }
 
@@ -211,7 +211,9 @@ class RecordSetValidationsSpec
             List(),
             okZone,
             Some(dottedARecord.copy(ttl = 300)),
-            Nil
+            Nil,
+            true,
+            VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
           ) should be(right)
         }
 
@@ -222,7 +224,9 @@ class RecordSetValidationsSpec
             List(),
             okZone,
             Some(dottedCNAMERecord.copy(ttl = 300)),
-            Nil
+            Nil,
+            true,
+            VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
           ) should be(right)
         }
 
@@ -234,7 +238,9 @@ class RecordSetValidationsSpec
               List(),
               okZone,
               Some(dottedNSRecord.copy(ttl = 300)),
-              Nil
+              Nil,
+              true,
+              VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet
             )
           ) shouldBe an[InvalidRequest]
         }
@@ -245,35 +251,35 @@ class RecordSetValidationsSpec
           val test = srv.copy(name = "_sip._tcp.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
         "return success for an SRV record following convention without FQDN" in {
           val test = srv.copy(name = "_sip._tcp")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
         "return success for an SRV record following convention with a record name" in {
           val test = srv.copy(name = "_sip._tcp.foo.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
         "return success on a wildcard SRV that follows convention" in {
           val test = srv.copy(name = "*._tcp.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
         "return success on a wildcard in second position SRV that follows convention" in {
           val test = srv.copy(name = "_sip._*.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
       }
       "Skip dotted checks on NAPTR" should {
@@ -281,21 +287,21 @@ class RecordSetValidationsSpec
           val test = naptr.copy(name = "sub.naptr.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
         "return success for an NAPTR record without FQDN" in {
           val test = naptr.copy(name = "sub.naptr")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
         "return success on a wildcard NAPTR" in {
           val test = naptr.copy(name = "*.sub.naptr.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
       }
@@ -304,7 +310,7 @@ class RecordSetValidationsSpec
           val test = ptrIp4.copy(name = "10.1.2.")
           val zone = zoneIp4.copy(name = "198.in-addr.arpa.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
       }
       "Skip dotted checks on TXT" should {
@@ -312,7 +318,7 @@ class RecordSetValidationsSpec
           val test = txt.copy(name = "sub.txt.example.com.")
           val zone = okZone.copy(name = "example.com.")
 
-          typeSpecificValidations(test, List(), zone, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
 
       }
@@ -329,7 +335,7 @@ class RecordSetValidationsSpec
             List(SOAData(Fqdn("something"), "other", 1, 2, 3, 5, 6))
           )
 
-          typeSpecificValidations(test, List(), zoneIp4, None, Nil) should be(right)
+          typeSpecificValidations(test, List(), zoneIp4, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
         }
       }
     }
@@ -342,29 +348,29 @@ class RecordSetValidationsSpec
           records = List(NSData(Fqdn("some.test.ns.")))
         )
 
-        nsValidations(valid, okZone, None, List(new Regex(".*"))) should be(right)
+        nsValidations(valid, okZone, None, List(new Regex(".*")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
       }
 
       "return an InvalidRequest if an NS record is '@'" in {
-        val error = leftValue(nsValidations(invalidNsApexRs, okZone, None, Nil))
+        val error = leftValue(nsValidations(invalidNsApexRs, okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if an NS record is the same as the zone" in {
         val invalid = invalidNsApexRs.copy(name = okZone.name)
-        val error = leftValue(nsValidations(invalid, okZone, None, Nil))
+        val error = leftValue(nsValidations(invalid, okZone, None, Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if the NS record being updated is '@'" in {
         val valid = invalidNsApexRs.copy(name = "this-is-not-origin-mate")
-        val error = leftValue(nsValidations(valid, okZone, Some(invalidNsApexRs), Nil))
+        val error = leftValue(nsValidations(valid, okZone, Some(invalidNsApexRs), Nil, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
 
       "return an InvalidRequest if an NS record data is not in the approved server list" in {
         val ns = invalidNsApexRs.copy(records = List(NSData(Fqdn("not.approved."))))
-        val error = leftValue(nsValidations(ns, okZone, None, List(new Regex("not.*"))))
+        val error = leftValue(nsValidations(ns, okZone, None, List(new Regex("not.*")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
     }
@@ -372,25 +378,25 @@ class RecordSetValidationsSpec
     "DSValidations" should {
       val matchingNs = ns.copy(zoneId = ds.zoneId, name = ds.name, ttl = ds.ttl)
       "return ok if the record is non-origin DS with matching NS" in {
-        dsValidations(ds, List(matchingNs), okZone) should be(right)
+        dsValidations(ds, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
       }
       "return an InvalidRequest if a DS record is '@'" in {
         val apex = ds.copy(name = "@")
-        val error = leftValue(dsValidations(apex, List(matchingNs), okZone))
+        val error = leftValue(dsValidations(apex, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a DS record is the same as the zone" in {
         val apex = ds.copy(name = okZone.name)
-        val error = leftValue(dsValidations(apex, List(matchingNs), okZone))
+        val error = leftValue(dsValidations(apex, List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if there is no NS matching the record" in {
-        val error = leftValue(dsValidations(ds, List(), okZone))
+        val error = leftValue(dsValidations(ds, List(), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if the DS is dotted" in {
         val error =
-          leftValue(dsValidations(ds.copy(name = "test.dotted"), List(matchingNs), okZone))
+          leftValue(dsValidations(ds.copy(name = "test.dotted"), List(matchingNs), okZone, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
     }
@@ -398,51 +404,51 @@ class RecordSetValidationsSpec
     "CnameValidations" should {
       val invalidCnameApexRs: RecordSet = cname.copy(name = "@")
       "return a RecordSetAlreadyExistsError if a record with the same name exists and creating a cname" in {
-        val error = leftValue(cnameValidations(cname, List(aaaa), okZone))
+        val error = leftValue(cnameValidations(cname, List(aaaa), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe a[RecordSetAlreadyExists]
       }
       "return ok if name is not '@'" in {
-        cnameValidations(cname, List(), okZone) should be(right)
+        cnameValidations(cname, List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(right)
       }
       "return an InvalidRequest if a cname record set name is '@'" in {
-        val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone))
+        val error = leftValue(cnameValidations(invalidCnameApexRs, List(), okZone, None,  true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is same as zone" in {
         val invalid = invalidCnameApexRs.copy(name = okZone.name)
-        val error = leftValue(cnameValidations(invalid, List(), okZone))
+        val error = leftValue(cnameValidations(invalid, List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if a cname record set name is dotted" in {
-        val error = leftValue(cnameValidations(cname.copy(name = "dot.ted"), List(), okZone))
+        val error = leftValue(cnameValidations(cname.copy(name = "dot.ted"), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return ok if new recordset name does not contain dot" in {
-        cnameValidations(cname, List(), okZone, Some(cname.copy(name = "not-dotted"))) should be(
+        cnameValidations(cname, List(), okZone, Some(cname.copy(name = "not-dotted")), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(
           right
         )
       }
       "return ok if dotted host name doesn't change" in {
         val newRecord = cname.copy(name = "dot.ted", ttl = 500)
-        cnameValidations(newRecord, List(), okZone, Some(newRecord.copy(ttl = 300))) should be(
+        cnameValidations(newRecord, List(), okZone, Some(newRecord.copy(ttl = 300)), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(
           right
         )
       }
       "return an InvalidRequest if a cname record set name is updated to '@'" in {
-        val error = leftValue(cnameValidations(cname.copy(name = "@"), List(), okZone, Some(cname)))
+        val error = leftValue(cnameValidations(cname.copy(name = "@"), List(), okZone, Some(cname), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an InvalidRequest if updated cname record set name is same as zone" in {
         val error =
-          leftValue(cnameValidations(cname.copy(name = okZone.name), List(), okZone, Some(cname)))
+          leftValue(cnameValidations(cname.copy(name = okZone.name), List(), okZone, Some(cname), true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[InvalidRequest]
       }
       "return an RecordSetValidation error if recordset data contain more than one sequential '.'" in {
-        val error = leftValue(cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record..zone")))), List(), okZone))
+        val error = leftValue(cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record..zone")))), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet))
         error shouldBe an[RecordSetValidation]
       }
       "return ok if recordset data does not contain sequential '.'" in {
-        cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record.zone")))), List(), okZone) should be(
+        cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("record.zone")))), List(), okZone, None, true, VinylDNSTestHelpers.dottedHostsConfig.zoneList.toSet) should be(
           right
         )
       }

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -111,6 +111,8 @@ trait EmptyGroupRepo extends GroupRepository {
 
   def getGroups(groupIds: Set[String]): IO[Set[Group]] = IO.pure(Set())
 
+  def getGroupsByName(groupNames: Set[String]): IO[Set[Group]] = IO.pure(Set())
+
   def getGroupByName(groupName: String): IO[Option[Group]] = IO.pure(None)
 
   def getAllGroups(): IO[Set[Group]] = IO.pure(Set())

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -109,10 +109,10 @@ final case class ZoneDiscoveryError(name: String, fatal: Boolean = false)
       "If zone exists, then it must be connected to in VinylDNS."
 }
 
-final case class DottedHostError(name: String, rsType: String) extends DomainValidationError {
+final case class DottedHostError(name: String, zone: String) extends DomainValidationError {
   def message: String =
-    s"Record with name $name and type $rsType already exists. " +
-      s"Please check the record and zone that's already present and make the change there."
+    s"Record with fqdn '$name.$zone' cannot be created. " +
+      s"Please check if there's a zone or record that already exist and make the change there."
 }
 
 final case class RecordAlreadyExists(name: String) extends DomainValidationError {

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -121,12 +121,6 @@ final case class ZoneDiscoveryError(name: String, fatal: Boolean = false)
       "If zone exists, then it must be connected to in VinylDNS."
 }
 
-final case class DottedHostError(name: String, zone: String) extends DomainValidationError {
-  def message: String =
-    s"Record with fqdn '$name.$zone' cannot be created. " +
-      s"Please check if user has permission or if there's a zone/record that already exist and make the change there."
-}
-
 final case class RecordAlreadyExists(name: String) extends DomainValidationError {
   def message: String =
     s"""Record "$name" Already Exists: cannot add an existing record; to update it, """ +

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -109,6 +109,12 @@ final case class ZoneDiscoveryError(name: String, fatal: Boolean = false)
       "If zone exists, then it must be connected to in VinylDNS."
 }
 
+final case class DottedHostError(name: String, rsType: String) extends DomainValidationError {
+  def message: String =
+    s"Record with name $name and type $rsType already exists. " +
+      s"Please check the record and zone that's already present and make the change there."
+}
+
 final case class RecordAlreadyExists(name: String) extends DomainValidationError {
   def message: String =
     s"""Record "$name" Already Exists: cannot add an existing record; to update it, """ +

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -112,7 +112,7 @@ final case class ZoneDiscoveryError(name: String, fatal: Boolean = false)
 final case class DottedHostError(name: String, zone: String) extends DomainValidationError {
   def message: String =
     s"Record with fqdn '$name.$zone' cannot be created. " +
-      s"Please check if there's a zone or record that already exist and make the change there."
+      s"Please check if user has permission or if there's a zone/record that already exist and make the change there."
 }
 
 final case class RecordAlreadyExists(name: String) extends DomainValidationError {

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -32,7 +32,7 @@ object DomainValidationErrorType extends Enumeration {
   val ChangeLimitExceeded, BatchChangeIsEmpty, GroupDoesNotExist, NotAMemberOfOwnerGroup,
   InvalidDomainName, InvalidLength, InvalidEmail, InvalidRecordType, InvalidPortNumber,
   InvalidIpv4Address, InvalidIpv6Address, InvalidIPAddress, InvalidTTL, InvalidMxPreference,
-  InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
+  InvalidBatchRecordType, ZoneDiscoveryError, DottedHostError, RecordAlreadyExists, RecordDoesNotExist,
   CnameIsNotUniqueError, UserIsNotAuthorized, UserIsNotAuthorizedError, RecordNameNotUniqueInBatch,
   RecordInReverseZoneError, HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError,
   NewMultiRecordError, CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
@@ -57,6 +57,7 @@ object DomainValidationErrorType extends Enumeration {
       case _: InvalidMxPreference => InvalidMxPreference
       case _: InvalidBatchRecordType => InvalidBatchRecordType
       case _: ZoneDiscoveryError => ZoneDiscoveryError
+      case _: DottedHostError => DottedHostError
       case _: RecordAlreadyExists => RecordAlreadyExists
       case _: RecordDoesNotExist => RecordDoesNotExist
       case _: CnameIsNotUniqueError => CnameIsNotUniqueError

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -32,7 +32,7 @@ object DomainValidationErrorType extends Enumeration {
   val ChangeLimitExceeded, BatchChangeIsEmpty, GroupDoesNotExist, NotAMemberOfOwnerGroup,
   InvalidDomainName, InvalidCname, InvalidLength, InvalidEmail, InvalidRecordType, InvalidPortNumber,
   InvalidIpv4Address, InvalidIpv6Address, InvalidIPAddress, InvalidTTL, InvalidMxPreference,
-  InvalidBatchRecordType, ZoneDiscoveryError, DottedHostError, RecordAlreadyExists, RecordDoesNotExist,
+  InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
   CnameIsNotUniqueError, UserIsNotAuthorized, UserIsNotAuthorizedError, RecordNameNotUniqueInBatch,
   RecordInReverseZoneError, HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError,
   NewMultiRecordError, CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
@@ -58,7 +58,6 @@ object DomainValidationErrorType extends Enumeration {
       case _: InvalidMxPreference => InvalidMxPreference
       case _: InvalidBatchRecordType => InvalidBatchRecordType
       case _: ZoneDiscoveryError => ZoneDiscoveryError
-      case _: DottedHostError => DottedHostError
       case _: RecordAlreadyExists => RecordAlreadyExists
       case _: RecordDoesNotExist => RecordDoesNotExist
       case _: CnameIsNotUniqueError => CnameIsNotUniqueError

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupRepository.scala
@@ -31,6 +31,8 @@ trait GroupRepository extends Repository {
 
   def getGroups(groupIds: Set[String]): IO[Set[Group]]
 
+  def getGroupsByName(groupNames: Set[String]): IO[Set[Group]]
+
   def getGroupByName(groupName: String): IO[Option[Group]]
 
   def getAllGroups(): IO[Set[Group]]

--- a/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
@@ -36,6 +36,7 @@ object TestMembershipData {
 
   val dummyUser = User("dummyName", "dummyAccess", "dummySecret")
   val superUser = User("super", "superAccess", "superSecret", isSuper = true)
+  val xyzUser = User("xyz", "xyzAccess", "xyzSecret")
   val supportUser = User("support", "supportAccess", "supportSecret", isSupport = true)
   val lockedUser = User("locked", "lockedAccess", "lockedSecret", lockStatus = LockStatus.Locked)
   val sharedZoneUser = User("sharedZoneAdmin", "sharedAccess", "sharedSecret")

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -35,6 +35,7 @@ object TestZoneData {
     connection = testConnection
   )
   val dottedZone: Zone = Zone("dotted.xyz.", "dotted@xyz.com", adminGroupId = xyzGroup.id)
+  val dotZone: Zone = Zone("dot.xyz.", "dotted@xyz.com", adminGroupId = xyzGroup.id)
   val abcZone: Zone = Zone("abc.zone.recordsets.", "test@test.com", adminGroupId = abcGroup.id)
   val xyzZone: Zone = Zone("xyz.", "abc@xyz.com", adminGroupId = xyzGroup.id)
   val zoneIp4: Zone = Zone("0.162.198.in-addr.arpa.", "test@test.com", adminGroupId = abcGroup.id)

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -34,6 +34,7 @@ object TestZoneData {
     adminGroupId = okGroup.id,
     connection = testConnection
   )
+  val dottedZone: Zone = Zone("dotted.xyz", "dotted@xyz.com", adminGroupId = xyzGroup.id)
   val abcZone: Zone = Zone("abc.zone.recordsets.", "test@test.com", adminGroupId = abcGroup.id)
   val xyzZone: Zone = Zone("xyz.", "abc@xyz.com", adminGroupId = xyzGroup.id)
   val zoneIp4: Zone = Zone("0.162.198.in-addr.arpa.", "test@test.com", adminGroupId = abcGroup.id)

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -34,7 +34,7 @@ object TestZoneData {
     adminGroupId = okGroup.id,
     connection = testConnection
   )
-  val dottedZone: Zone = Zone("dotted.xyz", "dotted@xyz.com", adminGroupId = xyzGroup.id)
+  val dottedZone: Zone = Zone("dotted.xyz.", "dotted@xyz.com", adminGroupId = xyzGroup.id)
   val abcZone: Zone = Zone("abc.zone.recordsets.", "test@test.com", adminGroupId = abcGroup.id)
   val xyzZone: Zone = Zone("xyz.", "abc@xyz.com", adminGroupId = xyzGroup.id)
   val zoneIp4: Zone = Zone("0.162.198.in-addr.arpa.", "test@test.com", adminGroupId = abcGroup.id)

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -580,7 +580,9 @@ In the above, the dotted hosts can be created only in the zone `dummy.` and zone
 
 Also, it must satisfy the allowed users or group users and record type of the respective zone to create a dotted host.
 
-For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `allowed-record-type`
+For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `allowed-record-type`.
+And the user `professor` can't create a dotted host in the zone `dummy.` as the user is not in `allowed-user-list` or 
+`allowed-group-list`.
 
 The config can be left empty as follows if we don't want to use it:
 

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -536,7 +536,50 @@ v6-discovery-nibble-boundaries {
   min = 5
   max = 20
 }
+```
 
+### Dotted Hosts
+
+Configuration setting that determines the zones, users (either individual or based on group) and record types that are 
+allowed to create dotted hosts. If only all the above are satisfied, one can create a dotted host in VinylDNS.
+
+Note the following: 
+1. The config `type = "auth-configs"` is a default which shouldn't be changed.
+2. Zones defined in the `zone` must always end with a dot. Eg: `comcast.com.`
+3. Wildcard character `*` can be used in `zone` to allow dotted hosts for all zones matching it.
+4. Individual users who are allowed to create dotted hosts are added to the `allowed-user-list` using their username.
+5. A set of users in a group who are allowed to create dotted hosts are added to the `allowed-group-list` using group name.
+6. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
+
+```yaml
+# approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+dotted-hosts = {
+   allowed-settings = [
+      {
+      type = "auth-configs"
+      zone = "dummy."
+      allowed-user-list = ["testuser"]
+      allowed-group-list = ["dummy-group"]
+      allowed-record-type = ["AAAA"]
+      },
+      {
+      # for wildcard zones. Settings will be applied to all matching zones
+      type = "auth-configs"
+      zone = "*ent.com."
+      allowed-user-list = ["professor", "testuser"]
+      allowed-group-list = ["testing-group"]
+      allowed-record-type = ["A", "CNAME"]
+      }
+   ]
+}
+```
+
+The config can be left empty as follows if we don't want to use it:
+
+```yaml
+dotted-hosts = {
+   allowed-settings = []
+}
 ```
 
 ### Full Example Config
@@ -711,6 +754,27 @@ v6-discovery-nibble-boundaries {
         # Regional endpoint to make your requests (eg. 'us-west-2', 'us-east-1', etc.). This is the region where your SNS is housed.
         signing-region = "us-east-1"
      }
+  }
+
+  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  dotted-hosts = {
+     allowed-settings = [
+        {
+        type = "auth-configs"
+        zone = "dummy."
+        allowed-user-list = ["testuser"]
+        allowed-group-list = ["dummy-group"]
+        allowed-record-type = ["AAAA"]
+        },
+        {
+        # for wildcard zones. Settings will be applied to all matching zones
+        type = "auth-configs"
+        zone = "*ent.com."
+        allowed-user-list = ["professor", "testuser"]
+        allowed-group-list = ["testing-group"]
+        allowed-record-type = ["A", "CNAME"]
+        }
+     ]
   }
 
   # true if you want to enable manual review for non-fatal errors

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -546,18 +546,18 @@ allowed to create dotted hosts. If only all the above are satisfied, one can cre
 Note the following:
 1. Zones defined in the `zone` must always end with a dot. Eg: `comcast.com.`
 2. Wildcard character `*` can be used in `zone` to allow dotted hosts for all zones matching it.
-3. Individual users who are allowed to create dotted hosts are added to the `allowed-user-list` using their username.
-4. A set of users in a group who are allowed to create dotted hosts are added to the `allowed-group-list` using group name.
-5. If the user is either in `allowed-user-list` or `allowed-group-list`, they are allowed to create a dotted host. It is
-not necessary for the user to be in both `allowed-user-list` and `allowed-group-list`.
-6. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
-7. The number of dots allowed in a record name for a zone is given in `allowed-dots-limit`.
-8. If `allowed-user-list` is left empty (`allowed-user-list = []`), no user will be allowed to create dotted hosts unless 
-they're present in `allowed-group-list` and vice-versa. If both `allowed-user-list` and `allowed-group-list` is left empty
+3. Individual users who are allowed to create dotted hosts are added to the `user-list` using their username.
+4. A set of users in a group who are allowed to create dotted hosts are added to the `group-list` using group name.
+5. If the user is either in `user-list` or `group-list`, they are allowed to create a dotted host. It is
+not necessary for the user to be in both `user-list` and `group-list`.
+6. The record types which are allowed while creating a dotted host is added to the `record-types`.
+7. The number of dots allowed in a record name for a zone is given in `dots-limit`.
+8. If `user-list` is left empty (`user-list = []`), no user will be allowed to create dotted hosts unless 
+they're present in `group-list` and vice-versa. If both `user-list` and `group-list` is left empty
 no users will be allowed to create dotted hosts in that zone.
-9. If `allowed-record-type` is left empty (`allowed-record-type = []`), user cannot create dotted hosts of any record type
+9. If `record-types` is left empty (`record-types = []`), user cannot create dotted hosts of any record type
 in that zone.
-10. If `allowed-dots-limit` is set to 0 (`allowed-dots-limit = 0`), we cannot create dotted hosts record in that zone.
+10. If `dots-limit` is set to 0 (`dots-limit = 0`), we cannot create dotted hosts record in that zone.
 
 ```yaml
 # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
@@ -565,18 +565,18 @@ dotted-hosts = {
    allowed-settings = [
       {
       zone = "dummy."
-      allowed-user-list = ["testuser"]
-      allowed-group-list = ["dummy-group"]
-      allowed-record-type = ["AAAA"]
-      allowed-dots-limit = 3
+      user-list = ["testuser"]
+      group-list = ["dummy-group"]
+      record-types = ["AAAA"]
+      dots-limit = 3
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
       zone = "*ent.com."
-      allowed-user-list = ["professor", "testuser"]
-      allowed-group-list = ["testing-group"]
-      allowed-record-type = ["A", "CNAME"]
-      allowed-dots-limit = 3
+      user-list = ["professor", "testuser"]
+      group-list = ["testing-group"]
+      record-types = ["A", "CNAME"]
+      dots-limit = 3
       }
    ]
 }
@@ -586,9 +586,9 @@ In the above, the dotted hosts can be created only in the zone `dummy.` and zone
 
 Also, it must satisfy the allowed users or group users and record type of the respective zone to create a dotted host.
 
-For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `allowed-record-type`.
-And the user `professor` can't create a dotted host in the zone `dummy.` as the user is not in `allowed-user-list` or 
-`allowed-group-list` (not part of `dummy-group`).
+For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `record-types`.
+And the user `professor` can't create a dotted host in the zone `dummy.` as the user is not in `user-list` or 
+`group-list` (not part of `dummy-group`).
 
 The config can be left empty as follows if we don't want to use it:
 
@@ -777,18 +777,18 @@ dotted-hosts = {
      allowed-settings = [
         {
         zone = "dummy."
-        allowed-user-list = ["testuser"]
-        allowed-group-list = ["dummy-group"]
-        allowed-record-type = ["AAAA"]
-        allowed-dots-limit = 3
+        user-list = ["testuser"]
+        group-list = ["dummy-group"]
+        record-types = ["AAAA"]
+        dots-limit = 3
         },
         {
         # for wildcard zones. Settings will be applied to all matching zones
         zone = "*ent.com."
-        allowed-user-list = ["professor", "testuser"]
-        allowed-group-list = ["testing-group"]
-        allowed-record-type = ["A", "CNAME"]
-        allowed-dots-limit = 3
+        user-list = ["professor", "testuser"]
+        group-list = ["testing-group"]
+        record-types = ["A", "CNAME"]
+        dots-limit = 3
         }
      ]
   }

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -560,7 +560,7 @@ in that zone.
 10. If `dots-limit` is set to 0 (`dots-limit = 0`), we cannot create dotted hosts record in that zone.
 
 ```yaml
-# approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+# approved zones, individual users, users in groups, record types and no.of.dots that are allowed for dotted hosts
 dotted-hosts = {
    allowed-settings = [
       {
@@ -772,7 +772,7 @@ dotted-hosts = {
      }
   }
 
-  # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
+  # approved zones, individual users, users in groups, record types and no.of.dots that are allowed for dotted hosts
   dotted-hosts = {
      allowed-settings = [
         {

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -551,6 +551,7 @@ Note the following:
 5. If the user is either in `allowed-user-list` or `allowed-group-list`, they are allowed to create a dotted host. It is
 not necessary for the user to be in both `allowed-user-list` and `allowed-group-list`.
 6. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
+7. The number of dots allowed in a record name for a zone is given in `allowed-dots-limit`.
 
 ```yaml
 # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
@@ -561,6 +562,7 @@ dotted-hosts = {
       allowed-user-list = ["testuser"]
       allowed-group-list = ["dummy-group"]
       allowed-record-type = ["AAAA"]
+      allowed-dots-limit = 3
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
@@ -568,6 +570,7 @@ dotted-hosts = {
       allowed-user-list = ["professor", "testuser"]
       allowed-group-list = ["testing-group"]
       allowed-record-type = ["A", "CNAME"]
+      allowed-dots-limit = 3
       }
    ]
 }
@@ -771,6 +774,7 @@ dotted-hosts = {
         allowed-user-list = ["testuser"]
         allowed-group-list = ["dummy-group"]
         allowed-record-type = ["AAAA"]
+        allowed-dots-limit = 3
         },
         {
         # for wildcard zones. Settings will be applied to all matching zones
@@ -778,6 +782,7 @@ dotted-hosts = {
         allowed-user-list = ["professor", "testuser"]
         allowed-group-list = ["testing-group"]
         allowed-record-type = ["A", "CNAME"]
+        allowed-dots-limit = 3
         }
      ]
   }

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -543,22 +543,20 @@ v6-discovery-nibble-boundaries {
 Configuration setting that determines the zones, users (either individual or based on group) and record types that are 
 allowed to create dotted hosts. If only all the above are satisfied, one can create a dotted host in VinylDNS.
 
-Note the following: 
-1. The config `type = "auth-configs"` is a default which shouldn't be changed.
-2. Zones defined in the `zone` must always end with a dot. Eg: `comcast.com.`
-3. Wildcard character `*` can be used in `zone` to allow dotted hosts for all zones matching it.
-4. Individual users who are allowed to create dotted hosts are added to the `allowed-user-list` using their username.
-5. A set of users in a group who are allowed to create dotted hosts are added to the `allowed-group-list` using group name.
-6. If the user is either in `allowed-user-list` or `allowed-group-list`, they are allowed to create a dotted host. It is
+Note the following:
+1. Zones defined in the `zone` must always end with a dot. Eg: `comcast.com.`
+2. Wildcard character `*` can be used in `zone` to allow dotted hosts for all zones matching it.
+3. Individual users who are allowed to create dotted hosts are added to the `allowed-user-list` using their username.
+4. A set of users in a group who are allowed to create dotted hosts are added to the `allowed-group-list` using group name.
+5. If the user is either in `allowed-user-list` or `allowed-group-list`, they are allowed to create a dotted host. It is
 not necessary for the user to be in both `allowed-user-list` and `allowed-group-list`.
-7. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
+6. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
 
 ```yaml
 # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
 dotted-hosts = {
    allowed-settings = [
       {
-      type = "auth-configs"
       zone = "dummy."
       allowed-user-list = ["testuser"]
       allowed-group-list = ["dummy-group"]
@@ -566,7 +564,6 @@ dotted-hosts = {
       },
       {
       # for wildcard zones. Settings will be applied to all matching zones
-      type = "auth-configs"
       zone = "*ent.com."
       allowed-user-list = ["professor", "testuser"]
       allowed-group-list = ["testing-group"]
@@ -770,7 +767,6 @@ dotted-hosts = {
   dotted-hosts = {
      allowed-settings = [
         {
-        type = "auth-configs"
         zone = "dummy."
         allowed-user-list = ["testuser"]
         allowed-group-list = ["dummy-group"]
@@ -778,7 +774,6 @@ dotted-hosts = {
         },
         {
         # for wildcard zones. Settings will be applied to all matching zones
-        type = "auth-configs"
         zone = "*ent.com."
         allowed-user-list = ["professor", "testuser"]
         allowed-group-list = ["testing-group"]

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -549,7 +549,9 @@ Note the following:
 3. Wildcard character `*` can be used in `zone` to allow dotted hosts for all zones matching it.
 4. Individual users who are allowed to create dotted hosts are added to the `allowed-user-list` using their username.
 5. A set of users in a group who are allowed to create dotted hosts are added to the `allowed-group-list` using group name.
-6. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
+6. If the user is either in `allowed-user-list` or `allowed-group-list`, they are allowed to create a dotted host. It is
+not necessary for the user to be in both `allowed-user-list` and `allowed-group-list`.
+7. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
 
 ```yaml
 # approved zones, individual users, users in groups and record types that are allowed for dotted hosts
@@ -576,7 +578,7 @@ dotted-hosts = {
 
 In the above, the dotted hosts can be created only in the zone `dummy.` and zones matching `*ent.com.` (parent.com., child.parent.com.)
 
-Also, it must satisfy the allowed users, group users and record type of the respective zone to create a dotted host.
+Also, it must satisfy the allowed users or group users and record type of the respective zone to create a dotted host.
 
 For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `allowed-record-type`
 

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -574,6 +574,12 @@ dotted-hosts = {
 }
 ```
 
+In the above, the dotted hosts can be created only in the zone `dummy.` and zones matching `*ent.com.` (parent.com., child.parent.com.)
+
+Also, it must satisfy the allowed users, group users and record type of the respective zone to create a dotted host.
+
+For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `allowed-record-type`
+
 The config can be left empty as follows if we don't want to use it:
 
 ```yaml

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -579,7 +579,7 @@ Also, it must satisfy the allowed users or group users and record type of the re
 
 For eg, we can't create a dotted host with `CNAME` record type in the zone `dummy.` as it's not in `allowed-record-type`.
 And the user `professor` can't create a dotted host in the zone `dummy.` as the user is not in `allowed-user-list` or 
-`allowed-group-list`.
+`allowed-group-list` (not part of `dummy-group`).
 
 The config can be left empty as follows if we don't want to use it:
 

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -552,6 +552,12 @@ Note the following:
 not necessary for the user to be in both `allowed-user-list` and `allowed-group-list`.
 6. The record types which are allowed while creating a dotted host is added to the `allowed-record-type`.
 7. The number of dots allowed in a record name for a zone is given in `allowed-dots-limit`.
+8. If `allowed-user-list` is left empty (`allowed-user-list = []`), no user will be allowed to create dotted hosts unless 
+they're present in `allowed-group-list` and vice-versa. If both `allowed-user-list` and `allowed-group-list` is left empty
+no users will be allowed to create dotted hosts in that zone.
+9. If `allowed-record-type` is left empty (`allowed-record-type = []`), user cannot create dotted hosts of any record type
+in that zone.
+10. If `allowed-dots-limit` is set to 0 (`allowed-dots-limit = 0`), we cannot create dotted hosts record in that zone.
 
 ```yaml
 # approved zones, individual users, users in groups and record types that are allowed for dotted hosts

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
@@ -93,6 +93,24 @@ class MySqlGroupRepositoryIntegrationSpec
     }
   }
 
+  "MySqlGroupRepository.getGroupsByName" should {
+    "omits all non existing groups" in {
+      val result = repo.getGroupsByName(Set("no-existo", groups.head.name)).unsafeRunSync()
+      result should contain theSameElementsAs Set(groups.head)
+    }
+
+    "returns correct list of groups" in {
+      val names = Set(groups(0).name, groups(1).name, groups(2).name)
+      val result = repo.getGroupsByName(names).unsafeRunSync()
+      result should contain theSameElementsAs groups.take(3).toSet
+    }
+
+    "returns empty list when given no names" in {
+      val result = repo.getGroupsByName(Set[String]()).unsafeRunSync()
+      result should contain theSameElementsAs Set()
+    }
+  }
+
   "MySqlGroupRepository.getGroupByName" should {
     "retrieve a group" in {
       repo.getGroupByName(groups.head.name).unsafeRunSync() shouldBe Some(groups.head)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
@@ -69,6 +69,13 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
       | WHERE id
     """.stripMargin
 
+  private val BASE_GET_GROUPS_BY_NAMES =
+    """
+      |SELECT data
+      |  FROM groups
+      | WHERE name
+    """.stripMargin
+
   def save(db: DB, group: Group): IO[Group] =
     monitor("repo.Group.save") {
       IO {
@@ -133,6 +140,27 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
             val query = BASE_GET_GROUPS_BY_IDS + inClause
             SQL(query)
               .bind(groupIdList: _*)
+              .map(toGroup(1))
+              .list()
+              .apply()
+          }.toSet
+        }
+      }
+    }
+
+  def getGroupsByName(groupNames: Set[String]): IO[Set[Group]] =
+    monitor("repo.Group.getGroups") {
+      IO {
+        logger.debug(s"Getting group with names: $groupNames")
+        if (groupNames.isEmpty)
+          Set[Group]()
+        else {
+          DB.readOnly { implicit s =>
+            val groupNameList = groupNames.toList
+            val inClause = " IN (" + groupNameList.as("?").mkString(",") + ")"
+            val query = BASE_GET_GROUPS_BY_NAMES + inClause
+            SQL(query)
+              .bind(groupNameList: _*)
               .map(toGroup(1))
               .list()
               .apply()

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -122,7 +122,7 @@
                 <tr ng-repeat="(recordName, record) in records track by $index">
                     <td>
                         <div ng-if="record.isDotted && record.type != 'TXT' && record.type != 'SRV' && record.type != 'NAPTR'" class="text-danger wrap-long-text" data-toggle="tooltip" data-placement="top"
-                        title="Dotted hosts are invalid! Please delete or update without a '.'">
+                        title="This is a dotted host!">
                             {{record.name}} <span class="fa fa-warning" />
                         </div>
                         <div class="wrap-long-text" ng-if="!record.isDotted || (record.type != 'TXT' || record.type != 'SRV' || record.type != 'NAPTR')">


### PR DESCRIPTION
Changes in this pull request:
- Added a config with settings which are used to allow the creation of dotted hosts.
- Details about the config can be found in `modules/docs/src/main/mdoc/operator/config-api.md`.
