### PR TITLE
Refactor crypto be strongly typed

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/backend/dns/DnsBackendIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/backend/dns/DnsBackendIntegrationSpec.scala
@@ -21,14 +21,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import vinyldns.api.backend.dns.DnsProtocol.NoError
 import vinyldns.core.crypto.NoOpCrypto
-import vinyldns.core.domain.record.{
-  AData,
-  RecordSet,
-  RecordSetChange,
-  RecordSetChangeType,
-  RecordSetStatus,
-  RecordType
-}
+import vinyldns.core.domain.Encrypted
+import vinyldns.core.domain.record.{AData, RecordSet, RecordSetChange, RecordSetChangeType, RecordSetStatus, RecordType}
 import vinyldns.core.domain.zone.{Algorithm, Zone, ZoneConnection}
 
 class DnsBackendIntegrationSpec extends AnyWordSpec with Matchers {
@@ -36,7 +30,7 @@ class DnsBackendIntegrationSpec extends AnyWordSpec with Matchers {
   private val testConnection = ZoneConnection(
     "vinyldns.",
     "vinyldns.",
-    "nzisn+4G2ldMn0q1CV3vsg==",
+    Encrypted("nzisn+4G2ldMn0q1CV3vsg=="),
     sys.env.getOrElse("DEFAULT_DNS_ADDRESS", "127.0.0.1:19001"),
     Algorithm.HMAC_MD5
   )

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -34,7 +34,7 @@ import vinyldns.api.engine.TestMessageQueue
 import vinyldns.mysql.TransactionProvider
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData.testConnection
-import vinyldns.core.domain.{Fqdn, HighValueDomainError}
+import vinyldns.core.domain.{Encrypted, Fqdn, HighValueDomainError}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.backend.{Backend, BackendResolver}
 import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
@@ -63,8 +63,8 @@ class RecordSetServiceIntegrationSpec
 
   private var testRecordSetService: RecordSetServiceAlgebra = _
 
-  private val user = User("live-test-user", "key", "secret")
-  private val user2 = User("shared-record-test-user", "key-shared", "secret-shared")
+  private val user = User("live-test-user", "key", Encrypted("secret"))
+  private val user2 = User("shared-record-test-user", "key-shared", Encrypted("secret-shared"))
   private val group = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id))
   private val group2 = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id, user2.id))
   private val sharedGroup =

--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -62,9 +62,9 @@ class RecordSetServiceIntegrationSpec
 
   private var testRecordSetService: RecordSetServiceAlgebra = _
 
-  private val user = User("live-test-user", "key", "secret")
-  private val testUser = User("testuser", "key", "secret")
-  private val user2 = User("shared-record-test-user", "key-shared", "secret-shared")
+  private val user = User("live-test-user", "key", Encrypted("secret"))
+  private val testUser = User("testuser", "key", Encrypted("secret"))
+  private val user2 = User("shared-record-test-user", "key-shared", Encrypted("secret-shared"))
 
   private val group = Group(s"test-group", "test@test.com", adminUserIds = Set(user.id))
   private val dummyGroup = Group(s"dummy-group", "test@test.com", adminUserIds = Set(testUser.id))

--- a/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneViewLoaderIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/zone/ZoneViewLoaderIntegrationSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.xbill.DNS.ZoneTransferException
 import vinyldns.api.backend.dns.DnsBackend
 import vinyldns.api.config.VinylDNSConfig
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.backend.BackendResolver
 import vinyldns.core.domain.zone.{Zone, ZoneConnection}
 
@@ -50,12 +51,12 @@ class ZoneViewLoaderIntegrationSpec extends AnyWordSpec with Matchers {
             ZoneConnection(
               "vinyldns.",
               "vinyldns.",
-              "nzisn+4G2ldMn0q1CV3vsg==",
+              Encrypted("nzisn+4G2ldMn0q1CV3vsg=="),
               sys.env.getOrElse("DEFAULT_DNS_ADDRESS", "127.0.0.1:19001")
             )
           ),
           transferConnection =
-            Some(ZoneConnection("invalid-connection.", "bad-key", "invalid-key", "10.1.1.1"))
+            Some(ZoneConnection("invalid-connection.", "bad-key", Encrypted("invalid-key"), "10.1.1.1"))
         )
         val backend = backendResolver.resolve(zone).asInstanceOf[DnsBackend]
         println(s"${backend.id}, ${backend.xfrInfo}, ${backend.resolver.getAddress}")
@@ -83,7 +84,7 @@ class ZoneViewLoaderIntegrationSpec extends AnyWordSpec with Matchers {
             ZoneConnection(
               "vinyldns.",
               "vinyldns.",
-              "nzisn+4G2ldMn0q1CV3vsg==",
+              Encrypted("nzisn+4G2ldMn0q1CV3vsg=="),
               sys.env.getOrElse("DEFAULT_DNS_ADDRESS", "127.0.0.1:19001")
             )
           ),
@@ -91,7 +92,7 @@ class ZoneViewLoaderIntegrationSpec extends AnyWordSpec with Matchers {
             ZoneConnection(
               "vinyldns.",
               "vinyldns.",
-              "nzisn+4G2ldMn0q1CV3vsg==",
+              Encrypted("nzisn+4G2ldMn0q1CV3vsg=="),
               sys.env.getOrElse("DEFAULT_DNS_ADDRESS", "127.0.0.1:19001")
             )
           )

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -293,7 +293,7 @@ object DnsBackend {
     new DNS.TSIG(
       parseAlgorithm(conn.algorithm),
       decryptedConnection.keyName,
-      decryptedConnection.key
+      decryptedConnection.key.value
     )
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -196,7 +196,7 @@ object TestDataLoader extends TransactionProvider {
     id = "super-user-id",
     created = Instant.now.truncatedTo(ChronoUnit.SECONDS),
     accessKey = "superUserAccessKey",
-    secretKey = "superUserSecretKey",
+    secretKey = Encrypted("superUserSecretKey"),
     firstName = Some("super-user"),
     lastName = Some("super-user"),
     email = Some("test@test.com"),

--- a/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/repository/TestDataLoader.scala
@@ -21,6 +21,7 @@ import cats.implicits._
 import org.joda.time.DateTime
 import org.slf4j.{Logger, LoggerFactory}
 import scalikejdbc.DB
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership._
 import vinyldns.core.domain.zone._
 import vinyldns.mysql.TransactionProvider
@@ -38,7 +39,7 @@ object TestDataLoader extends TransactionProvider {
     id = "testuser",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "testUserAccessKey",
-    secretKey = "testUserSecretKey",
+    secretKey = Encrypted("testUserSecretKey"),
     firstName = Some("Test"),
     lastName = Some("User"),
     email = Some("test@test.com"),
@@ -49,7 +50,7 @@ object TestDataLoader extends TransactionProvider {
     id = "ok",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "okAccessKey",
-    secretKey = "okSecretKey",
+    secretKey = Encrypted("okSecretKey"),
     firstName = Some("ok"),
     lastName = Some("ok"),
     email = Some("test@test.com"),
@@ -60,7 +61,7 @@ object TestDataLoader extends TransactionProvider {
     id = "dummy",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "dummyAccessKey",
-    secretKey = "dummySecretKey",
+    secretKey = Encrypted("dummySecretKey"),
     isTest = true
   )
   final val sharedZoneUser = User(
@@ -68,7 +69,7 @@ object TestDataLoader extends TransactionProvider {
     id = "sharedZoneUser",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "sharedZoneUserAccessKey",
-    secretKey = "sharedZoneUserSecretKey",
+    secretKey = Encrypted("sharedZoneUserSecretKey"),
     firstName = Some("sharedZoneUser"),
     lastName = Some("sharedZoneUser"),
     email = Some("test@test.com"),
@@ -79,7 +80,7 @@ object TestDataLoader extends TransactionProvider {
     id = "locked",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "lockedAccessKey",
-    secretKey = "lockedSecretKey",
+    secretKey = Encrypted("lockedSecretKey"),
     firstName = Some("Locked"),
     lastName = Some("User"),
     email = Some("testlocked@test.com"),
@@ -92,7 +93,7 @@ object TestDataLoader extends TransactionProvider {
       id = "dummy%03d".format(runner),
       created = DateTime.now.secondOfDay().roundFloorCopy(),
       accessKey = "dummy",
-      secretKey = "dummy",
+      secretKey = Encrypted("dummy"),
       isTest = true
     )
   }
@@ -101,7 +102,7 @@ object TestDataLoader extends TransactionProvider {
     id = "list-group-user",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "listGroupAccessKey",
-    secretKey = "listGroupSecretKey",
+    secretKey = Encrypted("listGroupSecretKey"),
     firstName = Some("list-group"),
     lastName = Some("list-group"),
     email = Some("test@test.com"),
@@ -113,7 +114,7 @@ object TestDataLoader extends TransactionProvider {
     id = "list-zones-user",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "listZonesAccessKey",
-    secretKey = "listZonesSecretKey",
+    secretKey = Encrypted("listZonesSecretKey"),
     firstName = Some("list-zones"),
     lastName = Some("list-zones"),
     email = Some("test@test.com"),
@@ -125,7 +126,7 @@ object TestDataLoader extends TransactionProvider {
     id = "history-id",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "history-key",
-    secretKey = "history-secret",
+    secretKey = Encrypted("history-secret"),
     firstName = Some("history-first"),
     lastName = Some("history-last"),
     email = Some("history@history.com"),
@@ -137,7 +138,7 @@ object TestDataLoader extends TransactionProvider {
     id = "list-records-user",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "listRecordsAccessKey",
-    secretKey = "listRecordsSecretKey",
+    secretKey = Encrypted("listRecordsSecretKey"),
     firstName = Some("list-records"),
     lastName = Some("list-records"),
     email = Some("test@test.com"),
@@ -149,7 +150,7 @@ object TestDataLoader extends TransactionProvider {
     id = "list-batch-summaries-id",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "listBatchSummariesAccessKey",
-    secretKey = "listBatchSummariesSecretKey",
+    secretKey = Encrypted("listBatchSummariesSecretKey"),
     firstName = Some("list-batch-summaries"),
     lastName = Some("list-batch-summaries"),
     email = Some("test@test.com"),
@@ -169,7 +170,7 @@ object TestDataLoader extends TransactionProvider {
     id = "list-zero-summaries-id",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "listZeroSummariesAccessKey",
-    secretKey = "listZeroSummariesSecretKey",
+    secretKey = Encrypted("listZeroSummariesSecretKey"),
     firstName = Some("list-zero-summaries"),
     lastName = Some("list-zero-summaries"),
     email = Some("test@test.com"),
@@ -181,7 +182,7 @@ object TestDataLoader extends TransactionProvider {
     id = "support-user-id",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "supportUserAccessKey",
-    secretKey = "supportUserSecretKey",
+    secretKey = Encrypted("supportUserSecretKey"),
     firstName = Some("support-user"),
     lastName = Some("support-user"),
     email = Some("test@test.com"),

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -26,7 +26,7 @@ import scodec.bits.{Bases, ByteVector}
 import vinyldns.api.domain.zone.{RecordSetGlobalInfo, RecordSetInfo, RecordSetListInfo}
 import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 import vinyldns.core.domain.DomainHelpers.removeWhitespace
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{EncryptFromJson, Encrypted, Fqdn}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone._
 import vinyldns.core.Messages._
@@ -39,6 +39,7 @@ trait DnsJsonProtocol extends JsonValidation {
     UpdateZoneInputSerializer,
     ZoneConnectionSerializer,
     AlgorithmSerializer,
+    EncryptedSerializer,
     RecordSetSerializer,
     RecordSetListInfoSerializer,
     RecordSetGlobalInfoSerializer,
@@ -129,12 +130,22 @@ trait DnsJsonProtocol extends JsonValidation {
     override def toJson(a: Algorithm): JValue = JString(a.name)
   }
 
+  case object EncryptedSerializer extends ValidationSerializer[Encrypted] {
+    override def fromJson(js: JValue): ValidatedNel[String, Encrypted] =
+      js match {
+        case JString(value) => EncryptFromJson.fromString(value).toValidatedNel
+        case _ => "Unsupported type for zone connection key, must be a string".invalidNel
+      }
+
+    override def toJson(a: Encrypted): JValue = JString(a.value)
+  }
+
   case object ZoneConnectionSerializer extends ValidationSerializer[ZoneConnection] {
     override def fromJson(js: JValue): ValidatedNel[String, ZoneConnection] =
       (
         (js \ "name").required[String]("Missing ZoneConnection.name"),
         (js \ "keyName").required[String]("Missing ZoneConnection.keyName"),
-        (js \ "key").required[String]("Missing ZoneConnection.key"),
+        (js \ "key").required[Encrypted]("Missing ZoneConnection.key"),
         (js \ "primaryServer").required[String]("Missing ZoneConnection.primaryServer"),
         (js \ "algorithm").default[Algorithm](Algorithm.HMAC_MD5)
         ).mapN(ZoneConnection.apply)

--- a/modules/api/src/test/scala/vinyldns/api/backend/dns/DnsBackendSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/dns/DnsBackendSpec.scala
@@ -29,6 +29,7 @@ import org.xbill.DNS
 import org.xbill.DNS.{Lookup, Name, TSIG}
 import vinyldns.api.backend.dns.DnsProtocol._
 import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.backend.BackendResponse
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record._
@@ -46,7 +47,7 @@ class DnsBackendSpec
     with EitherValues {
 
   private val zoneConnection =
-    ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
+    ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")
   private val testZone = Zone("vinyldns", "test@test.com")
   private val testA = RecordSet(
     testZone.id,

--- a/modules/api/src/test/scala/vinyldns/api/config/VinylDNSConfigSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/config/VinylDNSConfigSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import vinyldns.api.backend.dns.DnsBackendProviderConfig
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.zone.ZoneConnection
 import vinyldns.core.repository.RepositoryName._
 
@@ -68,7 +69,7 @@ class VinylDNSConfigSpec extends AnyWordSpec with Matchers with BeforeAndAfterAl
     }
 
     "load specified backends" in {
-      val zc = ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", sys.env.getOrElse("DEFAULT_DNS_ADDRESS", "127.0.0.1:19001"))
+      val zc = ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), sys.env.getOrElse("DEFAULT_DNS_ADDRESS", "127.0.0.1:19001"))
       val tc = zc.copy()
 
       val backends = underTest.backendConfigs.backendProviders

--- a/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/access/AccessValidationsSpec.scala
@@ -25,7 +25,7 @@ import vinyldns.api.domain.zone.{NotAuthorizedError, RecordSetInfo, RecordSetLis
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData._
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{Encrypted, Fqdn}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record._
@@ -94,7 +94,7 @@ class AccessValidationsSpec
     VinylDNSTestHelpers.sharedApprovedTypes
   )
 
-  private val testUser = User("test", "test", "test", isTest = true)
+  private val testUser = User("test", "test", Encrypted("test"), isTest = true)
 
   "canSeeZone" should {
     "return a NotAuthorizedError if the user is not admin or super user with no acl rules" in {

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipValidationsSpec.scala
@@ -25,6 +25,7 @@ import vinyldns.api.ResultHelpers
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.api.domain.zone.NotAuthorizedError
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership.User
 
 class MembershipValidationsSpec
@@ -64,13 +65,13 @@ class MembershipValidationsSpec
         canEditGroup(okGroup, superUserAuth) should be(right)
       }
       "return an error when the user is a support admin only" in {
-        val user = User("some", "new", "user", isSupport = true)
+        val user = User("some", "new", Encrypted("user"), isSupport = true)
         val supportAuth = AuthPrincipal(user, Seq())
         val error = leftValue(canEditGroup(okGroup, supportAuth))
         error shouldBe an[NotAuthorizedError]
       }
       "return an error when the user has no access and is not super" in {
-        val user = User("some", "new", "user")
+        val user = User("some", "new", Encrypted("user"))
         val nonSuperAuth = AuthPrincipal(user, Seq())
         val error = leftValue(canEditGroup(okGroup, nonSuperAuth))
         error shouldBe an[NotAuthorizedError]
@@ -85,12 +86,12 @@ class MembershipValidationsSpec
         canSeeGroup(okGroup.id, superUserAuth) should be(right)
       }
       "return true when the user is a support admin" in {
-        val user = User("some", "new", "user", isSupport = true)
+        val user = User("some", "new", Encrypted("user"), isSupport = true)
         val supportAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, supportAuth) should be(right)
       }
       "return true even when a user is not a member of the group or super" in {
-        val user = User("some", "new", "user")
+        val user = User("some", "new", Encrypted("user"))
         val nonSuperAuth = AuthPrincipal(user, Seq())
         canSeeGroup(okGroup.id, nonSuperAuth) should be(right)
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneConnectionValidatorSpec.scala
@@ -27,7 +27,7 @@ import vinyldns.core.domain.record._
 import vinyldns.api.ResultHelpers
 import cats.effect._
 import org.mockito.Matchers.any
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{Encrypted, Fqdn}
 import vinyldns.core.domain.backend.{Backend, BackendResolver}
 import vinyldns.core.domain.zone.{ConfiguredDnsConnections, LegacyDnsBackend, Zone, ZoneConnection}
 
@@ -85,9 +85,9 @@ class ZoneConnectionValidatorSpec
     "vinyldns.",
     "test@test.com",
     connection =
-      Some(ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")),
+      Some(ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")),
     transferConnection =
-      Some(ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1"))
+      Some(ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1"))
   )
 
   private val successSoa = RecordSet(
@@ -134,8 +134,8 @@ class ZoneConnectionValidatorSpec
     List(NSData(Fqdn("sub.some.test.ns.")))
   )
 
-  val zc = ZoneConnection("zc.", "zc.", "zc", "10.1.1.1")
-  val transfer = ZoneConnection("transfer.", "transfer.", "transfer", "10.1.1.1")
+  val zc = ZoneConnection("zc.", "zc.", Encrypted("zc"), "10.1.1.1")
+  val transfer = ZoneConnection("transfer.", "transfer.", Encrypted("transfer"), "10.1.1.1")
   val backend = LegacyDnsBackend(
     "some-backend-id",
     zc.copy(name = "backend-conn"),
@@ -195,9 +195,9 @@ class ZoneConnectionValidatorSpec
         "error.",
         "test@test.com",
         connection =
-          Some(ZoneConnection("error.", "error.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")),
+          Some(ZoneConnection("error.", "error.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")),
         transferConnection =
-          Some(ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1"))
+          Some(ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1"))
       )
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])
       doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
@@ -211,9 +211,9 @@ class ZoneConnectionValidatorSpec
         "error.",
         "test@test.com",
         connection =
-          Some(ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")),
+          Some(ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")),
         transferConnection =
-          Some(ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1"))
+          Some(ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1"))
       )
 
       doReturn(IO.pure(true)).when(mockBackend).zoneExists(any[Zone])

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -35,6 +35,7 @@ import vinyldns.core.queue.MessageQueue
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData._
 import vinyldns.core.crypto.NoOpCrypto
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.backend.BackendResolver
 
 import scala.concurrent.duration._
@@ -53,7 +54,7 @@ class ZoneServiceSpec
   private val mockZoneChangeRepo = mock[ZoneChangeRepository]
   private val mockMessageQueue = mock[MessageQueue]
   private val mockBackendResolver = mock[BackendResolver]
-  private val badConnection = ZoneConnection("bad", "bad", "bad", "bad")
+  private val badConnection = ZoneConnection("bad", "bad", Encrypted("bad"), "bad")
   private val abcZoneSummary = ZoneSummaryInfo(abcZone, abcGroup.name, AccessLevel.Delete)
   private val xyzZoneSummary = ZoneSummaryInfo(xyzZone, xyzGroup.name, AccessLevel.NoAccess)
 
@@ -442,7 +443,7 @@ class ZoneServiceSpec
     }
 
     "filter out ACL rules that have no matching group or user" in {
-      val goodUser = User("goodUser", "access", "secret")
+      val goodUser = User("goodUser", "access", Encrypted("secret"))
       val goodGroup = Group("goodGroup", "email")
 
       val goodUserRule = baseAclRule.copy(userId = Some(goodUser.id), groupId = None)

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
@@ -32,7 +32,7 @@ import vinyldns.core.domain.record._
 import scala.collection.mutable
 import cats.effect._
 import vinyldns.api.backend.dns.DnsConversions
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{Encrypted, Fqdn}
 import vinyldns.core.domain.backend.{Backend, BackendResolver}
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
@@ -43,7 +43,7 @@ class ZoneViewLoaderSpec extends AnyWordSpec with Matchers with MockitoSugar wit
   private val testZoneName = "vinyldns."
 
   private val testZoneConnection: Option[ZoneConnection] = Some(
-    ZoneConnection(testZoneName, testZoneName, "nzisn+4G2ldMn0q1CV3vsg==", "127.0.0.1:19001")
+    ZoneConnection(testZoneName, testZoneName, Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "127.0.0.1:19001")
   )
 
   private val mockBackendResolver = mock[BackendResolver]

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -29,7 +29,7 @@ import scalikejdbc.{ConnectionPool, DB}
 import vinyldns.api.VinylDNSTestHelpers
 import vinyldns.api.domain.record.RecordSetChangeGenerator
 import vinyldns.api.domain.zone.{DnsZoneViewLoader, VinylDNSZoneViewLoader, ZoneView}
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{Encrypted, Fqdn}
 import vinyldns.core.domain.backend.{Backend, BackendResolver}
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
@@ -180,16 +180,16 @@ class ZoneSyncHandlerSpec
     zoneName,
     "test@test.com",
     ZoneStatus.Active,
-    connection = Some(ZoneConnection(zoneName, dnsKeyName, dnsTsig, dnsServerAddress)),
-    transferConnection = Some(ZoneConnection(zoneName, dnsKeyName, dnsTsig, dnsServerAddress))
+    connection = Some(ZoneConnection(zoneName, dnsKeyName, Encrypted(dnsTsig), dnsServerAddress)),
+    transferConnection = Some(ZoneConnection(zoneName, dnsKeyName, Encrypted(dnsTsig), dnsServerAddress))
   )
 
   private val testReverseZone = Zone(
     reverseZoneName,
     "test@test.com",
     ZoneStatus.Active,
-    connection = Some(ZoneConnection(zoneName, dnsKeyName, dnsTsig, dnsServerAddress)),
-    transferConnection = Some(ZoneConnection(zoneName, dnsKeyName, dnsTsig, dnsServerAddress))
+    connection = Some(ZoneConnection(zoneName, dnsKeyName, Encrypted(dnsTsig), dnsServerAddress)),
+    transferConnection = Some(ZoneConnection(zoneName, dnsKeyName, Encrypted(dnsTsig), dnsServerAddress))
   )
 
   private val testRecord1 = RecordSet(

--- a/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/notifier/email/EmailNotifierSpec.scala
@@ -22,22 +22,22 @@ import org.scalatestplus.mockito.MockitoSugar
 import vinyldns.api.CatsHelpers
 import javax.mail.{Provider, Session, Transport, URLName}
 import java.util.Properties
-
-import vinyldns.core.domain.membership.UserRepository
+import vinyldns.core.domain.membership.{User, UserRepository}
 import vinyldns.core.notifier.Notification
+
 import javax.mail.internet.InternetAddress
 import org.mockito.Matchers.{eq => eqArg, _}
 import org.mockito.Mockito._
 import org.mockito.ArgumentCaptor
 import cats.effect.IO
 import javax.mail.{Address, Message}
-import vinyldns.core.domain.membership.User
 import _root_.vinyldns.core.domain.batch._
 import org.joda.time.DateTime
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.record.AData
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import vinyldns.core.domain.Encrypted
 
 import scala.collection.JavaConverters._
 import vinyldns.core.notifier.NotifierConfig
@@ -122,7 +122,7 @@ class EmailNotifierSpec
         mockUserRepository
       )
 
-      doReturn(IO.pure(Some(User("testUser", "access", "secret"))))
+      doReturn(IO.pure(Some(User("testUser", "access", Encrypted("secret")))))
         .when(mockUserRepository)
         .getUser("test")
 
@@ -156,7 +156,7 @@ class EmailNotifierSpec
       )
 
       doReturn(
-        IO.pure(Some(User("testUser", "access", "secret", None, None, Some("testuser@test.com"))))
+        IO.pure(Some(User("testUser", "access", Encrypted("secret"), None, None, Some("testuser@test.com"))))
       ).when(mockUserRepository)
         .getUser("test")
 

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -312,6 +312,25 @@ class VinylDNSJsonProtocolSpec
     }
   }
 
+  "EncryptedSerializer" should {
+    "parse a secret key to Encrypted type" in {
+      val secretKeyInput: JValue = "primaryConnectionKey"
+
+      val actual = secretKeyInput.extract[Encrypted]
+      val expected = Encrypted("primaryConnectionKey")
+      actual shouldBe expected
+    }
+
+    "throw an error if there is a type mismatch during deserialization" in {
+      val secretKeyInput: JObject =
+        "key" -> List(
+          "primaryConnectionKey"
+        )
+
+      assertThrows[MappingException](secretKeyInput.extract[Encrypted])
+    }
+  }
+
   "RecordSetSerializer" should {
     "parse a record set with an absolute CNAME record passes" in {
       val recordSetJValue: JValue =

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -26,7 +26,7 @@ import vinyldns.api.VinylDNSTestHelpers
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.{CreateZoneInput, UpdateZoneInput, ZoneConnection}
 import vinyldns.core.TestRecordSetData._
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{Encrypted, Fqdn}
 import vinyldns.core.Messages._
 
 class VinylDNSJsonProtocolSpec
@@ -43,7 +43,7 @@ class VinylDNSJsonProtocolSpec
       ZoneConnection(
         "primaryConnection",
         "primaryConnectionKeyName",
-        "primaryConnectionKey",
+        Encrypted("primaryConnectionKey"),
         "10.1.1.1"
       )
     ),
@@ -51,7 +51,7 @@ class VinylDNSJsonProtocolSpec
       ZoneConnection(
         "transferConnection",
         "transferConnectionKeyName",
-        "transferConnectionKey",
+        Encrypted("transferConnectionKey"),
         "10.1.1.2"
       )
     ),
@@ -66,7 +66,7 @@ class VinylDNSJsonProtocolSpec
       ZoneConnection(
         "primaryConnection",
         "primaryConnectionKeyName",
-        "primaryConnectionKey",
+        Encrypted("primaryConnectionKey"),
         "10.1.1.1"
       )
     ),
@@ -74,7 +74,7 @@ class VinylDNSJsonProtocolSpec
       ZoneConnection(
         "transferConnection",
         "transferConnectionKeyName",
-        "transferConnectionKey",
+        Encrypted("transferConnectionKey"),
         "10.1.1.2"
       )
     ),

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -33,6 +33,7 @@ import vinyldns.api.domain.zone.{ZoneServiceAlgebra, _}
 import vinyldns.core.TestMembershipData._
 import vinyldns.core.TestZoneData._
 import vinyldns.core.crypto.{JavaCrypto, NoOpCrypto}
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone._
@@ -86,18 +87,18 @@ class ZoneRoutingSpec
   private val connectionOk = Zone(
     "connection.ok.",
     "connection-ok@test.com",
-    connection = Some(ZoneConnection("connection.ok", "keyName", "key", "10.1.1.1")),
-    transferConnection = Some(ZoneConnection("connection.ok", "keyName", "key", "10.1.1.1"))
+    connection = Some(ZoneConnection("connection.ok", "keyName", Encrypted("key"), "10.1.1.1")),
+    transferConnection = Some(ZoneConnection("connection.ok", "keyName", Encrypted("key"), "10.1.1.1"))
   )
   private val connectionFailed = Zone(
     "connection.fail",
     "connection-failed@test.com",
-    connection = Some(ZoneConnection("connection.fail", "keyName", "key", "10.1.1.1"))
+    connection = Some(ZoneConnection("connection.fail", "keyName", Encrypted("key"), "10.1.1.1"))
   )
   private val zoneValidationFailed = Zone(
     "validation.fail",
     "zone-validation-failed@test.com",
-    connection = Some(ZoneConnection("validation.fail", "keyName", "key", "10.1.1.1"))
+    connection = Some(ZoneConnection("validation.fail", "keyName", Encrypted("key"), "10.1.1.1"))
   )
   private val zone1 = Zone("zone1.", "zone1@test.com", ZoneStatus.Active)
   private val zoneSummaryInfo1 = ZoneSummaryInfo(zone1, okGroup.name, AccessLevel.NoAccess)
@@ -664,10 +665,10 @@ class ZoneRoutingSpec
         val resultKey = result.zone.connection.get.key
         val resultTCKey = result.zone.transferConnection.get.key
 
-        val decrypted = crypto.decrypt(resultKey)
-        val decryptedTC = crypto.decrypt(resultTCKey)
-        decrypted shouldBe connectionOk.connection.get.key
-        decryptedTC shouldBe connectionOk.transferConnection.get.key
+        val decrypted = crypto.decrypt(resultKey.value)
+        val decryptedTC = crypto.decrypt(resultTCKey.value)
+        decrypted shouldBe connectionOk.connection.get.key.value
+        decryptedTC shouldBe connectionOk.transferConnection.get.key.value
       }
     }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/Encryption.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/Encryption.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain
+
+import vinyldns.core.crypto.CryptoAlgebra
+
+final case class Encrypted private (value: String) extends AnyVal
+
+object Encryption {
+  def apply(crypto: CryptoAlgebra, value: String): Encrypted = Encrypted(crypto.encrypt(value))
+  def decrypt(crypto: CryptoAlgebra, x: Encrypted): String = crypto.decrypt(x.value)
+}
+
+object EncryptFromJson {
+  def fromString(name: String): Either[String, Encrypted] =
+    Option(Encrypted(name)).toRight[String](s"Unsupported format")
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/auth/AuthPrincipal.scala
@@ -34,7 +34,7 @@ case class AuthPrincipal(signedInUser: User, memberGroupIds: Seq[String]) {
 
   def isTestUser: Boolean = signedInUser.isTest
 
-  val secretKey: String = signedInUser.secretKey
+  val secretKey: String = signedInUser.secretKey.value
 
   val userId: String = signedInUser.id
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import vinyldns.core.crypto.CryptoAlgebra
+import vinyldns.core.domain.{Encrypted, Encryption}
 import vinyldns.core.domain.membership.LockStatus.LockStatus
 
 object LockStatus extends Enumeration {
@@ -31,7 +32,7 @@ object LockStatus extends Enumeration {
 final case class User(
     userName: String,
     accessKey: String,
-    secretKey: String,
+    secretKey: Encrypted,
     firstName: Option[String] = None,
     lastName: Option[String] = None,
     email: Option[String] = None,
@@ -47,10 +48,10 @@ final case class User(
     this.copy(lockStatus = lockStatus)
 
   def regenerateCredentials(): User =
-    copy(accessKey = User.generateKey, secretKey = User.generateKey)
+    copy(accessKey = User.generateKey, secretKey = Encrypted(User.generateKey))
 
   def withEncryptedSecretKey(cryptoAlgebra: CryptoAlgebra): User =
-    copy(secretKey = cryptoAlgebra.encrypt(secretKey))
+    copy(secretKey = Encryption.apply(cryptoAlgebra, secretKey.value))
 }
 
 object User {

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/Zone.scala
@@ -25,6 +25,7 @@ import pureconfig.{ConfigReader, ConfigSource}
 import pureconfig.error.CannotConvert
 import pureconfig.generic.auto._
 import vinyldns.core.crypto.CryptoAlgebra
+import vinyldns.core.domain.{Encrypted, Encryption}
 import scala.collection.JavaConverters._
 
 object ZoneStatus extends Enumeration {
@@ -178,16 +179,16 @@ object Algorithm {
 case class ZoneConnection(
     name: String,
     keyName: String,
-    key: String,
+    key: Encrypted,
     primaryServer: String,
     algorithm: Algorithm = Algorithm.HMAC_MD5
 ) {
 
   def encrypted(crypto: CryptoAlgebra): ZoneConnection =
-    copy(key = crypto.encrypt(key))
+    copy(key = Encryption.apply(crypto, key.value))
 
   def decrypted(crypto: CryptoAlgebra): ZoneConnection =
-    copy(key = crypto.decrypt(key))
+    copy(key = Encrypted(Encryption.decrypt(crypto, key)))
 }
 
 final case class LegacyDnsBackend(
@@ -220,7 +221,7 @@ object ConfiguredDnsConnections {
           if (connectionConfig.hasPath("algorithm"))
             Algorithm.Map.getOrElse(connectionConfig.getString("algorithm"), Algorithm.HMAC_MD5)
           else Algorithm.HMAC_MD5
-        ZoneConnection(name, keyName, key, primaryServer, algorithm).encrypted(crypto)
+        ZoneConnection(name, keyName, Encrypted(key), primaryServer, algorithm).encrypted(crypto)
       }
 
       val defaultTransferConnection = {
@@ -233,7 +234,7 @@ object ConfiguredDnsConnections {
           if (connectionConfig.hasPath("algorithm"))
             Algorithm.Map.getOrElse(connectionConfig.getString("algorithm"), Algorithm.HMAC_MD5)
           else Algorithm.HMAC_MD5
-        ZoneConnection(name, keyName, key, primaryServer, algorithm).encrypted(crypto)
+        ZoneConnection(name, keyName, Encrypted(key), primaryServer, algorithm).encrypted(crypto)
       }
 
       val dnsBackends = {

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -25,7 +25,7 @@ import vinyldns.core.domain.membership.{LockStatus, User, UserChange, UserChange
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone._
-import vinyldns.core.domain.{Fqdn, record, zone}
+import vinyldns.core.domain.{Encrypted, Fqdn, record, zone}
 import vinyldns.proto.VinylDNSProto
 
 import scala.collection.JavaConverters._
@@ -132,7 +132,7 @@ trait ProtobufConversions {
     ZoneConnection(
       zc.getName,
       zc.getKeyName,
-      zc.getKey,
+      Encrypted(zc.getKey),
       zc.getPrimaryServer,
       fromPB(zc.getAlgorithm)
     )
@@ -417,7 +417,7 @@ trait ProtobufConversions {
       .newBuilder()
       .setName(conn.name)
       .setKeyName(conn.keyName)
-      .setKey(conn.key)
+      .setKey(conn.key.value)
       .setPrimaryServer(conn.primaryServer)
       .setAlgorithm(toPB(conn.algorithm))
       .build()
@@ -441,7 +441,7 @@ trait ProtobufConversions {
     User(
       data.getUserName,
       data.getAccessKey,
-      data.getSecretKey,
+      Encrypted(data.getSecretKey),
       if (data.hasFirstName) Some(data.getFirstName) else None,
       if (data.hasLastName) Some(data.getLastName) else None,
       if (data.hasEmail) Some(data.getEmail) else None,
@@ -458,7 +458,7 @@ trait ProtobufConversions {
       .newBuilder()
       .setUserName(user.userName)
       .setAccessKey(user.accessKey)
-      .setSecretKey(user.secretKey)
+      .setSecretKey(user.secretKey.value)
       .setCreated(user.created.getMillis)
       .setId(user.id)
       .setIsSuper(user.isSuper)

--- a/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
@@ -17,6 +17,7 @@
 package vinyldns.core
 
 import org.joda.time.DateTime
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership._
 
@@ -28,17 +29,17 @@ object TestMembershipData {
     id = "ok",
     created = DateTime.now.secondOfDay().roundFloorCopy(),
     accessKey = "okAccessKey",
-    secretKey = "okSecretKey",
+    secretKey = Encrypted("okSecretKey"),
     firstName = Some("ok"),
     lastName = Some("ok"),
     email = Some("test@test.com")
   )
 
-  val dummyUser = User("dummyName", "dummyAccess", "dummySecret")
-  val superUser = User("super", "superAccess", "superSecret", isSuper = true)
-  val supportUser = User("support", "supportAccess", "supportSecret", isSupport = true)
-  val lockedUser = User("locked", "lockedAccess", "lockedSecret", lockStatus = LockStatus.Locked)
-  val sharedZoneUser = User("sharedZoneAdmin", "sharedAccess", "sharedSecret")
+  val dummyUser = User("dummyName", "dummyAccess", Encrypted("dummySecret"))
+  val superUser = User("super", "superAccess", Encrypted("superSecret"), isSuper = true)
+  val supportUser = User("support", "supportAccess", Encrypted("supportSecret"), isSupport = true)
+  val lockedUser = User("locked", "lockedAccess", Encrypted("lockedSecret"), lockStatus = LockStatus.Locked)
+  val sharedZoneUser = User("sharedZoneAdmin", "sharedAccess", Encrypted("sharedSecret"))
 
   val listOfDummyUsers: List[User] = List.range(0, 200).map { runner =>
     User(
@@ -46,7 +47,7 @@ object TestMembershipData {
       id = "dummy%03d".format(runner),
       created = DateTime.now.secondOfDay().roundFloorCopy(),
       accessKey = "dummy",
-      secretKey = "dummy"
+      secretKey = Encrypted("dummy")
     )
   }
 
@@ -117,7 +118,7 @@ object TestMembershipData {
 
   val dummyAuth: AuthPrincipal = AuthPrincipal(dummyUser, Seq(dummyGroup.id))
 
-  val notAuth: AuthPrincipal = AuthPrincipal(User("not", "auth", "secret"), Seq.empty)
+  val notAuth: AuthPrincipal = AuthPrincipal(User("not", "auth", Encrypted("secret")), Seq.empty)
 
   val sharedAuth: AuthPrincipal = AuthPrincipal(sharedZoneUser, Seq(abcGroup.id))
 

--- a/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestMembershipData.scala
@@ -35,12 +35,12 @@ object TestMembershipData {
     email = Some("test@test.com")
   )
 
-  val dummyUser = User("dummyName", "dummyAccess", "dummySecret")
-  val superUser = User("super", "superAccess", "superSecret", isSuper = true)
-  val xyzUser = User("xyz", "xyzAccess", "xyzSecret")
-  val supportUser = User("support", "supportAccess", "supportSecret", isSupport = true)
-  val lockedUser = User("locked", "lockedAccess", "lockedSecret", lockStatus = LockStatus.Locked)
-  val sharedZoneUser = User("sharedZoneAdmin", "sharedAccess", "sharedSecret")
+  val dummyUser = User("dummyName", "dummyAccess", Encrypted("dummySecret"))
+  val superUser = User("super", "superAccess", Encrypted("superSecret"), isSuper = true)
+  val xyzUser = User("xyz", "xyzAccess", Encrypted("xyzSecret"))
+  val supportUser = User("support", "supportAccess", Encrypted("supportSecret"), isSupport = true)
+  val lockedUser = User("locked", "lockedAccess", Encrypted("lockedSecret"), lockStatus = LockStatus.Locked)
+  val sharedZoneUser = User("sharedZoneAdmin", "sharedAccess", Encrypted("sharedSecret"))
 
   val listOfDummyUsers: List[User] = List.range(0, 200).map { runner =>
     User(

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -19,12 +19,13 @@ package vinyldns.core
 import vinyldns.core.domain.zone._
 import TestMembershipData._
 import org.joda.time.DateTime
+import vinyldns.core.domain.Encrypted
 
 object TestZoneData {
 
   /* ZONE CONNECTIONS */
   val testConnection: Option[ZoneConnection] = Some(
-    ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
+    ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")
   )
 
   /* ZONES */

--- a/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/membership/UserChangeSpec.scala
@@ -20,10 +20,11 @@ import org.joda.time.DateTime
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import vinyldns.core.domain.Encrypted
 
 class UserChangeSpec extends AnyWordSpec with Matchers with EitherMatchers with EitherValues {
 
-  private val newUser = User("foo", "key", "secret")
+  private val newUser = User("foo", "key", Encrypted("secret"))
   private val currentDate = DateTime.now
 
   "apply" should {

--- a/modules/core/src/test/scala/vinyldns/core/domain/zone/ZoneConnectionSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/zone/ZoneConnectionSpec.scala
@@ -20,6 +20,7 @@ import cats.scalatest.EitherMatchers
 import vinyldns.core.crypto.CryptoAlgebra
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import vinyldns.core.domain.Encrypted
 
 class ZoneConnectionSpec extends AnyWordSpec with Matchers with EitherMatchers {
 
@@ -31,16 +32,16 @@ class ZoneConnectionSpec extends AnyWordSpec with Matchers with EitherMatchers {
 
   "ZoneConnection" should {
     "encrypt clear connections" in {
-      val test = ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
+      val test = ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")
 
-      test.encrypted(testCrypto).key shouldBe "encrypted!"
+      test.encrypted(testCrypto).key.value shouldBe "encrypted!"
     }
 
     "decrypt connections" in {
-      val test = ZoneConnection("vinyldns.", "vinyldns.", "nzisn+4G2ldMn0q1CV3vsg==", "10.1.1.1")
+      val test = ZoneConnection("vinyldns.", "vinyldns.", Encrypted("nzisn+4G2ldMn0q1CV3vsg=="), "10.1.1.1")
       val decrypted = test.decrypted(testCrypto)
 
-      decrypted.key shouldBe "decrypted!"
+      decrypted.key.value shouldBe "decrypted!"
     }
   }
 }

--- a/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/protobuf/ProtobufConversionsSpec.scala
@@ -19,7 +19,7 @@ package vinyldns.core.protobuf
 import org.joda.time.DateTime
 import org.scalatest.{Assertion, OptionValues}
 import vinyldns.core.TestRecordSetData.ds
-import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.{Encrypted, Fqdn}
 import vinyldns.core.domain.membership.UserChange.{CreateUser, UpdateUser}
 import vinyldns.core.domain.membership.{LockStatus, User, UserChangeType}
 import vinyldns.core.domain.record._
@@ -36,7 +36,7 @@ class ProtobufConversionsSpec
     with ProtobufConversions
     with OptionValues {
 
-  private val zoneConnection = ZoneConnection("name", "keyName", "key", "server")
+  private val zoneConnection = ZoneConnection("name", "keyName", Encrypted("key"), "server")
 
   private val zoneId = "test.zone.id"
 
@@ -63,8 +63,8 @@ class ProtobufConversionsSpec
   private val zone = Zone(
     "test.zone.actor.zone",
     "test@test.com",
-    connection = Some(ZoneConnection("connection.ok", "keyName", "key", "10.1.1.1")),
-    transferConnection = Some(ZoneConnection("connection.ok", "keyName", "key", "10.1.1.2")),
+    connection = Some(ZoneConnection("connection.ok", "keyName", Encrypted("key"), "10.1.1.1")),
+    transferConnection = Some(ZoneConnection("connection.ok", "keyName", Encrypted("key"), "10.1.1.2")),
     shared = true,
     id = zoneId,
     acl = zoneAcl,
@@ -269,7 +269,7 @@ class ProtobufConversionsSpec
       val pbconn = pb.getConnection
       val conn = zn.connection.get
       pbconn.getName shouldBe conn.name
-      pbconn.getKey shouldBe conn.key
+      pbconn.getKey shouldBe conn.key.value
       pbconn.getKeyName shouldBe conn.keyName
       pbconn.getPrimaryServer shouldBe conn.primaryServer
     } else {
@@ -279,7 +279,7 @@ class ProtobufConversionsSpec
       val pbTransConn = pb.getTransferConnection
       val transConn = zn.transferConnection.get
       pbTransConn.getName shouldBe transConn.name
-      pbTransConn.getKey shouldBe transConn.key
+      pbTransConn.getKey shouldBe transConn.key.value
       pbTransConn.getKeyName shouldBe transConn.keyName
       pbTransConn.getPrimaryServer shouldBe transConn.primaryServer
     } else {
@@ -368,7 +368,7 @@ class ProtobufConversionsSpec
     "convert from ZoneConnection" in {
       val pb = toPB(zoneConnection)
 
-      pb.getKey shouldBe zoneConnection.key
+      pb.getKey shouldBe zoneConnection.key.value
       pb.getKeyName shouldBe zoneConnection.keyName
       pb.getPrimaryServer shouldBe zoneConnection.primaryServer
       pb.getName shouldBe zoneConnection.name
@@ -807,12 +807,12 @@ class ProtobufConversionsSpec
 
   "User conversion" should {
     "convert to/from protobuf with user defaults" in {
-      val user = User("testName", "testAccess", "testSecret")
+      val user = User("testName", "testAccess", Encrypted("testSecret"))
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName
       pb.getAccessKey shouldBe user.accessKey
-      pb.getSecretKey shouldBe user.secretKey
+      pb.getSecretKey shouldBe user.secretKey.value
       pb.hasFirstName shouldBe false
       pb.hasLastName shouldBe false
       pb.hasEmail shouldBe false
@@ -830,7 +830,7 @@ class ProtobufConversionsSpec
       val user = User(
         "testName",
         "testAccess",
-        "testSecret",
+        Encrypted("testSecret"),
         firstName = Some("testFirstName"),
         lastName = Some("testLastName"),
         email = Some("testEmail"),
@@ -840,7 +840,7 @@ class ProtobufConversionsSpec
 
       pb.getUserName shouldBe user.userName
       pb.getAccessKey shouldBe user.accessKey
-      pb.getSecretKey shouldBe user.secretKey
+      pb.getSecretKey shouldBe user.secretKey.value
       Some(pb.getFirstName) shouldBe user.firstName
       Some(pb.getLastName) shouldBe user.lastName
       Some(pb.getEmail) shouldBe user.email
@@ -855,12 +855,12 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf with superUser true" in {
-      val user = User("testName", "testAccess", "testSecret", isSuper = true)
+      val user = User("testName", "testAccess", Encrypted("testSecret"), isSuper = true)
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName
       pb.getAccessKey shouldBe user.accessKey
-      pb.getSecretKey shouldBe user.secretKey
+      pb.getSecretKey shouldBe user.secretKey.value
       pb.hasFirstName shouldBe false
       pb.hasLastName shouldBe false
       pb.hasEmail shouldBe false
@@ -874,12 +874,12 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf with locked user" in {
-      val user = User("testName", "testAccess", "testSecret", lockStatus = LockStatus.Locked)
+      val user = User("testName", "testAccess", Encrypted("testSecret"), lockStatus = LockStatus.Locked)
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName
       pb.getAccessKey shouldBe user.accessKey
-      pb.getSecretKey shouldBe user.secretKey
+      pb.getSecretKey shouldBe user.secretKey.value
       pb.hasFirstName shouldBe false
       pb.hasLastName shouldBe false
       pb.hasEmail shouldBe false
@@ -893,12 +893,12 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf with test user" in {
-      val user = User("testName", "testAccess", "testSecret", isTest = true)
+      val user = User("testName", "testAccess", Encrypted("testSecret"), isTest = true)
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName
       pb.getAccessKey shouldBe user.accessKey
-      pb.getSecretKey shouldBe user.secretKey
+      pb.getSecretKey shouldBe user.secretKey.value
       pb.hasFirstName shouldBe false
       pb.hasLastName shouldBe false
       pb.hasEmail shouldBe false
@@ -912,12 +912,12 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf with supportAdmin true" in {
-      val user = User("testName", "testAccess", "testSecret", isSupport = true)
+      val user = User("testName", "testAccess", Encrypted("testSecret"), isSupport = true)
       val pb = toPB(user)
 
       pb.getUserName shouldBe user.userName
       pb.getAccessKey shouldBe user.accessKey
-      pb.getSecretKey shouldBe user.secretKey
+      pb.getSecretKey shouldBe user.secretKey.value
       pb.hasFirstName shouldBe false
       pb.hasLastName shouldBe false
       pb.hasEmail shouldBe false
@@ -933,7 +933,7 @@ class ProtobufConversionsSpec
 
   "User change conversion" should {
     "convert to/from protobuf for CreateUser" in {
-      val user = User("createUser", "createUserAccess", "createUserSecret")
+      val user = User("createUser", "createUserAccess", Encrypted("createUserSecret"))
       val createChange = CreateUser(user, "createUserId", user.created)
       val pb = toPb(createChange)
 
@@ -942,7 +942,7 @@ class ProtobufConversionsSpec
       new User(
         pb.getNewUser.getUserName,
         pb.getNewUser.getAccessKey,
-        pb.getNewUser.getSecretKey,
+        Encrypted(pb.getNewUser.getSecretKey),
         created = user.created,
         id = user.id
       ) shouldBe user
@@ -955,7 +955,7 @@ class ProtobufConversionsSpec
     }
 
     "convert to/from protobuf for UpdateUser" in {
-      val oldUser = User("updateUser", "updateUserAccess", "updateUserSecret")
+      val oldUser = User("updateUser", "updateUserAccess", Encrypted("updateUserSecret"))
       val newUser = oldUser.copy(userName = "updateUserNewName")
       val updateChange = UpdateUser(newUser, "createUserId", newUser.created, oldUser)
       val pb = toPb(updateChange)
@@ -965,7 +965,7 @@ class ProtobufConversionsSpec
       new User(
         pb.getNewUser.getUserName,
         pb.getNewUser.getAccessKey,
-        pb.getNewUser.getSecretKey,
+        Encrypted(pb.getNewUser.getSecretKey),
         created = newUser.created,
         id = newUser.id
       ) shouldBe newUser
@@ -976,7 +976,7 @@ class ProtobufConversionsSpec
       new User(
         pb.getOldUser.getUserName,
         pb.getOldUser.getAccessKey,
-        pb.getOldUser.getSecretKey,
+        Encrypted(pb.getOldUser.getSecretKey),
         created = oldUser.created,
         id = oldUser.id
       ) shouldBe oldUser

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserChangeRepositoryIntegrationSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc.DB
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership.UserChange.{CreateUser, UpdateUser}
 import vinyldns.core.domain.membership.{User, UserChangeRepository}
 import vinyldns.mysql.TestMySqlInstance
@@ -31,7 +32,7 @@ class MySqlUserChangeRepositoryIntegrationSpec
     with Matchers {
 
   private val repo: UserChangeRepository = TestMySqlInstance.userChangeRepository
-  private val user: User = User("user-id", "access-key", "secret-key")
+  private val user: User = User("user-id", "access-key", Encrypted("secret-key"))
   private val createUser = CreateUser(user, "creator-id", user.created)
   private val updateUser =
     UpdateUser(user.copy(userName = "new-username"), "creator-id", user.created, user)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlUserRepositoryIntegrationSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc.DB
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership.{LockStatus, User, UserRepository}
 import vinyldns.mysql.TestMySqlInstance
 
@@ -35,15 +36,15 @@ class MySqlUserRepositoryIntegrationSpec
 
   private val testUserIds = (for { i <- 0 to 100 } yield s"test-user-$i").toList.sorted
   private val users = testUserIds.map { id =>
-    User(id = id, userName = "name" + id, accessKey = s"abc$id", secretKey = "123")
+    User(id = id, userName = "name" + id, accessKey = s"abc$id", secretKey = Encrypted("123"))
   }
 
   private val caseInsensitiveUser1 =
-    User(id = "caseInsensitiveUser1", userName = "Name1", accessKey = "a1", secretKey = "s1")
+    User(id = "caseInsensitiveUser1", userName = "Name1", accessKey = "a1", secretKey = Encrypted("s1"))
   private val caseInsensitiveUser2 =
-    User(id = "caseInsensitiveUser2", userName = "namE2", accessKey = "a2", secretKey = "s2")
+    User(id = "caseInsensitiveUser2", userName = "namE2", accessKey = "a2", secretKey = Encrypted("s2"))
   private val caseInsensitiveUser3 =
-    User(id = "caseInsensitiveUser3", userName = "name3", accessKey = "a3", secretKey = "s3")
+    User(id = "caseInsensitiveUser3", userName = "name3", accessKey = "a3", secretKey = Encrypted("s3"))
 
   override protected def beforeAll(): Unit = {
     repo = TestMySqlInstance.userRepository
@@ -81,7 +82,7 @@ class MySqlUserRepositoryIntegrationSpec
     }
 
     "save super user with super status" in {
-      val superUser = User("superName", "superAccess", "superSecret", isSuper = true)
+      val superUser = User("superName", "superAccess", Encrypted("superSecret"), isSuper = true)
       repo.save(superUser).unsafeRunSync() shouldBe superUser
       val result = repo.getUser(superUser.id).unsafeRunSync()
       result shouldBe Some(superUser)
@@ -89,7 +90,7 @@ class MySqlUserRepositoryIntegrationSpec
     }
 
     "save non-super user with non-super status" in {
-      val nonSuperUser = User("nonSuperName", "nonSuperAccess", "nonSuperSecret")
+      val nonSuperUser = User("nonSuperName", "nonSuperAccess", Encrypted("nonSuperSecret"))
       repo.save(nonSuperUser).unsafeRunSync() shouldBe nonSuperUser
       val result = repo.getUser(nonSuperUser.id).unsafeRunSync()
       result shouldBe Some(nonSuperUser)
@@ -98,7 +99,7 @@ class MySqlUserRepositoryIntegrationSpec
 
     "save locked user with locked status" in {
       val lockedUser =
-        User("lockedName", "lockedAccess", "lockedSecret", lockStatus = LockStatus.Locked)
+        User("lockedName", "lockedAccess", Encrypted("lockedSecret"), lockStatus = LockStatus.Locked)
       repo.save(lockedUser).unsafeRunSync() shouldBe lockedUser
       val result = repo.getUser(lockedUser.id).unsafeRunSync()
       result shouldBe Some(lockedUser)
@@ -106,7 +107,7 @@ class MySqlUserRepositoryIntegrationSpec
     }
 
     "save unlocked user with unlocked status" in {
-      val unlockedUser = User("unlockedName", "unlockedAccess", "unlockedSecret")
+      val unlockedUser = User("unlockedName", "unlockedAccess", Encrypted("unlockedSecret"))
       repo.save(unlockedUser).unsafeRunSync() shouldBe unlockedUser
       val result = repo.getUser(unlockedUser.id).unsafeRunSync()
       result shouldBe Some(unlockedUser)
@@ -114,7 +115,7 @@ class MySqlUserRepositoryIntegrationSpec
     }
 
     "save support user with support status" in {
-      val supportUser = User("lockedName", "lockedAccess", "lockedSecret", isSupport = true)
+      val supportUser = User("lockedName", "lockedAccess", Encrypted("lockedSecret"), isSupport = true)
       repo.save(supportUser).unsafeRunSync() shouldBe supportUser
       val result = repo.getUser(supportUser.id).unsafeRunSync()
       result shouldBe Some(supportUser)
@@ -122,7 +123,7 @@ class MySqlUserRepositoryIntegrationSpec
     }
 
     "save non-support user with non-support status" in {
-      val nonSupportUser = User("unlockedName", "unlockedAccess", "unlockedSecret")
+      val nonSupportUser = User("unlockedName", "unlockedAccess", Encrypted("unlockedSecret"))
       repo.save(nonSupportUser).unsafeRunSync() shouldBe nonSupportUser
       val result = repo.getUser(nonSupportUser.id).unsafeRunSync()
       result shouldBe Some(nonSupportUser)
@@ -131,7 +132,7 @@ class MySqlUserRepositoryIntegrationSpec
 
     "save a list of users" in {
       val userList = (0 to 10).toList.map { i =>
-        User(userName = s"batch-save-user-$i", "accessKey", "secretKey")
+        User(userName = s"batch-save-user-$i", "accessKey", Encrypted("secretKey"))
       }
 
       repo.save(userList).unsafeRunSync() shouldBe userList

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -30,6 +30,7 @@ import vinyldns.core.domain.zone.ZoneChangeStatus.ZoneChangeStatus
 import vinyldns.core.domain.zone._
 import vinyldns.core.TestZoneData.okZone
 import vinyldns.core.TestZoneData.testConnection
+import vinyldns.core.domain.Encrypted
 import vinyldns.mysql.TestMySqlInstance
 
 import scala.concurrent.duration._
@@ -58,7 +59,7 @@ class MySqlZoneChangeRepositoryIntegrationSpec
         systemMessage = Some("test")
       )
 
-    val goodUser: User = User(s"live-test-acct", "key", "secret")
+    val goodUser: User = User(s"live-test-acct", "key", Encrypted("secret"))
 
     val zones: IndexedSeq[Zone] = for { i <- 1 to 3 } yield Zone(
       s"${goodUser.userName}.zone$i.",

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -28,6 +28,7 @@ import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.zone._
 import vinyldns.core.TestZoneData.okZone
 import vinyldns.core.TestMembershipData._
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.zone.ZoneRepository.DuplicateZoneError
 import vinyldns.mysql.TestMySqlInstance
 
@@ -331,7 +332,7 @@ class MySqlZoneRepositoryIntegrationSpec
 
     "return an empty list of zones if the user is not authorized to any" in {
       val unauthorized = AuthPrincipal(
-        signedInUser = User("not-authorized", "not-authorized", "not-authorized"),
+        signedInUser = User("not-authorized", "not-authorized", Encrypted("not-authorized")),
         memberGroupIds = Seq.empty
       )
 

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -35,6 +35,7 @@ import play.api.libs.json._
 import play.api.libs.ws.{BodyWritable, InMemoryBody, WSClient}
 import play.api.mvc._
 import vinyldns.core.crypto.CryptoAlgebra
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership.LockStatus.LockStatus
 import vinyldns.core.domain.membership.{LockStatus, User}
 import vinyldns.core.logging.RequestTracing
@@ -282,7 +283,7 @@ class VinylDNS @Inject() (
         .format(
           user.userName,
           user.accessKey,
-          crypto.decrypt(user.secretKey),
+          crypto.decrypt(user.secretKey.value),
           vinyldnsServiceBackend
         )
     ).as("text/csv")
@@ -324,7 +325,7 @@ class VinylDNS @Inject() (
       User(
         details.username,
         User.generateKey,
-        User.generateKey,
+        Encrypted(User.generateKey),
         details.firstName,
         details.lastName,
         details.email
@@ -629,7 +630,7 @@ class VinylDNS @Inject() (
     implicit userRequest: UserRequest[_]
   ) = {
     val signableRequest = new SignableVinylDNSRequest(request)
-    val credentials = new BasicAWSCredentials(user.accessKey, crypto.decrypt(user.secretKey))
+    val credentials = new BasicAWSCredentials(user.accessKey, crypto.decrypt(user.secretKey.value))
     signer.sign(signableRequest, credentials)
     logger.info(s"Request to send: [${signableRequest.getResourcePath}]")
 

--- a/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
@@ -24,6 +24,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mock.mockito.ArgumentCapture
 import org.specs2.mutable.Specification
 import play.api.{Configuration, Environment}
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.health.HealthCheck._
 import vinyldns.core.domain.membership.User
 import vinyldns.core.health.HealthCheck.HealthCheckError
@@ -65,7 +66,7 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
 
   val testDomain1 = LdapSearchDomain("someDomain", "DC=test,DC=test,DC=com")
   val testDomain2 = LdapSearchDomain("anotherDomain", "DC=test,DC=com")
-  val nonexistentUser = User("does-not-exist", "accessKey", "secretKey")
+  val nonexistentUser = User("does-not-exist", "accessKey", Encrypted("secretKey"))
 
   "LdapAuthenticator" should {
     "apply method must create an LDAP Authenticator" in {

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -25,6 +25,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.{Application, Configuration, Environment}
 import vinyldns.core.crypto.{CryptoAlgebra, NoOpCrypto}
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership._
 import vinyldns.core.domain.record._
 import vinyldns.core.health.HealthService
@@ -41,7 +42,7 @@ trait TestApplicationData { this: Mockito =>
   val frodoUser = User(
     "fbaggins",
     "key",
-    "secret",
+    Encrypted("secret"),
     Some("Frodo"),
     Some("Baggins"),
     Some("fbaggins@hobbitmail.me"),
@@ -52,7 +53,7 @@ trait TestApplicationData { this: Mockito =>
   val lockedFrodoUser = User(
     "lockedFbaggins",
     "lockedKey",
-    "lockedSecret",
+    Encrypted("lockedSecret"),
     Some("LockedFrodo"),
     Some("LockedBaggins"),
     Some("lockedfbaggins@hobbitmail.me"),
@@ -65,7 +66,7 @@ trait TestApplicationData { this: Mockito =>
   val superFrodoUser = User(
     "superBaggins",
     "superKey",
-    "superSecret",
+    Encrypted("superSecret"),
     Some("SuperFrodo"),
     Some("SuperBaggins"),
     Some("superfbaggins@hobbitmail.me"),
@@ -87,7 +88,7 @@ trait TestApplicationData { this: Mockito =>
   val serviceAccountDetails =
     LdapUserDetails("CN=frodo,OU=hobbits,DC=middle,DC=earth", "service", None, None, None)
   val serviceAccount =
-    User("service", "key", "secret", None, None, None, DateTime.now, "service-uuid")
+    User("service", "key", Encrypted("secret"), None, None, None, DateTime.now, "service-uuid")
 
   val frodoJsonString: String =
     s"""{
@@ -103,7 +104,7 @@ trait TestApplicationData { this: Mockito =>
   val samAccount = User(
     "sgamgee",
     "key",
-    "secret",
+    Encrypted("secret"),
     Some("Samwise"),
     Some("Gamgee"),
     Some("sgamgee@hobbitmail.me"),

--- a/modules/portal/test/controllers/UserAccountAccessorSpec.scala
+++ b/modules/portal/test/controllers/UserAccountAccessorSpec.scala
@@ -21,6 +21,7 @@ import org.joda.time.DateTime
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.BeforeEach
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership._
 
 class UserAccountAccessorSpec extends Specification with Mockito with BeforeEach {
@@ -28,7 +29,7 @@ class UserAccountAccessorSpec extends Specification with Mockito with BeforeEach
   private val user = User(
     "fbaggins",
     "key",
-    "secret",
+    Encrypted("secret"),
     Some("Frodo"),
     Some("Baggins"),
     Some("fbaggins@hobbitmail.me"),
@@ -61,7 +62,7 @@ class UserAccountAccessorSpec extends Specification with Mockito with BeforeEach
     }
 
     "return the new user when storing a user that already exists in the store" in {
-      val newUser = user.copy(accessKey = "new-key", secretKey = "new-secret")
+      val newUser = user.copy(accessKey = "new-key", secretKey = Encrypted("new-secret"))
       mockRepo.save(any[User]).returns(IO.pure(newUser))
       mockChangeRepo.save(any[UserChange]).returns(IO.pure(userLog))
       underTest.update(newUser, user).unsafeRunSync() must beEqualTo(newUser)

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -1277,8 +1277,8 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
         content must contain("NT ID")
         content must contain(frodoUser.userName)
         content must contain(frodoUser.accessKey)
-        content must contain(frodoUser.secretKey)
-        there.was(one(crypto).decrypt(frodoUser.secretKey))
+        content must contain(frodoUser.secretKey.value)
+        there.was(one(crypto).decrypt(frodoUser.secretKey.value))
       }
       "redirect to login if user is not logged in" in new WithApplication(app) {
         import play.api.mvc.Result

--- a/modules/portal/test/tasks/UserSyncTaskSpec.scala
+++ b/modules/portal/test/tasks/UserSyncTaskSpec.scala
@@ -20,10 +20,11 @@ import cats.effect.IO
 import controllers.{Authenticator, UserAccountAccessor}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import vinyldns.core.domain.Encrypted
 import vinyldns.core.domain.membership._
 
 class UserSyncTaskSpec extends Specification with Mockito {
-  val notAuthUser: User = User("not-authorized", "accessKey", "secretKey")
+  val notAuthUser: User = User("not-authorized", "accessKey", Encrypted("secretKey"))
   val lockedNotAuthUser: User = notAuthUser.copy(lockStatus = LockStatus.Locked)
   val mockAuthenticator: Authenticator = {
     val mockObject = mock[Authenticator]


### PR DESCRIPTION
Fixes #193.

Changes in this pull request:
- Created a strongly typed value to represent a `String` as being encrypted or decrypted.
- Updated the `ZoneConnection` type to use the new encrypted type.
- Updated the `User` type to use the new encrypted type.
