### PR TITLE
Revert groups maxItems (PR #1142 fix)

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -110,8 +110,8 @@ vinyldns {
     limits {
       batchchange-routing-max-items-limit = 100
       membership-routing-default-max-items = 100
-      membership-routing-max-items-limit = 100
-      membership-routing-max-groups-list-limit = 100
+      membership-routing-max-items-limit = 1000
+      membership-routing-max-groups-list-limit = 1500
       recordset-routing-default-max-items= 100
       zone-routing-default-max-items = 100
       zone-routing-max-items-limit = 100

--- a/modules/portal/public/lib/services/groups/service.groups.js
+++ b/modules/portal/public/lib/services/groups/service.groups.js
@@ -56,7 +56,7 @@ angular.module('service.groups', [])
 
         this.getGroupMemberList = function (uuid) {
             var url = '/api/groups/' + uuid + '/members';
-            url = this.urlBuilder(url, { maxItems: 100 });
+            url = this.urlBuilder(url, { maxItems: 1000 });
             return $http.get(url);
         };
 
@@ -75,7 +75,7 @@ angular.module('service.groups', [])
                 query = null;
             }
             var params = {
-                "maxItems": 100,
+                "maxItems": 1500,
                 "groupNameFilter": query,
                 "ignoreAccess": ignoreAccess
             };


### PR DESCRIPTION
Fixes #1142.

Changes in this pull request:
- Revert the `groups maxItems` that was changed in the [groups pagination PR](https://github.com/vinyldns/vinyldns/pull/1142) to how it was before, so that we don't see only 100 groups in dropdown.