### PR TITLE
Fix dotted hosts update (PR #1187)

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -169,14 +169,13 @@ class RecordSetService(
       isRecordTypeAllowed = checkIfInAllowedRecordType(zone, dottedHostsConfig, rsForValidations)
       isRecordTypeAndUserAllowed = isAllowedUser && isRecordTypeAllowed
       allowedDotsLimit = getAllowedDotsLimit(zone, dottedHostsConfig)
-      recordFqdnDoesNotAlreadyExist <- recordFQDNDoesNotExist(rsForValidations, zone).toResult[Boolean]
       _ <- typeSpecificValidations(
         rsForValidations,
         existingRecordsWithName,
         zone,
         Some(existing),
         approvedNameServers,
-        recordFqdnDoesNotAlreadyExist,
+        true,
         allowedZoneList,
         isRecordTypeAndUserAllowed,
         allowedDotsLimit


### PR DESCRIPTION
Fixes #1187 

Changes in this pull request:
- When we `update` a created dotted host, we currently get an error and doesn’t allow us to `update`. The problem is with the validation which is added to check the conflict while `creating` dotted hosts. That validation is not necessary to be in `update` since we already handle it while `creating` and recordset name cannot be changed during `update`. 
- Removed the validation from `update` now and it works as expected.
- Added tests to verify the working.
