### PR TITLE
Hotfix: Raise Limit of Maximum Items in a Group List to 3000

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -134,7 +134,7 @@ vinyldns {
       batchchange-routing-max-items-limit = 100
       membership-routing-default-max-items = 100
       membership-routing-max-items-limit = 1000
-      membership-routing-max-groups-list-limit = 1500
+      membership-routing-max-groups-list-limit = 3000
       recordset-routing-default-max-items= 100
       zone-routing-default-max-items = 100
       zone-routing-max-items-limit = 100

--- a/modules/portal/public/lib/services/groups/service.groups.js
+++ b/modules/portal/public/lib/services/groups/service.groups.js
@@ -75,7 +75,7 @@ angular.module('service.groups', [])
                 query = null;
             }
             var params = {
-                "maxItems": 1500,
+                "maxItems": 3000,
                 "groupNameFilter": query,
                 "ignoreAccess": ignoreAccess
             };


### PR DESCRIPTION
Fixes #1196

Currently we are hitting the 1500 item limit for groups that can be displayed in a dropdown. This fix increases the limit to 3000.