### PR TITLE
Update zone record change pagination

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/ListRecordSetChangesResponse.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/ListRecordSetChangesResponse.scala
@@ -22,8 +22,8 @@ import vinyldns.core.domain.record.ListRecordSetChangesResults
 case class ListRecordSetChangesResponse(
     zoneId: String,
     recordSetChanges: List[RecordSetChangeInfo] = Nil,
-    nextId: Option[String],
-    startFrom: Option[String],
+    nextId: Option[Int],
+    startFrom: Option[Int],
     maxItems: Int
 )
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -569,7 +569,7 @@ class RecordSetService(
 
   def listRecordSetChanges(
                             zoneId: String,
-                            startFrom: Option[String] = None,
+                            startFrom: Option[Int] = None,
                             maxItems: Int = 100,
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetChangesResponse] =

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
@@ -98,7 +98,7 @@ trait RecordSetServiceAlgebra {
 
   def listRecordSetChanges(
                             zoneId: String,
-                            startFrom: Option[String],
+                            startFrom: Option[Int],
                             maxItems: Int,
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetChangesResponse]

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -215,8 +215,8 @@ class RecordSetRoute(
     } ~
     path("zones" / Segment / "recordsetchanges") { zoneId =>
       (get & monitor("Endpoint.listRecordSetChanges")) {
-        parameters("startFrom".?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS)) {
-          (startFrom: Option[String], maxItems: Int) =>
+        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS)) {
+          (startFrom: Option[Int], maxItems: Int) =>
             handleRejections(invalidQueryHandler) {
               validate(
                 check = 0 < maxItems && maxItems <= DEFAULT_MAX_ITEMS,

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -83,6 +83,17 @@ def test_list_recordset_changes_no_start(shared_zone_test_context):
     response = client.list_recordset_changes(original_zone["id"], start_from=None, max_items=None)
     check_changes_response(response, recordChanges=True, startFrom=False, nextId=False)
 
+    deleteChanges = response["recordSetChanges"][0:3]
+    updateChanges = response["recordSetChanges"][3:6]
+    createChanges = response["recordSetChanges"][6:9]
+
+    for change in deleteChanges:
+        assert_that(change["changeType"], is_("Delete"))
+    for change in updateChanges:
+        assert_that(change["changeType"], is_("Update"))
+    for change in createChanges:
+        assert_that(change["changeType"], is_("Create"))
+
 
 def test_list_recordset_changes_paging(shared_zone_test_context):
     """
@@ -101,6 +112,13 @@ def test_list_recordset_changes_paging(shared_zone_test_context):
     check_changes_response(response_2, recordChanges=True, nextId=True, startFrom=response_1["nextId"], maxItems=3)
     check_changes_response(response_3, recordChanges=True, nextId=False, startFrom=response_2["nextId"], maxItems=11)
 
+    for change in response_1["recordSetChanges"]:
+        assert_that(change["changeType"], is_("Delete"))
+    for change in response_2["recordSetChanges"]:
+        assert_that(change["changeType"], is_("Update"))
+    for change in response_3["recordSetChanges"]:
+        assert_that(change["changeType"], is_("Create"))
+
 
 def test_list_recordset_changes_exhausted(shared_zone_test_context):
     """
@@ -111,15 +129,26 @@ def test_list_recordset_changes_exhausted(shared_zone_test_context):
     response = client.list_recordset_changes(original_zone["id"], start_from=None, max_items=17)
     check_changes_response(response, recordChanges=True, startFrom=False, nextId=False, maxItems=17)
 
+    deleteChanges = response["recordSetChanges"][0:3]
+    updateChanges = response["recordSetChanges"][3:6]
+    createChanges = response["recordSetChanges"][6:9]
+
+    for change in deleteChanges:
+        assert_that(change["changeType"], is_("Delete"))
+    for change in updateChanges:
+        assert_that(change["changeType"], is_("Update"))
+    for change in createChanges:
+        assert_that(change["changeType"], is_("Create"))
+
 
 def test_list_recordset_returning_no_changes(shared_zone_test_context):
     """
-    Pass in startFrom of random should return empty list because start key is id
+    Pass in startFrom of "2000" should return empty list because start key exceeded no.of.recordset changes
     """
     client = shared_zone_test_context.history_client
     original_zone = shared_zone_test_context.history_zone
-    response = client.list_recordset_changes(original_zone["id"], start_from="random", max_items=None)
-    check_changes_response(response, recordChanges=False, startFrom="random", nextId=False)
+    response = client.list_recordset_changes(original_zone["id"], start_from="2000", max_items=None)
+    check_changes_response(response, recordChanges=False, startFrom="2000", nextId=False)
 
 
 def test_list_recordset_changes_default_max_items(shared_zone_test_context):

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -143,7 +143,7 @@ def test_list_recordset_changes_exhausted(shared_zone_test_context):
 
 def test_list_recordset_returning_no_changes(shared_zone_test_context):
     """
-    Pass in startFrom of "2000" should return empty list because start key exceeded no.of.recordset changes
+    Pass in startFrom of "2000" should return empty list because start key exceeded number of recordset changes
     """
     client = shared_zone_test_context.history_client
     original_zone = shared_zone_test_context.history_zone

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -147,8 +147,8 @@ def test_list_recordset_returning_no_changes(shared_zone_test_context):
     """
     client = shared_zone_test_context.history_client
     original_zone = shared_zone_test_context.history_zone
-    response = client.list_recordset_changes(original_zone["id"], start_from="2000", max_items=None)
-    check_changes_response(response, recordChanges=False, startFrom="2000", nextId=False)
+    response = client.list_recordset_changes(original_zone["id"], start_from=2000, max_items=None)
+    check_changes_response(response, recordChanges=False, startFrom=2000, nextId=False)
 
 
 def test_list_recordset_changes_default_max_items(shared_zone_test_context):

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -83,17 +83,6 @@ def test_list_recordset_changes_no_start(shared_zone_test_context):
     response = client.list_recordset_changes(original_zone["id"], start_from=None, max_items=None)
     check_changes_response(response, recordChanges=True, startFrom=False, nextId=False)
 
-    deleteChanges = response["recordSetChanges"][0:3]
-    updateChanges = response["recordSetChanges"][3:6]
-    createChanges = response["recordSetChanges"][6:9]
-
-    for change in deleteChanges:
-        assert_that(change["changeType"], is_("Delete"))
-    for change in updateChanges:
-        assert_that(change["changeType"], is_("Update"))
-    for change in createChanges:
-        assert_that(change["changeType"], is_("Create"))
-
 
 def test_list_recordset_changes_paging(shared_zone_test_context):
     """
@@ -112,13 +101,6 @@ def test_list_recordset_changes_paging(shared_zone_test_context):
     check_changes_response(response_2, recordChanges=True, nextId=True, startFrom=response_1["nextId"], maxItems=3)
     check_changes_response(response_3, recordChanges=True, nextId=False, startFrom=response_2["nextId"], maxItems=11)
 
-    for change in response_1["recordSetChanges"]:
-        assert_that(change["changeType"], is_("Delete"))
-    for change in response_2["recordSetChanges"]:
-        assert_that(change["changeType"], is_("Update"))
-    for change in response_3["recordSetChanges"]:
-        assert_that(change["changeType"], is_("Create"))
-
 
 def test_list_recordset_changes_exhausted(shared_zone_test_context):
     """
@@ -129,26 +111,15 @@ def test_list_recordset_changes_exhausted(shared_zone_test_context):
     response = client.list_recordset_changes(original_zone["id"], start_from=None, max_items=17)
     check_changes_response(response, recordChanges=True, startFrom=False, nextId=False, maxItems=17)
 
-    deleteChanges = response["recordSetChanges"][0:3]
-    updateChanges = response["recordSetChanges"][3:6]
-    createChanges = response["recordSetChanges"][6:9]
-
-    for change in deleteChanges:
-        assert_that(change["changeType"], is_("Delete"))
-    for change in updateChanges:
-        assert_that(change["changeType"], is_("Update"))
-    for change in createChanges:
-        assert_that(change["changeType"], is_("Create"))
-
 
 def test_list_recordset_returning_no_changes(shared_zone_test_context):
     """
-    Pass in startFrom of 0 should return empty list because start key is created time
+    Pass in startFrom of random should return empty list because start key is created time
     """
     client = shared_zone_test_context.history_client
     original_zone = shared_zone_test_context.history_zone
-    response = client.list_recordset_changes(original_zone["id"], start_from="0", max_items=None)
-    check_changes_response(response, recordChanges=False, startFrom="0", nextId=False)
+    response = client.list_recordset_changes(original_zone["id"], start_from="random", max_items=None)
+    check_changes_response(response, recordChanges=False, startFrom="random", nextId=False)
 
 
 def test_list_recordset_changes_default_max_items(shared_zone_test_context):

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -114,7 +114,7 @@ def test_list_recordset_changes_exhausted(shared_zone_test_context):
 
 def test_list_recordset_returning_no_changes(shared_zone_test_context):
     """
-    Pass in startFrom of random should return empty list because start key is created time
+    Pass in startFrom of random should return empty list because start key is id
     """
     client = shared_zone_test_context.history_client
     original_zone = shared_zone_test_context.history_zone

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -674,7 +674,7 @@ class RecordSetRoutingSpec
 
     def listRecordSetChanges(
                               zoneId: String,
-                              startFrom: Option[String],
+                              startFrom: Option[Int],
                               maxItems: Int,
                               authPrincipal: AuthPrincipal
                             ): Result[ListRecordSetChangesResponse] = {

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/ListRecordSetChangesResults.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/ListRecordSetChangesResults.scala
@@ -18,7 +18,7 @@ package vinyldns.core.domain.record
 
 case class ListRecordSetChangesResults(
     items: List[RecordSetChange] = List[RecordSetChange](),
-    nextId: Option[String] = None,
-    startFrom: Option[String] = None,
+    nextId: Option[Int] = None,
+    startFrom: Option[Int] = None,
     maxItems: Int = 100
 )

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordChangeRepository.scala
@@ -26,7 +26,7 @@ trait RecordChangeRepository extends Repository {
 
   def listRecordSetChanges(
       zoneId: String,
-      startFrom: Option[String] = None,
+      startFrom: Option[Int] = None,
       maxItems: Int = 100
   ): IO[ListRecordSetChangesResults]
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordChangeRepositoryIntegrationSpec.scala
@@ -100,22 +100,26 @@ class MySqlRecordChangeRepositoryIntegrationSpec
       (result.items should have).length(5)
     }
     "page through record changes" in {
-      val inserts = generateInserts(okZone, 5)
+      // sort by created desc, so adding additional seconds makes it more current, the last
+      val timeSpaced =
+        generateInserts(okZone, 5).zipWithIndex.map {
+          case (c, i) => c.copy(created = c.created.plusSeconds(i))
+        }
 
-      // expect to be sorted by id in ascending order
-      val expectedOrder = inserts.sortBy(_.id)
+      // expect to be sorted by created descending so reverse that
+      val expectedOrder = timeSpaced.sortBy(_.created.getMillis).reverse
 
       val saveRecChange = executeWithinTransaction { db: DB =>
-        repo.save(db, ChangeSet(inserts))
+        repo.save(db, ChangeSet(timeSpaced))
       }
       saveRecChange.attempt.unsafeRunSync() shouldBe right
       val page1 = repo.listRecordSetChanges(okZone.id, None, 2).unsafeRunSync()
-      page1.nextId shouldBe Some(expectedOrder(1).id)
+      page1.nextId shouldBe Some(2)
       page1.maxItems shouldBe 2
       (page1.items should contain).theSameElementsInOrderAs(expectedOrder.take(2))
 
       val page2 = repo.listRecordSetChanges(okZone.id, page1.nextId, 2).unsafeRunSync()
-      page2.nextId shouldBe Some(expectedOrder(3).id)
+      page2.nextId shouldBe Some(4)
       page2.maxItems shouldBe 2
       (page2.items should contain).theSameElementsInOrderAs(expectedOrder.slice(2, 4))
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
@@ -35,8 +35,8 @@ class MySqlRecordChangeRepository
       |SELECT data
       |  FROM record_change
       | WHERE zone_id = {zoneId}
-      |   AND created < {created}
-      |  ORDER BY created DESC
+      |   AND id > {id}
+      |  ORDER BY id ASC
       |  LIMIT {limit}
     """.stripMargin
 
@@ -45,7 +45,7 @@ class MySqlRecordChangeRepository
       |SELECT data
       |  FROM record_change
       | WHERE zone_id = {zoneId}
-      |  ORDER BY created DESC
+      |  ORDER BY id ASC
       |  LIMIT {limit}
     """.stripMargin
 
@@ -98,7 +98,7 @@ class MySqlRecordChangeRepository
           val changes = startFrom match {
             case Some(start) =>
               LIST_CHANGES_WITH_START
-                .bindByName('zoneId -> zoneId, 'created -> start.toLong, 'limit -> maxItems)
+                .bindByName('zoneId -> zoneId, 'id -> start, 'limit -> maxItems)
                 .map(toRecordSetChange)
                 .list()
                 .apply()
@@ -112,7 +112,7 @@ class MySqlRecordChangeRepository
 
           val nextId =
             if (changes.size < maxItems) None
-            else changes.lastOption.map(_.created.getMillis.toString)
+            else changes.lastOption.map(_.id)
 
           ListRecordSetChangesResults(
             changes,

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
@@ -33,20 +33,19 @@ class MySqlRecordChangeRepository
   private val LIST_CHANGES_WITH_START =
     sql"""
       |SELECT data
-      |  FROM record_change
+      | FROM record_change
       | WHERE zone_id = {zoneId}
-      |   AND id > {id}
-      |  ORDER BY id ASC
-      |  LIMIT {limit}
+      | ORDER BY created DESC
+      | LIMIT {limit} OFFSET {startFrom}
     """.stripMargin
 
   private val LIST_CHANGES_NO_START =
     sql"""
       |SELECT data
-      |  FROM record_change
+      | FROM record_change
       | WHERE zone_id = {zoneId}
-      |  ORDER BY id ASC
-      |  LIMIT {limit}
+      | ORDER BY created DESC
+      | LIMIT {limit}
     """.stripMargin
 
   private val GET_CHANGE =
@@ -89,7 +88,7 @@ class MySqlRecordChangeRepository
 
   def listRecordSetChanges(
       zoneId: String,
-      startFrom: Option[String],
+      startFrom: Option[Int],
       maxItems: Int
   ): IO[ListRecordSetChangesResults] =
     monitor("repo.RecordChange.listRecordSetChanges") {
@@ -98,7 +97,7 @@ class MySqlRecordChangeRepository
           val changes = startFrom match {
             case Some(start) =>
               LIST_CHANGES_WITH_START
-                .bindByName('zoneId -> zoneId, 'id -> start, 'limit -> maxItems)
+                .bindByName('zoneId -> zoneId, 'startFrom -> start, 'limit -> maxItems)
                 .map(toRecordSetChange)
                 .list()
                 .apply()
@@ -110,9 +109,8 @@ class MySqlRecordChangeRepository
                 .apply()
           }
 
-          val nextId =
-            if (changes.size < maxItems) None
-            else changes.lastOption.map(_.id)
+          val startValue = startFrom.getOrElse(0)
+          val nextId = if (changes.size < maxItems) None else Some(startValue + maxItems)
 
           ListRecordSetChangesResults(
             changes,


### PR DESCRIPTION
Fixes #566
Changes in this pull request:
- Updated record change paging in api to paginate properly using `LIMIT` and `OFFSET`, like while listing and paginating in [batch changes](https://github.com/vinyldns/vinyldns/blob/5e9616c12f61d59708c2fff0dc5ad3ff4903467d/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala#L234)