### PR TITLE
Check Records Resolution through portal and api

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -36,6 +36,7 @@ import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 import vinyldns.core.domain.backend.{Backend, BackendResolver}
 
+import scala.sys.process._
 import scala.util.matching.Regex
 
 object RecordSetService {
@@ -177,6 +178,11 @@ class RecordSetService(
       recordSet <- getRecordSet(recordSetId)
       groupName <- getGroupName(recordSet.ownerGroupId)
     } yield RecordSetInfo(recordSet, groupName)
+
+  def dig(fqdn: String): Result[String] = {
+    val dig = "dig "+fqdn
+    dig.!! // Captures the dig output
+  }.toResult
 
   def getRecordSetByZone(
                           recordSetId: String,
@@ -511,4 +517,8 @@ class RecordSetService(
       ensureTrailingDot(recordNameFilter)
     }
   }.toResult
+
+   def getRecordSetResolution(fqdn: String, authPrincipal: AuthPrincipal): Result[String] = {
+    for{output <- dig(fqdn)} yield output
+   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
@@ -41,6 +41,11 @@ trait RecordSetServiceAlgebra {
                     authPrincipal: AuthPrincipal
                   ): Result[RecordSetInfo]
 
+  def getRecordSetResolution(
+                              fqdn: String,
+                              authPrincipal: AuthPrincipal
+                       ): Result[String]
+
   def getRecordSetByZone(
                           recordSetId: String,
                           zoneId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -179,6 +179,19 @@ class RecordSetRoute(
         }
       }
     } ~
+    path("recordsetresolution" / Segment ) { fqdn =>
+      (get & monitor("Endpoint.recordsetresolution"))
+      {
+        authenticateAndExecute(
+          recordSetService
+            .getRecordSetResolution(
+              fqdn,
+              _
+            )) { rs =>
+          complete(StatusCodes.OK, rs)
+        }
+      }
+    } ~
     path("zones" / Segment / "recordsets" / Segment) { (zoneId, rsId) =>
       (get & monitor("Endpoint.getRecordSetByZone")) {
         authenticateAndExecute(recordSetService.getRecordSetByZone(rsId, zoneId, _)) { rs =>

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -561,6 +561,23 @@ class VinylDNS @Inject() (
     // $COVERAGE-ON$
   }
 
+  def getRecordSetResolution(fqdn: String): Action[AnyContent] = userAction.async { implicit request =>
+    val queryParameters = new HashMap[String, java.util.List[String]]()
+    for {
+      (name, values) <- request.queryString
+    } queryParameters.put(name, values.asJava)
+    val vinyldnsRequest = VinylDNSRequest(
+      "GET",
+      s"$vinyldnsServiceBackend",
+      s"recordsetresolution/$fqdn",
+      parameters = queryParameters
+    )
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+  }
+
   def listRecordSetChanges(id: String): Action[AnyContent] = userAction.async { implicit request =>
     // $COVERAGE-OFF$
     val queryParameters = new HashMap[String, java.util.List[String]]()

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -2,6 +2,7 @@
 
     <!-- START ACCORDION -->
     <!-- START RECENT RECORDSET CHANGES TABLE PANEL -->
+
 <div class="panel panel-default x_panel" ng-init="sharedDisplayEnabled = @meta.sharedDisplayEnabled; defaultTtl = @meta.defaultTtl">
     <div class="panel-heading">
         <h3 class="panel-title">
@@ -55,6 +56,10 @@
 </div>
     <!-- START RECENT RECORDSET CHANGES TABLE PANEL -->
     <!-- END ACCORDION -->
+<modal modal-id="dig" modal-title="Record Resolution">
+        <p id="digResponse"></p>
+</modal>
+
 
     <!-- START RECORD TABLE -->
 <div class="panel panel-default">
@@ -69,8 +74,7 @@
             <button id="create-record-button" class="btn btn-default" ng-if="canCreateRecords" ng-click="createRecord(defaultTtl)"><span class="fa fa-plus"></span> Create Record Set</button>
             <button id="zone-sync-button" class="btn btn-default mb-control" ng-if="zoneInfo.accessLevel=='Delete'" data-toggle="modal" data-target="#mb-sync"><span class="fa fa-exchange"></span> Sync Zone</button>
         </div>
-
-        <div>
+          <div>
             <form class="input-group" ng-submit="refreshRecords()">
                 <div class="input-group">
                     <span class="input-group-btn">
@@ -116,6 +120,7 @@
                         <th ng-if="zoneInfo.shared">Owner Group Name</th>
                     }
                     <th>Actions</th>
+                    <th>DNS Resolve</th>
                 </tr>
             </thead>
             <tbody>
@@ -331,6 +336,13 @@
                             </div>
                         </span>
                     </td>
+                    <td>
+                        <span>
+                            <button id="dig" class="btn btn-default" ng-click="clickDig(record.fqdn)">
+                                <span style="font-size:24px" class="fa">&#xf021;</span>
+                            </button>
+                        </span>
+                    </td>
                 </tr>
             </tbody>
         </table>
@@ -375,3 +387,5 @@
     </div>
 </div>
     <!-- END MESSAGE MODAL-->
+
+

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -37,6 +37,7 @@ DELETE        /api/zones/:id                     @controllers.VinylDNS.deleteZon
 POST          /api/zones/:id/sync                @controllers.VinylDNS.syncZone(id: String)
 
 GET           /api/zones/:id/recordsets          @controllers.VinylDNS.listRecordSetsByZone(id: String)
+GET           /api/recordsetresolution/:fqdn     @controllers.VinylDNS.getRecordSetResolution(fqdn: String)
 POST          /api/zones/:id/recordsets          @controllers.VinylDNS.addRecordSet(id: String)
 DELETE        /api/zones/:zid/recordsets/:rid    @controllers.VinylDNS.deleteRecordSet(zid: String, rid:String)
 PUT           /api/zones/:zid/recordsets/:rid    @controllers.VinylDNS.updateRecordSet(zid: String, rid:String)

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -522,3 +522,8 @@ input[type="file"] {
     top: 0;
     z-index: 1000;
 }
+
+#digResponse {
+  background-color: #000000; /* Fallback color */
+  color: #ffffff;
+}

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -46,6 +46,7 @@ angular.module('controller.records', [])
     $scope.currentRecord = {};
     $scope.zoneInfo = {};
     $scope.profile = {};
+    $scope.dig = {};
 
     var loadZonesPromise;
     var loadRecordsPromise;
@@ -480,6 +481,25 @@ angular.module('controller.records', [])
             .catch(function (error){
                 handleError(error, 'recordsService::listRecordSetsByZone-failure');
             });
+    };
+
+    $scope.clickDig = function(fqdn) {
+        function success(response) {
+        var dig = response.data;
+        var digString= JSON.stringify(dig)
+        var digReplaceBr = digString.replace(/\\n/g,'<br>')
+        var digReplaceTab =  digReplaceBr.replace(/\\t/g,'    ')
+        var digReplaceSlash =  digReplaceTab.replace(/\\/g,' ')
+        $scope.dig = digReplaceSlash.replace('"',' ')
+        document.getElementById("digResponse").innerHTML = $scope.dig;
+        $("#dig").modal("show");
+        }
+        return recordsService
+                  .dig(fqdn)
+                  .then(success)
+                  .catch(function (error) {
+                  handleError(error, 'dnsChangesService::getRecordSet-failure');
+                  });
     };
 
     function updateRecordDisplay(records) {

--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -76,6 +76,11 @@ angular.module('service.records', [])
             return $http.get(url);
         };
 
+        this.dig = function (fqdn) {
+                    var url = utilityService.urlBuilder("/api/recordsetresolution/"+fqdn);
+                    return $http.get(url);
+                };
+
         this.getRecordSet = function (rsid) {
             return $http.get("/api/recordsets/"+rsid);
         };


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
- Check Records Resolution through portal(by clicking DNS resolve button) and api(http://<hostname>:9000/recordsetresolution/<fqdn>)
#todo - Yet to discuss functionality with the DNS team.
