### PR TITLE
Added metrics api for zone change failure and record change failure

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/ListRecordSetChangesResponse.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/ListRecordSetChangesResponse.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain.record
 
 import vinyldns.api.domain.zone.RecordSetChangeInfo
-import vinyldns.core.domain.record.ListRecordSetChangesResults
+import vinyldns.core.domain.record.{ListRecordSetChangesResults, RecordSetChange}
 
 case class ListRecordSetChangesResponse(
     zoneId: String,
@@ -41,3 +41,7 @@ object ListRecordSetChangesResponse {
       listResults.maxItems
     )
 }
+
+case class ListFailedRecordSetChangesResponse(
+                                               failedRecordSetChanges: List[RecordSetChange] = Nil,
+                                             )

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -581,6 +581,25 @@ class RecordSetService(
       recordSetChangesInfo <- buildRecordSetChangeInfo(recordSetChangesResults.items)
     } yield ListRecordSetChangesResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
 
+
+  def listFailedRecordSetChanges(
+                                  authPrincipal: AuthPrincipal
+                                ): Result[ListFailedRecordSetChangesResponse] =
+    for {
+      recordSetChangesFailedResults <- recordChangeRepository
+        .listFailedRecordSetChanges()
+        .toResult[List[RecordSetChange]]
+      _ <- zoneAccess(recordSetChangesFailedResults, authPrincipal).toResult
+    } yield ListFailedRecordSetChangesResponse(recordSetChangesFailedResults)
+
+  def zoneAccess(
+                  RecordSetCh: List[RecordSetChange],
+                  auth: AuthPrincipal
+                ): List[Result[Unit]] =
+    RecordSetCh.map { zn =>
+      canSeeZone(auth, zn.zone).toResult
+    }
+
   def getZone(zoneId: String): Result[Zone] =
     zoneRepository
       .getZone(zoneId)

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
@@ -103,4 +103,8 @@ trait RecordSetServiceAlgebra {
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetChangesResponse]
 
+  def listFailedRecordSetChanges(
+                                  authPrincipal: AuthPrincipal
+                                ): Result[ListFailedRecordSetChangesResponse]
+
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ListZoneChangesResponse.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ListZoneChangesResponse.scala
@@ -37,3 +37,7 @@ object ListZoneChangesResponse {
       listResults.maxItems
     )
 }
+
+case class ListFailedZoneChangesResponse(
+                                          failedZoneChanges: List[ZoneChange] = Nil,
+                                        )

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -226,6 +226,25 @@ class ZoneService(
         .toResult[ListZoneChangesResults]
     } yield ListZoneChangesResponse(zone.id, zoneChangesResults)
 
+  def listFailedZoneChanges(
+                             authPrincipal: AuthPrincipal
+                           ): Result[ListFailedZoneChangesResponse] =
+    for {
+      zoneChangesFailedResults <- zoneChangeRepository
+        .listFailedZoneChanges()
+        .toResult[List[ZoneChange]]
+      _ <- zoneAccess(zoneChangesFailedResults, authPrincipal).toResult
+    } yield {
+      ListFailedZoneChangesResponse(zoneChangesFailedResults)}
+
+  def zoneAccess(
+                  zoneCh: List[ZoneChange],
+                  auth: AuthPrincipal
+                ): List[Result[Unit]] =
+    zoneCh.map { zn =>
+      canSeeZone(auth, zn.zone).toResult
+    }
+
   def addACLRule(
       zoneId: String,
       aclRuleInfo: ACLRuleInfo,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -67,4 +67,7 @@ trait ZoneServiceAlgebra {
 
   def getBackendIds(): Result[List[String]]
 
+  def listFailedZoneChanges(
+                             authPrincipal: AuthPrincipal
+                           ): Result[ListFailedZoneChangesResponse]
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -233,7 +233,17 @@ class RecordSetRoute(
             }
         }
       }
+    } ~
+    path("metrics" / "health" / "recordsetchangesfailure") {
+      (get & monitor("Endpoint.listFailedRecordSetChanges")) {
+          handleRejections(invalidQueryHandler) {
+              authenticateAndExecute(recordSetService.listFailedRecordSetChanges(_)) {
+                  changes =>
+                  complete(StatusCodes.OK, changes)
+            }
+        }
     }
+}
 
   private val invalidQueryHandler = RejectionHandler
     .newBuilder()

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -163,6 +163,16 @@ class ZoneRoute(
         }
       }
     } ~
+    path("metrics" / "health" / "zonechangesfailure") {
+      (get & monitor("Endpoint.listFailedZoneChanges")) {
+        handleRejections(invalidQueryHandler) {
+          authenticateAndExecute(zoneService.listFailedZoneChanges(_)) {
+            changes =>
+              complete(StatusCodes.OK, changes)
+          }
+        }
+      }
+    } ~
     path("zones" / Segment / "acl" / "rules") { id =>
       (put & monitor("Endpoint.addZoneACLRule")) {
         authenticateAndExecuteWithEntity[ZoneCommandResult, ACLRuleInfo](

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -1928,6 +1928,30 @@ class RecordSetServiceSpec
       result shouldBe expectedResults
     }
 
+    "listFailedRecordSetChanges" should {
+      "retrieve the recordset changes" in {
+        val completeRecordSetChanges: List[RecordSetChange] = List(
+          pendingCreateAAAA.copy(status = RecordSetChangeStatus.Failed),
+          pendingCreateCNAME.copy(status = RecordSetChangeStatus.Failed),
+          completeCreateAAAA.copy(status = RecordSetChangeStatus.Failed),
+          completeCreateCNAME.copy(status = RecordSetChangeStatus.Failed)
+        )
+        //val recordSetChange= List[RecordSetChange]
+        doReturn(IO.pure(completeRecordSetChanges))
+          .when(mockRecordChangeRepo)
+          .listFailedRecordSetChanges()
+
+
+        val result: ListFailedRecordSetChangesResponse =
+          underTest.listFailedRecordSetChanges(authPrincipal = okAuth).value.unsafeRunSync().toOption.get
+
+        val changesWithName =
+          ListFailedRecordSetChangesResponse(completeRecordSetChanges)
+
+        result shouldBe changesWithName
+      }
+    }
+
     "return a NotAuthorizedError" in {
       val error = leftResultOf(
         underTest.listRecordSetChanges(zoneNotAuthorized.id, authPrincipal = okAuth).value

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -771,6 +771,23 @@ class ZoneServiceSpec
     }
   }
 
+  "listFailedZoneChanges" should {
+    "retrieve the zone changes" in {
+
+      doReturn(IO.pure(List[ZoneChange](
+        zoneUpdate.copy(status = ZoneChangeStatus.Failed)
+      )))
+        .when(mockZoneChangeRepo)
+        .listFailedZoneChanges()
+
+      val result: ListFailedZoneChangesResponse =
+        underTest.listFailedZoneChanges(okAuth).value.unsafeRunSync().toOption.get
+
+      result.failedZoneChanges shouldBe List(
+        zoneUpdate.copy(status = ZoneChangeStatus.Failed))
+    }
+  }
+
   "AddAclRule" should {
     "fail if the user is not authorized for the zone" in {
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(anyString)

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -133,6 +133,10 @@ class ZoneRoutingSpec
     maxItems = 100
   )
 
+  private val listFailedZoneChangeResponse = ListFailedZoneChangesResponse(
+    List(zoneCreate.copy(status=ZoneChangeStatus.Failed), zoneUpdate.copy(status=ZoneChangeStatus.Failed))
+  )
+
   val crypto = new JavaCrypto(
     ConfigFactory.parseString(
       """secret = "8B06A7F3BC8A2497736F1916A123AA40E88217BE9264D8872597EF7A6E5DCE61""""
@@ -349,6 +353,15 @@ class ZoneRoutingSpec
         case notFound.id => Left(ZoneNotFoundError(s"$zoneId"))
         case notAuthorized.id => Left(NotAuthorizedError("no way"))
         case _ => Right(listZoneChangeResponse)
+      }
+      outcome.toResult
+    }
+
+    def listFailedZoneChanges(
+                               authPrincipal: AuthPrincipal
+                             ): Result[ListFailedZoneChangesResponse] = {
+      val outcome = authPrincipal match {
+        case _ => Right(listFailedZoneChangeResponse)
       }
       outcome.toResult
     }
@@ -988,6 +1001,18 @@ class ZoneRoutingSpec
       }
       Get(s"/zones/${ok.id}/changes?maxItems=0") ~> zoneRoute ~> check {
         status shouldBe BadRequest
+      }
+    }
+  }
+
+  "GET failed zone changes" should {
+    "return the failed zone changes" in {
+      val zoneCreateFailed = zoneCreate.copy(status = ZoneChangeStatus.Failed)
+      val zoneUpdateFailed = zoneUpdate.copy(status = ZoneChangeStatus.Failed)
+      Get(s"/metrics/health/zonechangesfailure") ~> zoneRoute ~> check {
+        val changes = responseAs[ListFailedZoneChangesResponse]
+        changes.failedZoneChanges.map(_.id) shouldBe List(zoneCreateFailed.id, zoneUpdateFailed.id)
+
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordChangeRepository.scala
@@ -31,4 +31,7 @@ trait RecordChangeRepository extends Repository {
   ): IO[ListRecordSetChangesResults]
 
   def getRecordSetChange(zoneId: String, changeId: String): IO[Option[RecordSetChange]]
+
+  def listFailedRecordSetChanges(): IO[List[RecordSetChange]]
+
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChangeRepository.scala
@@ -28,4 +28,7 @@ trait ZoneChangeRepository extends Repository {
       startFrom: Option[String] = None,
       maxItems: Int = 100
   ): IO[ListZoneChangesResults]
+
+  def listFailedZoneChanges(
+                           ): IO[List[ZoneChange]]
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordChangeRepositoryIntegrationSpec.scala
@@ -17,13 +17,12 @@
 package vinyldns.mysql.repository
 
 import java.util.UUID
-
 import cats.scalatest.EitherMatchers
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc._
-import vinyldns.core.domain.record.{ChangeSet, RecordChangeRepository, RecordSetChange, RecordSetChangeType}
+import vinyldns.core.domain.record.{ChangeSet, RecordChangeRepository, RecordSetChange, RecordSetChangeStatus, RecordSetChangeType}
 import vinyldns.core.domain.zone.Zone
 import vinyldns.mysql.TestMySqlInstance
 import vinyldns.mysql.TransactionProvider
@@ -162,7 +161,6 @@ class MySqlRecordChangeRepositoryIntegrationSpec
       result shouldBe List()
     }
   }
-}
 }
 
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -81,24 +81,24 @@ class MySqlZoneChangeRepositoryIntegrationSpec
       status,
       created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusSeconds(Random.nextInt(1000))
     )
-  }
 
-  val failedChanges
-  : IndexedSeq[ZoneChange] = for { zone <- zones } yield ZoneChange(
-    zone,
-    zone.account,
-    ZoneChangeType.Update,
-    status= ZoneChangeStatus.Failed,
-    created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusSeconds(Random.nextInt(1000))
-  )
-  val successChanges
-  : IndexedSeq[ZoneChange] = for { zone <- zones } yield ZoneChange(
-    zone,
-    zone.account,
-    ZoneChangeType.Update,
-    status= ZoneChangeStatus.Synced,
-    created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusSeconds(Random.nextInt(1000))
-  )
+    val failedChanges
+    : IndexedSeq[ZoneChange] = for { zone <- zones } yield ZoneChange(
+      zone,
+      zone.account,
+      ZoneChangeType.Update,
+      status= ZoneChangeStatus.Failed,
+      created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusSeconds(Random.nextInt(1000))
+    )
+    val successChanges
+    : IndexedSeq[ZoneChange] = for { zone <- zones } yield ZoneChange(
+      zone,
+      zone.account,
+      ZoneChangeType.Update,
+      status= ZoneChangeStatus.Synced,
+      created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusSeconds(Random.nextInt(1000))
+    )
+  }
 
   import TestData._
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -47,6 +47,13 @@ class MySqlZoneChangeRepository
       |  LIMIT {maxItems}
     """.stripMargin
 
+  private final val LIST_ZONES_CHANGES_DATA =
+    sql"""
+         |SELECT zc.data
+         |  FROM zone_change zc
+         |  JOIN zone z ON z.id = zc.zone_id
+    """.stripMargin
+
   override def save(zoneChange: ZoneChange): IO[ZoneChange] =
     monitor("repo.ZoneChange.save") {
       IO {
@@ -98,6 +105,22 @@ class MySqlZoneChangeRepository
           }
 
           ListZoneChangesResults(maxQueries, nextId, startFrom, maxItems)
+        }
+      }
+    }
+
+  def listFailedZoneChanges(): IO[List[ZoneChange]] =
+    monitor("repo.ZoneChange.listFailedZoneChanges") {
+      IO {
+        DB.readOnly { implicit s =>
+          val queryResult = LIST_ZONES_CHANGES_DATA
+            .map(extractZoneChange(1))
+            .list()
+            .apply()
+
+          val failedZoneChanges = queryResult.filter(zc => zc.status == ZoneChangeStatus.Failed)
+
+          failedZoneChanges
         }
       }
     }


### PR DESCRIPTION
Fixes #439.

Changes in this pull request:

> Added metrics api for zone change failure and record change failure.
```
/metrics/health/zonechangesfailure
/metrics/health/recordsetchangesfailure
```
