### PR TITLE
Update group history message

### DIFF
--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -891,11 +891,12 @@ class MembershipServiceSpec
     "determine group difference" should {
       "return difference between two groups" in {
         val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate, okGroupChange.copy(changeType = GroupChangeType.Delete))
-        val result: Seq[String] = rightResultOf(underTest.determineGroupDifference(groupChange).value)
+        val allUserMap = Map("ok" -> "ok", "12345-abcde-6789" -> "dummyName", "56789-edcba-1234" -> "super")
+        val result: Seq[String] = rightResultOf(underTest.determineGroupDifference(groupChange, allUserMap).value)
         // Newly created group's change message
         result(0) shouldBe "Group Created."
         // Updated group's change message
-        result(1) shouldBe "Group name changed to 'dummy-group'. Group email changed to 'dummy@test.com'. Group description changed to 'dummy group'. Group admin/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group admin/s with userId/s (ok) removed. Group member/s with userId/s (12345-abcde-6789,56789-edcba-1234) added. Group member/s with userId/s (ok) removed."
+        result(1) shouldBe "Group name changed to 'dummy-group'. Group email changed to 'dummy@test.com'. Group description changed to 'dummy group'. Group admin/s with user name/s 'dummyName','super' added. Group admin/s with user name/s 'ok' removed. Group member/s with user name/s 'dummyName','super' added. Group member/s with user name/s 'ok' removed."
         // Deleted group's change message
         result(2) shouldBe "Group Deleted."
       }

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -888,6 +888,14 @@ class MembershipServiceSpec
     }
   }
 
+    "get group user ids" should {
+      "get all users in a group change" in {
+        val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate, okGroupChange.copy(changeType = GroupChangeType.Delete))
+        val result: Set[String] = underTest.getGroupUserIds(groupChange)
+        result shouldBe Set("12345-abcde-6789", "56789-edcba-1234", "ok")
+      }
+    }
+
     "determine group difference" should {
       "return difference between two groups" in {
         val groupChange = Seq(okGroupChange, dummyGroupChangeUpdate, okGroupChange.copy(changeType = GroupChangeType.Delete))


### PR DESCRIPTION
Fixes #1201.

Changes in this pull request:
- Updated group change history message to display `username` instead of `userid` when there's a change in members or admins of the group,  to make it easier to find out who is added or removed.
