### PR TITLE
Trim multi line log messages to single line

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -97,7 +97,7 @@ object CommandHandler {
         .handleErrorWith { error =>
           val errorMessage = new StringWriter
           error.printStackTrace(new PrintWriter(errorMessage))
-          logger.error(s"Encountered unexpected error in main flow. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+          logger.error(s"Encountered unexpected error in main flow. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
 
           // just continue, the flow should never stop unless explicitly told to do so
           flow()
@@ -128,7 +128,7 @@ object CommandHandler {
           // or processing is disabled
           val errorMessage = new StringWriter
           error.printStackTrace(new PrintWriter(errorMessage))
-          logger.error(s"Encountered error polling message queue. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+          logger.error(s"Encountered error polling message queue. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
 
           // just keep going on the stream
           pollingStream()
@@ -189,7 +189,7 @@ object CommandHandler {
         case Left(e) =>
           val errorMessage = new StringWriter
           e.printStackTrace(new PrintWriter(errorMessage))
-          logger.warn(s"Failed processing message need to retry; $message. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+          logger.warn(s"Failed processing message need to retry; $message. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
           RetryMessage(message)
         case Right(ok) => ok
       }

--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -39,6 +39,7 @@ import vinyldns.core.queue.{CommandMessage, MessageCount, MessageQueue}
 
 import scala.concurrent.duration._
 import vinyldns.core.notifier.AllNotifiers
+import java.io.{PrintWriter, StringWriter}
 
 object CommandHandler {
 
@@ -94,7 +95,9 @@ object CommandHandler {
         )
         .parJoin(maxOpen)
         .handleErrorWith { error =>
-          logger.error("Encountered unexpected error in main flow", error.getMessage.replaceAll("\n",";"))
+          val errorMessage = new StringWriter
+          error.printStackTrace(new PrintWriter(errorMessage))
+          logger.error(s"Encountered unexpected error in main flow. Error: ${errorMessage.toString.replaceAll("\n",";")}")
 
           // just continue, the flow should never stop unless explicitly told to do so
           flow()
@@ -123,7 +126,9 @@ object CommandHandler {
         .handleErrorWith { error =>
           // on error, we make sure we still continue; should only stop when the app stops
           // or processing is disabled
-          logger.error("Encountered error polling message queue", error.getMessage.replaceAll("\n",";"))
+          val errorMessage = new StringWriter
+          error.printStackTrace(new PrintWriter(errorMessage))
+          logger.error(s"Encountered error polling message queue. Error: ${errorMessage.toString.replaceAll("\n",";")}")
 
           // just keep going on the stream
           pollingStream()
@@ -182,7 +187,9 @@ object CommandHandler {
       .attempt
       .map {
         case Left(e) =>
-          logger.warn(s"Failed processing message need to retry; $message. Error: ${e.getMessage.replaceAll("\n",";")}")
+          val errorMessage = new StringWriter
+          e.printStackTrace(new PrintWriter(errorMessage))
+          logger.warn(s"Failed processing message need to retry; $message. Error: ${errorMessage.toString.replaceAll("\n",";")}")
           RetryMessage(message)
         case Right(ok) => ok
       }

--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -94,7 +94,7 @@ object CommandHandler {
         )
         .parJoin(maxOpen)
         .handleErrorWith { error =>
-          logger.error("Encountered unexpected error in main flow", error)
+          logger.error("Encountered unexpected error in main flow", error.getMessage.replaceAll("\n",";"))
 
           // just continue, the flow should never stop unless explicitly told to do so
           flow()
@@ -123,7 +123,7 @@ object CommandHandler {
         .handleErrorWith { error =>
           // on error, we make sure we still continue; should only stop when the app stops
           // or processing is disabled
-          logger.error("Encountered error polling message queue", error)
+          logger.error("Encountered error polling message queue", error.getMessage.replaceAll("\n",";"))
 
           // just keep going on the stream
           pollingStream()
@@ -182,7 +182,7 @@ object CommandHandler {
       .attempt
       .map {
         case Left(e) =>
-          logger.warn(s"Failed processing message need to retry; $message", e)
+          logger.warn(s"Failed processing message need to retry; $message. Error: ${e.getMessage.replaceAll("\n",";")}")
           RetryMessage(message)
         case Right(ok) => ok
       }

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -214,7 +214,7 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
       } yield resp
 
     val receivedResponse = result match {
-      case Right(value) => value.toString.replaceAll("\n"," ").replaceAll("\t"," ")
+      case Right(value) => value.toString.replaceAll("\n",";").replaceAll("\t"," ")
       case Left(e) =>
         val errorMessage = new StringWriter
         e.printStackTrace(new PrintWriter(errorMessage))

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -214,15 +214,15 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
       } yield resp
 
     val receivedResponse = result match {
-      case Right(value) => value.toString.replaceAll("\n",";")
+      case Right(value) => value.toString.replaceAll("\n"," ").replaceAll("\t"," ")
       case Left(e) =>
         val errorMessage = new StringWriter
         e.printStackTrace(new PrintWriter(errorMessage))
-        errorMessage.toString.replaceAll("\n",";")
+        errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")
     }
 
     logger.info(
-      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";")}. Received response: $receivedResponse"
+      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";").replaceAll("\t"," ")}. Received response: $receivedResponse"
     )
 
     result

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -213,8 +213,13 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
         resp <- toDnsResponse(resp)
       } yield resp
 
+    val receivedResponse = result match {
+      case Right(value) => value.toString.replaceAll("\n",";")
+      case Left(e) => e.toString.replaceAll("\n",";")
+    }
+
     logger.info(
-      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString}\n...received response $result"
+      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";")}. Received response: $receivedResponse"
     )
 
     result
@@ -234,10 +239,10 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
         // so if we can parse the error into an rcode, then we need to handle it properly; otherwise, we can try again
         // The DNS.Rcode.value function will return -1 if the error cannot be parsed into an integer
         if (DNS.Rcode.value(query.error) >= 0) {
-          logger.info(s"Received TRY_AGAIN from DNS lookup; converting error: ${query.error}")
+          logger.warn(s"Received TRY_AGAIN from DNS lookup; converting error: ${query.error.replaceAll("\n",";")}")
           fromDnsRcodeToError(DNS.Rcode.value(query.error), query.error)
         } else {
-          logger.warn(s"Unparseable error code returned from DNS: ${query.error}")
+          logger.warn(s"Unparseable error code returned from DNS: ${query.error.replaceAll("\n",";")}")
           Left(TryAgain(query.error))
         }
 

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -28,7 +28,7 @@ import vinyldns.core.domain.backend.{Backend, BackendResponse}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.{RecordSet, RecordSetChange, RecordSetChangeType, RecordType}
 import vinyldns.core.domain.zone.{Algorithm, Zone, ZoneConnection}
-
+import java.io.{PrintWriter, StringWriter}
 import scala.collection.JavaConverters._
 
 object DnsProtocol {
@@ -215,7 +215,10 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
 
     val receivedResponse = result match {
       case Right(value) => value.toString.replaceAll("\n",";")
-      case Left(e) => e.toString.replaceAll("\n",";")
+      case Left(e) =>
+        val errorMessage = new StringWriter
+        e.printStackTrace(new PrintWriter(errorMessage))
+        errorMessage.toString.replaceAll("\n",";")
     }
 
     logger.info(

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -173,7 +173,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
           val errorMessage = new StringWriter
           e.printStackTrace(new PrintWriter(errorMessage))
           logger.error(
-            s"Encountered error syncing ; zoneName='${zoneChange.zone.name}'; zoneChange='${zoneChange.id}'. Error: ${errorMessage.toString.replaceAll("\n",";")}"
+            s"Encountered error syncing ; zoneName='${zoneChange.zone.name}'; zoneChange='${zoneChange.id}'. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}"
           )
           // We want to just move back to an active status, do not update latest sync
           zoneChange.copy(

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -171,7 +171,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
         case Left(e: Throwable) =>
           logger.error(
             s"Encountered error syncing ; zoneName='${zoneChange.zone.name}'; zoneChange='${zoneChange.id}'",
-            e
+            e.getMessage.replaceAll("\n",";")
           )
           // We want to just move back to an active status, do not update latest sync
           zoneChange.copy(

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -156,9 +156,6 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
                 recordSetCacheRepository.save(db,changeSet)
               )
 
-              val Str: Option[String] = None
-              println(Str.get)
-
               // join together the results of saving both the record changes as well as the record sets
               for {
                 _ <- saveRecordChanges

--- a/modules/api/src/main/scala/vinyldns/api/notifier/sns/SnsNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/sns/SnsNotifier.scala
@@ -52,6 +52,6 @@ class SnsNotifier(config: SnsNotifierConfig, sns: AmazonSNS)
       sns.publish(request)
       logger.info(s"Sending batch change success; batchChange='${bc.id}'")
     }.handleErrorWith { e =>
-      IO(logger.error(s"Failed sending batch change; batchChange='${bc.id}'", e))
+      IO(logger.error(s"Failed sending batch change; batchChange='${bc.id}'", e.getMessage.replaceAll("\n",";")))
     }.void
 }

--- a/modules/api/src/main/scala/vinyldns/api/notifier/sns/SnsNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/sns/SnsNotifier.scala
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 import vinyldns.api.route.VinylDNSJsonProtocol
 import vinyldns.core.domain.batch.BatchChange
 import vinyldns.core.notifier.{Notification, Notifier}
+import java.io.{PrintWriter, StringWriter}
 
 class SnsNotifier(config: SnsNotifierConfig, sns: AmazonSNS)
     extends Notifier
@@ -52,6 +53,8 @@ class SnsNotifier(config: SnsNotifierConfig, sns: AmazonSNS)
       sns.publish(request)
       logger.info(s"Sending batch change success; batchChange='${bc.id}'")
     }.handleErrorWith { e =>
-      IO(logger.error(s"Failed sending batch change; batchChange='${bc.id}'", e.getMessage.replaceAll("\n",";")))
+      val errorMessage = new StringWriter
+      e.printStackTrace(new PrintWriter(errorMessage))
+      IO(logger.error(s"Failed sending batch change; batchChange='${bc.id}'. Error: ${errorMessage.toString.replaceAll("\n",";")}"))
     }.void
 }

--- a/modules/api/src/main/scala/vinyldns/api/notifier/sns/SnsNotifier.scala
+++ b/modules/api/src/main/scala/vinyldns/api/notifier/sns/SnsNotifier.scala
@@ -55,6 +55,6 @@ class SnsNotifier(config: SnsNotifierConfig, sns: AmazonSNS)
     }.handleErrorWith { e =>
       val errorMessage = new StringWriter
       e.printStackTrace(new PrintWriter(errorMessage))
-      IO(logger.error(s"Failed sending batch change; batchChange='${bc.id}'. Error: ${errorMessage.toString.replaceAll("\n",";")}"))
+      IO(logger.error(s"Failed sending batch change; batchChange='${bc.id}'. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}"))
     }.void
 }

--- a/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
+++ b/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
@@ -34,7 +34,7 @@ object HealthCheck {
         case Left(err) =>
           val errorMessage = new StringWriter
           err.printStackTrace(new PrintWriter(errorMessage))
-          logger.error(s"HealthCheck for ${caller.getCanonicalName} failed. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+          logger.error(s"HealthCheck for ${caller.getCanonicalName} failed. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
           val msg = Option(err.getMessage).getOrElse("no message from error")
           Left(
             HealthCheckError(s"${caller.getCanonicalName} health check failed with msg='${msg}'")

--- a/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
+++ b/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
@@ -18,6 +18,7 @@ package vinyldns.core.health
 
 import cats.effect.IO
 import org.slf4j.LoggerFactory
+import java.io.{PrintWriter, StringWriter}
 
 object HealthCheck {
 
@@ -31,7 +32,9 @@ object HealthCheck {
     def asHealthCheck(caller: Class[_]): HealthCheck =
       io.map {
         case Left(err) =>
-          logger.error(s"HealthCheck for ${caller.getCanonicalName} Failed", err.getMessage.replaceAll("\n",";"))
+          val errorMessage = new StringWriter
+          err.printStackTrace(new PrintWriter(errorMessage))
+          logger.error(s"HealthCheck for ${caller.getCanonicalName} failed. Error: ${errorMessage.toString.replaceAll("\n",";")}")
           val msg = Option(err.getMessage).getOrElse("no message from error")
           Left(
             HealthCheckError(s"${caller.getCanonicalName} health check failed with msg='${msg}'")

--- a/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
+++ b/modules/core/src/main/scala/vinyldns/core/health/HealthCheck.scala
@@ -31,7 +31,7 @@ object HealthCheck {
     def asHealthCheck(caller: Class[_]): HealthCheck =
       io.map {
         case Left(err) =>
-          logger.error(s"HealthCheck for ${caller.getCanonicalName} Failed", err)
+          logger.error(s"HealthCheck for ${caller.getCanonicalName} Failed", err.getMessage.replaceAll("\n",";"))
           val msg = Option(err.getMessage).getOrElse("no message from error")
           Left(
             HealthCheckError(s"${caller.getCanonicalName} health check failed with msg='${msg}'")

--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -20,6 +20,7 @@ import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.slf4j.LoggerFactory
 import vinyldns.core.route.Monitored
+import java.io.{PrintWriter, StringWriter}
 
 final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: ContextShift[IO])
     extends Monitored {
@@ -34,8 +35,10 @@ final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: Contex
   def notify(notifier: Notifier, notification: Notification[_]): IO[Unit] =
     monitor(notifier.getClass.getSimpleName) {
       notifier.notify(notification).handleErrorWith { e =>
+        val errorMessage = new StringWriter
+        e.printStackTrace(new PrintWriter(errorMessage))
         IO {
-          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e.getMessage.replaceAll("\n",";"))
+          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed. Error: ${errorMessage.toString.replaceAll("\n",";")}")
         }
       }
     }

--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -35,7 +35,7 @@ final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: Contex
     monitor(notifier.getClass.getSimpleName) {
       notifier.notify(notification).handleErrorWith { e =>
         IO {
-          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e)
+          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed.", e.getMessage.replaceAll("\n",";"))
         }
       }
     }

--- a/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
+++ b/modules/core/src/main/scala/vinyldns/core/notifier/AllNotifiers.scala
@@ -38,7 +38,7 @@ final case class AllNotifiers(notifiers: List[Notifier])(implicit val cs: Contex
         val errorMessage = new StringWriter
         e.printStackTrace(new PrintWriter(errorMessage))
         IO {
-          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+          logger.error(s"Notifier ${notifier.getClass.getSimpleName} failed. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
         }
       }
     }

--- a/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
+++ b/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import nl.grons.metrics.scala.{Histogram, Meter, MetricName}
 import org.slf4j.{Logger, LoggerFactory}
 import vinyldns.core.Instrumented
-
+import java.io.{PrintWriter, StringWriter}
 import scala.collection._
 
 trait Monitored {
@@ -52,7 +52,9 @@ trait Monitored {
           IO(t)
 
         case Left(e) =>
-          logger.error(s"Finished $id; success=false; duration=$duration seconds", e.getMessage.replaceAll("\n",";"))
+          val errorMessage = new StringWriter
+          e.printStackTrace(new PrintWriter(errorMessage))
+          logger.error(s"Finished $id; success=false; duration=$duration seconds. Error: ${errorMessage.toString.replaceAll("\n",";")}")
           IO.raiseError(e)
       }
   }

--- a/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
+++ b/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
@@ -52,7 +52,7 @@ trait Monitored {
           IO(t)
 
         case Left(e) =>
-          logger.error(s"Finished $id; success=false; duration=$duration seconds", e)
+          logger.error(s"Finished $id; success=false; duration=$duration seconds", e.getMessage.replaceAll("\n",";"))
           IO.raiseError(e)
       }
   }

--- a/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
+++ b/modules/core/src/main/scala/vinyldns/core/route/Monitor.scala
@@ -54,7 +54,7 @@ trait Monitored {
         case Left(e) =>
           val errorMessage = new StringWriter
           e.printStackTrace(new PrintWriter(errorMessage))
-          logger.error(s"Finished $id; success=false; duration=$duration seconds. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+          logger.error(s"Finished $id; success=false; duration=$duration seconds. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
           IO.raiseError(e)
       }
   }

--- a/modules/core/src/main/scala/vinyldns/core/task/TaskScheduler.scala
+++ b/modules/core/src/main/scala/vinyldns/core/task/TaskScheduler.scala
@@ -91,7 +91,7 @@ object TaskScheduler extends Monitored {
     def runOnceSafely(task: Task): IO[Unit] =
       monitor(s"task.${task.name}") {
         claimTask().bracket(runTask)(releaseTask).handleError { error =>
-          logger.error(s"""Unexpected error running task; taskName="${task.name}" """, error)
+          logger.error(s"""Unexpected error running task; taskName="${task.name}" """, error.getMessage.replaceAll("\n",";"))
         }
       }
 

--- a/modules/core/src/main/scala/vinyldns/core/task/TaskScheduler.scala
+++ b/modules/core/src/main/scala/vinyldns/core/task/TaskScheduler.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import fs2._
 import org.slf4j.LoggerFactory
 import vinyldns.core.route.Monitored
-
+import java.io.{PrintWriter, StringWriter}
 import scala.concurrent.duration.FiniteDuration
 
 // Interface for all Tasks that need to be run
@@ -91,7 +91,9 @@ object TaskScheduler extends Monitored {
     def runOnceSafely(task: Task): IO[Unit] =
       monitor(s"task.${task.name}") {
         claimTask().bracket(runTask)(releaseTask).handleError { error =>
-          logger.error(s"""Unexpected error running task; taskName="${task.name}" """, error.getMessage.replaceAll("\n",";"))
+          val errorMessage = new StringWriter
+          error.printStackTrace(new PrintWriter(errorMessage))
+          logger.error(s"""Unexpected error running task; taskName="${task.name}". Error: ${errorMessage.toString.replaceAll("\n",";")} """)
         }
       }
 

--- a/modules/core/src/main/scala/vinyldns/core/task/TaskScheduler.scala
+++ b/modules/core/src/main/scala/vinyldns/core/task/TaskScheduler.scala
@@ -93,7 +93,7 @@ object TaskScheduler extends Monitored {
         claimTask().bracket(runTask)(releaseTask).handleError { error =>
           val errorMessage = new StringWriter
           error.printStackTrace(new PrintWriter(errorMessage))
-          logger.error(s"""Unexpected error running task; taskName="${task.name}". Error: ${errorMessage.toString.replaceAll("\n",";")} """)
+          logger.error(s"""Unexpected error running task; taskName="${task.name}". Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")} """)
         }
       }
 

--- a/modules/core/src/test/scala/vinyldns/core/route/MonitorSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/route/MonitorSpec.scala
@@ -116,7 +116,7 @@ class MonitorSpec
         val msgCaptor = ArgumentCaptor.forClass(classOf[String])
         val errorCaptor = ArgumentCaptor.forClass(classOf[String])
         verify(traitTest.logger, times(1)).info(msgCaptor.capture())
-        verify(traitTest.logger, times(1)).error(errorCaptor.capture(), any(classOf[Throwable]))
+        verify(traitTest.logger, times(1)).error(errorCaptor.capture())
 
         msgCaptor.getValue shouldBe "Starting timeSomethingBad"
         errorCaptor.getValue should include("Finished timeSomethingBad; success=false; duration=")

--- a/modules/mysql/src/main/scala/vinyldns/mysql/TransactionProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/TransactionProvider.scala
@@ -54,7 +54,7 @@ trait TransactionProvider {
           case e: Throwable =>
             val errorMessage = new StringWriter
             e.printStackTrace(new PrintWriter(errorMessage))
-            logger.error(s"Encountered error executing function within a database transaction ($txId). Rolling back transaction. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+            logger.error(s"Encountered error executing function within a database transaction ($txId). Rolling back transaction. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
             db.rollbackIfActive()
             throw e
         } finally {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/TransactionProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/TransactionProvider.scala
@@ -19,7 +19,7 @@ package vinyldns.mysql
 import cats.effect.IO
 import org.slf4j.{Logger, LoggerFactory}
 import scalikejdbc.{ConnectionPool, DB}
-
+import java.io.{PrintWriter, StringWriter}
 import java.sql.SQLException
 import java.util.UUID
 
@@ -52,7 +52,9 @@ trait TransactionProvider {
           result
         } catch {
           case e: Throwable =>
-            logger.error(s"Encountered error executing function within a database transaction ($txId). Rolling back transaction.", e.getMessage.replaceAll("\n",";"))
+            val errorMessage = new StringWriter
+            e.printStackTrace(new PrintWriter(errorMessage))
+            logger.error(s"Encountered error executing function within a database transaction ($txId). Rolling back transaction. Error: ${errorMessage.toString.replaceAll("\n",";")}")
             db.rollbackIfActive()
             throw e
         } finally {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/TransactionProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/TransactionProvider.scala
@@ -52,7 +52,7 @@ trait TransactionProvider {
           result
         } catch {
           case e: Throwable =>
-            logger.error(s"Encountered error executing function within a database transaction ($txId). Rolling back transaction.", e)
+            logger.error(s"Encountered error executing function within a database transaction ($txId). Rolling back transaction.", e.getMessage.replaceAll("\n",";"))
             db.rollbackIfActive()
             throw e
         } finally {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
@@ -34,6 +34,7 @@ import vinyldns.mysql.queue.MessageType.{
   RecordChangeMessageType,
   ZoneChangeMessageType
 }
+import java.io.{PrintWriter, StringWriter}
 import vinyldns.proto.VinylDNSProto
 import java.time.temporal.ChronoUnit
 import scala.concurrent.duration._
@@ -210,7 +211,9 @@ class MySqlMessageQueue(maxRetries: Int)
           // Errors could not be deserialized, have an invalid type, or exceeded retries
           val errors = claimed.collect {
             case Left((e, id)) =>
-              logger.error(s"Encountered error for message with id $id", e.getMessage.replaceAll("\n",";"))
+              val errorMessage = new StringWriter
+              e.printStackTrace(new PrintWriter(errorMessage))
+              logger.error(s"Encountered error for message with id $id. Error: ${errorMessage.toString.replaceAll("\n",";")}")
               id
           }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
@@ -210,7 +210,7 @@ class MySqlMessageQueue(maxRetries: Int)
           // Errors could not be deserialized, have an invalid type, or exceeded retries
           val errors = claimed.collect {
             case Left((e, id)) =>
-              logger.error(s"Encountered error for message with id $id", e)
+              logger.error(s"Encountered error for message with id $id", e.getMessage.replaceAll("\n",";"))
               id
           }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/queue/MySqlMessageQueue.scala
@@ -213,7 +213,7 @@ class MySqlMessageQueue(maxRetries: Int)
             case Left((e, id)) =>
               val errorMessage = new StringWriter
               e.printStackTrace(new PrintWriter(errorMessage))
-              logger.error(s"Encountered error for message with id $id. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+              logger.error(s"Encountered error for message with id $id. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
               id
           }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -103,7 +103,7 @@ class MySqlDataStoreProvider extends DataStoreProvider {
       .handleError{ e =>
         val errorMessage = new StringWriter
         e.printStackTrace(new PrintWriter(errorMessage))
-        logger.error(s"Exception occurred while shutting down. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+        logger.error(s"Exception occurred while shutting down. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
       }
 
   private final val HEALTH_CHECK =

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -29,6 +29,7 @@ import vinyldns.core.repository._
 import vinyldns.core.health.HealthCheck._
 import vinyldns.mysql.{HikariCloser, MySqlConnectionConfig, MySqlDataSourceSettings}
 import vinyldns.mysql.MySqlConnector._
+import java.io.{PrintWriter, StringWriter}
 
 class MySqlDataStoreProvider extends DataStoreProvider {
 
@@ -99,7 +100,11 @@ class MySqlDataStoreProvider extends DataStoreProvider {
 
   private def shutdown(): IO[Unit] =
     IO(DBs.close())
-      .handleError(e => logger.error(s"Exception occurred while shutting down", e.getMessage.replaceAll("\n",";")))
+      .handleError{ e =>
+        val errorMessage = new StringWriter
+        e.printStackTrace(new PrintWriter(errorMessage))
+        logger.error(s"Exception occurred while shutting down. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+      }
 
   private final val HEALTH_CHECK =
     sql"""

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlDataStoreProvider.scala
@@ -99,7 +99,7 @@ class MySqlDataStoreProvider extends DataStoreProvider {
 
   private def shutdown(): IO[Unit] =
     IO(DBs.close())
-      .handleError(e => logger.error(s"Exception occurred while shutting down", e))
+      .handleError(e => logger.error(s"Exception occurred while shutting down", e.getMessage.replaceAll("\n",";")))
 
   private final val HEALTH_CHECK =
     sql"""

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -139,7 +139,7 @@ class MySqlRecordSetCacheRepository
         }
         logger.info(s"Deleted $numDeleted records from zone $zoneName (zone id: $zone_id)")
       }.handleErrorWith { error =>
-        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zone_id)", error)
+        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zone_id)", error.getMessage.replaceAll("\n",";"))
         IO.raiseError(error)
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -141,7 +141,7 @@ class MySqlRecordSetCacheRepository
       }.handleErrorWith { error =>
         val errorMessage = new StringWriter
         error.printStackTrace(new PrintWriter(errorMessage))
-        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zone_id). Error: ${errorMessage.toString.replaceAll("\n",";")}")
+        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zone_id). Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
         IO.raiseError(error)
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -28,8 +28,8 @@ import vinyldns.core.domain.record.NameSort.{ASC, NameSort}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.mysql.repository.MySqlRecordSetRepository.{PagingKey, fromRecordType, toFQDN}
 import vinyldns.proto.VinylDNSProto
-
-import scala.util.{Try, Success, Failure}
+import java.io.{PrintWriter, StringWriter}
+import scala.util.{Failure, Success, Try}
 
 class MySqlRecordSetCacheRepository
   extends RecordSetCacheRepository
@@ -139,7 +139,9 @@ class MySqlRecordSetCacheRepository
         }
         logger.info(s"Deleted $numDeleted records from zone $zoneName (zone id: $zone_id)")
       }.handleErrorWith { error =>
-        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zone_id)", error.getMessage.replaceAll("\n",";"))
+        val errorMessage = new StringWriter
+        error.printStackTrace(new PrintWriter(errorMessage))
+        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zone_id). Error: ${errorMessage.toString.replaceAll("\n",";")}")
         IO.raiseError(error)
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -382,7 +382,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
       }.handleErrorWith { error =>
         val errorMessage = new StringWriter
         error.printStackTrace(new PrintWriter(errorMessage))
-        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId). Error: ${errorMessage.toString.replaceAll("\n",";")}")
+        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId). Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
         IO.raiseError(error)
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -380,7 +380,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
         }
         logger.debug(s"Deleted $numDeleted records from zone $zoneName (zone id: $zoneId)")
       }.handleErrorWith { error =>
-        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId)", error)
+        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId)", error.getMessage.replaceAll("\n",";"))
         IO.raiseError(error)
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -26,7 +26,7 @@ import vinyldns.core.domain.record._
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
 import vinyldns.proto.VinylDNSProto
-
+import java.io.{PrintWriter, StringWriter}
 import scala.util.Try
 
 class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
@@ -380,7 +380,9 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
         }
         logger.debug(s"Deleted $numDeleted records from zone $zoneName (zone id: $zoneId)")
       }.handleErrorWith { error =>
-        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId)", error.getMessage.replaceAll("\n",";"))
+        val errorMessage = new StringWriter
+        error.printStackTrace(new PrintWriter(errorMessage))
+        logger.error(s"Failed deleting records from zone $zoneName (zone id: $zoneId). Error: ${errorMessage.toString.replaceAll("\n",";")}")
         IO.raiseError(error)
       }
     }

--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -27,7 +27,7 @@ import javax.naming.directory._
 import org.slf4j.LoggerFactory
 import vinyldns.core.domain.membership.User
 import vinyldns.core.health.HealthCheck._
-
+import java.io.{PrintWriter, StringWriter}
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -134,9 +134,10 @@ object LdapAuthenticator {
         else Left(UserDoesNotExistException(s"[$lookupUserName] LDAP entity does not exist"))
       } catch {
         case unexpectedError: Throwable =>
+          val errorMessage = new StringWriter
+          unexpectedError.printStackTrace(new PrintWriter(errorMessage))
           logger.error(
-            s"LDAP Unexpected Error searching for user; userName='$lookupUserName'",
-            unexpectedError.getMessage.replaceAll("\n",";")
+            s"LDAP Unexpected Error searching for user; userName='$lookupUserName'. Error: ${errorMessage.toString.replaceAll("\n",";")}"
           )
           Left(LdapServiceException(unexpectedError.getMessage))
       } finally {

--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -136,7 +136,7 @@ object LdapAuthenticator {
         case unexpectedError: Throwable =>
           logger.error(
             s"LDAP Unexpected Error searching for user; userName='$lookupUserName'",
-            unexpectedError
+            unexpectedError.getMessage.replaceAll("\n",";")
           )
           Left(LdapServiceException(unexpectedError.getMessage))
       } finally {

--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -137,7 +137,7 @@ object LdapAuthenticator {
           val errorMessage = new StringWriter
           unexpectedError.printStackTrace(new PrintWriter(errorMessage))
           logger.error(
-            s"LDAP Unexpected Error searching for user; userName='$lookupUserName'. Error: ${errorMessage.toString.replaceAll("\n",";")}"
+            s"LDAP Unexpected Error searching for user; userName='$lookupUserName'. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}"
           )
           Left(LdapServiceException(unexpectedError.getMessage))
       } finally {

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -46,6 +46,7 @@ import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 import scala.collection.JavaConverters._
 import pureconfig.ConfigSource
+import java.io.{PrintWriter, StringWriter}
 
 object OidcAuthenticator {
   final case class OidcConfig(
@@ -186,7 +187,9 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     val claimsSet = Try(JWTClaimsSet.parse(jwtClaimsSetString)) match {
       case Success(s) => Some(s)
       case Failure(e) =>
-        logger.error(s"oidc session token parse error: ${e.getMessage.replaceAll("\n",";")}")
+        val errorMessage = new StringWriter
+        e.printStackTrace(new PrintWriter(errorMessage))
+        logger.error(s"oidc session token parse error: ${errorMessage.toString.replaceAll("\n",";")}")
         None
     }
 
@@ -260,7 +263,9 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     Either
       .fromTry(Try(t))
       .leftMap { err =>
-        logger.error(s"Unexpected error in OIDC flow: ${err.getMessage.replaceAll("\n",";")}")
+        val errorMessage = new StringWriter
+        err.printStackTrace(new PrintWriter(errorMessage))
+        logger.error(s"Unexpected error in OIDC flow: ${errorMessage.toString.replaceAll("\n",";")}")
         ErrorResponse(500, err.getMessage)
       }
 }

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -189,7 +189,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       case Failure(e) =>
         val errorMessage = new StringWriter
         e.printStackTrace(new PrintWriter(errorMessage))
-        logger.error(s"oidc session token parse error: ${errorMessage.toString.replaceAll("\n",";")}")
+        logger.error(s"oidc session token parse error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
         None
     }
 
@@ -265,7 +265,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       .leftMap { err =>
         val errorMessage = new StringWriter
         err.printStackTrace(new PrintWriter(errorMessage))
-        logger.error(s"Unexpected error in OIDC flow: ${errorMessage.toString.replaceAll("\n",";")}")
+        logger.error(s"Unexpected error in OIDC flow: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
         ErrorResponse(500, err.getMessage)
       }
 }

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -186,7 +186,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     val claimsSet = Try(JWTClaimsSet.parse(jwtClaimsSetString)) match {
       case Success(s) => Some(s)
       case Failure(e) =>
-        logger.error(s"oidc session token parse error: ${e.getMessage}")
+        logger.error(s"oidc session token parse error: ${e.getMessage.replaceAll("\n",";")}")
         None
     }
 
@@ -260,7 +260,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     Either
       .fromTry(Try(t))
       .leftMap { err =>
-        logger.error(s"Unexpected error in OIDC flow: ${err.getMessage}")
+        logger.error(s"Unexpected error in OIDC flow: ${err.getMessage.replaceAll("\n",";")}")
         ErrorResponse(500, err.getMessage)
       }
 }

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -107,7 +107,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
       case Left(e) =>
         val errorMessage = new StringWriter
         e.printStackTrace(new PrintWriter(errorMessage))
-        logger.error(s"Failed handling message with id '${message.getMessageId}'. Error: ${errorMessage.toString.replaceAll("\n",";")}")
+        logger.error(s"Failed handling message with id '${message.getMessageId}'. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}")
         delete(message.getReceiptHandle).as(Left(e))
       case Right(ok) => IO.pure(Right(ok))
     }

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -105,7 +105,7 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
     // This is tricky, we need to attempt to parse the message.  If we cannot, delete it; otherwise return ok
     IO(SqsMessage.parseSqsMessage(message)).flatMap {
       case Left(e) =>
-        logger.error(s"Failed handling message with id '${message.getMessageId}'", e)
+        logger.error(s"Failed handling message with id '${message.getMessageId}'", e.getMessage.replaceAll("\n",";"))
         delete(message.getReceiptHandle).as(Left(e))
       case Right(ok) => IO.pure(Right(ok))
     }

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -39,7 +39,7 @@ import vinyldns.sqs.queue.SqsMessageType.{
   SqsRecordSetChangeMessage,
   SqsZoneChangeMessage
 }
-
+import java.io.{PrintWriter, StringWriter}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
@@ -105,7 +105,9 @@ class SqsMessageQueue(val queueUrl: String, val client: AmazonSQSAsync)
     // This is tricky, we need to attempt to parse the message.  If we cannot, delete it; otherwise return ok
     IO(SqsMessage.parseSqsMessage(message)).flatMap {
       case Left(e) =>
-        logger.error(s"Failed handling message with id '${message.getMessageId}'", e.getMessage.replaceAll("\n",";"))
+        val errorMessage = new StringWriter
+        e.printStackTrace(new PrintWriter(errorMessage))
+        logger.error(s"Failed handling message with id '${message.getMessageId}'. Error: ${errorMessage.toString.replaceAll("\n",";")}")
         delete(message.getReceiptHandle).as(Left(e))
       case Right(ok) => IO.pure(Right(ok))
     }


### PR DESCRIPTION
Fixes #1209.

Changes in this pull request:
- Trims the log messages that have multi line messages to single line. Replaced the `\n` and `\t` characters with `;` and ` ` characters in the log message to make it single line.
