### PR TITLE
Resolve datetime json response

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -84,6 +84,18 @@ trait DnsJsonProtocol extends JsonValidation {
         (js \ "id").default[String](UUID.randomUUID.toString),
         (js \ "singleBatchChangeIds").default[List[String]](List())
         ).mapN(RecordSetChange.apply)
+
+    override def toJson(rs: RecordSetChange): JValue =
+      ("zone" -> Extraction.decompose(rs.zone)) ~
+        ("recordSet" -> Extraction.decompose(rs.recordSet)) ~
+        ("userId" -> rs.userId) ~
+        ("changeType" -> Extraction.decompose(rs.changeType)) ~
+        ("status" -> Extraction.decompose(rs.status)) ~
+        ("created" -> Extraction.decompose(rs.created)) ~
+        ("systemMessage" -> rs.systemMessage) ~
+        ("updates" -> Extraction.decompose(rs.updates)) ~
+        ("id" -> rs.id) ~
+        ("singleBatchChangeIds" -> Extraction.decompose(rs.singleBatchChangeIds))
   }
 
   case object CreateZoneInputSerializer extends ValidationSerializer[CreateZoneInput] {


### PR DESCRIPTION
Fixes #1211.

Changes in this pull request:
- Added an override method to convert the json response fields `created` and `latestSync` to `string` type instead of `int`.
