### PR TITLE
Fix batch change validation bug

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
@@ -30,11 +30,14 @@ import vinyldns.core.domain.zone.Zone
 import vinyldns.core.domain.batch._
 import vinyldns.core.domain.record.RecordType.{RecordType, UNKNOWN}
 import vinyldns.core.queue.MessageQueue
+import java.net.InetAddress
 
 class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue: MessageQueue)
     extends BatchChangeConverterAlgebra {
 
-  private val notExistCompletedMessage: String = "This record does not exist." +
+  private val NonExistentRecordDeleteMessage: String = "This record does not exist." +
+    "No further action is required."
+  private val NonExistentRecordDataDeleteMessage: String = "Record data entered does not exist." +
     "No further action is required."
   private val failedMessage: String = "Error queueing RecordSetChange for processing"
   private val logger = LoggerFactory.getLogger(classOf[BatchChangeConverter])
@@ -49,16 +52,17 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
       s"Converting BatchChange [${batchChange.id}] with SingleChanges [${batchChange.changes.map(_.id)}]"
     )
     for {
+      updatedBatchChange <- updateBatchChange(batchChange, groupedChanges).toRightBatchResult
       recordSetChanges <- createRecordSetChangesForBatch(
-        batchChange.changes,
+        updatedBatchChange.changes,
         existingZones,
         groupedChanges,
         batchChange.userId,
         ownerGroupId
       ).toRightBatchResult
-      _ <- allChangesWereConverted(batchChange.changes, recordSetChanges)
+      _ <- allChangesWereConverted(updatedBatchChange.changes, recordSetChanges)
       _ <- batchChangeRepo
-        .save(batchChange)
+        .save(updatedBatchChange)
         .toBatchResult // need to save the change before queueing, backend processing expects the changes to exist
       queued <- putChangesOnQueue(recordSetChanges, batchChange.id)
       changeToStore = updateWithQueueingFailures(batchChange, queued)
@@ -125,7 +129,7 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
           change match {
             case _: SingleDeleteRRSetChange if change.recordSetId.isEmpty =>
               // Mark as Complete since we don't want to throw it as an error
-              change.withDoesNotExistMessage(notExistCompletedMessage)
+              change.withDoesNotExistMessage(NonExistentRecordDeleteMessage)
             case _ =>
               // Failure here means there was a message queue issue for this change
               change.withFailureMessage(failedMessage)
@@ -138,10 +142,34 @@ class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue:
   def storeQueuingFailures(batchChange: BatchChange): BatchResult[Unit] = {
     // Update if Single change is Failed or if a record that does not exist is deleted
     val failedAndNotExistsChanges = batchChange.changes.collect {
-      case change if change.status == SingleChangeStatus.Failed || change.systemMessage.contains(notExistCompletedMessage) => change
+      case change if change.status == SingleChangeStatus.Failed || change.systemMessage.contains(NonExistentRecordDeleteMessage) => change
     }
     batchChangeRepo.updateSingleChanges(failedAndNotExistsChanges).as(())
   }.toBatchResult
+
+  def matchRecordData(existingRecordSetData: List[RecordData], recordData: RecordData): Boolean =
+    existingRecordSetData.exists { rd =>
+      (rd, recordData) match {
+        case (AAAAData(rdAddress), AAAAData(proposedAddress)) =>
+          InetAddress.getByName(proposedAddress).getHostName == InetAddress
+            .getByName(rdAddress)
+            .getHostName
+        case _ => rd == recordData
+      }
+    }
+
+  def updateBatchChange(batchChange: BatchChange, groupedChanges: ChangeForValidationMap): BatchChange = {
+    // Update system message to be display the information if record data doesn't exist for the delete request
+    val singleChanges = batchChange.changes.map {
+      case change@(sd: SingleDeleteRRSetChange) =>
+        if (sd.recordData.isDefined && !groupedChanges.getExistingRecordSet(change.recordKey.get).exists(rs => matchRecordData(rs.records, sd.recordData.get))) {
+          sd.copy(systemMessage = Some(NonExistentRecordDataDeleteMessage))
+        }
+        else change
+      case change => change
+    }
+    batchChange.copy(changes = singleChanges)
+  }
 
   def createRecordSetChangesForBatch(
       changes: List[SingleChange],

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeConverter.scala
@@ -35,9 +35,9 @@ import java.net.InetAddress
 class BatchChangeConverter(batchChangeRepo: BatchChangeRepository, messageQueue: MessageQueue)
     extends BatchChangeConverterAlgebra {
 
-  private val nonExistentRecordDeleteMessage: String = "This record does not exist." +
+  private val nonExistentRecordDeleteMessage: String = "This record does not exist. " +
     "No further action is required."
-  private val nonExistentRecordDataDeleteMessage: String = "Record data entered does not exist." +
+  private val nonExistentRecordDataDeleteMessage: String = "Record data entered does not exist. " +
     "No further action is required."
   private val failedMessage: String = "Error queueing RecordSetChange for processing"
   private val logger = LoggerFactory.getLogger(classOf[BatchChangeConverter])

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -214,9 +214,9 @@ class BatchChangeValidations(
   }
 
   def validateDeleteRRSetChangeInput(
-                                      deleteRRSetChangeInput: DeleteRRSetChangeInput,
-                                      isApproved: Boolean
-                                    ): SingleValidation[Unit] = {
+    deleteRRSetChangeInput: DeleteRRSetChangeInput,
+    isApproved: Boolean
+  ): SingleValidation[Unit] = {
     val validRecord = deleteRRSetChangeInput.record match {
       case Some(recordData) => validateRecordData(recordData, deleteRRSetChangeInput)
       case None => ().validNel

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -318,25 +318,6 @@ class BatchChangeValidations(
       }
     }
 
-  def ensureRecordExists(
-      change: ChangeForValidation,
-      groupedChanges: ChangeForValidationMap
-  ): SingleValidation[Unit] =
-    change match {
-      // For DeleteRecord inputs, need to verify that the record data actually exists
-      case DeleteRRSetChangeForValidation(
-          _,
-          _,
-          DeleteRRSetChangeInput(inputName, _, Some(recordData))
-          )
-          if !groupedChanges
-            .getExistingRecordSet(change.recordKey)
-            .exists(rs => matchRecordData(rs.records, recordData)) =>
-        DeleteRecordDataDoesNotExist(inputName, recordData).invalidNel
-      case _ =>
-        ().validNel
-    }
-
   def validateDeleteWithContext(
       change: ChangeForValidation,
       groupedChanges: ChangeForValidationMap,
@@ -359,8 +340,7 @@ class BatchChangeValidations(
       groupedChanges.getExistingRecordSet(change.recordKey) match {
         case Some(rs) =>
           userCanDeleteRecordSet(change, auth, rs.ownerGroupId, rs.records) |+|
-            zoneDoesNotRequireManualReview(change, isApproved) |+|
-            ensureRecordExists(change, groupedChanges)
+            zoneDoesNotRequireManualReview(change, isApproved)
         case None =>
           if(isSameRecordUpdateInBatch) InvalidUpdateRequest(change.inputChange.inputName).invalidNel else ().validNel
       }
@@ -425,8 +405,7 @@ class BatchChangeValidations(
         case Some(rs) =>
           val adds = groupedChanges.getProposedAdds(change.recordKey).toList
           userCanUpdateRecordSet(change, auth, rs.ownerGroupId, adds) |+|
-            zoneDoesNotRequireManualReview(change, isApproved) |+|
-            ensureRecordExists(change, groupedChanges)
+            zoneDoesNotRequireManualReview(change, isApproved)
         case None =>
           if(isSameRecordUpdateInBatch) InvalidUpdateRequest(change.inputChange.inputName).invalidNel else ().validNel
       }
@@ -459,6 +438,7 @@ class BatchChangeValidations(
     }
 
     val deletes = groupedChanges.getProposedDeletes(change.recordKey)
+    val isDeleteExists = deletes.nonEmpty
     val isSameRecordUpdateInBatch = if(recordData.nonEmpty){
       if(deletes.contains(RecordData.fromString(recordData, change.inputChange.typ).get)) true else false
     } else false
@@ -484,7 +464,8 @@ class BatchChangeValidations(
           change.inputChange.typ,
           change.inputChange.record,
           groupedChanges,
-          isApproved
+          isApproved,
+          isDeleteExists
         ) |+|
         ownerGroupProvidedIfNeeded(change, None, ownerGroupId) |+|
         zoneDoesNotRequireManualReview(change, isApproved)
@@ -527,13 +508,14 @@ class BatchChangeValidations(
       typ: RecordType,
       recordData: RecordData,
       groupedChanges: ChangeForValidationMap,
-      isApproved: Boolean
+      isApproved: Boolean,
+      isDeleteExist: Boolean
   ): SingleValidation[Unit] = {
     val record = groupedChanges.getExistingRecordSetData(RecordKeyData(zoneId, recordName, typ, recordData))
     if(record.isDefined) {
       record.get.records.contains(recordData) match {
         case true => ().validNel
-        case false => RecordAlreadyExists(inputName, recordData, isApproved).invalidNel}
+        case false => if(isDeleteExist) ().validNel else RecordAlreadyExists(inputName, recordData, isApproved).invalidNel}
     } else ().validNel
     }
 

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -106,7 +106,7 @@ object RecordSetChangeHandler extends TransactionProvider {
   ): List[SingleChange] =
     recordSetChange.status match {
       case RecordSetChangeStatus.Complete =>
-        singleChanges.map(_.complete(recordSetChange.systemMessage, recordSetChange.id, recordSetChange.recordSet.id))
+        singleChanges.map(_.complete(recordSetChange.id, recordSetChange.recordSet.id))
       case RecordSetChangeStatus.Failed =>
         singleChanges.map(_.withProcessingError(recordSetChange.systemMessage, recordSetChange.id))
       case _ => singleChanges

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -3734,7 +3734,7 @@ def test_create_batch_delete_record_that_does_not_exists_completes(shared_zone_t
     response = client.create_batch_change(batch_change_input, status=202)
     get_batch = client.get_batch_change(response["id"])
 
-    assert_that(get_batch["changes"][0]["systemMessage"], is_("This record does not exist." +
+    assert_that(get_batch["changes"][0]["systemMessage"], is_("This record does not exist. " +
                                                               "No further action is required."))
 
     assert_successful_change_in_error_response(response["changes"][0], input_name=f"delete-non-existent-record.{ok_zone_name}", record_data="1.1.1.1", change_type="DeleteRecordSet")

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -37,9 +37,9 @@ import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
 
 class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
-  private val nonExistentRecordDeleteMessage: String = "This record does not exist." +
+  private val nonExistentRecordDeleteMessage: String = "This record does not exist. " +
     "No further action is required."
-  private val nonExistentRecordDataDeleteMessage: String = "Record data entered does not exist." +
+  private val nonExistentRecordDataDeleteMessage: String = "Record data entered does not exist. " +
     "No further action is required."
 
   private def makeSingleAddChange(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -37,9 +37,9 @@ import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
 
 class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
-  private val NonExistentRecordDeleteMessage: String = "This record does not exist." +
+  private val nonExistentRecordDeleteMessage: String = "This record does not exist." +
     "No further action is required."
-  private val NonExistentRecordDataDeleteMessage: String = "Record data entered does not exist." +
+  private val nonExistentRecordDataDeleteMessage: String = "Record data entered does not exist." +
     "No further action is required."
 
   private def makeSingleAddChange(
@@ -581,8 +581,8 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
       val receivedChange = returnedBatch.changes(0)
       receivedChange.status shouldBe SingleChangeStatus.Complete
       receivedChange.recordChangeId shouldBe None
-      receivedChange.systemMessage shouldBe Some(NonExistentRecordDeleteMessage)
-      returnedBatch.changes(0) shouldBe singleChangesOneDelete(0).copy(systemMessage = Some(NonExistentRecordDeleteMessage), status = SingleChangeStatus.Complete)
+      receivedChange.systemMessage shouldBe Some(nonExistentRecordDeleteMessage)
+      returnedBatch.changes(0) shouldBe singleChangesOneDelete(0).copy(systemMessage = Some(nonExistentRecordDeleteMessage), status = SingleChangeStatus.Complete)
 
       // check the update has been made in the DB
       val savedBatch: Option[BatchChange] =
@@ -641,8 +641,8 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
 
       // validate the batch change returned
       val receivedChange = result.changes(0)
-      receivedChange.systemMessage shouldBe Some(NonExistentRecordDataDeleteMessage)
-      result.changes(0) shouldBe singleChangesOneDeleteGood(0).copy(systemMessage = Some(NonExistentRecordDataDeleteMessage))
+      receivedChange.systemMessage shouldBe Some(nonExistentRecordDataDeleteMessage)
+      result.changes(0) shouldBe singleChangesOneDeleteGood(0).copy(systemMessage = Some(nonExistentRecordDataDeleteMessage))
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -646,6 +646,20 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "matchRecordData" should {
+    "check if the record data given matches the record data present" in {
+      val recordDatas = List(AData("1.2.3.5"), AAAAData("caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
+      val result1 = underTest.matchRecordData(recordDatas, AData("1.2.3.5"))
+      result1 shouldBe true
+      val result2 = underTest.matchRecordData(recordDatas, AData("1.2.3.4"))
+      result2 shouldBe false
+      val result3 = underTest.matchRecordData(recordDatas, AAAAData("caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
+      result3 shouldBe true
+      val result4 = underTest.matchRecordData(recordDatas, AAAAData("abcd:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
+      result4 shouldBe false
+    }
+  }
+
   "generateAddChange" should {
     val singleAddChange = makeSingleAddChange("shared-rs", AData("1.2.3.4"), A, sharedZone)
     val ownerGroupId = Some("some-owner-group-id")

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -648,14 +648,14 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
 
   "matchRecordData" should {
     "check if the record data given matches the record data present" in {
-      val recordDatas = List(AData("1.2.3.5"), AAAAData("caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
-      val result1 = underTest.matchRecordData(recordDatas, AData("1.2.3.5"))
+      val recordData = List(AData("1.2.3.5"), AAAAData("caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
+      val result1 = underTest.matchRecordData(recordData, AData("1.2.3.5"))
       result1 shouldBe true
-      val result2 = underTest.matchRecordData(recordDatas, AData("1.2.3.4"))
+      val result2 = underTest.matchRecordData(recordData, AData("1.2.3.4"))
       result2 shouldBe false
-      val result3 = underTest.matchRecordData(recordDatas, AAAAData("caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
+      val result3 = underTest.matchRecordData(recordData, AAAAData("caec:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
       result3 shouldBe true
-      val result4 = underTest.matchRecordData(recordDatas, AAAAData("abcd:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
+      val result4 = underTest.matchRecordData(recordData, AAAAData("abcd:cec6:c4ef:bb7b:1a78:d055:216d:3a78"))
       result4 shouldBe false
     }
   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1006,7 +1006,30 @@ class BatchChangeValidationsSpec
     )
   }
 
-  property("validateChangesWithContext: should complete for update if record does not exist") {
+  property("validateChangesWithContext: should fail for update if same record data is provided for add and delete") {
+    val deleteRecord = makeDeleteUpdateDeleteRRSet("deleteRecord", Some(AData("1.2.3.4")))
+    val result = validateChangesWithContext(
+      ChangeForValidationMap(
+        List(
+          makeAddUpdateRecord("deleteRecord"), // Record does not exist
+          deleteRecord
+        ).map(_.validNel),
+        ExistingRecordSets(List(rsOk))
+      ),
+      okAuth,
+      false,
+      None
+    )
+
+    result(0) should haveInvalid[DomainValidationError](
+      InvalidUpdateRequest(makeAddUpdateRecord("deleteRecord").inputChange.inputName)
+    )
+    result(1) should haveInvalid[DomainValidationError](
+      InvalidUpdateRequest(deleteRecord.inputChange.inputName)
+    )
+  }
+
+  property("validateChangesWithContext: should fail for update if record exist") {
     val deleteRRSet = makeDeleteUpdateDeleteRRSet("deleteRRSet")
     val deleteRecord = makeDeleteUpdateDeleteRRSet("deleteRecord", Some(AData("1.1.1.1")))
     val deleteNonExistentEntry = makeDeleteUpdateDeleteRRSet("ok", Some(AData("1.1.1.1")))

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1029,7 +1029,7 @@ class BatchChangeValidationsSpec
     )
   }
 
-  property("validateChangesWithContext: should fail for update if record exist") {
+  property("validateChangesWithContext: should complete for update if record does not exist") {
     val deleteRRSet = makeDeleteUpdateDeleteRRSet("deleteRRSet")
     val deleteRecord = makeDeleteUpdateDeleteRRSet("deleteRecord", Some(AData("1.1.1.1")))
     val deleteNonExistentEntry = makeDeleteUpdateDeleteRRSet("ok", Some(AData("1.1.1.1")))
@@ -1053,14 +1053,8 @@ class BatchChangeValidationsSpec
     result(0) shouldBe valid
     result(1) shouldBe valid
     result(3) shouldBe valid
-    result(4) should haveInvalid[DomainValidationError](
-      RecordAlreadyExists(makeAddUpdateRecord("ok").inputChange.inputName, makeAddUpdateRecord("ok").inputChange.record, false)
-    )
-    deleteNonExistentEntry.inputChange.record.foreach { record =>
-      result(5) should haveInvalid[DomainValidationError](
-        DeleteRecordDataDoesNotExist(deleteNonExistentEntry.inputChange.inputName, record)
-      )
-    }
+    result(4) shouldBe valid
+    result(5) shouldBe valid
   }
 
   property(

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -526,7 +526,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateInputName: should fail with a HighValueDomainError
-      |if inputName is a High Value Domain""".stripMargin) {
+             |if inputName is a High Value Domain""".stripMargin) {
     val changeA = AddChangeInput("high-value-domain.foo.", RecordType.A, ttl, AData("1.1.1.1"))
     val changeIpV4 = AddChangeInput("192.0.2.252", RecordType.PTR, ttl, PTRData(Fqdn("test.")))
     val changeIpV6 =
@@ -571,7 +571,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""zoneDoesNotRequireManualReview: should fail with RecordRequiresManualReview
-              |if zone name matches domain requiring manual review""".stripMargin) {
+             |if zone name matches domain requiring manual review""".stripMargin) {
     val addChangeInput =
       AddChangeInput("not-allowed.zone.NEEDS.review", RecordType.A, ttl, AData("1.1.1.1"))
     val addChangeForValidation = AddChangeForValidation(
@@ -599,14 +599,14 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateInputName: should fail with a DomainValidationError for deletes
-      |if validateHostName fails for an invalid domain name""".stripMargin) {
+             |if validateHostName fails for an invalid domain name""".stripMargin) {
     val change = DeleteRRSetChangeInput("invalidDomainName$", RecordType.A)
     val result = validateInputName(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
   }
 
   property("""validateInputName: should fail with a DomainValidationError for deletes
-      |if validateHostName fails for an invalid domain name length""".stripMargin) {
+             |if validateHostName fails for an invalid domain name length""".stripMargin) {
     val invalidDomainName = Random.alphanumeric.take(256).mkString
     val change = DeleteRRSetChangeInput(invalidDomainName, RecordType.AAAA)
     val result = validateInputName(change, false)
@@ -615,7 +615,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateInputName: PTR should fail with InvalidIPAddress for deletes
-      |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
+             |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
     val invalidIp = "invalidIp.111"
     val change = DeleteRRSetChangeInput(invalidIp, RecordType.PTR)
     val result = validateInputName(change, false)
@@ -639,14 +639,14 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateAddChangeInput: should fail with a DomainValidationError
-      |if validateHostName fails for an invalid domain name""".stripMargin) {
+             |if validateHostName fails for an invalid domain name""".stripMargin) {
     val change = AddChangeInput("invalidDomainName$", RecordType.A, ttl, AData("1.1.1.1"))
     val result = validateAddChangeInput(change, false)
     result should haveInvalid[DomainValidationError](InvalidDomainName("invalidDomainName$."))
   }
 
   property("""validateAddChangeInput: should fail with a DomainValidationError
-      |if validateHostName fails for an invalid domain name length""".stripMargin) {
+             |if validateHostName fails for an invalid domain name length""".stripMargin) {
     val invalidDomainName = Random.alphanumeric.take(256).mkString
     val change = AddChangeInput(invalidDomainName, RecordType.A, ttl, AData("1.1.1.1"))
     val result = validateAddChangeInput(change, false)
@@ -676,7 +676,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateAddChangeInput: should fail with InvalidIpv6Address
-      |if validateRecordData fails for an invalid ipv6 address""".stripMargin) {
+             |if validateRecordData fails for an invalid ipv6 address""".stripMargin) {
     val invalidIpv6 = "invalidIpv6:123"
     val change = AddChangeInput("test.comcast.com.", RecordType.AAAA, ttl, AAAAData(invalidIpv6))
     val result = validateAddChangeInput(change, false)
@@ -703,7 +703,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateAddChangeInput: should fail with InvalidDomainName
-      |if validateRecordData fails for invalid CNAME record data""".stripMargin) {
+             |if validateRecordData fails for invalid CNAME record data""".stripMargin) {
     val invalidCNAMERecordData = "$$$"
     val change =
       AddChangeInput(
@@ -718,7 +718,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateAddChangeInput: should fail with InvalidLength
-      |if validateRecordData fails for invalid CNAME record data""".stripMargin) {
+             |if validateRecordData fails for invalid CNAME record data""".stripMargin) {
     val invalidCNAMERecordData = "s" * 256
     val change =
       AddChangeInput(
@@ -735,7 +735,7 @@ class BatchChangeValidationsSpec
   }
 
   property("""validateAddChangeInput: PTR should fail with InvalidIPAddress
-      |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
+             |if inputName is not a valid ipv4 or ipv6 address""".stripMargin) {
     val invalidIp = "invalidip.111."
     val change = AddChangeInput(invalidIp, RecordType.PTR, ttl, PTRData(Fqdn("test.comcast.com")))
     val result = validateAddChangeInput(change, false)
@@ -1030,7 +1030,9 @@ class BatchChangeValidationsSpec
     result(0) shouldBe valid
     result(1) shouldBe valid
     result(3) shouldBe valid
-    result(4) shouldBe valid
+    result(4) should haveInvalid[DomainValidationError](
+      RecordAlreadyExists(makeAddUpdateRecord("ok").inputChange.inputName, makeAddUpdateRecord("ok").inputChange.record, false)
+    )
     deleteNonExistentEntry.inputChange.record.foreach { record =>
       result(5) should haveInvalid[DomainValidationError](
         DeleteRecordDataDoesNotExist(deleteNonExistentEntry.inputChange.inputName, record)

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -137,6 +137,12 @@ final case class RecordDoesNotExist(name: String) extends DomainValidationError 
     s"""Record "$name" Does Not Exist: cannot delete a record that does not exist."""
 }
 
+final case class InvalidUpdateRequest(name: String) extends DomainValidationError {
+  def message: String =
+    s"""Cannot perform request for the record "$name". """ +
+      "Add and Delete for the record with same record data exists in the batch."
+}
+
 final case class CnameIsNotUniqueError(name: String, typ: RecordType)
     extends DomainValidationError {
   def message: String =

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -32,7 +32,7 @@ object DomainValidationErrorType extends Enumeration {
   val ChangeLimitExceeded, BatchChangeIsEmpty, GroupDoesNotExist, NotAMemberOfOwnerGroup,
   InvalidDomainName, InvalidCname, InvalidLength, InvalidEmail, InvalidRecordType, InvalidPortNumber,
   InvalidIpv4Address, InvalidIpv6Address, InvalidIPAddress, InvalidTTL, InvalidMxPreference,
-  InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
+  InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist, InvalidUpdateRequest,
   CnameIsNotUniqueError, UserIsNotAuthorized, UserIsNotAuthorizedError, RecordNameNotUniqueInBatch,
   RecordInReverseZoneError, HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError,
   NewMultiRecordError, CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
@@ -60,6 +60,7 @@ object DomainValidationErrorType extends Enumeration {
       case _: ZoneDiscoveryError => ZoneDiscoveryError
       case _: RecordAlreadyExists => RecordAlreadyExists
       case _: RecordDoesNotExist => RecordDoesNotExist
+      case _: InvalidUpdateRequest => InvalidUpdateRequest
       case _: CnameIsNotUniqueError => CnameIsNotUniqueError
       case _: UserIsNotAuthorized => UserIsNotAuthorized
       case _: UserIsNotAuthorizedError => UserIsNotAuthorizedError

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/SingleChange.scala
@@ -69,18 +69,16 @@ sealed trait SingleChange {
         )
     }
 
-  def complete(message: Option[String], completeRecordChangeId: String, recordSetId: String): SingleChange = this match {
+  def complete(completeRecordChangeId: String, recordSetId: String): SingleChange = this match {
     case add: SingleAddChange =>
       add.copy(
         status = SingleChangeStatus.Complete,
-        systemMessage = message,
         recordChangeId = Some(completeRecordChangeId),
         recordSetId = Some(recordSetId)
       )
     case delete: SingleDeleteRRSetChange =>
       delete.copy(
         status = SingleChangeStatus.Complete,
-        systemMessage = message,
         recordChangeId = Some(completeRecordChangeId),
         recordSetId = Some(recordSetId)
       )

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -116,7 +116,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
     val pendingBatchChange: BatchChange = randomBatchChange().copy(createdTimestamp = Instant.now.truncatedTo(ChronoUnit.MILLIS))
 
     val completeBatchChange: BatchChange = randomBatchChangeWithList(
-      randomBatchChange().changes.map(_.complete(Some("Complete"),"recordChangeId", "recordSetId"))
+      randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
     ).copy(createdTimestamp = Instant.now.truncatedTo(ChronoUnit.MILLIS).plusMillis(1000))
 
     val failedBatchChange: BatchChange =
@@ -124,7 +124,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
         .copy(createdTimestamp = Instant.now.truncatedTo(ChronoUnit.MILLIS).plusMillis(100000))
 
     val partialFailureBatchChange: BatchChange = randomBatchChangeWithList(
-      randomBatchChange().changes.take(2).map(_.complete(Some("Complete"),"recordChangeId", "recordSetId"))
+      randomBatchChange().changes.take(2).map(_.complete("recordChangeId", "recordSetId"))
         ++ randomBatchChange().changes.drop(2).map(_.withFailureMessage("failed"))
     ).copy(createdTimestamp = Instant.now.truncatedTo(ChronoUnit.MILLIS).plusMillis(1000000))
 
@@ -411,7 +411,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
     "update single changes" in {
       val batchChange = randomBatchChange()
-      val completed = batchChange.changes.map(_.complete(Some("Complete"),"aaa", "bbb"))
+      val completed = batchChange.changes.map(_.complete("aaa", "bbb"))
       val f =
         for {
           _ <- repo.save(batchChange)
@@ -430,7 +430,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
     "update some changes in a batch" in {
       val batchChange = randomBatchChange()
-      val completed = batchChange.changes.take(2).map(_.complete(Some("Complete"),"recordChangeId", "recordSetId"))
+      val completed = batchChange.changes.take(2).map(_.complete("recordChangeId", "recordSetId"))
       val incomplete = batchChange.changes.drop(2)
       val f =
         for {
@@ -444,7 +444,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
     "return the batch when updating single changes" in {
       val batchChange = randomBatchChange()
-      val completed = batchChange.changes.take(2).map(_.complete(Some("Complete"),"recordChangeId", "recordSetId"))
+      val completed = batchChange.changes.take(2).map(_.complete("recordChangeId", "recordSetId"))
       val f =
         for {
           _ <- repo.save(batchChange)

--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -165,9 +165,14 @@
                                         {{error.message ? error.message : error}} </p>{{change.systemMessage}}</div>
                                     <div ng-if="batch.approvalStatus =='ManuallyRejected' || batch.approvalStatus =='Cancelled'">
                                     </div>
-                                    <div ng-if="batch.approvalStatus == 'AutoApproved'
+                                    <div ng-if="change.systemMessage == undefined && batch.approvalStatus == 'AutoApproved'
                                              && change.status =='Complete'">
-                                        ℹ️ No further action is required.</div>
+                                        ℹ️ No further action is required.
+                                    </div>
+                                    <div ng-if="(change.systemMessage != '' && change.systemMessage != undefined)  && batch.approvalStatus == 'AutoApproved'
+                                             && change.status =='Complete'">
+                                        ℹ️ {{change.systemMessage}}
+                                    </div>
                                 </td>
                             </tr>
                             </tbody>


### PR DESCRIPTION
Fixes #1217.

Changes in this pull request:
- When user submit add and delete for non-existent record with same record data in the batch, it displays a validation error.
- When user submit add and delete for non-existent record with different record data in the batch, it just creates the record and omits the delete request as changes made for the issue [Requested record deletes with (RecordDoesNotExist) should not prevent batch submission #1138](https://github.com/vinyldns/vinyldns/issues/1138)
