### PR TITLE
Add current and next color to status route

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -114,8 +114,8 @@ vinyldns {
   }
 
   # color should be green or blue, used in order to do blue/green deployment
-  next-color = "green"
   current-color = "blue"
+  next-color = "green"
 
   # version of vinyldns
   base-version = "unset"

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -114,7 +114,8 @@ vinyldns {
   }
 
   # color should be green or blue, used in order to do blue/green deployment
-  color = "green"
+  next-color = "green"
+  current-color = "blue"
 
   # version of vinyldns
   base-version = "unset"

--- a/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
@@ -29,7 +29,8 @@ final case class ServerConfig(
                                syncDelay: Int,
                                validateRecordLookupAgainstDnsBackend: Boolean,
                                approvedNameServers: List[Regex],
-                               color: String,
+                               currentColor: String,
+                               nextColor: String,
                                version: String,
                                keyName: String,
                                processingDisabled: Boolean,
@@ -40,7 +41,7 @@ object ServerConfig {
 
   import ZoneRecordValidations.toCaseIgnoredRegexList
 
-  implicit val configReader: ConfigReader[ServerConfig] = ConfigReader.forProduct12[
+  implicit val configReader: ConfigReader[ServerConfig] = ConfigReader.forProduct13[
     ServerConfig,
     Int,
     Int,
@@ -48,6 +49,7 @@ object ServerConfig {
     Int,
     Boolean,
     List[String],
+    String,
     String,
     String,
     Config,
@@ -61,7 +63,8 @@ object ServerConfig {
     "sync-delay",
     "validate-record-lookup-against-dns-backend",
     "approved-name-servers",
-    "color",
+    "current-color",
+    "next-color",
     "version",
     "defaultZoneConnection",
     "processing-disabled",
@@ -75,7 +78,8 @@ object ServerConfig {
       syncDelay,
       validateDnsBackend,
       approvedNameServers,
-      color,
+      currentColor,
+      nextColor,
       version,
       zoneConnConfig,
       processingDisabled,
@@ -88,7 +92,8 @@ object ServerConfig {
         syncDelay,
         validateDnsBackend,
         toCaseIgnoredRegexList(approvedNameServers),
-        color,
+        currentColor,
+        nextColor,
         version,
         zoneConnConfig.getString("keyName"),
         processingDisabled,

--- a/modules/api/src/main/scala/vinyldns/api/route/BlueGreenRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BlueGreenRouting.scala
@@ -30,7 +30,7 @@ import akka.http.scaladsl.server.{Directives, Route}
 trait BlueGreenRoute extends Directives {
 
   def colorRoute(nextColor: String): Route =
-    (get & path("color")) {
+    (get & path("next-color")) {
       complete(nextColor)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/BlueGreenRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BlueGreenRouting.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.route
 
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Directives, Route}
 
 /**
   * Used for deployment, determines the current color of this node / cluster
@@ -29,8 +29,8 @@ import akka.http.scaladsl.server.Directives
   */
 trait BlueGreenRoute extends Directives {
 
-  def colorRoute(color: String) =
+  def colorRoute(nextColor: String): Route =
     (get & path("color")) {
-      complete(color)
+      complete(nextColor)
     }
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/StatusRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/StatusRouting.scala
@@ -31,7 +31,8 @@ import scala.concurrent.duration._
 
 final case class CurrentStatus(
     processingDisabled: Boolean,
-    color: String,
+    currentColor: String,
+    nextColor: String,
     keyName: String,
     version: String
 )
@@ -72,7 +73,8 @@ class StatusRoute(
           StatusCodes.OK,
           CurrentStatus(
             isProcessingDisabled,
-            serverConfig.color,
+            serverConfig.currentColor,
+            serverConfig.nextColor,
             serverConfig.keyName,
             serverConfig.version
           )
@@ -87,7 +89,8 @@ class StatusRoute(
                 StatusCodes.OK,
                 CurrentStatus(
                   isProcessingDisabled,
-                  serverConfig.color,
+                  serverConfig.currentColor,
+                  serverConfig.nextColor,
                   serverConfig.keyName,
                   serverConfig.version
                 )

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
@@ -105,7 +105,7 @@ class VinylDNSService(
 
   val unloggedUris = Seq(
     Uri.Path("/health"),
-    Uri.Path("/color"),
+    Uri.Path("/next-color"),
     Uri.Path("/ping"),
     Uri.Path("/metrics/prometheus")
   )

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSService.scala
@@ -110,7 +110,7 @@ class VinylDNSService(
     Uri.Path("/metrics/prometheus")
   )
   val unloggedRoutes: Route = healthCheckRoute ~ pingRoute ~ colorRoute(
-    vinyldnsConfig.serverConfig.color
+    vinyldnsConfig.serverConfig.nextColor
   ) ~ prometheusRoute
 
   val allRoutes: Route = unloggedRoutes ~

--- a/modules/api/src/test/functional/tests/internal/status_test.py
+++ b/modules/api/src/test/functional/tests/internal/status_test.py
@@ -13,7 +13,8 @@ def test_get_status_success(shared_zone_test_context):
     result = client.get_status()
 
     assert_that([True, False], has_item(result["processingDisabled"]))
-    assert_that(["green", "blue"], has_item(result["color"]))
+    assert_that(["green", "blue"], has_item(result["nextColor"]))
+    assert_that(["green", "blue"], has_item(result["currentColor"]))
     assert_that(result["keyName"], not_none())
     assert_that(result["version"], not_none())
 

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -160,7 +160,7 @@ class VinylDNSClient(object):
         Gets the current color for the application
         :return: the content of the response, which should be "blue" or "green"
         """
-        url = urljoin(self.index_url, "/color")
+        url = urljoin(self.index_url, "/next-color")
         response, data = self.make_request(url)
         return data
 

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -85,7 +85,7 @@ trait VinylDNSTestHelpers {
     LimitsConfig(100,100,1000,1500,100,100,100)
 
   val testServerConfig: ServerConfig =
-    ServerConfig(100, 100, 100, 100, true, approvedNameServers, "blue", "unset", "vinyldns.", false, true, true)
+    ServerConfig(100, 100, 100, 100, true, approvedNameServers, "green", "blue", "unset", "vinyldns.", false, true, true)
 
   val batchChangeConfig: BatchChangeConfig =
     BatchChangeConfig(batchChangeLimit, sharedApprovedTypes, v6DiscoveryNibbleBoundaries)

--- a/modules/api/src/test/scala/vinyldns/api/route/BlueGreenRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BlueGreenRoutingSpec.scala
@@ -32,7 +32,7 @@ class BlueGreenRoutingSpec
 
   "GET color" should {
     "return blue" in {
-      Get("/color") ~> colorRoute("blue") ~> check {
+      Get("/next-color") ~> colorRoute("blue") ~> check {
         response.status shouldBe StatusCodes.OK
 
         // set in the application.conf in src/test/resources

--- a/modules/api/src/test/scala/vinyldns/api/route/StatusRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/StatusRoutingSpec.scala
@@ -64,7 +64,8 @@ class StatusRoutingSpec
         response.status shouldBe StatusCodes.OK
         val resultStatus = responseAs[CurrentStatus]
         resultStatus.processingDisabled shouldBe false
-        resultStatus.color shouldBe "blue"
+        resultStatus.currentColor shouldBe "green"
+        resultStatus.nextColor shouldBe "blue"
         resultStatus.keyName shouldBe "vinyldns."
         resultStatus.version shouldBe "unset"
       }

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSServiceSpec.scala
@@ -265,7 +265,7 @@ class VinylDNSServiceSpec
 
     "return an optional log entry when given both a request and response" in {
       val unloggedUris =
-        Seq(Uri.Path("/health"), Uri.Path("/color"), Uri.Path("/ping"), Uri.Path("/status"))
+        Seq(Uri.Path("/health"), Uri.Path("/next-color"), Uri.Path("/ping"), Uri.Path("/status"))
       val req = buildMockRequest()
       val res = buildMockResponse()
 
@@ -279,7 +279,7 @@ class VinylDNSServiceSpec
     }
     "return a log message even if the response is not a response" in {
       val unloggedUris =
-        Seq(Uri.Path("/health"), Uri.Path("/color"), Uri.Path("/ping"), Uri.Path("/status"))
+        Seq(Uri.Path("/health"), Uri.Path("/next-color"), Uri.Path("/ping"), Uri.Path("/status"))
       val req = buildMockRequest()
       val res = 0
 


### PR DESCRIPTION
Fixes #1220.

Changes in this pull request:
- Added the current color and next color to `/status` route.
- Changed the route name from `/color` to `/next-color`, to make it more meaningful.