### PR TITLE
Debug DNS Resolver Info

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -21,7 +21,7 @@ import cats.effect._
 import cats.syntax.all._
 import org.slf4j.{Logger, LoggerFactory}
 import org.xbill.DNS
-import org.xbill.DNS.{EDNSOption, Name}
+import org.xbill.DNS.{ExtendedFlags, NSIDOption, Name}
 import vinyldns.api.domain.zone.ZoneTooLargeError
 import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.backend.{Backend, BackendResponse}
@@ -167,10 +167,29 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
     logger.info(s"Querying for dns dnsRecordName='${dnsName.toString}'; recordType='$typ'")
     val lookup = new DNS.Lookup(dnsName, toDnsRecordType(typ))
 
-    // enable NSID
-    val data = Array[Byte](0, 3, 0, 2, 0, 1)
-    val option = EDNSOption.fromWire(data)
-    Either.catchNonFatal(resolver.setEDNS(0, 0, 0, option))
+//    // enable NSID
+//    val data = Array[Byte](0, 3, 0, 2, 0, 1)
+//    val nsid_opt = new NSIDOption(Array[Byte](0, 3, 0, 2, 0, 1))
+//    val nsid_opt = new NSIDOption(null)
+//    logger.info(s"NSID: $nsid_opt")
+//    val nsidOption = new GenericEDNSOption(3, new Array[Byte](0))
+//    val opt_list = List(nsid_opt)
+//    val option = List(new NSIDOption(Array[Byte](0, 3, 0, 2, 0, 1)))
+//    val option = EDNSOption.fromWire(data)
+//    Either.catchNonFatal(resolver.setEDNS()
+//    resolver.setEDNS(0, 0, 0, nsid_opt)
+//    logger.info(s"EDNS INFO: ${resolver.getEDNS}")
+//    val ednsPayloadSize = 0
+//    val ednsVersion = 0
+//    val ednsFlags = ExtendedFlags.DO
+//    val nsidOption = new NSIDOption(Array[Byte]())
+//    val ednsOptions = List(new GenericEDNSOption(3, new Array[Byte](0)))
+//    val ednsOptions = List(nsidOption)
+//    resolver.setEDNS(ednsPayloadSize, ednsVersion, ednsFlags, nsidOption)
+//    val nsidOption = new GenericEDNSOption(3, new Array[Byte](0))
+//    resolver.setEDNS(0, 0, 0, nsidOption)
+//    logger.info(s"EDNS: ${resolver.getEDNS}")
+
 
     lookup.setResolver(resolver)
     lookup.setSearchPath(List(Name.empty).asJava)

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -207,12 +207,13 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
   }
 
   private def send(msg: DNS.Message): Either[Throwable, DnsResponse] = {
-    val resolver_debug_message =  s"Resolver address=${resolver.getAddress}, Port=${resolver.getPort}, Timeout=${resolver.getTimeout}"
     val result =
       for {
         resp <- Either.catchNonFatal(resolver.send(msg))
         resp <- toDnsResponse(resp)
       } yield resp
+
+    val resolver_debug_message =  s"DNS Resolver: ${resolver.toString}, Resolver Address=${resolver.getAddress.getAddress}, Resolver Host=${resolver.getAddress.getHostName}, Resolver Port=${resolver.getPort}, Timeout=${resolver.getTimeout.toString}"
 
     val receivedResponse = result match {
       case Right(value) => value.toString.replaceAll("\n",";").replaceAll("\t"," ")
@@ -223,7 +224,7 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
     }
 
     logger.info(
-      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";").replaceAll("\t"," ")}. Received response: $receivedResponse. Resolver Info: $resolver_debug_message"
+      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";").replaceAll("\t"," ")}. Received response: $receivedResponse. DNS Resolver Info: $resolver_debug_message"
     )
 
     result

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -207,6 +207,7 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
   }
 
   private def send(msg: DNS.Message): Either[Throwable, DnsResponse] = {
+    val resolver_debug_message =  s"Resolver address=${resolver.getAddress}, Port=${resolver.getPort}, Timeout=${resolver.getTimeout}"
     val result =
       for {
         resp <- Either.catchNonFatal(resolver.send(msg))
@@ -222,7 +223,7 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
     }
 
     logger.info(
-      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";").replaceAll("\t"," ")}. Received response: $receivedResponse"
+      s"DnsConnection.send - Sending DNS Message ${obscuredDnsMessage(msg).toString.replaceAll("\n",";").replaceAll("\t"," ")}. Received response: $receivedResponse. Resolver Info: $resolver_debug_message"
     )
 
     result

--- a/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/dns/DnsBackend.scala
@@ -21,7 +21,7 @@ import cats.effect._
 import cats.syntax.all._
 import org.slf4j.{Logger, LoggerFactory}
 import org.xbill.DNS
-import org.xbill.DNS.{ExtendedFlags, NSIDOption, Name}
+import org.xbill.DNS.Name
 import vinyldns.api.domain.zone.ZoneTooLargeError
 import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.backend.{Backend, BackendResponse}
@@ -167,30 +167,6 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
     logger.info(s"Querying for dns dnsRecordName='${dnsName.toString}'; recordType='$typ'")
     val lookup = new DNS.Lookup(dnsName, toDnsRecordType(typ))
 
-//    // enable NSID
-//    val data = Array[Byte](0, 3, 0, 2, 0, 1)
-//    val nsid_opt = new NSIDOption(Array[Byte](0, 3, 0, 2, 0, 1))
-//    val nsid_opt = new NSIDOption(null)
-//    logger.info(s"NSID: $nsid_opt")
-//    val nsidOption = new GenericEDNSOption(3, new Array[Byte](0))
-//    val opt_list = List(nsid_opt)
-//    val option = List(new NSIDOption(Array[Byte](0, 3, 0, 2, 0, 1)))
-//    val option = EDNSOption.fromWire(data)
-//    Either.catchNonFatal(resolver.setEDNS()
-//    resolver.setEDNS(0, 0, 0, nsid_opt)
-//    logger.info(s"EDNS INFO: ${resolver.getEDNS}")
-//    val ednsPayloadSize = 0
-//    val ednsVersion = 0
-//    val ednsFlags = ExtendedFlags.DO
-//    val nsidOption = new NSIDOption(Array[Byte]())
-//    val ednsOptions = List(new GenericEDNSOption(3, new Array[Byte](0)))
-//    val ednsOptions = List(nsidOption)
-//    resolver.setEDNS(ednsPayloadSize, ednsVersion, ednsFlags, nsidOption)
-//    val nsidOption = new GenericEDNSOption(3, new Array[Byte](0))
-//    resolver.setEDNS(0, 0, 0, nsidOption)
-//    logger.info(s"EDNS: ${resolver.getEDNS}")
-
-
     lookup.setResolver(resolver)
     lookup.setSearchPath(List(Name.empty).asJava)
     lookup.setCache(null)
@@ -243,7 +219,7 @@ class DnsBackend(val id: String, val resolver: DNS.SimpleResolver, val xfrInfo: 
       for {
         str <- Either.catchNonFatal(s"DNS Resolver: ${resolver.toString}, " +
           s"Resolver Address=${resolver.getAddress.getAddress}, Resolver Host=${resolver.getAddress.getHostName}, " +
-          s"Resolver Port=${resolver.getPort}, Timeout=${resolver.getTimeout.toString}, EDNS=${resolver.getEDNS.getOptions}, ${resolver.getEDNS.getFlags}, ${resolver.getEDNS.getPayloadSize}"
+          s"Resolver Port=${resolver.getPort}, Timeout=${resolver.getTimeout.toString}"
         )
       } yield str
 

--- a/quickstart/bind9/etc/named.conf.local
+++ b/quickstart/bind9/etc/named.conf.local
@@ -29,6 +29,10 @@ key "vinyldns-sha512." {
   secret "xfKA0DYb88tiUGND+cWddwUg3/SugYSsdvCfBOJ1jr8MEdgbVRyrlVDEXLsfTUGorQ3ShENdymw2yw+rTr+lwA==";
 };
 
+options {
+	request-nsid true;
+};
+
 include "/etc/bind/named.conf.default";
 include "/etc/bind/named.conf.partition1";
 include "/etc/bind/named.conf.partition2";

--- a/quickstart/bind9/etc/named.conf.local
+++ b/quickstart/bind9/etc/named.conf.local
@@ -29,10 +29,6 @@ key "vinyldns-sha512." {
   secret "xfKA0DYb88tiUGND+cWddwUg3/SugYSsdvCfBOJ1jr8MEdgbVRyrlVDEXLsfTUGorQ3ShENdymw2yw+rTr+lwA==";
 };
 
-options {
-	request-nsid true;
-};
-
 include "/etc/bind/named.conf.default";
 include "/etc/bind/named.conf.partition1";
 include "/etc/bind/named.conf.partition2";


### PR DESCRIPTION
Added additional logging to the send method in the DNSBackend class to help with debugging DNS resolver issues.

Example log from local testing:
`DNS Resolver Info: DNS Resolver: SimpleResolver [/127.0.0.1:19001], Resolver Address=/127.0.0.1, Resolver Host=localhost, Resolver Port=19001, Timeout=PT10S"`