### PR TITLE
Add zookeeper to handle scheduler

### DIFF
--- a/modules/api/src/it/resources/logback-test.xml
+++ b/modules/api/src/it/resources/logback-test.xml
@@ -9,4 +9,6 @@
     <root level="OFF">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <logger name="org.apache.zookeeper" level="ERROR" />
 </configuration>

--- a/modules/api/src/main/resources/logback.xml
+++ b/modules/api/src/main/resources/logback.xml
@@ -10,4 +10,6 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <logger name="org.apache.zookeeper" level="ERROR" />
 </configuration>

--- a/modules/api/src/main/resources/test/logback.xml
+++ b/modules/api/src/main/resources/test/logback.xml
@@ -14,4 +14,6 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <logger name="org.apache.zookeeper" level="ERROR" />
 </configuration>

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -71,6 +71,9 @@ object Boot extends App {
       true
     } catch {
       case _: NodeExistsException => false
+      case _: Exception =>
+        ()
+        false
     }
   }
   def releaseLock(path: String): Unit = {

--- a/modules/api/src/test/resources/logback-test.xml
+++ b/modules/api/src/test/resources/logback-test.xml
@@ -9,4 +9,6 @@
     <root level="OFF">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <logger name="org.apache.zookeeper" level="ERROR" />
 </configuration>

--- a/modules/api/src/universal/conf/logback.xml
+++ b/modules/api/src/universal/conf/logback.xml
@@ -10,4 +10,6 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <logger name="org.apache.zookeeper" level="ERROR" />
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
     "com.amazonaws"             %  "aws-java-sdk-sns"               % awsV withSources(),
     "co.elastic.logging"        %  "logback-ecs-encoder"            % "1.3.2",
     "com.cronutils"             %  "cron-utils"                     % "9.1.6",
-    "org.apache.zookeeper"      % "zookeeper"                       % "3.4.6",
+    "org.apache.zookeeper"      % "zookeeper"                       % "3.4.6" exclude("org.slf4j", "slf4j-log4j12"),
   )
 
   lazy val coreDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,7 +53,8 @@ object Dependencies {
     "javax.mail"                %  "javax.mail-api"                 % "1.6.2",
     "com.amazonaws"             %  "aws-java-sdk-sns"               % awsV withSources(),
     "co.elastic.logging"        %  "logback-ecs-encoder"            % "1.3.2",
-    "com.cronutils"             %  "cron-utils"                     % "9.1.6"
+    "com.cronutils"             %  "cron-utils"                     % "9.1.6",
+    "org.apache.zookeeper"      % "zookeeper"                       % "3.4.6",
   )
 
   lazy val coreDependencies = Seq(


### PR DESCRIPTION
Changes in this pull request:
- Currently the zone sync scheduler performs automated zone sync on 'n' instances that we have. Adding zookeeper to handle this and perform automated sync at the given time only on a single instance.
