### PR TITLE
Add config for zone sync scheduler

### DIFF
--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -27,10 +27,16 @@ vinyldns {
   scheduled-changes-enabled = ${?SCHEDULED_CHANGES_ENABLED}
   multi-record-batch-change-enabled = true
   multi-record-batch-change-enabled = ${?MULTI_RECORD_BATCH_CHANGE_ENABLED}
+
+  # Server settings
   use-recordset-cache = true
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = false
   load-test-data = ${?LOAD_TEST_DATA}
+  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  is-zone-sync-schedule-allowed = true
+  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 
   # configured backend providers
   backend {

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -27,10 +27,16 @@ vinyldns {
   scheduled-changes-enabled = ${?SCHEDULED_CHANGES_ENABLED}
   multi-record-batch-change-enabled = true
   multi-record-batch-change-enabled = ${?MULTI_RECORD_BATCH_CHANGE_ENABLED}
+
+  # Server settings
   use-recordset-cache = false
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = false
   load-test-data = ${?LOAD_TEST_DATA}
+  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  is-zone-sync-schedule-allowed = true
+  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 
   # configured backend providers
   backend {

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -232,4 +232,9 @@ vinyldns {
 
   load-test-data = false
   load-test-data = ${?LOAD_TEST_DATA}
+
+  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  is-zone-sync-schedule-allowed = true
+  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 }

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -100,7 +100,7 @@ object Boot extends App {
       )
       _ <- APIMetrics.initialize(vinyldnsConfig.apiMetricSettings)
       // Schedule the zone sync task to be executed every 5 seconds
-      _ <- IO(executor.scheduleAtFixedRate(() => {
+      _ <- if (vinyldnsConfig.serverConfig.isZoneSyncScheduleAllowed){ IO(executor.scheduleAtFixedRate(() => {
         val zoneChanges = for {
           zoneChanges <- ZoneSyncScheduleHandler.zoneSyncScheduler(repositories.zoneRepository)
           _ <- if (zoneChanges.nonEmpty) messageQueue.sendBatch(NonEmptyList.fromList(zoneChanges.toList).get) else IO.unit
@@ -111,7 +111,7 @@ object Boot extends App {
           case Left(error) =>
             logger.error(s"An error occurred while performing the scheduled zone sync. Error: $error")
         }
-      }, 0, 1, TimeUnit.SECONDS))
+      }, 0, 1, TimeUnit.SECONDS)) } else IO.unit
       _ <- CommandHandler.run(
         messageQueue,
         msgsPerPoll,

--- a/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
@@ -34,13 +34,14 @@ final case class ServerConfig(
                                keyName: String,
                                processingDisabled: Boolean,
                                useRecordSetCache: Boolean,
-                               loadTestData: Boolean
+                               loadTestData: Boolean,
+                               isZoneSyncScheduleAllowed: Boolean,
                              )
 object ServerConfig {
 
   import ZoneRecordValidations.toCaseIgnoredRegexList
 
-  implicit val configReader: ConfigReader[ServerConfig] = ConfigReader.forProduct12[
+  implicit val configReader: ConfigReader[ServerConfig] = ConfigReader.forProduct13[
     ServerConfig,
     Int,
     Int,
@@ -51,6 +52,7 @@ object ServerConfig {
     String,
     String,
     Config,
+    Boolean,
     Boolean,
     Boolean,
     Boolean
@@ -66,7 +68,8 @@ object ServerConfig {
     "defaultZoneConnection",
     "processing-disabled",
     "use-recordset-cache",
-    "load-test-data"
+    "load-test-data",
+    "is-zone-sync-schedule-allowed"
   ) {
     case (
       timeout,
@@ -80,7 +83,8 @@ object ServerConfig {
       zoneConnConfig,
       processingDisabled,
       useRecordSetCache,
-      loadTestData) =>
+      loadTestData,
+      isZoneSyncScheduleAllowed) =>
       ServerConfig(
         timeout,
         ttl,
@@ -93,7 +97,8 @@ object ServerConfig {
         zoneConnConfig.getString("keyName"),
         processingDisabled,
         useRecordSetCache,
-        loadTestData
+        loadTestData,
+        isZoneSyncScheduleAllowed
       )
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -85,7 +85,7 @@ trait VinylDNSTestHelpers {
     LimitsConfig(100,100,1000,1500,100,100,100)
 
   val testServerConfig: ServerConfig =
-    ServerConfig(100, 100, 100, 100, true, approvedNameServers, "blue", "unset", "vinyldns.", false, true, true)
+    ServerConfig(100, 100, 100, 100, true, approvedNameServers, "blue", "unset", "vinyldns.", false, true, true, true)
 
   val batchChangeConfig: BatchChangeConfig =
     BatchChangeConfig(batchChangeLimit, sharedApprovedTypes, v6DiscoveryNibbleBoundaries)

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -27,10 +27,16 @@ vinyldns {
   scheduled-changes-enabled = ${?SCHEDULED_CHANGES_ENABLED}
   multi-record-batch-change-enabled = true
   multi-record-batch-change-enabled = ${?MULTI_RECORD_BATCH_CHANGE_ENABLED}
+
+  # Server settings
   use-recordset-cache = false
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = false
   load-test-data = ${?LOAD_TEST_DATA}
+  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  is-zone-sync-schedule-allowed = true
+  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 
   # configured backend providers
   backend {

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -388,6 +388,14 @@ Version of the application that is deployed. Currently, this is a configuration 
 **Note: You can get installation information including color, version, default key name, and processing-disabled by
 hitting the _status_ endpoint GET /status**
 
+### Is Zone Sync Schedule Allowed
+
+Used while deploying. Should be set to `true` only on one api server/instance and `false` on every other api servers/instances. 
+Thus automated sync will be done only once on a single server/instance instead of every api servers/instances.
+Set it to `true` while running locally or when we have only a single api server/instance.
+
+`is-zone-sync-schedule-allowed = true`
+
 ### HTTP Host and Port
 
 To specify what host and port to bind to when starting up the API server, default is 9000.

--- a/test/api/functional/application.conf
+++ b/test/api/functional/application.conf
@@ -262,10 +262,16 @@ vinyldns {
   manual-batch-review-enabled = true
   scheduled-changes-enabled = true
   multi-record-batch-change-enabled = true
+
+  #Server settings
   use-recordset-cache = true
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = true
   load-test-data = ${?LOAD_TEST_DATA}
+  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  is-zone-sync-schedule-allowed = true
+  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 
   global-acl-rules = [
     {

--- a/test/api/integration/application.conf
+++ b/test/api/integration/application.conf
@@ -31,10 +31,16 @@ vinyldns {
   scheduled-changes-enabled = ${?SCHEDULED_CHANGES_ENABLED}
   multi-record-batch-change-enabled = true
   multi-record-batch-change-enabled = ${?MULTI_RECORD_BATCH_CHANGE_ENABLED}
+
+  # Server settings
   use-recordset-cache = true
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = true
   load-test-data = ${?LOAD_TEST_DATA}
+  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  is-zone-sync-schedule-allowed = true
+  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 
   # configured backend providers
   backend {


### PR DESCRIPTION
Fixes #1232.

Changes in this pull request:
- Add a config for zone sync scheduler to perform automated sync only on a single api server/instance instead of being done on all the api servers/instances.
