### PR TITLE
Restrict IPv4 as Cname in manage records

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -20,6 +20,7 @@ import cats.syntax.either._
 import vinyldns.api.Interfaces._
 import vinyldns.api.backend.dns.DnsConversions
 import vinyldns.api.config.HighValueDomainConfig
+import vinyldns.api.domain.DomainValidations.validateIpv4Address
 import vinyldns.api.domain._
 import vinyldns.core.domain.DomainHelpers._
 import vinyldns.core.domain.record.RecordType._
@@ -236,6 +237,16 @@ object RecordSetValidations {
       )
     }
 
+    val isNotIPv4inCname = {
+      ensuring(
+        RecordSetValidation(
+          s"""Invalid CNAME: ${newRecordSet.records.head.toString.dropRight(1)}, valid CNAME record data cannot be an IP address."""
+        )
+      )(
+        validateIpv4Address(newRecordSet.records.head.toString.dropRight(1)).isInvalid
+      )
+    }
+
     for {
       _ <- isNotOrigin(
         newRecordSet,
@@ -243,6 +254,7 @@ object RecordSetValidations {
         "CNAME RecordSet cannot have name '@' because it points to zone origin"
       )
       _ <- noRecordWithName
+      _ <- isNotIPv4inCname
       _ <- RDataWithConsecutiveDots
       _ <- checkForDot(newRecordSet, zone, existingRecordSet, recordFqdnDoesNotExist, dottedHostZoneConfig, isRecordTypeAndUserAllowed, allowedDotsLimit)
     } yield ()

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -681,6 +681,24 @@ def test_create_dotted_cname_record_succeeds_if_all_dotted_hosts_config_satisfie
             client.wait_until_recordset_change_status(delete_result, "Complete")
 
 
+def test_create_IPv4_cname_record_fails(shared_zone_test_context):
+    """
+    Test that creating a CNAME record set as IPv4 address records returns an error.
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    zone = shared_zone_test_context.parent_zone
+    apex_cname_rs = {
+        "zoneId": zone["id"],
+        "name": "test_create_cname_with_ipaddress",
+        "type": "CNAME",
+        "ttl": 500,
+        "records": [{"cname": "1.2.3.4"}]
+    }
+
+    error = client.create_recordset(apex_cname_rs, status=400)
+    assert_that(error, is_(f'Invalid CNAME: 1.2.3.4, valid CNAME record data cannot be an IP address.'))
+
+
 def test_create_cname_with_multiple_records(shared_zone_test_context):
     """
     Test that creating a CNAME record set with multiple records returns an error

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -486,6 +486,10 @@ class RecordSetValidationsSpec
         val error = leftValue(cnameValidations(invalid, List(), okZone, None, true, dottedHostsConfigZonesAllowed.toSet, false))
         error shouldBe an[InvalidRequest]
       }
+      "return an InvalidRequest if a cname record set fqdn is IPv4 address" in {
+        val error = leftValue(cnameValidations(cname.copy(records = List(CNAMEData(Fqdn("1.2.3.4")))), List(), okZone, None, true, dottedHostsConfigZonesAllowed.toSet, false))
+        error shouldBe an[RecordSetValidation]
+      }
       "return an InvalidRequest if a cname record set name is dotted" in {
         val error = leftValue(cnameValidations(cname.copy(name = "dot.ted"), List(), okZone, None, true, dottedHostsConfigZonesAllowed.toSet, false))
         error shouldBe an[InvalidRequest]


### PR DESCRIPTION
Fixes #1181.

**Changes in this pull request:**

- Restrict IPv4 as record data in Cname validation.
