### PR TITLE
Add logs and time converter for automated zone syncs

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -164,6 +164,7 @@ object CommandHandler {
       message.command match {
         case sync: ZoneChange
             if sync.changeType == ZoneChangeType.Sync || sync.changeType == ZoneChangeType.AutomatedSync || sync.changeType == ZoneChangeType.Create =>
+          logger.info(s"Performing zone sync for zone with zone change id: '${sync.id}', zone name: '${sync.zone.name}'")
           outcomeOf(message)(zoneSyncProcessor(sync))
 
         case zoneChange: ZoneChange =>

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneChangeHandler.scala
@@ -17,12 +17,16 @@
 package vinyldns.api.engine
 
 import cats.effect.IO
+import org.slf4j.{Logger, LoggerFactory}
 import scalikejdbc.DB
 import vinyldns.api.engine.ZoneSyncHandler.executeWithinTransaction
 import vinyldns.core.domain.record.{RecordSetCacheRepository, RecordSetRepository}
 import vinyldns.core.domain.zone._
 
 object ZoneChangeHandler {
+
+  private implicit val logger: Logger = LoggerFactory.getLogger("vinyldns.engine.ZoneChangeHandler")
+
   def apply(
              zoneRepository: ZoneRepository,
              zoneChangeRepository: ZoneChangeRepository,
@@ -54,6 +58,7 @@ object ZoneChangeHandler {
               zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
             }
         case Right(_) =>
+          logger.info(s"Saving zone change with id: '${zoneChange.id}', zone name: '${zoneChange.zone.name}'")
           zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
       }
 }

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -79,6 +79,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
           )
         )
       case Right(_) =>
+        logger.info(s"Saving zone sync details for zone change with id: '${zoneChange.id}', zone name: '${zoneChange.zone.name}'")
         zoneChangeRepository.save(zoneChange)
     }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -57,7 +57,7 @@ class MySqlZoneChangeRepository
   override def save(zoneChange: ZoneChange): IO[ZoneChange] =
     monitor("repo.ZoneChange.save") {
       IO {
-        logger.debug(s"Saving zone change ${zoneChange.id}")
+        logger.info(s"Saving zone change '${zoneChange.id}'. Zone name: '${zoneChange.zone.name}', change type: '${zoneChange.changeType}', status: '${zoneChange.status}'")
         DB.localTx { implicit s =>
           PUT_ZONE_CHANGE
             .bindByName(

--- a/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageZone.scala.html
@@ -360,6 +360,9 @@
         <cron-selection id="cron-lib" class="col-md-12" ng-model="zoneSyncSchedule.recurrenceSchedule" config="myZoneSyncScheduleConfig"></cron-selection>
         <span class="help-block">
             Schedule for zone sync at the provided time. Scheduled zone sync follows <b>UTC timezone</b>.
+            <a style="cursor: pointer;" ng-click="openTimeConverter();" id="open-time-converter-modal-button">
+                    Convert to UTC time
+            </a>
         </span>
         <div class="checkbox col-md-12" id="cron-lib-check">
             <label ng-if="recurrenceScheduleExist">
@@ -573,6 +576,33 @@
                         Close
                     </button>
                 </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade in" id="time_converter_modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span>
+                </button>
+                <div class="modal-title">Convert to UTC time</div>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="localTime">Select the time:</label>
+                    <div class="input-group">
+                        <input id="localTime" type="text" name="time" class="form-control" ng-model="time" />
+                        <div class="input-group-addon">{{ getLocalTimeZone() }}</div>
+                    </div>
+                    <p style="margin: 0px;"><b>Equivalent UTC time:</b> {{utcTime}}</p>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default pull-left" ng-click="resetTime();">Clear Form</button>
+                <button type="button" class="btn btn-default pull-right" ng-click="getUtcTime();">Get UTC time</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="resetTime();">Close</button>
             </div>
         </div>
     </div>

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -338,6 +338,7 @@ angular.module('controller.manageZones', ['angular-cron-jobs'])
         zoneHistoryPaging = pagingService.resetPaging(zoneHistoryPaging);
          function success(response) {
             $log.log('zonesService::getZoneChanges-success');
+            $log.log('zonesService::getZoneChanges: ', response.data.zoneChanges);
             zoneHistoryPaging.next = response.data.nextId;
             $scope.zoneChanges = response.data.zoneChanges;
             $scope.updateZoneChangeDisplay(response.data.zoneChanges);

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -36,6 +36,8 @@ angular.module('controller.manageZones', ['angular-cron-jobs'])
      * Zone scope data initial setup
      */
 
+    $scope.time = undefined;
+    $scope.utcTime = undefined;
     $scope.alerts = [];
     $scope.zoneInfo = {};
     $scope.zoneChanges = {};
@@ -97,6 +99,23 @@ angular.module('controller.manageZones', ['angular-cron-jobs'])
 
     $scope.confirmDeleteZone = function() {
         $("#delete_zone_connection_modal").modal("show");
+    };
+
+    $scope.openTimeConverter = function() {
+        $("#time_converter_modal").modal("show");
+    };
+
+    $scope.getLocalTimeZone = function() {
+        return new Date().toLocaleString('en-us', {timeZoneName:'short'}).split(' ')[3];
+    };
+
+    $scope.getUtcTime = function() {
+        $scope.utcTime = moment($scope.time, 'hh:mm A').utc().format('hh:mm A');
+    };
+
+    $scope.resetTime = function () {
+        $scope.time = undefined;
+        $scope.utcTime = undefined;
     };
 
     $scope.myZoneSyncScheduleConfig = {
@@ -505,6 +524,17 @@ angular.module('controller.manageZones', ['angular-cron-jobs'])
                 handleError(error, 'zonesService::updateZone-failure');
             });
     };
+
+    $('input[name="time"]').daterangepicker({
+        singleDatePicker: true,
+        startDate: moment().startOf('day'),
+        minDate: moment().startOf('day'),
+        maxDate: moment().endOf('day'),
+        timePicker: true,
+        locale: {
+          format: 'hh:mm A'
+        }
+    });
 
     $timeout($scope.refreshZone, 0);
 });


### PR DESCRIPTION
- Zone change seems to be saved multiple times in the zone change table while performing automated sync. Adding logs to debug. 
- Added a modal to convert the local time entered to it's equivalent UTC time. The modal can be viewed by clicking `Convert to UTC time` below the scheduler.