### PR TITLE
Enable debug logging for hikariCP

### DIFF
--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -188,9 +188,9 @@ vinyldns {
       name = ${?DATABASE_NAME}
       driver = "org.mariadb.jdbc.Driver"
       driver = ${?JDBC_DRIVER}
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass&socketTimeout=20000"
       migration-url = ${?JDBC_MIGRATION_URL}
-      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
+      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass&socketTimeout=20000"
       url = ${?JDBC_URL}
       user = "root"
       user = ${?JDBC_USER}

--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -198,6 +198,12 @@ vinyldns {
       password = ${?JDBC_PASSWORD}
       flyway-out-of-order = false
       flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
+
+      max-lifetime = 300000
+      connection-timeout-millis = 30000
+      idle-timeout = 150000
+      maximum-pool-size = 20
+      minimum-idle = 5
     }
 
     # TODO: Remove the need for these useless configuration blocks

--- a/build/docker/api/logback.xml
+++ b/build/docker/api/logback.xml
@@ -9,9 +9,14 @@
         </encoder>
     </appender>
 
+
     <logger name="vinyldns.core.route.Monitor" level="OFF"/>
 
     <logger name="scalikejdbc.StatementExecutor$$anon$1" level="OFF"/>
+
+    <logger name="com.zaxxer.hikari" level="TRACE">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
 
     <root level="${VINYLDNS_LOG_LEVEL}">
         <appender-ref ref="CONSOLE"/>

--- a/build/docker/portal/application.conf
+++ b/build/docker/portal/application.conf
@@ -50,9 +50,9 @@ mysql {
     name = ${?DATABASE_NAME}
     driver = "org.mariadb.jdbc.Driver"
     driver = ${?JDBC_DRIVER}
-    migration-url = "jdbc:mariadb://"${mysql.endpoint}"/?user=root&password=pass"
+    migration-url = "jdbc:mariadb://"${mysql.endpoint}"/?user=root&password=pass&socketTimeout=20000"
     migration-url = ${?JDBC_MIGRATION_URL}
-    url = "jdbc:mariadb://"${mysql.endpoint}"/vinyldns?user=root&password=pass"
+    url = "jdbc:mariadb://"${mysql.endpoint}"/vinyldns?user=root&password=pass&socketTimeout=20000"
     url = ${?JDBC_URL}
     user = "root"
     user = ${?JDBC_USER}

--- a/build/docker/portal/application.conf
+++ b/build/docker/portal/application.conf
@@ -60,6 +60,12 @@ mysql {
     password = ${?JDBC_PASSWORD}
     flyway-out-of-order = false
     flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
+
+    max-lifetime = 300000
+    connection-timeout-millis = 30000
+    idle-timeout = 150000
+    maximum-pool-size = 20
+    minimum-idle = 5
   }
 }
 

--- a/build/docker/portal/logback.xml
+++ b/build/docker/portal/logback.xml
@@ -15,6 +15,10 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
+  <logger name="com.zaxxer.hikari" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+
   <root level="${VINYLDNS_LOG_LEVEL}">
     <appender-ref ref="CONSOLE" />
   </root>

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -214,6 +214,12 @@ vinyldns {
       password = ${?JDBC_PASSWORD}
       flyway-out-of-order = false
       flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
+
+      max-lifetime = 300000
+      connection-timeout-millis = 30000
+      idle-timeout = 150000
+      maximum-pool-size = 20
+      minimum-idle = 5
     }
 
     # TODO: Remove the need for these useless configuration blocks

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -204,9 +204,9 @@ vinyldns {
       name = ${?DATABASE_NAME}
       driver = "org.mariadb.jdbc.Driver"
       driver = ${?JDBC_DRIVER}
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass&socketTimeout=20000"
       migration-url = ${?JDBC_MIGRATION_URL}
-      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
+      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass&socketTimeout=20000"
       url = ${?JDBC_URL}
       user = "root"
       user = ${?JDBC_USER}

--- a/modules/api/src/main/resources/logback.xml
+++ b/modules/api/src/main/resources/logback.xml
@@ -7,6 +7,10 @@
         </encoder>
     </appender>
 
+    <logger name="com.zaxxer.hikari" level="TRACE">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -188,9 +188,9 @@ vinyldns {
       name = ${?DATABASE_NAME}
       driver = "org.mariadb.jdbc.Driver"
       driver = ${?JDBC_DRIVER}
-      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass"
+      migration-url = "jdbc:mariadb://localhost:19002/?user=root&password=pass&socketTimeout=20000"
       migration-url = ${?JDBC_MIGRATION_URL}
-      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass"
+      url = "jdbc:mariadb://localhost:19002/vinyldns?user=root&password=pass&socketTimeout=20000"
       url = ${?JDBC_URL}
       user = "root"
       user = ${?JDBC_USER}

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -198,6 +198,12 @@ vinyldns {
       password = ${?JDBC_PASSWORD}
       flyway-out-of-order = false
       flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
+
+      max-lifetime = 300000
+      connection-timeout-millis = 30000
+      idle-timeout = 150000
+      maximum-pool-size = 20
+      minimum-idle = 5
     }
 
     # TODO: Remove the need for these useless configuration blocks

--- a/modules/api/src/universal/conf/logback.xml
+++ b/modules/api/src/universal/conf/logback.xml
@@ -7,6 +7,10 @@
         </encoder>
     </appender>
 
+    <logger name="com.zaxxer.hikari" level="TRACE">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/modules/portal/conf/application.conf
+++ b/modules/portal/conf/application.conf
@@ -37,6 +37,38 @@ LDAP {
   }
 }
 
+mysql {
+  class-name = "vinyldns.mysql.repository.MySqlDataStoreProvider"
+  endpoint = "localhost:19002"
+  endpoint = ${?MYSQL_ENDPOINT}
+
+  settings {
+    # JDBC Settings, these are all values in scalikejdbc-config, not our own
+    # these must be overridden to use MYSQL for production use
+    # assumes a docker or mysql instance running locally
+    name = "vinyldns"
+    name = ${?DATABASE_NAME}
+    driver = "org.mariadb.jdbc.Driver"
+    driver = ${?JDBC_DRIVER}
+    migration-url = "jdbc:mariadb://"${mysql.endpoint}"/?user=root&password=pass"
+    migration-url = ${?JDBC_MIGRATION_URL}
+    url = "jdbc:mariadb://"${mysql.endpoint}"/vinyldns?user=root&password=pass"
+    url = ${?JDBC_URL}
+    user = "root"
+    user = ${?JDBC_USER}
+    password = "pass"
+    password = ${?JDBC_PASSWORD}
+    flyway-out-of-order = false
+    flyway-out-of-order = ${?FLYWAY_OUT_OF_ORDER}
+
+    max-lifetime = 300000
+    connection-timeout-millis = 30000
+    idle-timeout = 150000
+    maximum-pool-size = 20
+    minimum-idle = 5
+  }
+}
+
 # Note: This MUST match the API or strange errors will ensue, NoOpCrypto should not be used for production
 crypto {
   type = "vinyldns.core.crypto.NoOpCrypto"

--- a/modules/portal/conf/application.conf
+++ b/modules/portal/conf/application.conf
@@ -50,9 +50,9 @@ mysql {
     name = ${?DATABASE_NAME}
     driver = "org.mariadb.jdbc.Driver"
     driver = ${?JDBC_DRIVER}
-    migration-url = "jdbc:mariadb://"${mysql.endpoint}"/?user=root&password=pass"
+    migration-url = "jdbc:mariadb://"${mysql.endpoint}"/?user=root&password=pass&socketTimeout=20000"
     migration-url = ${?JDBC_MIGRATION_URL}
-    url = "jdbc:mariadb://"${mysql.endpoint}"/vinyldns?user=root&password=pass"
+    url = "jdbc:mariadb://"${mysql.endpoint}"/vinyldns?user=root&password=pass&socketTimeout=20000"
     url = ${?JDBC_URL}
     user = "root"
     user = ${?JDBC_USER}

--- a/modules/portal/conf/logback.xml
+++ b/modules/portal/conf/logback.xml
@@ -15,6 +15,10 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
+  <logger name="com.zaxxer.hikari" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
   </root>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     "com.amazonaws"             %  "aws-java-sdk-core"              % awsV withSources(),
     "com.github.ben-manes.caffeine" % "caffeine"                    % "2.2.7",
     "com.github.cb372"          %% "scalacache-caffeine"            % "0.9.4",
-    "com.google.protobuf"       %  "protobuf-java"                  % "3.21.7",
+    "com.google.protobuf"       %  "protobuf-java"                  % "2.6.1",
     "dnsjava"                   %  "dnsjava"                        % "3.4.2",
     "org.apache.commons"        %  "commons-lang3"                  % "3.4",
     "org.apache.commons"        %  "commons-text"                   % "1.4",
@@ -37,7 +37,7 @@ object Dependencies {
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "org.scodec"                %% "scodec-bits"                    % scodecV,
-    "org.slf4j"                 %  "slf4j-api"                      % "1.8.0-beta4",
+    "org.slf4j"                 %  "slf4j-api"                      % "1.7.25",
     "co.fs2"                    %% "fs2-core"                       % fs2V,
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
@@ -67,7 +67,7 @@ object Dependencies {
     "javax.xml.bind"            %  "jaxb-api"                       % jaxbV % "provided",
     "com.sun.xml.bind"          %  "jaxb-core"                      % jaxbV,
     "com.sun.xml.bind"          %  "jaxb-impl"                      % jaxbV,
-    "ch.qos.logback"            %  "logback-classic"                % "1.4.6",
+    "ch.qos.logback"            %  "logback-classic"                % "1.0.7",
     "io.dropwizard.metrics"     %  "metrics-jvm"                    % "3.2.2",
     "co.fs2"                    %% "fs2-core"                       % fs2V,
     "javax.xml.bind"            %  "jaxb-api"                       % "2.3.0",
@@ -83,7 +83,7 @@ object Dependencies {
     "org.mariadb.jdbc"          %  "mariadb-java-client"            % "2.3.0",
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
-    "com.zaxxer"                %  "HikariCP"                       % "5.0.1",
+    "com.zaxxer"                %  "HikariCP"                       % "3.2.0",
     "com.h2database"            %  "h2"                             % "1.4.200"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     "com.amazonaws"             %  "aws-java-sdk-core"              % awsV withSources(),
     "com.github.ben-manes.caffeine" % "caffeine"                    % "2.2.7",
     "com.github.cb372"          %% "scalacache-caffeine"            % "0.9.4",
-    "com.google.protobuf"       %  "protobuf-java"                  % "2.6.1",
+    "com.google.protobuf"       %  "protobuf-java"                  % "3.21.7",
     "dnsjava"                   %  "dnsjava"                        % "3.4.2",
     "org.apache.commons"        %  "commons-lang3"                  % "3.4",
     "org.apache.commons"        %  "commons-text"                   % "1.4",
@@ -37,7 +37,7 @@ object Dependencies {
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "org.scodec"                %% "scodec-bits"                    % scodecV,
-    "org.slf4j"                 %  "slf4j-api"                      % "1.7.25",
+    "org.slf4j"                 %  "slf4j-api"                      % "1.8.0-beta4",
     "co.fs2"                    %% "fs2-core"                       % fs2V,
     "com.github.pureconfig"     %% "pureconfig"                     % pureConfigV,
     "com.github.pureconfig"     %% "pureconfig-cats-effect"         % pureConfigV,
@@ -67,7 +67,7 @@ object Dependencies {
     "javax.xml.bind"            %  "jaxb-api"                       % jaxbV % "provided",
     "com.sun.xml.bind"          %  "jaxb-core"                      % jaxbV,
     "com.sun.xml.bind"          %  "jaxb-impl"                      % jaxbV,
-    "ch.qos.logback"            %  "logback-classic"                % "1.0.7",
+    "ch.qos.logback"            %  "logback-classic"                % "1.4.6",
     "io.dropwizard.metrics"     %  "metrics-jvm"                    % "3.2.2",
     "co.fs2"                    %% "fs2-core"                       % fs2V,
     "javax.xml.bind"            %  "jaxb-api"                       % "2.3.0",
@@ -83,7 +83,7 @@ object Dependencies {
     "org.mariadb.jdbc"          %  "mariadb-java-client"            % "2.3.0",
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
-    "com.zaxxer"                %  "HikariCP"                       % "3.2.0",
+    "com.zaxxer"                %  "HikariCP"                       % "5.0.1",
     "com.h2database"            %  "h2"                             % "1.4.200"
   )
 


### PR DESCRIPTION
Hikari pool stats are now logged on the console. Every 30 seconds the stats get output like this:
`{"@timestamp":"2023-04-26T00:17:26.667Z", "log.level":"DEBUG", "message":"mysqlDbPool - Pool stats (total=10, active=0, idle=10, waiting=0)", "ecs.version": "1.2.0","service.name":"vinyldns-portal","service.node.name":"vinyldns-portal","event.dataset":"vinyldns-portal","process.thread.name":"mysqlDbPool housekeeper","log.logger":"com.zaxxer.hikari.pool.HikariPool"}`
