### PR TITLE
Add an Option to Filter Out PTR Zones in the Zones View

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -274,7 +274,8 @@ case class ListZonesResponse(
                               startFrom: Option[String] = None,
                               nextId: Option[String] = None,
                               maxItems: Int = 100,
-                              ignoreAccess: Boolean = false
+                              ignoreAccess: Boolean = false,
+                              includeReverse: Boolean = true
                             )
 
 // Errors

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -202,7 +202,8 @@ class ZoneService(
           startFrom,
           maxItems,
           groupIds,
-          ignoreAccess
+          ignoreAccess,
+          includeReverse
         )
         zones = listZonesResult.zones
         groups <- groupRepository.getGroups(groupIds)
@@ -213,7 +214,8 @@ class ZoneService(
         listZonesResult.startFrom,
         listZonesResult.nextId,
         listZonesResult.maxItems,
-        listZonesResult.ignoreAccess
+        listZonesResult.ignoreAccess,
+        listZonesResult.includeReverse
       )
     }
   }.toResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -168,7 +168,8 @@ class ZoneService(
       startFrom: Option[String] = None,
       maxItems: Int = 100,
       searchByAdminGroup: Boolean = false,
-      ignoreAccess: Boolean = false
+      ignoreAccess: Boolean = false,
+      includeReverse: Boolean = true
   ): Result[ListZonesResponse] = {
     if(!searchByAdminGroup || nameFilter.isEmpty){
       for {
@@ -177,21 +178,22 @@ class ZoneService(
           nameFilter,
           startFrom,
           maxItems,
-          ignoreAccess
-        )
-        zones = listZonesResult.zones
-        groupIds = zones.map(_.adminGroupId).toSet
-        groups <- groupRepository.getGroups(groupIds)
-        zoneSummaryInfos = zoneSummaryInfoMapping(zones, authPrincipal, groups)
-      } yield ListZonesResponse(
-        zoneSummaryInfos,
-        listZonesResult.zonesFilter,
-        listZonesResult.startFrom,
-        listZonesResult.nextId,
-        listZonesResult.maxItems,
-        listZonesResult.ignoreAccess
+          ignoreAccess,
+          includeReverse
       )
-    }
+      zones = listZonesResult.zones
+      groupIds = zones.map(_.adminGroupId).toSet
+      groups <- groupRepository.getGroups(groupIds)
+      zoneSummaryInfos = zoneSummaryInfoMapping(zones, authPrincipal, groups)
+    } yield ListZonesResponse(
+      zoneSummaryInfos,
+      listZonesResult.zonesFilter,
+      listZonesResult.startFrom,
+      listZonesResult.nextId,
+      listZonesResult.maxItems,
+      listZonesResult.ignoreAccess,
+      listZonesResult.includeReverse
+    )}
     else {
       for {
         groupIds <- getGroupsIdsByName(nameFilter.get)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -43,7 +43,8 @@ trait ZoneServiceAlgebra {
       startFrom: Option[String],
       maxItems: Int,
       searchByAdminGroup: Boolean,
-      ignoreAccess: Boolean
+      ignoreAccess: Boolean,
+      includeReverse: Boolean
   ): Result[ListZonesResponse]
 
   def listZoneChanges(

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -81,14 +81,16 @@ class ZoneRoute(
           "startFrom".as[String].?,
           "maxItems".as[Int].?(DEFAULT_MAX_ITEMS),
           "searchByAdminGroup".as[Boolean].?(false),
-          "ignoreAccess".as[Boolean].?(false)
+          "ignoreAccess".as[Boolean].?(false),
+          "includeReverse".as[Boolean].?(true)
         ) {
           (
               nameFilter: Option[String],
               startFrom: Option[String],
               maxItems: Int,
               searchByAdminGroup: Boolean,
-              ignoreAccess: Boolean
+              ignoreAccess: Boolean,
+              includeReverse: Boolean
           ) =>
             {
               handleRejections(invalidQueryHandler) {
@@ -98,7 +100,7 @@ class ZoneRoute(
                 ) {
                   authenticateAndExecute(
                     zoneService
-                      .listZones(_, nameFilter, startFrom, maxItems, searchByAdminGroup, ignoreAccess)
+                      .listZones(_, nameFilter, startFrom, maxItems, searchByAdminGroup, ignoreAccess, includeReverse)
                   ) { result =>
                     complete(StatusCodes.OK, result)
                   }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -874,7 +874,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
       doReturn(IO.pure(ListZonesResults(List(abcZone), ignoreAccess = true, zonesFilter = Some("abcZone"))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, Some("abcZone"), None, 100, true)
+        .listZones(abcAuth, Some("abcZone"), None, 100, true, true)
 
       // When searchByAdminGroup is false, zone name given in nameFilter is returned
       val result: ListZonesResponse =

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -854,7 +854,7 @@ class ZoneServiceSpec
         .getGroupsByName(any[String])
       doReturn(IO.pure(ListZonesResults(List(abcZone), ignoreAccess = true, zonesFilter = Some("abcGroup"))))
         .when(mockZoneRepo)
-        .listZonesByAdminGroupIds(abcAuth, None, 100, Set(abcGroup.id), ignoreAccess = true)
+        .listZonesByAdminGroupIds(abcAuth, None, 100, Set(abcGroup.id), ignoreAccess = true, includeReverse = true)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       // When searchByAdminGroup is true, zones are filtered by admin group name given in nameFilter

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -801,7 +801,7 @@ class ZoneServiceSpec
     "not fail with no zones returned" in {
       doReturn(IO.pure(ListZonesResults(List())))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false)
+        .listZones(abcAuth, None, None, 100, false, true)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
@@ -816,7 +816,7 @@ class ZoneServiceSpec
     "return the appropriate zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false)
+        .listZones(abcAuth, None, None, 100, false, true)
       doReturn(IO.pure(Set(abcGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -833,7 +833,7 @@ class ZoneServiceSpec
     "return all zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone), ignoreAccess = true)))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, true)
+        .listZones(abcAuth, None, None, 100, true, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -890,7 +890,7 @@ class ZoneServiceSpec
     "return Unknown group name if zone admin group cannot be found" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false)
+        .listZones(abcAuth, None, None, 100, false, true)
       doReturn(IO.pure(Set(okGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
@@ -914,7 +914,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 2, false)
+        .listZones(abcAuth, None, None, 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -940,7 +940,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, Some("foo"), None, 2, false)
+        .listZones(abcAuth, Some("foo"), None, 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -964,7 +964,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, Some("zone4."), 2, false)
+        .listZones(abcAuth, None, Some("zone4."), 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -987,7 +987,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, Some("zone4."), 2, false)
+        .listZones(abcAuth, None, Some("zone4."), 2, false, true)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -89,7 +89,8 @@ trait EmptyZoneRepo extends ZoneRepository {
      startFrom: Option[String] = None,
      maxItems: Int = 100,
      adminGroupIds: Set[String],
-     ignoreAccess: Boolean = false
+     ignoreAccess: Boolean = false,
+     includeReverse: Boolean = true
    ): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def listZones(

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -97,7 +97,8 @@ trait EmptyZoneRepo extends ZoneRepository {
                  zoneNameFilter: Option[String] = None,
                  startFrom: Option[String] = None,
                  maxItems: Int = 100,
-                 ignoreAccess: Boolean = false
+                 ignoreAccess: Boolean = false,
+                 includeReverse: Boolean = true
                ): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]] = IO.pure(List())

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -258,7 +258,8 @@ class ZoneRoutingSpec
         startFrom: Option[String],
         maxItems: Int,
         searchByAdminGroup: Boolean = false,
-        ignoreAccess: Boolean = false
+        ignoreAccess: Boolean = false,
+        includeReverse: Boolean = true
     ): Result[ListZonesResponse] = {
 
       val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess) match {

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -112,6 +112,9 @@ class ZoneRoutingSpec
   private val zone5 =
     Zone("zone5.", "zone5@test.com", ZoneStatus.Active, adminGroupId = xyzGroup.id)
   private val zoneSummaryInfo5 = ZoneSummaryInfo(zone5, xyzGroup.name, AccessLevel.NoAccess)
+  private val zone6 =
+    Zone("zone6.in-addr.arpa.", "zone6@test.com", ZoneStatus.Active, adminGroupId = xyzGroup.id)
+  private val zoneSummaryInfo6 = ZoneSummaryInfo(zone6, xyzGroup.name, AccessLevel.NoAccess)
   private val error = Zone("error.", "error@test.com")
 
   private val missingFields: JValue =
@@ -262,8 +265,8 @@ class ZoneRoutingSpec
         includeReverse: Boolean = true
     ): Result[ListZonesResponse] = {
 
-      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess) match {
-        case (_, None, Some("zone3."), 3, false) =>
+      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess, includeReverse) match {
+        case (_, None, Some("zone3."), 3, false, true) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -274,7 +277,7 @@ class ZoneRoutingSpec
               ignoreAccess = false
             )
           )
-        case (_, None, Some("zone4."), 4, false) =>
+        case (_, None, Some("zone4."), 4, false, true) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -286,7 +289,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, 3, false) =>
+        case (_, None, None, 3, false, true) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -298,7 +301,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, 5, true) =>
+        case (_, None, None, 6, true, true) =>
           Right(
             ListZonesResponse(
               zones = List(
@@ -306,17 +309,38 @@ class ZoneRoutingSpec
                 zoneSummaryInfo2,
                 zoneSummaryInfo3,
                 zoneSummaryInfo4,
-                zoneSummaryInfo5
+                zoneSummaryInfo5,
+                zoneSummaryInfo6
               ),
               nameFilter = None,
               startFrom = None,
               nextId = None,
-              maxItems = 5,
-              ignoreAccess = true
+              maxItems = 6,
+              ignoreAccess = true,
+              includeReverse = true
             )
           )
 
-        case (_, Some(filter), Some("zone4."), 4, false) =>
+        case (_, None, None, 6, true, false) =>
+          Right(
+            ListZonesResponse(
+              zones = List(
+                zoneSummaryInfo1,
+                zoneSummaryInfo2,
+                zoneSummaryInfo3,
+                zoneSummaryInfo4,
+                zoneSummaryInfo5,
+              ),
+              nameFilter = None,
+              startFrom = None,
+              nextId = None,
+              maxItems = 6,
+              ignoreAccess = true,
+              includeReverse = false
+            )
+          )
+
+        case (_, Some(filter), Some("zone4."), 4, false, true) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -328,7 +352,20 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, _, _) =>
+        case (_, Some(filter), Some("zone4."), 4, true, false) =>
+          Right(
+            ListZonesResponse(
+              zones = List(zoneSummaryInfo4, zoneSummaryInfo5),
+              nameFilter = Some(filter),
+              startFrom = Some("zone4."),
+              nextId = None,
+              maxItems = 4,
+              ignoreAccess = true,
+              includeReverse = false
+            )
+          )
+
+        case (_, None, None, _, _, true) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -950,17 +987,48 @@ class ZoneRoutingSpec
       }
     }
 
+    "return zones by admin group name when searchByAdminGroup is true and includeReverse is false" in {
+      Get(s"/zones?nameFilter=xyz&startFrom=zone4.&maxItems=4&searchByAdminGroup=true&ignoreAccess=true&includeReverse=false") ~> zoneRoute ~> check {
+        val resp = responseAs[ListZonesResponse]
+        val zones = resp.zones
+        (zones.map(_.id) should contain)
+          .only(zone4.id, zone5.id)
+        resp.nextId shouldBe None
+        resp.maxItems shouldBe 4
+        resp.startFrom shouldBe Some("zone4.")
+        resp.nameFilter shouldBe Some("xyz")
+        resp.ignoreAccess shouldBe true
+        resp.includeReverse shouldBe false
+      }
+    }
+
     "return all zones when list all is true" in {
-      Get(s"/zones?maxItems=5&ignoreAccess=true") ~> zoneRoute ~> check {
+      Get(s"/zones?maxItems=6&ignoreAccess=true") ~> zoneRoute ~> check {
+        val resp = responseAs[ListZonesResponse]
+        val zones = resp.zones
+        (zones.map(_.id) should contain)
+          .only(zone1.id, zone2.id, zone3.id, zone4.id, zone5.id, zone6.id)
+        resp.nextId shouldBe None
+        resp.maxItems shouldBe 6
+        resp.startFrom shouldBe None
+        resp.nameFilter shouldBe None
+        resp.ignoreAccess shouldBe true
+        resp.includeReverse shouldBe true
+      }
+    }
+
+    "return all forward zones when list all is true and includeReverse is false" in {
+      Get(s"/zones?maxItems=6&ignoreAccess=true&includeReverse=false") ~> zoneRoute ~> check {
         val resp = responseAs[ListZonesResponse]
         val zones = resp.zones
         (zones.map(_.id) should contain)
           .only(zone1.id, zone2.id, zone3.id, zone4.id, zone5.id)
         resp.nextId shouldBe None
-        resp.maxItems shouldBe 5
+        resp.maxItems shouldBe 6
         resp.startFrom shouldBe None
         resp.nameFilter shouldBe None
         resp.ignoreAccess shouldBe true
+        resp.includeReverse shouldBe false
       }
     }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZonesResults.scala
@@ -22,5 +22,6 @@ case class ListZonesResults(
     startFrom: Option[String] = None,
     maxItems: Int = 100,
     ignoreAccess: Boolean = false,
-    zonesFilter: Option[String] = None
+    zonesFilter: Option[String] = None,
+    includeReverse: Boolean = true
 )

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -50,7 +50,8 @@ trait ZoneRepository extends Repository {
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      ignoreAccess: Boolean = false
+      ignoreAccess: Boolean = false,
+      includeReverse: Boolean = true
   ): IO[ListZonesResults]
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -42,7 +42,8 @@ trait ZoneRepository extends Repository {
        startFrom: Option[String] = None,
        maxItems: Int = 100,
        adminGroupIds: Set[String],
-       ignoreAccess: Boolean = false
+       ignoreAccess: Boolean = false,
+       includeReverse: Boolean = true
      ): IO[ListZonesResults]
 
   def listZones(

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -552,10 +552,53 @@ class MySqlZoneRepositoryIntegrationSpec
       f.unsafeRunSync().zones should contain theSameElementsAs expectedZones
     }
 
+    "apply the reverse zone filter as a super user" in {
+
+      val testZones = Seq(
+        testZone("system-test."),
+        testZone("system-test.ip6.arpa."),
+        testZone("system-temp.in-addr.arpa."),
+        testZone("nomatch.in-addr.arpa.")
+      )
+
+      val expectedZones = Seq(testZones(0))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(superUserAuth, includeReverse = false)
+        } yield retrieved
+
+      f.unsafeRunSync().zones should contain theSameElementsAs expectedZones
+    }
+
+    "apply the zone filter and reverse zone filter as a super user" in {
+
+      val testZones = Seq(
+        testZone("system-test."),
+        testZone("system-temp.ip6.arpa."),
+        testZone("system-test.ip6.arpa."),
+        testZone("system-temp.in-addr.arpa."),
+        testZone("no-match.")
+      )
+
+      val expectedZones = Seq(testZones(0)).sortBy(_.name)
+
+      val auth = AuthPrincipal(dummyUser, Seq("foo"))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"), includeReverse = false)
+        } yield retrieved
+
+      (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)
+    }
+
     "apply the zone filter as a normal user" in {
 
       val testZones = Seq(
-        testZone("system-test.", adminGroupId = "foo"),
+        testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
         testZone("system-temp.", adminGroupId = "foo"),
         testZone("system-nomatch.", adminGroupId = "bar")
       )
@@ -589,6 +632,52 @@ class MySqlZoneRepositoryIntegrationSpec
         for {
           _ <- saveZones(testZones)
           retrieved <- repo.listZones(auth, zoneNameFilter = Some("SyStEm*"))
+        } yield retrieved
+
+      (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)
+    }
+
+    "apply the zone filter and reverse zone filter as a normal user" in {
+
+      val testZones = Seq(
+        testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
+        testZone("system-temp.", adminGroupId = "foo"),
+        testZone("system-temp.in-addr.arpa.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar")
+      )
+
+      val expectedZones = Seq(testZones(1)).sortBy(_.name)
+
+      val auth = AuthPrincipal(dummyUser, Seq("foo"))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(auth, zoneNameFilter = Some("system*"), includeReverse = false)
+        } yield retrieved
+
+      (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)
+    }
+
+    "apply the reverse zone filter as a normal user" in {
+
+      val testZones = Seq(
+        testZone("system-test.ip6.arpa.", adminGroupId = "foo"),
+        testZone("system-test.in-addr.arpa.", adminGroupId = "foo"),
+        testZone("system-temp.in-addr.arpa.", adminGroupId = "foo"),
+        testZone("system-match.", adminGroupId = "foo"),
+        testZone("system-nomatch.", adminGroupId = "bar"),
+        testZone("system-nomatch.in-addr.arpa.", adminGroupId = "bar")
+      )
+
+      val expectedZones = Seq(testZones(3)).sortBy(_.name)
+
+      val auth = AuthPrincipal(dummyUser, Seq("foo"))
+
+      val f =
+        for {
+          _ <- saveZones(testZones)
+          retrieved <- repo.listZones(auth, includeReverse = false)
         } yield retrieved
 
       (f.unsafeRunSync().zones should contain).theSameElementsInOrderAs(expectedZones)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -323,7 +323,8 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
       zoneNameFilter: Option[String] = None,
       startFrom: Option[String] = None,
       maxItems: Int = 100,
-      ignoreAccess: Boolean = false
+      ignoreAccess: Boolean = false,
+      includeReverse: Boolean = true
   ): IO[ListZonesResults] =
     monitor("repo.ZoneJDBC.listZones") {
       IO {
@@ -332,6 +333,11 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             withAccessors(authPrincipal.signedInUser, authPrincipal.memberGroupIds, ignoreAccess)
           val sb = new StringBuilder
           sb.append(withAccessorCheck)
+
+          val noReverseRegex =
+            if (!includeReverse)
+              """(in-addr\.arpa\.)|(ip6\.arpa\.)$"""
+            else None
 
           val filters = if (zoneNameFilter.isDefined && (zoneNameFilter.get.takeRight(1) == "." || zoneNameFilter.get.contains("*"))) {
             List(
@@ -348,6 +354,17 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           if (filters.nonEmpty) {
             sb.append(" WHERE ")
             sb.append(filters.mkString(" AND "))
+          }
+
+          if (!includeReverse) {
+            if (filters.nonEmpty) {
+              sb.append(" AND ")
+              sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
+            }
+            else {
+              sb.append(" WHERE ")
+              sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
+            }
           }
 
           sb.append(s" GROUP BY z.name ")
@@ -372,7 +389,8 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             startFrom = startFrom,
             maxItems = maxItems,
             zonesFilter = zoneNameFilter,
-            ignoreAccess = ignoreAccess
+            ignoreAccess = ignoreAccess,
+            includeReverse = includeReverse
           )
         }
       }

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -49,19 +49,19 @@
                                         </button>
                                     </div>
 
-                                    <div class="pull-right">
-                                        <div class="input-group" style="padding-left: 10px;">
-                                            <div class="ptr-zone-filter">
-                                                <form action="">
-                                                    <div class="checkbox pull-right">
-                                                        <label>
-                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones
-                                                        </label>
-                                                    </div>
-                                                </form>
-                                            </div>
-                                        </div>
-                                    </div>
+<!--                                    <div class="pull-right">-->
+<!--                                        <div class="input-group" style="padding-left: 10px;">-->
+<!--                                            <div class="ptr-zone-filter">-->
+<!--                                                <form action="">-->
+<!--                                                    <div class="checkbox pull-right">-->
+<!--                                                        <label>-->
+<!--                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones-->
+<!--                                                        </label>-->
+<!--                                                    </div>-->
+<!--                                                </form>-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                    </div>-->
                                     <!-- SEARCH BOX -->
                                     <div class="pull-right">
                                         <form class="input-group" ng-submit="refreshZones()">
@@ -77,6 +77,19 @@
                                                 <label>
                                                     <input class="isGroupSearch" type="checkbox" ng-model="searchByAdminGroup" ng-change="refreshZones()"> Search by admin group
                                                 </label>
+                                            </div>
+                                            <div class="pull-right">
+                                                <div class="input-group" style="padding-right: 10px;">
+                                                    <div class="ptr-zone-filter">
+                                                        <form action="">
+                                                            <div class="checkbox pull-right">
+                                                                <label>
+                                                                    <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones
+                                                                </label>
+                                                            </div>
+                                                        </form>
+                                                    </div>
+                                                </div>
                                             </div>
                                         </form>
                                     </div>
@@ -187,12 +200,24 @@
                                                 </span>
                                                 <input ng-model="query" type="text" class="form-control zone-search-text"  placeholder="{{!searchByAdminGroup ? 'Zone Name' : 'Admin Group Name'}}"/>
                                             </div>
-
-                                                <div class="checkbox pull-right">
-                                                    <label>
-                                                        <input class="isGroupSearch" type="checkbox" ng-model="searchByAdminGroup" ng-change="refreshZones()"> Search by admin group
-                                                    </label>
+                                            <div class="checkbox pull-right">
+                                                <label>
+                                                    <input class="isGroupSearch" type="checkbox" ng-model="searchByAdminGroup" ng-change="refreshZones()"> Search by admin group
+                                                </label>
+                                            </div>
+                                            <div class="pull-right">
+                                                <div class="input-group" style="padding-right: 10px;">
+                                                    <div class="ptr-zone-filter">
+                                                        <form action="">
+                                                            <div class="checkbox pull-right">
+                                                                <label>
+                                                                    <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones
+                                                                </label>
+                                                            </div>
+                                                        </form>
+                                                    </div>
                                                 </div>
+                                            </div>
                                         </form>
                                     </div>
                                     <!-- END SEARCH BOX -->

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -1,5 +1,4 @@
 @(rootAccountName: String)(implicit request: play.api.mvc.Request[Any], customLinks: models.CustomLinks, meta: models.Meta)
-
 @content = {
 <!-- PAGE CONTENT -->
 <div class="right_col" role="main">
@@ -50,6 +49,19 @@
                                         </button>
                                     </div>
 
+                                    <div class="pull-right">
+                                        <div class="input-group" style="padding-left: 10px;">
+                                            <div class="ptr-zone-filter">
+                                                <form action="">
+                                                    <div class="checkbox pull-right">
+                                                        <label>
+                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones
+                                                        </label>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
                                     <!-- SEARCH BOX -->
                                     <div class="pull-right">
                                         <form class="input-group" ng-submit="refreshZones()">

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -48,20 +48,6 @@
                                             <span class="fa fa-refresh"></span> Refresh
                                         </button>
                                     </div>
-
-<!--                                    <div class="pull-right">-->
-<!--                                        <div class="input-group" style="padding-left: 10px;">-->
-<!--                                            <div class="ptr-zone-filter">-->
-<!--                                                <form action="">-->
-<!--                                                    <div class="checkbox pull-right">-->
-<!--                                                        <label>-->
-<!--                                                            <input type="checkbox" ng-model="includeReverse" ng-true-value="false" ng-false-value="true" ng-change="refreshZones()"> Hide PTR Zones-->
-<!--                                                        </label>-->
-<!--                                                    </div>-->
-<!--                                                </form>-->
-<!--                                            </div>-->
-<!--                                        </div>-->
-<!--                                    </div>-->
                                     <!-- SEARCH BOX -->
                                     <div class="pull-right">
                                         <form class="input-group" ng-submit="refreshZones()">

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -188,7 +188,7 @@ angular.module('controller.zones', [])
             });
 
         zonesService
-            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchByAdminGroup, true)
+            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchByAdminGroup, true, $scope.includeReverse)
             .then(function (response) {
                 $log.debug('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 allZonesPaging.next = response.data.nextId;

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -34,6 +34,7 @@ angular.module('controller.zones', [])
     }
 
     $scope.query = "";
+    $scope.includeReverse = true;
 
     $scope.keyAlgorithms = ['HMAC-MD5', 'HMAC-SHA1', 'HMAC-SHA224', 'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512'];
 
@@ -173,7 +174,7 @@ angular.module('controller.zones', [])
         allZonesPaging = pagingService.resetPaging(allZonesPaging);
 
         zonesService
-            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchByAdminGroup)
+            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchByAdminGroup, true, $scope.includeReverse)
             .then(function (response) {
                 $log.debug('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 zonesPaging.next = response.data.nextId;
@@ -306,7 +307,7 @@ angular.module('controller.zones', [])
     $scope.prevPageMyZones = function() {
         var startFrom = pagingService.getPrevStartFrom(zonesPaging);
         return zonesService
-            .getZones(zonesPaging.maxItems, startFrom, $scope.query, $scope.searchByAdminGroup, false)
+            .getZones(zonesPaging.maxItems, startFrom, $scope.query, $scope.searchByAdminGroup, false, true)
             .then(function(response) {
                 zonesPaging = pagingService.prevPageUpdate(response.data.nextId, zonesPaging);
                 updateZoneDisplay(response.data.zones);
@@ -319,7 +320,7 @@ angular.module('controller.zones', [])
     $scope.prevPageAllZones = function() {
         var startFrom = pagingService.getPrevStartFrom(allZonesPaging);
         return zonesService
-            .getZones(allZonesPaging.maxItems, startFrom, $scope.query, $scope.searchByAdminGroup, true)
+            .getZones(allZonesPaging.maxItems, startFrom, $scope.query, $scope.searchByAdminGroup, true, true)
             .then(function(response) {
                 allZonesPaging = pagingService.prevPageUpdate(response.data.nextId, allZonesPaging);
                 updateAllZonesDisplay(response.data.zones);
@@ -331,7 +332,7 @@ angular.module('controller.zones', [])
 
     $scope.nextPageMyZones = function () {
         return zonesService
-            .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query, $scope.searchByAdminGroup, false)
+            .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query, $scope.searchByAdminGroup, false, true)
             .then(function(response) {
                 var zoneSets = response.data.zones;
                 zonesPaging = pagingService.nextPageUpdate(zoneSets, response.data.nextId, zonesPaging);
@@ -347,7 +348,7 @@ angular.module('controller.zones', [])
 
     $scope.nextPageAllZones = function () {
         return zonesService
-            .getZones(allZonesPaging.maxItems, allZonesPaging.next, $scope.query, $scope.searchByAdminGroup, true)
+            .getZones(allZonesPaging.maxItems, allZonesPaging.next, $scope.query, $scope.searchByAdminGroup, true, true)
             .then(function(response) {
                 var zoneSets = response.data.zones;
                 allZonesPaging = pagingService.nextPageUpdate(zoneSets, response.data.nextId, allZonesPaging);

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -80,12 +80,13 @@ describe('Controller: ZonesController', function () {
         var expectedQuery = this.scope.query;
         var expectedSearchByAdminGroup = this.scope.searchByAdminGroup;
         var expectedignoreAccess = false;
+        var expectedincludeReverse = true;
 
         this.scope.nextPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess]);
+          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess, expectedincludeReverse]);
     });
 
     it('prevPageMyZones should call getZones with the correct parameters', function () {
@@ -98,18 +99,19 @@ describe('Controller: ZonesController', function () {
         var expectedQuery = this.scope.query;
         var expectedSearchByAdminGroup = this.scope.searchByAdminGroup;
         var expectedignoreAccess = false;
+        var expectedincludeReverse = true;
 
         this.scope.prevPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(1);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess, expectedincludeReverse]);
 
         this.scope.nextPageMyZones();
         this.scope.prevPageMyZones();
 
         expect(getZoneSets.calls.count()).toBe(3);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess, expectedincludeReverse]);
     });
 });

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -19,7 +19,7 @@
 angular.module('service.zones', [])
     .service('zonesService', function ($http, groupsService, $log, utilityService) {
 
-        this.getZones = function (limit, startFrom, query, searchByAdminGroup, ignoreAccess) {
+        this.getZones = function (limit, startFrom, query, searchByAdminGroup, ignoreAccess, includeReverse) {
             if (query == "") {
                 query = null;
             }
@@ -28,7 +28,8 @@ angular.module('service.zones', [])
                 "startFrom": startFrom,
                 "nameFilter": query,
                 "searchByAdminGroup": searchByAdminGroup,
-                "ignoreAccess": ignoreAccess
+                "ignoreAccess": ignoreAccess,
+                "includeReverse": includeReverse
             };
             var url = groupsService.urlBuilder("/api/zones", params);
             let loader = $("#loader");

--- a/modules/portal/public/lib/services/zones/service.zones.spec.js
+++ b/modules/portal/public/lib/services/zones/service.zones.spec.js
@@ -27,8 +27,8 @@ describe('Service: zoneService', function () {
     }));
 
     it('http backend gets called properly when getting zones', function () {
-        this.$httpBackend.expectGET('/api/zones?maxItems=100&startFrom=start&nameFilter=someQuery&searchByAdminGroup=false&ignoreAccess=false').respond('zone returned');
-        this.zonesService.getZones('100', 'start', 'someQuery', false, false)
+        this.$httpBackend.expectGET('/api/zones?maxItems=100&startFrom=start&nameFilter=someQuery&searchByAdminGroup=false&ignoreAccess=false&includeReverse=true').respond('zone returned');
+        this.zonesService.getZones('100', 'start', 'someQuery', false, false, true)
             .then(function(response) {
                 expect(response.data).toBe('zone returned');
             });


### PR DESCRIPTION
Fixes https://github.com/vinyldns/vinyldns/issues/1122

A checkbox option to filter out PTR zones has been added in the zones view. This filter will still apply when searching for zone names