### PR TITLE
list abandoned zones

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ListZoneChangesResponse.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ListZoneChangesResponse.scala
@@ -38,6 +38,15 @@ object ListZoneChangesResponse {
     )
 }
 
+case class ListDeletedZoneChangesResponse(
+     zonesDeletedInfo: List[ZoneChangeDeletedInfo],
+     zoneChangeFilter: Option[String] = None,
+     nextId: Option[String] = None,
+     startFrom: Option[String] = None,
+     maxItems: Int = 100,
+     ignoreAccess: Boolean = false
+)
+
 case class ListFailedZoneChangesResponse(
                                           failedZoneChanges: List[ZoneChange] = Nil,
                                           nextId: Int,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -22,7 +22,7 @@ import vinyldns.core.domain.record.RecordSetChangeType.RecordSetChangeType
 import vinyldns.core.domain.record.RecordSetStatus.RecordSetStatus
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.{RecordData, RecordSet, RecordSetChange}
-import vinyldns.core.domain.zone.{ACLRuleInfo, AccessLevel, Zone, ZoneACL, ZoneConnection}
+import vinyldns.core.domain.zone.{ACLRuleInfo, AccessLevel, Zone, ZoneACL, ZoneChange, ZoneConnection}
 import vinyldns.core.domain.zone.AccessLevel.AccessLevel
 import vinyldns.core.domain.zone.ZoneStatus.ZoneStatus
 
@@ -141,6 +141,27 @@ object ZoneSummaryInfo {
       zone.backendId,
       recurrenceSchedule = zone.recurrenceSchedule,
       scheduleRequestor = zone.scheduleRequestor,
+      accessLevel = accessLevel
+    )
+}
+
+case class ZoneChangeDeletedInfo(
+                         zoneChange: ZoneChange,
+                         adminGroupName: String,
+                         userName: String,
+                         accessLevel: AccessLevel
+                          )
+
+object ZoneChangeDeletedInfo {
+  def apply(zoneChange: List[ZoneChange],
+            groupName: String,
+            userName: String,
+            accessLevel: AccessLevel)
+  : ZoneChangeDeletedInfo =
+    ZoneChangeDeletedInfo(
+      zoneChange= zoneChange,
+      groupName = groupName,
+      userName = userName,
       accessLevel = accessLevel
     )
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -23,7 +23,7 @@ import vinyldns.api.Interfaces
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.api.repository.ApiDataAccessor
 import vinyldns.core.crypto.CryptoAlgebra
-import vinyldns.core.domain.membership.{Group, GroupRepository, User, UserRepository}
+import vinyldns.core.domain.membership.{Group, GroupRepository, ListUsersResults, User, UserRepository}
 import vinyldns.core.domain.zone._
 import vinyldns.core.queue.MessageQueue
 import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
@@ -225,6 +225,58 @@ class ZoneService(
       )
     }
   }.toResult
+
+  def listDeletedZones(
+                        authPrincipal: AuthPrincipal,
+                        nameFilter: Option[String] = None,
+                        startFrom: Option[String] = None,
+                        maxItems: Int = 100,
+                        ignoreAccess: Boolean = false
+                      ): Result[ListDeletedZoneChangesResponse] = {
+    for {
+      listZonesChangeResult <- zoneChangeRepository.listDeletedZones(
+        authPrincipal,
+        nameFilter,
+        startFrom,
+        maxItems,
+        ignoreAccess
+      )
+      zoneChanges = listZonesChangeResult.zoneDeleted
+      groupIds = zoneChanges.map(_.zone.adminGroupId).toSet
+      groups <- groupRepository.getGroups(groupIds)
+      userId = zoneChanges.map(_.userId).toSet
+      users <- userRepository.getUsers(userId,None,None)
+      zoneDeleteSummaryInfos = ZoneChangeDeletedInfoMapping(zoneChanges, authPrincipal, groups, users)
+    } yield {
+      ListDeletedZoneChangesResponse(
+        zoneDeleteSummaryInfos,
+        listZonesChangeResult.zoneChangeFilter,
+        listZonesChangeResult.nextId,
+        listZonesChangeResult.startFrom,
+        listZonesChangeResult.maxItems,
+        listZonesChangeResult.ignoreAccess
+      )
+    }
+  }.toResult
+
+  private def ZoneChangeDeletedInfoMapping(
+                                            zoneChange: List[ZoneChange],
+                                            auth: AuthPrincipal,
+                                            groups: Set[Group],
+                                            users: ListUsersResults
+                                          ): List[ZoneChangeDeletedInfo] =
+    zoneChange.map { zc =>
+      val groupName = groups.find(_.id == zc.zone.adminGroupId) match {
+        case Some(group) => group.name
+        case None => "Unknown group name"
+      }
+      val userName = users.users.find(_.id == zc.userId) match {
+        case Some(user) => user.userName
+        case None => "Unknown user name"
+      }
+      val zoneAccess = getZoneAccess(auth, zc.zone)
+      ZoneChangeDeletedInfo(zc, groupName,userName, zoneAccess)
+    }
 
   def zoneSummaryInfoMapping(
       zones: List[Zone],

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -49,6 +49,14 @@ trait ZoneServiceAlgebra {
       includeReverse: Boolean
   ): Result[ListZonesResponse]
 
+  def listDeletedZones(
+                        authPrincipal: AuthPrincipal,
+                        nameFilter: Option[String],
+                        startFrom: Option[String],
+                        maxItems: Int,
+                        ignoreAccess: Boolean
+                      ): Result[ListDeletedZoneChangesResponse]
+
   def listZoneChanges(
       zoneId: String,
       authPrincipal: AuthPrincipal,

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -1097,7 +1097,7 @@ class ZoneServiceSpec
         .when(mockUserRepo)
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
-      val result: ListDeletedZoneChangesResponse = rightResultOf(underTest.listDeletedZones(abcAuth).value)
+      val result: ListDeletedZoneChangesResponse = underTest.listDeletedZones(abcAuth).value.unsafeRunSync().toOption.get
       result.zonesDeletedInfo shouldBe List()
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
@@ -1117,7 +1117,7 @@ class ZoneServiceSpec
         .when(mockUserRepo)
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
-      val result: ListDeletedZoneChangesResponse = rightResultOf(underTest.listDeletedZones(abcAuth).value)
+      val result: ListDeletedZoneChangesResponse = underTest.listDeletedZones(abcAuth).value.unsafeRunSync().toOption.get
 
       result.zonesDeletedInfo shouldBe List(abcDeletedZoneSummary)
       result.maxItems shouldBe 100
@@ -1139,7 +1139,7 @@ class ZoneServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListDeletedZoneChangesResponse =
-        rightResultOf(underTest.listDeletedZones(abcAuth, ignoreAccess = true).value)
+        underTest.listDeletedZones(abcAuth, ignoreAccess = true).value.unsafeRunSync().toOption.get
       result.zonesDeletedInfo shouldBe List(abcDeletedZoneSummary,xyzDeletedZoneSummary)
       result.maxItems shouldBe 100
       result.startFrom shouldBe None
@@ -1157,7 +1157,7 @@ class ZoneServiceSpec
         .when(mockUserRepo)
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
-      val result: ListDeletedZoneChangesResponse = rightResultOf(underTest.listDeletedZones(abcAuth).value)
+      val result: ListDeletedZoneChangesResponse = underTest.listDeletedZones(abcAuth).value.unsafeRunSync().toOption.get
       val expectedZones =
         List(abcDeletedZoneSummary, xyzDeletedZoneSummary).map(_.copy(adminGroupName = "Unknown group name"))
       result.zonesDeletedInfo shouldBe expectedZones
@@ -1187,7 +1187,7 @@ class ZoneServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListDeletedZoneChangesResponse =
-        rightResultOf(underTest.listDeletedZones(abcAuth, maxItems = 2).value)
+        underTest.listDeletedZones(abcAuth, maxItems = 2).value.unsafeRunSync().toOption.get
       result.zonesDeletedInfo shouldBe List(abcDeletedZoneSummary, xyzDeletedZoneSummary)
       result.maxItems shouldBe 2
       result.startFrom shouldBe None
@@ -1216,7 +1216,7 @@ class ZoneServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListDeletedZoneChangesResponse =
-        rightResultOf(underTest.listDeletedZones(abcAuth, nameFilter = Some("foo"), maxItems = 2).value)
+        underTest.listDeletedZones(abcAuth, nameFilter = Some("foo"), maxItems = 2).value.unsafeRunSync().toOption.get
       result.zonesDeletedInfo shouldBe List(abcDeletedZoneSummary, xyzDeletedZoneSummary)
       result.zoneChangeFilter shouldBe Some("foo")
       result.nextId shouldBe Some("zone2.")
@@ -1243,7 +1243,7 @@ class ZoneServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListDeletedZoneChangesResponse =
-        rightResultOf(underTest.listDeletedZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value)
+        underTest.listDeletedZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value.unsafeRunSync().toOption.get
       result.zonesDeletedInfo shouldBe List(abcDeletedZoneSummary, xyzDeletedZoneSummary)
       result.startFrom shouldBe Some("zone4.")
     }
@@ -1269,7 +1269,7 @@ class ZoneServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListDeletedZoneChangesResponse =
-        rightResultOf(underTest.listDeletedZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value)
+        underTest.listDeletedZones(abcAuth, startFrom = Some("zone4."), maxItems = 2).value.unsafeRunSync().toOption.get
       result.zonesDeletedInfo shouldBe List(abcDeletedZoneSummary, xyzDeletedZoneSummary)
       result.nextId shouldBe Some("zone6.")
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -118,23 +118,23 @@ class ZoneRoutingSpec
   private val zoneSummaryInfo6 = ZoneSummaryInfo(zone6, xyzGroup.name, AccessLevel.NoAccess)
   private val error = Zone("error.", "error@test.com")
   private val deletedZone1 = Zone("ok1.", "ok1@test.com", ZoneStatus.Deleted , acl = zoneAcl)
-  private val deletedZoneChange1 = ZoneChange(deletedZone1, "ok1", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val deletedZoneChange1 = ZoneChange(deletedZone1, "ok1", ZoneChangeType.Create, ZoneChangeStatus.Synced)
   private val ZoneChangeDeletedInfo1 = ZoneChangeDeletedInfo(
     deletedZoneChange1, okGroup.name, okUser.userName, AccessLevel.NoAccess)
   private val deletedZone2 = Zone("ok2.", "ok2@test.com", ZoneStatus.Deleted , acl = zoneAcl)
-  private val deletedZoneChange2 = ZoneChange(deletedZone2, "ok2", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val deletedZoneChange2 = ZoneChange(deletedZone2, "ok2", ZoneChangeType.Create, ZoneChangeStatus.Synced)
   private val ZoneChangeDeletedInfo2 = ZoneChangeDeletedInfo(
     deletedZoneChange2, okGroup.name, okUser.userName, AccessLevel.NoAccess)
   private val deletedZone3 = Zone("ok3.", "ok3@test.com", ZoneStatus.Deleted , acl = zoneAcl)
-  private val deletedZoneChange3 = ZoneChange(deletedZone3, "ok3", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val deletedZoneChange3 = ZoneChange(deletedZone3, "ok3", ZoneChangeType.Create, ZoneChangeStatus.Synced)
   private val ZoneChangeDeletedInfo3= ZoneChangeDeletedInfo(
     deletedZoneChange3, okGroup.name, okUser.userName, AccessLevel.NoAccess)
   private val deletedZone4 = Zone("ok4.", "ok4@test.com", ZoneStatus.Deleted , acl = zoneAcl, adminGroupId = xyzGroup.id)
-  private val deletedZoneChange4 = ZoneChange(deletedZone4, "ok4", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val deletedZoneChange4 = ZoneChange(deletedZone4, "ok4", ZoneChangeType.Create, ZoneChangeStatus.Synced)
   private val ZoneChangeDeletedInfo4 = ZoneChangeDeletedInfo(
     deletedZoneChange4, okGroup.name, okUser.userName, AccessLevel.NoAccess)
   private val deletedZone5 = Zone("ok5.", "ok5@test.com", ZoneStatus.Deleted , acl = zoneAcl, adminGroupId = xyzGroup.id)
-  private val deletedZoneChange5 = ZoneChange(deletedZone5, "ok5", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val deletedZoneChange5 = ZoneChange(deletedZone5, "ok5", ZoneChangeType.Create, ZoneChangeStatus.Synced)
   private val ZoneChangeDeletedInfo5 = ZoneChangeDeletedInfo(
     deletedZoneChange5, okGroup.name, okUser.userName, AccessLevel.NoAccess)
 

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -117,6 +117,26 @@ class ZoneRoutingSpec
     Zone("zone6.in-addr.arpa.", "zone6@test.com", ZoneStatus.Active, adminGroupId = xyzGroup.id)
   private val zoneSummaryInfo6 = ZoneSummaryInfo(zone6, xyzGroup.name, AccessLevel.NoAccess)
   private val error = Zone("error.", "error@test.com")
+  private val deletedZone1 = Zone("ok1.", "ok1@test.com", ZoneStatus.Deleted , acl = zoneAcl)
+  private val deletedZoneChange1 = ZoneChange(deletedZone1, "ok1", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val ZoneChangeDeletedInfo1 = ZoneChangeDeletedInfo(
+    deletedZoneChange1, okGroup.name, okUser.userName, AccessLevel.NoAccess)
+  private val deletedZone2 = Zone("ok2.", "ok2@test.com", ZoneStatus.Deleted , acl = zoneAcl)
+  private val deletedZoneChange2 = ZoneChange(deletedZone2, "ok2", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val ZoneChangeDeletedInfo2 = ZoneChangeDeletedInfo(
+    deletedZoneChange2, okGroup.name, okUser.userName, AccessLevel.NoAccess)
+  private val deletedZone3 = Zone("ok3.", "ok3@test.com", ZoneStatus.Deleted , acl = zoneAcl)
+  private val deletedZoneChange3 = ZoneChange(deletedZone3, "ok3", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val ZoneChangeDeletedInfo3= ZoneChangeDeletedInfo(
+    deletedZoneChange3, okGroup.name, okUser.userName, AccessLevel.NoAccess)
+  private val deletedZone4 = Zone("ok4.", "ok4@test.com", ZoneStatus.Deleted , acl = zoneAcl, adminGroupId = xyzGroup.id)
+  private val deletedZoneChange4 = ZoneChange(deletedZone4, "ok4", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val ZoneChangeDeletedInfo4 = ZoneChangeDeletedInfo(
+    deletedZoneChange4, okGroup.name, okUser.userName, AccessLevel.NoAccess)
+  private val deletedZone5 = Zone("ok5.", "ok5@test.com", ZoneStatus.Deleted , acl = zoneAcl, adminGroupId = xyzGroup.id)
+  private val deletedZoneChange5 = ZoneChange(deletedZone5, "ok5", ZoneChangeType.Create, ZoneChangeStatus.Complete)
+  private val ZoneChangeDeletedInfo5 = ZoneChangeDeletedInfo(
+    deletedZoneChange5, okGroup.name, okUser.userName, AccessLevel.NoAccess)
 
   private val missingFields: JValue =
     ("invalidField" -> "randomValue") ~~
@@ -383,6 +403,92 @@ class ZoneRoutingSpec
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
               nameFilter = None,
+              startFrom = None,
+              nextId = None,
+              ignoreAccess = false
+            )
+          )
+
+        case _ => Left(InvalidRequest("shouldnt get here"))
+      }
+
+      outcome.toResult
+    }
+
+    def listDeletedZones(
+                          authPrincipal: AuthPrincipal,
+                          nameFilter: Option[String],
+                          startFrom: Option[String],
+                          maxItems: Int,
+                          ignoreAccess: Boolean = false
+                        ): Result[ListDeletedZoneChangesResponse] = {
+
+      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess) match {
+        case (_, None, Some("zone3."), 3, false) =>
+          Right(
+            ListDeletedZoneChangesResponse(
+              zonesDeletedInfo = List(ZoneChangeDeletedInfo1,ZoneChangeDeletedInfo2,ZoneChangeDeletedInfo3),
+              zoneChangeFilter = None,
+              startFrom = Some("zone3."),
+              nextId = Some("zone6."),
+              maxItems = 3,
+              ignoreAccess = false
+            )
+          )
+        case (_, None, Some("zone4."), 4, false) =>
+          Right(
+            ListDeletedZoneChangesResponse(
+              zonesDeletedInfo = List(ZoneChangeDeletedInfo1,ZoneChangeDeletedInfo2,ZoneChangeDeletedInfo3),
+              zoneChangeFilter = None,
+              startFrom = Some("zone4."),
+              nextId = None,
+              maxItems = 4,
+              ignoreAccess = false
+            )
+          )
+
+        case (_, None, None, 3, false) =>
+          Right(
+            ListDeletedZoneChangesResponse(
+              zonesDeletedInfo = List(ZoneChangeDeletedInfo1,ZoneChangeDeletedInfo2,ZoneChangeDeletedInfo3),
+              zoneChangeFilter = None,
+              startFrom = None,
+              nextId = Some("zone3."),
+              maxItems = 3,
+              ignoreAccess = false
+            )
+          )
+
+        case (_, None, None, 5, true) =>
+          Right(
+            ListDeletedZoneChangesResponse(
+              zonesDeletedInfo =
+                List(ZoneChangeDeletedInfo1,ZoneChangeDeletedInfo2,ZoneChangeDeletedInfo3, ZoneChangeDeletedInfo4,ZoneChangeDeletedInfo5),
+              zoneChangeFilter = None,
+              startFrom = None,
+              nextId = None,
+              maxItems = 5,
+              ignoreAccess = true
+            )
+          )
+
+        case (_, Some(filter), Some("zone4."), 4, false) =>
+          Right(
+            ListDeletedZoneChangesResponse(
+              zonesDeletedInfo = List(ZoneChangeDeletedInfo1,ZoneChangeDeletedInfo2,ZoneChangeDeletedInfo3),
+              zoneChangeFilter = Some(filter),
+              startFrom = Some("zone4."),
+              nextId = None,
+              maxItems = 4,
+              ignoreAccess = false
+            )
+          )
+
+        case (_, None, None, _, _) =>
+          Right(
+            ListDeletedZoneChangesResponse(
+              zonesDeletedInfo = List(ZoneChangeDeletedInfo1,ZoneChangeDeletedInfo2,ZoneChangeDeletedInfo3),
+              zoneChangeFilter = None,
               startFrom = None,
               nextId = None,
               ignoreAccess = false
@@ -1070,6 +1176,83 @@ class ZoneRoutingSpec
 
     "return an error if the max items is out of range" in {
       Get(s"/zones?maxItems=700") ~> zoneRoute ~> check {
+        status shouldBe BadRequest
+        responseEntity.toString should include(
+          "maxItems was 700, maxItems must be between 0 and 100"
+        )
+      }
+    }
+  }
+
+  "GET Deleted zones" should {
+    "return the next id when more results exist" in {
+      Get(s"/zones/deleted/changes?startFrom=zone3.&maxItems=3") ~> zoneRoute ~> check {
+        val resp = responseAs[ListDeletedZoneChangesResponse]
+        val deletedZones = resp.zonesDeletedInfo
+        (deletedZones.map(_.zoneChange.zone.id) should contain)
+          .only(deletedZone1.id, deletedZone2.id, deletedZone3.id)
+        resp.nextId shouldBe Some("zone6.")
+        resp.maxItems shouldBe 3
+        resp.startFrom shouldBe Some("zone3.")
+      }
+    }
+
+    "not return the next id when there are no more results" in {
+      Get(s"/zones/deleted/changes?startFrom=zone4.&maxItems=4") ~> zoneRoute ~> check {
+        val resp = responseAs[ListDeletedZoneChangesResponse]
+        val deletedZones = resp.zonesDeletedInfo
+        (deletedZones.map(_.zoneChange.zone.id) should contain)
+          .only(deletedZone1.id, deletedZone2.id, deletedZone3.id)
+        resp.nextId shouldBe None
+        resp.maxItems shouldBe 4
+        resp.startFrom shouldBe Some("zone4.")
+        resp.ignoreAccess shouldBe false
+      }
+    }
+
+    "not return the start from when not provided" in {
+      Get(s"/zones/deleted/changes?maxItems=3") ~> zoneRoute ~> check {
+        val resp = responseAs[ListDeletedZoneChangesResponse]
+        val deletedZones = resp.zonesDeletedInfo
+        (deletedZones.map(_.zoneChange.zone.id) should contain)
+          .only(deletedZone1.id, deletedZone2.id, deletedZone3.id)
+        resp.nextId shouldBe Some("zone3.")
+        resp.maxItems shouldBe 3
+        resp.startFrom shouldBe None
+        resp.ignoreAccess shouldBe false
+      }
+    }
+
+    "return the name filter when provided" in {
+      Get(s"/zones/deleted/changes?nameFilter=foo&startFrom=zone4.&maxItems=4") ~> zoneRoute ~> check {
+        val resp = responseAs[ListDeletedZoneChangesResponse]
+        val deletedZones = resp.zonesDeletedInfo
+        (deletedZones.map(_.zoneChange.zone.id) should contain)
+          .only(deletedZone1.id, deletedZone2.id, deletedZone3.id)
+        resp.nextId shouldBe None
+        resp.maxItems shouldBe 4
+        resp.startFrom shouldBe Some("zone4.")
+        resp.zoneChangeFilter shouldBe Some("foo")
+        resp.ignoreAccess shouldBe false
+      }
+    }
+
+    "return all zones when list all is true" in {
+      Get(s"/zones/deleted/changes?maxItems=5&ignoreAccess=true") ~> zoneRoute ~> check {
+        val resp = responseAs[ListDeletedZoneChangesResponse]
+        val deletedZones = resp.zonesDeletedInfo
+        (deletedZones.map(_.zoneChange.zone.id) should contain)
+          .only(deletedZone1.id, deletedZone2.id, deletedZone3.id, deletedZone4.id, deletedZone5.id)
+        resp.nextId shouldBe None
+        resp.maxItems shouldBe 5
+        resp.startFrom shouldBe None
+        resp.zoneChangeFilter shouldBe None
+        resp.ignoreAccess shouldBe true
+      }
+    }
+
+    "return an error if the max items is out of range" in {
+      Get(s"/zones/deleted/changes?maxItems=700") ~> zoneRoute ~> check {
         status shouldBe BadRequest
         responseEntity.toString should include(
           "maxItems was 700, maxItems must be between 0 and 100"

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZoneChangesResults.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ListZoneChangesResults.scala
@@ -23,6 +23,15 @@ case class ListZoneChangesResults(
     maxItems: Int = 100
 )
 
+case class ListDeletedZonesChangeResults(
+    zoneDeleted: List[ZoneChange] = List[ZoneChange](),
+    nextId: Option[String] = None,
+    startFrom: Option[String] = None,
+    maxItems: Int = 100,
+    ignoreAccess: Boolean = false,
+    zoneChangeFilter: Option[String] = None
+)
+
 case class ListFailedZoneChangesResults(
                                    items: List[ZoneChange] = List[ZoneChange](),
                                    nextId: Int = 0,

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChangeRepository.scala
@@ -17,6 +17,7 @@
 package vinyldns.core.domain.zone
 
 import cats.effect._
+import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.repository.Repository
 
 trait ZoneChangeRepository extends Repository {
@@ -28,6 +29,14 @@ trait ZoneChangeRepository extends Repository {
       startFrom: Option[String] = None,
       maxItems: Int = 100
   ): IO[ListZoneChangesResults]
+
+  def listDeletedZones(
+                        authPrincipal: AuthPrincipal,
+                        zoneNameFilter: Option[String] = None,
+                        startFrom: Option[String] = None,
+                        maxItems: Int = 100,
+                        ignoreAccess: Boolean = false
+                      ): IO[ListDeletedZonesChangeResults]
 
   def listFailedZoneChanges(
                              maxItems: Int = 100,

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -52,9 +52,21 @@ object TestZoneData {
     connection = testConnection
   )
 
+  val abcZoneDeleted: Zone = Zone("abc.zone.recordsets.", "test@test.com", adminGroupId = abcGroup.id, status = ZoneStatus.Deleted)
+  val xyzZoneDeleted: Zone = Zone("xyz.zone.recordsets.", "abc@xyz.com", adminGroupId = xyzGroup.id, status = ZoneStatus.Deleted)
+
   val zoneDeleted: Zone = Zone(
     "some.deleted.zone.",
     "test@test.com",
+    adminGroupId = abcGroup.id,
+    status = ZoneStatus.Deleted,
+    connection = testConnection
+  )
+
+  val zoneDeletedOkGroup: Zone = Zone(
+    "some.deleted.zone.",
+    "test@test.com",
+    adminGroupId = okGroup.id,
     status = ZoneStatus.Deleted,
     connection = testConnection
   )
@@ -88,6 +100,22 @@ object TestZoneData {
   )
 
   val zoneUpdate: ZoneChange = zoneChangePending.copy(status = ZoneChangeStatus.Synced)
+
+  val abcDeletedZoneChange: ZoneChange = ZoneChange(
+    abcZoneDeleted,
+    "ok",
+    ZoneChangeType.Create,
+    ZoneChangeStatus.Complete,
+    created = DateTime.now.minus(1000)
+  )
+
+  val xyzDeletedZoneChange: ZoneChange = ZoneChange(
+    xyzZoneDeleted,
+    "ok",
+    ZoneChangeType.Create,
+    ZoneChangeStatus.Complete,
+    created = DateTime.now.minus(1000)
+  )
 
   def makeTestPendingZoneChange(zone: Zone): ZoneChange =
     ZoneChange(zone, "userId", ZoneChangeType.Update, ZoneChangeStatus.Pending)

--- a/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
+++ b/modules/core/src/test/scala/vinyldns/core/TestZoneData.scala
@@ -105,16 +105,16 @@ object TestZoneData {
     abcZoneDeleted,
     "ok",
     ZoneChangeType.Create,
-    ZoneChangeStatus.Complete,
-    created = DateTime.now.minus(1000)
+    ZoneChangeStatus.Synced,
+    created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusMillis(1000)
   )
 
   val xyzDeletedZoneChange: ZoneChange = ZoneChange(
     xyzZoneDeleted,
     "ok",
     ZoneChangeType.Create,
-    ZoneChangeStatus.Complete,
-    created = DateTime.now.minus(1000)
+    ZoneChangeStatus.Synced,
+    created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusMillis(1000)
   )
 
   def makeTestPendingZoneChange(zone: Zone): ZoneChange =

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -156,7 +156,7 @@ class MySqlZoneChangeRepositoryIntegrationSpec
         testZone.account,
         ZoneChangeType.Create,
         ZoneChangeStatus.Synced,
-        created = DateTime.now().minusSeconds(Random.nextInt(1000))
+        created = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusMillis(1000)
       )}
 
     def saveZones(zones: Seq[Zone]): IO[Unit] =
@@ -408,7 +408,7 @@ class MySqlZoneChangeRepositoryIntegrationSpec
     }
     "return an empty list of zones if the user is not authorized to any" in {
       val unauthorized = AuthPrincipal(
-        signedInUser = User("not-authorized", "not-authorized", "not-authorized"),
+        signedInUser = User("not-authorized", "not-authorized", Encrypted("not-authorized")),
         memberGroupIds = Seq.empty
       )
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -952,12 +952,13 @@ class MySqlZoneRepositoryIntegrationSpec
     "check if an id has an ACL rule for at least one of the zones" in {
 
       val zoneId = UUID.randomUUID().toString
+      val adminId = UUID.randomUUID().toString
 
       val testZones = (1 until 3).map { num =>
         okZone.copy(
           name = num.toString + ".",
           id = zoneId,
-          adminGroupId = testZoneAdminGroupId,
+          adminGroupId = adminId,
           acl = testZoneAcl
         )
       }
@@ -965,7 +966,7 @@ class MySqlZoneRepositoryIntegrationSpec
       val f =
         for {
           _ <- saveZones(testZones)
-          zones <- repo.getFirstOwnedZoneAclGroupId(testZoneAdminGroupId)
+          zones <- repo.getFirstOwnedZoneAclGroupId(adminId)
         } yield zones
 
       f.unsafeRunSync() shouldBe Some(zoneId)

--- a/modules/mysql/src/main/resources/db/migration/V3.30__AddStatusZoneAccess.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.30__AddStatusZoneAccess.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+
+USE ${dbName};
+
+ALTER TABLE zone_access
+DROP CONSTRAINT fk_zone_access,
+ADD zone_status CHAR(36) NOT NULL
+;

--- a/modules/mysql/src/main/resources/test/ddl.sql
+++ b/modules/mysql/src/main/resources/test/ddl.sql
@@ -237,10 +237,7 @@ CREATE TABLE IF NOT EXISTS zone_access
 (
     accessor_id char(36) not null,
     zone_id     char(36) not null,
-    primary key (accessor_id, zone_id),
-    constraint fk_zone_access_zone_id
-    foreign key (zone_id) references zone (id)
-    on delete cascade
+    primary key (accessor_id, zone_id)
 );
 
 CREATE INDEX IF NOT EXISTS zone_access_accessor_id_index

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -206,7 +206,7 @@ class MySqlZoneChangeRepository
             }
 
           val deletedZonesWithStartFrom: List[ZoneChange] = startFrom match {
-            case Some(zoneName) => results.dropWhile(_.zone.name != zoneName)
+            case Some(zoneId) => results.dropWhile(_.zone.id != zoneId)
             case None => results
           }
 
@@ -214,7 +214,7 @@ class MySqlZoneChangeRepository
 
           val (newResults, nextId) =
             if (deletedZonesWithMaxItems.size > maxItems)
-              (deletedZonesWithMaxItems.dropRight(1), deletedZonesWithMaxItems.lastOption.map(_.zone.name))
+              (deletedZonesWithMaxItems.dropRight(1), deletedZonesWithMaxItems.lastOption.map(_.zone.id))
             else (deletedZonesWithMaxItems, None)
 
           ListDeletedZonesChangeResults(

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -17,10 +17,13 @@
 package vinyldns.mysql.repository
 
 import cats.effect.IO
+
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import org.slf4j.LoggerFactory
 import scalikejdbc._
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.zone._
 import vinyldns.core.protobuf._
 import vinyldns.core.route.Monitored
@@ -32,11 +35,25 @@ class MySqlZoneChangeRepository
     with Monitored {
   private final val logger = LoggerFactory.getLogger(classOf[MySqlZoneChangeRepository])
 
+  private final val MAX_ACCESSORS = 30
+
   private final val PUT_ZONE_CHANGE =
     sql"""
       |REPLACE INTO zone_change (change_id, zone_id, data, created_timestamp)
       |  VALUES ({change_id}, {zone_id}, {data}, {created_timestamp})
       """.stripMargin
+
+  private final val BASE_ZONE_CHANGE_SEARCH_SQL =
+    """
+      |SELECT zc.data
+      |  FROM zone_change zc
+       """.stripMargin
+
+  private final val BASE_GET_ZONES_SQL =
+    """
+      |SELECT z.data
+      |  FROM zone z
+       """.stripMargin
 
   private final val LIST_ZONES_CHANGES =
     sql"""
@@ -110,6 +127,106 @@ class MySqlZoneChangeRepository
       }
     }
 
+  private def withAccessors(
+                             user: User,
+                             groupIds: Seq[String],
+                             ignoreAccessZones: Boolean
+                           ): (String, Seq[Any]) =
+  // Super users do not need to join across to check zone access as they have access to all of the zones
+    if (ignoreAccessZones || user.isSuper || user.isSupport) {
+      (BASE_ZONE_CHANGE_SEARCH_SQL, Seq.empty)
+    } else {
+      // User is not super or support,
+      // let's join across to the zone access table so we return only zones a user has access to
+      val accessors = buildZoneSearchAccessorList(user, groupIds)
+      val questionMarks = List.fill(accessors.size)("?").mkString(",")
+      val withAccessorCheck = BASE_ZONE_CHANGE_SEARCH_SQL +
+        s"""
+           |    JOIN zone_access za ON zc.zone_id = za.zone_id
+           |      AND za.accessor_id IN ($questionMarks)
+    """.stripMargin
+      (withAccessorCheck, accessors)
+    }
+
+  /* Limit the accessors so that we don't have boundless parameterized queries */
+  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
+    val allAccessors = user.id +: groupIds
+
+    if (allAccessors.length > MAX_ACCESSORS) {
+      logger.warn(
+        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
+      )
+    }
+
+    // Take the top 30 accessors, but add "EVERYONE" to the list so that we include zones that have everyone access
+    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
+  }
+
+  def listDeletedZones(
+                        authPrincipal: AuthPrincipal,
+                        zoneNameFilter: Option[String] = None,
+                        startFrom: Option[String] = None,
+                        maxItems: Int = 100,
+                        ignoreAccess: Boolean = false
+                      ): IO[ListDeletedZonesChangeResults] =
+    monitor("repo.ZoneChange.listDeletedZoneInZoneChanges") {
+      IO {
+        DB.readOnly { implicit s =>
+          val (withAccessorCheck, accessors) =
+            withAccessors(authPrincipal.signedInUser, authPrincipal.memberGroupIds, ignoreAccess)
+          val sb = new StringBuilder
+          sb.append(withAccessorCheck)
+
+          val query = sb.toString
+
+          val zoneChangeResults: List[ZoneChange] =
+            SQL(query)
+              .bind(accessors: _*)
+              .map(extractZoneChange(1))
+              .list()
+              .apply()
+
+          val zoneResults: List[Zone] =
+            SQL(BASE_GET_ZONES_SQL)
+              .map(extractZone(1))
+              .list()
+              .apply()
+
+          val zoneNotInZoneChange: List[ZoneChange] =
+            zoneChangeResults.filter(z=> !zoneResults.map(_.name).contains(z.zone.name) && z.zone.status != ZoneStatus.Active)
+
+          val deletedZoneResults: List[ZoneChange] =
+            zoneNotInZoneChange.filter(_.zone.status.equals(ZoneStatus.Deleted)).distinct
+
+          val results: List[ZoneChange] =
+            if (zoneNameFilter.nonEmpty) {
+              deletedZoneResults.filter(r => r.zone.name.contains(zoneNameFilter.getOrElse("not found")))
+            } else {
+              deletedZoneResults
+            }
+
+          val deletedZonesWithStartFrom: List[ZoneChange] = startFrom match {
+            case Some(zoneName) => results.dropWhile(_.zone.name != zoneName)
+            case None => results
+          }
+
+          val deletedZonesWithMaxItems = deletedZonesWithStartFrom.take(maxItems + 1)
+
+          val (newResults, nextId) =
+            if (deletedZonesWithMaxItems.size > maxItems)
+              (deletedZonesWithMaxItems.dropRight(1), deletedZonesWithMaxItems.lastOption.map(_.zone.name))
+            else (deletedZonesWithMaxItems, None)
+
+          ListDeletedZonesChangeResults(
+            zoneDeleted = newResults,
+            nextId = nextId,
+            startFrom = startFrom,
+            maxItems = maxItems,
+            zoneChangeFilter = zoneNameFilter,
+            ignoreAccess = ignoreAccess
+          )
+        }}}
+
   def listFailedZoneChanges(maxItems: Int, startFrom: Int): IO[ListFailedZoneChangesResults] =
     monitor("repo.ZoneChange.listFailedZoneChanges") {
       IO {
@@ -129,5 +246,9 @@ class MySqlZoneChangeRepository
 
   private def extractZoneChange(colIndex: Int): WrappedResultSet => ZoneChange = res => {
     fromPB(VinylDNSProto.ZoneChange.parseFrom(res.bytes(colIndex)))
+  }
+
+  private def extractZone(columnIndex: Int): WrappedResultSet => Zone = res => {
+    fromPB(VinylDNSProto.Zone.parseFrom(res.bytes(columnIndex)))
   }
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -196,7 +196,7 @@ class MySqlZoneChangeRepository
             zoneChangeResults.filter(z=> !zoneResults.map(_.name).contains(z.zone.name) && z.zone.status != ZoneStatus.Active)
 
           val deletedZoneResults: List[ZoneChange] =
-            zoneNotInZoneChange.filter(_.zone.status.equals(ZoneStatus.Deleted)).distinct
+            zoneNotInZoneChange.filter(_.zone.status.equals(ZoneStatus.Deleted)).distinct.sortBy(_.zone.updated).reverse
 
           val results: List[ZoneChange] =
             if (zoneNameFilter.nonEmpty) {

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -477,6 +477,20 @@ class VinylDNS @Inject() (
     })
   }
 
+  def getDeletedZones: Action[AnyContent] = userAction.async { implicit request =>
+    val queryParameters = new HashMap[String, java.util.List[String]]()
+    for {
+      (name, values) <- request.queryString
+    } queryParameters.put(name, values.asJava)
+    val vinyldnsRequest =
+      new VinylDNSRequest("GET", s"$vinyldnsServiceBackend", "zones/deleted/changes", parameters = queryParameters)
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+    // $COVERAGE-ON$
+  }
+
   def getZoneChange(id: String): Action[AnyContent] = userAction.async { implicit request =>
     val queryParameters = new HashMap[String, java.util.List[String]]()
     for {

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -29,6 +29,7 @@
             <ul class="nav nav-tabs bar_tabs">
                 <li class="active"><a href="#myZones" data-toggle="tab" ng-click="myZonesAccess()">My Zones</a></li>
                 <li><a id="tab2-button" href="#allZones" data-toggle="tab" ng-click="allZonesAccess()">All Zones</a></li>
+                <li><a id="tab3-button" href="#deletedZones" data-toggle="tab">Abandoned Zones</a></li>
             </ul>
 
             <div class="panel-body tab-content">
@@ -281,6 +282,209 @@
                                     </div>
                                     <!-- END PAGINATION -->
 
+                                </div>
+                                <div class="panel-footer"></div>
+                            </div>
+                            <!-- END SIMPLE DATATABLE -->
+
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-pane" id="deletedZones">
+                    <div class="row">
+                        <div class="col-md-12">
+
+                            <!-- SIMPLE DATATABLE -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+
+                                    <button id="zone-refresh-button" class="btn btn-default" ng-click="refreshZones()">
+                                        <span class="fa fa-refresh"></span> Refresh
+                                    </button>
+
+                                    <!-- SEARCH BOX -->
+                                    <div class="pull-right">
+                                        <form class="input-group" ng-submit="refreshZones()">
+                                            <div class="input-group">
+                                                <span class="input-group-btn">
+                                                    <button id="my-deleted-zones-search-button" type="submit" class="btn btn-primary btn-left-round">
+                                                        <span class="fa fa-search"></span>
+                                                    </button>
+                                                </span>
+                                                <input id="deleted-zones-search-text" ng-model="query" type="text" class="form-control"  placeholder="Zone Name"/>
+                                            </div>
+                                        </form>
+                                    </div>
+                                    <!-- END SEARCH BOX -->
+
+                                    <!-- DELETED ZONES TABS -->
+                                    <div class="panel panel-default panel-tabs">
+                                        <ul class="nav nav-tabs bar_tabs">
+                                            <li class="active"><a href="#myDeletedZones" data-toggle="tab">My Zones</a></li>
+                                            <li><a id="tab2-button" href="#allDeletedZones" data-toggle="tab">All Zones</a></li>
+                                        </ul>
+                                        <div class="panel-body tab-content">
+                                            <div class="tab-pane active" id="myDeletedZones">
+                                                <div id="zone-list-table" class="panel-body">
+                                                    <p ng-if="!myDeletedZonesLoaded">Loading zones...</p>
+                                                    <p ng-if="myDeletedZonesLoaded && !myDeletedZones.length">No zones match the search criteria.</p>
+
+                                                    <!-- PAGINATION -->
+                                                    <div class="dataTables_paginate vinyldns_zones_paginate">
+                                                        <span class="vinyldns_zones_page_number">{{ getZonesPageNumber("myDeletedZones") }}</span>
+                                                        <ul class="pagination">
+                                                            <li class="paginate_button previous">
+                                                                <a ng-if="prevPageEnabled('myDeletedZones')" ng-click="prevPageMyDeletedZones()">Previous</a>
+                                                            </li>
+                                                            <li class="paginate_button next">
+                                                                <a ng-if="nextPageEnabled('myDeletedZones')" ng-click="nextPageMyDeletedZones()">Next</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                    <!-- END PAGINATION -->
+
+                                                    <table class="table" ng-if="myDeletedZones.length">
+                                                        <thead>
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Email</th>
+                                                            <th>Admin Group</th>
+                                                            <th>Created</th>
+                                                            <th>Abandoned</th>
+                                                            <th>Status</th>
+                                                            <th>Abandoned By</th>
+                                                            @if(meta.sharedDisplayEnabled) {
+                                                            <th>Access</th>
+                                                            }
+                                                        </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                        <tr ng-repeat="deletedZone in myDeletedZones">
+                                                            <td class="wrap-long-text" ng-bind="deletedZone.zoneChange.zone.name">
+                                                            </td>
+                                                            <td class="wrap-long-text" ng-bind="deletedZone.zoneChange.zone.email">
+                                                            </td>
+                                                            <td>
+                                                                <a ng-if="canAccessGroup(deletedZone.zoneChange.zone.adminGroupId)" ng-bind="deletedZone.adminGroupName"
+                                                                   href="/groups/{{deletedZone.zoneChange.zone.adminGroupId}}"></a>
+                                                                <span ng-if="!canAccessGroup(deletedZone.zoneChange.zone.adminGroupId)" ng-bind="deletedZone.adminGroupName"
+                                                                      style="line-height: 0"></span>
+                                                            </td>
+                                                            <td>
+                                                                {{deletedZone.zoneChange.zone.created}}
+                                                            </td>
+                                                            <td>
+                                                                {{deletedZone.zoneChange.zone.updated}}
+                                                            </td>
+                                                            <td ng-bind="deletedZone.zoneChange.zone.status"></td>
+                                                            <td>
+                                                                {{deletedZone.userName}}
+                                                            </td>
+                                                            @if(meta.sharedDisplayEnabled) {
+                                                            <td>{{zone.shared ? "Shared" : "Private"}}</td>
+                                                            }
+                                                        </tr>
+                                                        </tbody>
+                                                    </table>
+
+                                                    <!-- PAGINATION -->
+                                                    <div class="dataTables_paginate vinyldns_zones_paginate">
+                                                        <span class="vinyldns_zones_page_number">{{ getZonesPageNumber("myDeletedZones") }}</span>
+                                                        <ul class="pagination">
+                                                            <li class="paginate_button previous">
+                                                                <a ng-if="prevPageEnabled('myDeletedZones')" ng-click="prevPageMyDeletedZones()">Previous</a>
+                                                            </li>
+                                                            <li class="paginate_button next">
+                                                                <a ng-if="nextPageEnabled('myDeletedZones')" ng-click="nextPageMyDeletedZones()">Next</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                    <!-- END PAGINATION -->
+
+                                                </div>
+                                            </div>
+                                            <div class="tab-pane" id="allDeletedZones">
+                                                <div id="zone-list-table" class="panel-body">
+                                                    <p ng-if="!allDeletedZonesLoaded">Loading zones...</p>
+                                                    <p ng-if="allDeletedZonesLoaded && !allDeletedZones.length">No zones match the search criteria.</p>
+
+                                                    <!-- PAGINATION -->
+                                                    <div class="dataTables_paginate vinyldns_zones_paginate">
+                                                        <span class="vinyldns_zones_page_number">{{ getZonesPageNumber("allDeletedZones") }}</span>
+                                                        <ul class="pagination">
+                                                            <li class="paginate_button previous">
+                                                                <a ng-if="prevPageEnabled('allDeletedZones')" ng-click="prevPageAllDeletedZones()">Previous</a>
+                                                            </li>
+                                                            <li class="paginate_button next">
+                                                                <a ng-if="nextPageEnabled('allDeletedZones')" ng-click="nextPageAllDeletedZones()">Next</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                    <!-- END PAGINATION -->
+
+                                                    <table class="table" ng-if="allDeletedZones.length">
+                                                        <thead>
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Email</th>
+                                                            <th>Admin Group</th>
+                                                            <th>Created</th>
+                                                            <th>Abandoned</th>
+                                                            <th>Status</th>
+                                                            <th>Abandoned By</th>
+                                                            @if(meta.sharedDisplayEnabled) {
+                                                            <th>Access</th>
+                                                            }
+                                                        </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                        <tr ng-repeat="deletedZone in allDeletedZones">
+                                                            <td class="wrap-long-text" ng-bind="deletedZone.zoneChange.zone.name">
+                                                            </td>
+                                                            <td class="wrap-long-text" ng-bind="deletedZone.zoneChange.zone.email">
+                                                            </td>
+                                                            <td>
+                                                                <a ng-if="canAccessGroup(deletedZone.zoneChange.zone.adminGroupId)" ng-bind="deletedZone.adminGroupName"
+                                                                   href="/groups/{{deletedZone.zoneChange.zone.adminGroupId}}"></a>
+                                                                <span ng-if="!canAccessGroup(deletedZone.zoneChange.zone.adminGroupId)" ng-bind="deletedZone.adminGroupName"
+                                                                      style="line-height: 0"></span>
+                                                            </td>
+                                                            <td>
+                                                                {{deletedZone.zoneChange.zone.created}}
+                                                            </td>
+                                                            <td>
+                                                                {{deletedZone.zoneChange.zone.updated}}
+                                                            </td>
+                                                            <td ng-bind="deletedZone.zoneChange.zone.status"></td>
+                                                            <td>
+                                                                {{deletedZone.userName}}
+                                                            </td>
+                                                            @if(meta.sharedDisplayEnabled) {
+                                                            <td>{{zone.shared ? "Shared" : "Private"}}</td>
+                                                            }
+                                                        </tr>
+                                                        </tbody>
+                                                    </table>
+
+                                                    <!-- PAGINATION -->
+                                                    <div class="dataTables_paginate vinyldns_zones_paginate">
+                                                        <span class="vinyldns_zones_page_number">{{ getZonesPageNumber("allDeletedZones") }}</span>
+                                                        <ul class="pagination">
+                                                            <li class="paginate_button previous">
+                                                                <a ng-if="prevPageEnabled('allDeletedZones')" ng-click="prevPageAllDeletedZones()">Previous</a>
+                                                            </li>
+                                                            <li class="paginate_button next">
+                                                                <a ng-if="nextPageEnabled('allDeletedZones')" ng-click="nextPageAllDeletedZones()">Next</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                    <!-- END PAGINATION -->
+
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <!-- END DELETED ZONES TABS -->
                                 </div>
                                 <div class="panel-footer"></div>
                             </div>

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -31,6 +31,7 @@ GET           /api/zones/backendids              @controllers.VinylDNS.getBacken
 GET           /api/zones/:id                     @controllers.VinylDNS.getZone(id: String)
 GET           /api/zones/:id/details             @controllers.VinylDNS.getCommonZoneDetails(id: String)
 GET           /api/zones/name/:name              @controllers.VinylDNS.getZoneByName(name: String)
+GET           /api/zones/deleted/changes         @controllers.VinylDNS.getDeletedZones
 GET           /api/zones/:id/changes             @controllers.VinylDNS.getZoneChange(id: String)
 POST          /api/zones                         @controllers.VinylDNS.addZone
 PUT           /api/zones/:id                     @controllers.VinylDNS.updateZone(id: String)

--- a/modules/portal/public/lib/controllers/controller.manageZones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.spec.js
@@ -42,6 +42,13 @@ describe('Controller: ManageZonesController', function () {
                 }
             });
         };
+        zonesService.getDeletedZones = function() {
+                    return $q.when({
+                        data: {
+                            zonesDeletedInfo: ["all my deleted zones"]
+                        }
+                    });
+                };
         zonesService.getBackendIds = function() {
                     return $q.when({
                         data: ['backend-1', 'backend-2']

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -178,7 +178,7 @@ angular.module('controller.zones', [])
         allZonesPaging = pagingService.resetPaging(allZonesPaging);
 
         zonesService
-            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchByAdminGroup, true, $scope.includeReverse)
+            .getZones(zonesPaging.maxItems, undefined, $scope.query, $scope.searchByAdminGroup, false, $scope.includeReverse)
             .then(function (response) {
                 $log.debug('zonesService::getZones-success (' + response.data.zones.length + ' zones)');
                 zonesPaging.next = response.data.nextId;
@@ -212,6 +212,7 @@ angular.module('controller.zones', [])
                     .catch(function (error) {
                         handleError(error, 'zonesService::getDeletedZones-failure');
                     });
+
         zonesService
                     .getDeletedZones(allDeleteZonesPaging.maxItems, undefined, $scope.query, true)
                     .then(function (response) {

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -23,6 +23,8 @@ angular.module('controller.zones', [])
     $scope.allZonesLoaded = false;
     $scope.hasZones = false; // Re-assigned each time zones are fetched without a query
     $scope.allGroups = [];
+    $scope.myDeletedZones = [];
+    $scope.allDeletedZones = [];
     $scope.ignoreAccess = false;
     $scope.validEmailDomains= [];
     $scope.allZonesAccess = function () {
@@ -41,6 +43,8 @@ angular.module('controller.zones', [])
     // Paging status for zone sets
     var zonesPaging = pagingService.getNewPagingParams(100);
     var allZonesPaging = pagingService.getNewPagingParams(100);
+    var myDeleteZonesPaging = pagingService.getNewPagingParams(100);
+    var allDeleteZonesPaging = pagingService.getNewPagingParams(100);
     profileService.getAuthenticatedUserData().then(function (results) {
         if (results.data) {
             $scope.profile = results.data;
@@ -197,7 +201,51 @@ angular.module('controller.zones', [])
             .catch(function (error) {
                 handleError(error, 'zonesService::getZones-failure');
             });
+
+        zonesService
+                    .getDeletedZones(myDeleteZonesPaging.maxItems, undefined, $scope.query, false)
+                    .then(function (response) {
+                        $log.debug('zonesService::getMyDeletedZones-success (' + response.data.zonesDeletedInfo.length + ' zones)');
+                        myDeleteZonesPaging.next = response.data.nextId;
+                        updateMyDeletedZoneDisplay(response.data.zonesDeletedInfo);
+                    })
+                    .catch(function (error) {
+                        handleError(error, 'zonesService::getDeletedZones-failure');
+                    });
+        zonesService
+                    .getDeletedZones(allDeleteZonesPaging.maxItems, undefined, $scope.query, true)
+                    .then(function (response) {
+                        $log.debug('zonesService::getAllDeletedZones-success (' + response.data.zonesDeletedInfo.length + ' zones)');
+                        allDeleteZonesPaging.next = response.data.nextId;
+                        updateAllDeletedZoneDisplay(response.data.zonesDeletedInfo);
+                    })
+                    .catch(function (error) {
+                        handleError(error, 'zonesService::getDeletedZones-failure');
+                    });
+
     };
+
+    function updateMyDeletedZoneDisplay (myDeletedZones) {
+        $scope.myDeletedZones = myDeletedZones;
+        $scope.myDeletedZonesLoaded = true;
+        $log.debug("Displaying my Deleted zones: ", $scope.myDeletedZones);
+                if($scope.myDeletedZones.length > 0) {
+                    $("td.dataTables_empty").hide();
+                } else {
+                    $("td.dataTables_empty").show();
+                }
+    }
+
+    function updateAllDeletedZoneDisplay (allDeletedZones) {
+        $scope.allDeletedZones = allDeletedZones;
+        $scope.allDeletedZonesLoaded = true;
+        $log.debug("Displaying all Deleted zones: ", $scope.allDeletedZones);
+                if($scope.allDeletedZones.length > 0) {
+                    $("td.dataTables_empty").hide();
+                } else {
+                    $("td.dataTables_empty").show();
+                }
+    }
 
     function updateZoneDisplay (zones) {
         $scope.zones = zones;
@@ -283,6 +331,10 @@ angular.module('controller.zones', [])
                  return pagingService.getPanelTitle(zonesPaging);
              case 'allZones':
                  return pagingService.getPanelTitle(allZonesPaging);
+             case 'myDeletedZones':
+                 return pagingService.getPanelTitle(myDeleteZonesPaging);
+             case 'allDeletedZones':
+                 return pagingService.getPanelTitle(allDeleteZonesPaging);
          }
      };
 
@@ -292,6 +344,10 @@ angular.module('controller.zones', [])
                 return pagingService.prevPageEnabled(zonesPaging);
             case 'allZones':
                 return pagingService.prevPageEnabled(allZonesPaging);
+            case 'myDeletedZones':
+                return pagingService.prevPageEnabled(myDeleteZonesPaging);
+            case 'allDeletedZones':
+                return pagingService.prevPageEnabled(allDeleteZonesPaging);
         }
     };
 
@@ -301,6 +357,10 @@ angular.module('controller.zones', [])
                 return pagingService.nextPageEnabled(zonesPaging);
             case 'allZones':
                 return pagingService.nextPageEnabled(allZonesPaging);
+            case 'myDeletedZones':
+                return pagingService.nextPageEnabled(myDeleteZonesPaging);
+            case 'allDeletedZones':
+                return pagingService.nextPageEnabled(allDeleteZonesPaging);
         }
     };
 
@@ -330,6 +390,32 @@ angular.module('controller.zones', [])
             });
     }
 
+    $scope.prevPageMyDeletedZones = function() {
+        var startFrom = pagingService.getPrevStartFrom(myDeleteZonesPaging);
+        return zonesService
+            .getDeletedZones(myDeleteZonesPaging.maxItems, startFrom, $scope.query, false)
+            .then(function(response) {
+                myDeleteZonesPaging = pagingService.prevPageUpdate(response.data.nextId, myDeleteZonesPaging);
+                updateMyDeletedZoneDisplay(response.data.zonesDeletedInfo);
+            })
+            .catch(function (error) {
+                handleError(error,'zonesService::prevPage-failure');
+            });
+    }
+
+    $scope.prevPageAllDeletedZones = function() {
+            var startFrom = pagingService.getPrevStartFrom(allDeleteZonesPaging);
+            return zonesService
+                .getDeletedZones(allDeleteZonesPaging.maxItems, startFrom, $scope.query, true)
+                .then(function(response) {
+                    allDeleteZonesPaging = pagingService.prevPageUpdate(response.data.nextId, allDeleteZonesPaging);
+                    updateAllDeletedZoneDisplay(response.data.zonesDeletedInfo);
+                })
+                .catch(function (error) {
+                    handleError(error,'zonesService::prevPage-failure');
+                });
+        }
+
     $scope.nextPageMyZones = function () {
         return zonesService
             .getZones(zonesPaging.maxItems, zonesPaging.next, $scope.query, $scope.searchByAdminGroup, false, true)
@@ -355,6 +441,38 @@ angular.module('controller.zones', [])
 
                 if (zoneSets.length > 0) {
                     updateAllZonesDisplay(response.data.zones);
+                }
+            })
+            .catch(function (error) {
+               handleError(error,'zonesService::nextPage-failure')
+            });
+    };
+
+    $scope.nextPageMyDeletedZones = function () {
+        return zonesService
+            .getDeletedZones(myDeleteZonesPaging.maxItems, myDeleteZonesPaging.next, $scope.query, false)
+            .then(function(response) {
+                var myDeletedZoneSets = response.data.zonesDeletedInfo;
+                myDeleteZonesPaging = pagingService.nextPageUpdate(myDeletedZoneSets, response.data.nextId, myDeleteZonesPaging);
+
+                if (myDeletedZoneSets.length > 0) {
+                    updateMyDeletedZoneDisplay(response.data.zonesDeletedInfo);
+                }
+            })
+            .catch(function (error) {
+               handleError(error,'zonesService::nextPage-failure')
+            });
+    };
+
+    $scope.nextPageAllDeletedZones = function () {
+        return zonesService
+            .getDeletedZones(allDeleteZonesPaging.maxItems, allDeleteZonesPaging.next, $scope.query, false)
+            .then(function(response) {
+                var allDeletedZoneSets = response.data.zonesDeletedInfo;
+                allDeleteZonesPaging = pagingService.nextPageUpdate(allDeletedZoneSets, response.data.nextId, allDeleteZonesPaging);
+
+                if (allDeletedZoneSets.length > 0) {
+                    updateAllDeletedZoneDisplay(response.data.zonesDeletedInfo);
                 }
             })
             .catch(function (error) {

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -1,4 +1,4 @@
-c/*
+/*
  * Copyright 2018 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,7 +115,7 @@ describe('Controller: ZonesController', function () {
             [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess, expectedincludeReverse]);
     });
 
-    it('nextPageMyZones should call getDeletedZones with the correct parameters', function () {
+    it('nextPageZones should call getDeletedZones with the correct parameters', function () {
         mockDeletedZone = {zonesDeletedInfo:[ {
                                                         zoneChanges: [{ zone: {
                                                             name: "dummy.",
@@ -138,16 +138,16 @@ describe('Controller: ZonesController', function () {
         var expectedMaxItems = 100;
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
-        var expectedignoreAccess = true;
+        var expectedIgnoreAccess = false;
 
         this.scope.nextPageMyDeletedZones();
 
         expect(getDeletedZoneSets.calls.count()).toBe(1);
         expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
-          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedIgnoreAccess]);
     });
 
-    it('prevPageMyZones should call getZones with the correct parameters', function () {
+    it('prevPageZones should call getDeletedZones with the correct parameters', function () {
 
         mockDeletedZone = {zonesDeletedInfo:[ {
                                                         zoneChanges: [{ zone: {
@@ -171,19 +171,19 @@ describe('Controller: ZonesController', function () {
         var expectedMaxItems = 100;
         var expectedStartFrom = undefined;
         var expectedQuery = this.scope.query;
-        var expectedignoreAccess = true;
+        var expectedIgnoreAccess = false;
 
-        this.scope.prevPageMyDeletedZones();
+        this.scope.prevPageDeletedZones();
 
         expect(getDeletedZoneSets.calls.count()).toBe(1);
         expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedIgnoreAccess]);
 
         this.scope.nextPageMyDeletedZones();
         this.scope.prevPageMyDeletedZones();
 
         expect(getDeletedZoneSets.calls.count()).toBe(3);
         expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
-            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedIgnoreAccess]);
     });
 });

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -1,4 +1,4 @@
-/*
+c/*
  * Copyright 2018 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,5 +113,77 @@ describe('Controller: ZonesController', function () {
         expect(getZoneSets.calls.count()).toBe(3);
         expect(getZoneSets.calls.mostRecent().args).toEqual(
             [expectedMaxItems, expectedStartFrom, expectedQuery, expectedSearchByAdminGroup, expectedignoreAccess, expectedincludeReverse]);
+    });
+
+    it('nextPageMyZones should call getDeletedZones with the correct parameters', function () {
+        mockDeletedZone = {zonesDeletedInfo:[ {
+                                                        zoneChanges: [{ zone: {
+                                                            name: "dummy.",
+                                                            email: "test@test.com",
+                                                            status: "Deleted",
+                                                            created: "2017-02-15T14:58:39Z",
+                                                            account: "c8234503-bfda-4b80-897f-d74129051eaa",
+                                                            acl: {rules: []},
+                                                            adminGroupId: "c8234503-bfda-4b80-897f-d74129051eaa",
+                                                            id: "c5c87405-2ec8-4e03-b2dc-c6758a5d9666",
+                                                            shared: false,
+                                                            status: "Active",
+                                                            latestSync: "2017-02-15T14:58:39Z",
+                                                            isTest: true
+                                                        }}],maxItems: 100}]};
+        var getDeletedZoneSets = spyOn(this.zonesService, 'getDeletedZones')
+            .and.stub()
+            .and.returnValue(this.zonesService.q.when(mockDeletedZone));
+
+        var expectedMaxItems = 100;
+        var expectedStartFrom = undefined;
+        var expectedQuery = this.scope.query;
+        var expectedignoreAccess = true;
+
+        this.scope.nextPageMyDeletedZones();
+
+        expect(getDeletedZoneSets.calls.count()).toBe(1);
+        expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
+          [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+    });
+
+    it('prevPageMyZones should call getZones with the correct parameters', function () {
+
+        mockDeletedZone = {zonesDeletedInfo:[ {
+                                                        zoneChanges: [{ zone: {
+                                                            name: "dummy.",
+                                                            email: "test@test.com",
+                                                            status: "Deleted",
+                                                            created: "2017-02-15T14:58:39Z",
+                                                            account: "c8234503-bfda-4b80-897f-d74129051eaa",
+                                                            acl: {rules: []},
+                                                            adminGroupId: "c8234503-bfda-4b80-897f-d74129051eaa",
+                                                            id: "c5c87405-2ec8-4e03-b2dc-c6758a5d9666",
+                                                            shared: false,
+                                                            status: "Active",
+                                                            latestSync: "2017-02-15T14:58:39Z",
+                                                            isTest: true
+                                                        }}],maxItems: 100}]};
+        var getDeletedZoneSets = spyOn(this.zonesService, 'getDeletedZones')
+            .and.stub()
+            .and.returnValue(this.zonesService.q.when(mockDeletedZone));
+
+        var expectedMaxItems = 100;
+        var expectedStartFrom = undefined;
+        var expectedQuery = this.scope.query;
+        var expectedignoreAccess = true;
+
+        this.scope.prevPageMyDeletedZones();
+
+        expect(getDeletedZoneSets.calls.count()).toBe(1);
+        expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
+
+        this.scope.nextPageMyDeletedZones();
+        this.scope.prevPageMyDeletedZones();
+
+        expect(getDeletedZoneSets.calls.count()).toBe(3);
+        expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
+            [expectedMaxItems, expectedStartFrom, expectedQuery, expectedignoreAccess]);
     });
 });

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -173,7 +173,7 @@ describe('Controller: ZonesController', function () {
         var expectedQuery = this.scope.query;
         var expectedIgnoreAccess = false;
 
-        this.scope.prevPageDeletedZones();
+        this.scope.prevPageMyDeletedZones();
 
         expect(getDeletedZoneSets.calls.count()).toBe(1);
         expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -185,5 +185,6 @@ describe('Controller: ZonesController', function () {
         expect(getDeletedZoneSets.calls.count()).toBe(3);
         expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
             [expectedMaxItems, expectedStartFrom, expectedQuery, expectedIgnoreAccess]);
+
     });
 });

--- a/modules/portal/public/lib/services/zones/service.zones.js
+++ b/modules/portal/public/lib/services/zones/service.zones.js
@@ -53,6 +53,20 @@ angular.module('service.zones', [])
                     return $http.get(url);
         };
 
+        this.getDeletedZones = function (limit, startFrom, query, ignoreAccess) {
+            if (query == "") {
+                query = null;
+            }
+            var params = {
+                "maxItems": limit,
+                "startFrom": startFrom,
+                "nameFilter": query,
+                "ignoreAccess": ignoreAccess
+            };
+            var url = groupsService.urlBuilder("/api/zones/deleted/changes", params);
+            return $http.get(url);
+        };
+
         this.getBackendIds = function() {
             var url = "/api/zones/backendids";
             return $http.get(url);

--- a/modules/portal/public/lib/services/zones/service.zones.spec.js
+++ b/modules/portal/public/lib/services/zones/service.zones.spec.js
@@ -54,6 +54,15 @@ describe('Service: zoneService', function () {
         this.$httpBackend.flush();
     });
 
+    it('http backend gets called properly when getting deleted zones', function () {
+        this.$httpBackend.expectGET('/api/zones/deleted/changes?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=false').respond('deleted zone returned');
+        this.zonesService.getDeletedZones('100', 'start', 'someQuery', true)
+            .then(function(response) {
+                expect(response.data).toBe('deleted zone returned');
+            });
+        this.$httpBackend.flush();
+    });
+
     it('http backend gets called properly when deleting zone', function (done) {
         this.$httpBackend.expectDELETE('/api/zones/id').respond('zone deleted');
         this.zonesService.delZone('id')

--- a/modules/portal/public/lib/services/zones/service.zones.spec.js
+++ b/modules/portal/public/lib/services/zones/service.zones.spec.js
@@ -54,11 +54,20 @@ describe('Service: zoneService', function () {
         this.$httpBackend.flush();
     });
 
-    it('http backend gets called properly when getting deleted zones', function () {
-        this.$httpBackend.expectGET('/api/zones/deleted/changes?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=false').respond('deleted zone returned');
+    it('http backend gets called properly when getting my deleted zones', function () {
+        this.$httpBackend.expectGET('/api/zones/deleted/changes?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=true').respond('deleted my zone returned');
         this.zonesService.getDeletedZones('100', 'start', 'someQuery', true)
             .then(function(response) {
-                expect(response.data).toBe('deleted zone returned');
+                expect(response.data).toBe('deleted my zone returned');
+            });
+        this.$httpBackend.flush();
+    });
+
+    it('http backend gets called properly when getting all deleted zones', function () {
+        this.$httpBackend.expectGET('/api/zones/deleted/changes?maxItems=100&startFrom=start&nameFilter=someQuery&ignoreAccess=false').respond('deleted all zone returned');
+        this.zonesService.getDeletedZones('100', 'start', 'someQuery', false)
+            .then(function(response) {
+                expect(response.data).toBe('deleted all zone returned');
             });
         this.$httpBackend.flush();
     });

--- a/modules/portal/test/controllers/TestApplicationData.scala
+++ b/modules/portal/test/controllers/TestApplicationData.scala
@@ -240,6 +240,24 @@ trait TestApplicationData { this: Mockito =>
       | }
     """.stripMargin)
 
+  val hobbitDeletedZoneChange: JsValue = Json.parse(s"""{
+      | "zoneId":         "$hobbitZoneId",
+      | "zoneChanges":
+      |    [{ "zone": {
+      |             "name":           "$hobbitZoneName",
+      |             "email":          "hobbitAdmin@shire.me",
+      |             "status":         "Active",
+      |             "account":        "system",
+      |             "acl":            "rules",
+      |             "adminGroupId":   "$hobbitGroupId",
+      |             "id":             "$hobbitZoneId",
+      |             "shared":         false,
+      |             "status":         "Deleted"
+      |     }}],
+      | "maxItems":         100
+      | }
+      """.stripMargin)
+
   val hobbitZoneChange: JsValue = Json.parse(s"""{
        | "zoneId":         "$hobbitZoneId",
        | "zoneChanges":

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.18.8"
+version in ThisBuild := "0.19.0"


### PR DESCRIPTION
Fixes #617

Changes in this pull request:

- Added API for deleted zones history (zones/deleted/changes)
- Made Portal changes to view deleted zones history.
- Removed Cascade from zone_access table. We use this on comparing zone_change table .
- Added zone_status column in zone_access table to identify the deleted zones and used the same in deleting the group.