### PR TITLE
Batch change screen indicates if there are errors down by the "Confirm" button 

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -336,7 +336,8 @@
                                 <button type="button" id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange(manualReviewEnabled)">Submit</button>
                             </div>
                             <div ng-if="formStatus=='pendingConfirm'" class="pull-right">
-                                <span>{{ confirmationPrompt }}</span>
+                                <span ng-if="!batchChangeErrors">{{ confirmationPrompt }}</span>
+                                <span ng-if="batchChangeErrors" class="batch-change-error-help">There were errors, please review the highlighted rows and then proceed.</span>
                                 <button class="btn btn-default" ng-click="cancelSubmit()">Cancel</button>
                                 <button class="btn btn-success" type="submit" ng-click="confirmSubmit(createBatchChangeForm)">Confirm</button>
                             </div>


### PR DESCRIPTION
When users make batch changes through the Portal, VinylDNS highlights rows that are problematic in the batch (e.g.,, cannot delete a record that is already deleted). However, when you have 1000 rows, and row 300 is highlighted, you won't see it while you're at the bottom of the page.

Changes in this pull request:

Added a message at the bottom, near the Submit button that says: "There were errors, please review the highlighted rows and then proceed." as discussed before.