### PR TITLE
Temporarily remove record change history

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -242,33 +242,6 @@ class RecordSetRoute(
         }
       }
     } ~
-    path("recordsetchange" / "history") {
-      (get & monitor("Endpoint.listRecordSetChangeHistory")) {
-        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS), "fqdn".as[String].?, "recordType".as[String].?) {
-          (startFrom: Option[Int], maxItems: Int, fqdn: Option[String], recordType: Option[String]) =>
-            handleRejections(invalidQueryHandler) {
-              val errorMessage = if(fqdn.isEmpty || recordType.isEmpty) {
-                "recordType and fqdn cannot be empty"
-              } else {
-                s"maxItems was $maxItems, maxItems must be between 0 exclusive " +
-                  s"and $DEFAULT_MAX_ITEMS inclusive"
-              }
-              val isValid = (0 < maxItems && maxItems <= DEFAULT_MAX_ITEMS) && (fqdn.nonEmpty && recordType.nonEmpty)
-              validate(
-                check = isValid,
-                errorMsg = errorMessage
-              ){
-                authenticateAndExecute(
-                  recordSetService
-                    .listRecordSetChangeHistory(None, startFrom, maxItems, fqdn, RecordType.find(recordType.get), _)
-                ) { changes =>
-                  complete(StatusCodes.OK, changes)
-                }
-              }
-            }
-        }
-      }
-    } ~
     path("metrics" / "health" / "recordsetchangesfailure") {
       (get & monitor("Endpoint.listFailedRecordSetChanges")) {
         parameters("startFrom".as[Int].?(0), "maxItems".as[Int].?(DEFAULT_MAX_ITEMS)) {

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -30,7 +30,8 @@ def check_changes_response(response, recordChanges=False, nextId=False, startFro
         assert_that(change["userName"], is_("history-user"))
 
 
-def check_change_history_response(response, fqdn, type, recordChanges=False, nextId=False, startFrom=False, maxItems=100):
+def check_change_history_response(response, fqdn, type, recordChanges=False, nextId=False, startFrom=False,
+                                  maxItems=100):
     """
     :param type: type of the record
     :param fqdn: fqdn of the record
@@ -208,6 +209,7 @@ def test_list_recordset_changes_max_items_boundaries(shared_zone_test_context):
     assert_that(too_small, is_("maxItems was 0, maxItems must be between 0 exclusive and 100 inclusive"))
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_no_authorization(shared_zone_test_context):
     """
     Test that recordset history without authorization fails
@@ -218,6 +220,7 @@ def test_list_recordset_history_no_authorization(shared_zone_test_context):
     client.list_recordset_change_history(fqdn, type, sign_request=False, status=401)
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_member_auth_success(shared_zone_test_context):
     """
     Test recordset history succeeds with membership auth for member of admin group
@@ -229,6 +232,7 @@ def test_list_recordset_history_member_auth_success(shared_zone_test_context):
     check_change_history_response(response, fqdn, type, recordChanges=True, startFrom=False, nextId=False)
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_member_auth_no_access(shared_zone_test_context):
     """
     Test recordset history fails for user not in admin group with no acl rules
@@ -239,6 +243,7 @@ def test_list_recordset_history_member_auth_no_access(shared_zone_test_context):
     client.list_recordset_change_history(fqdn, type, status=403)
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_success(shared_zone_test_context):
     """
     Test recordset history succeeds with membership auth for member of admin group
@@ -250,6 +255,7 @@ def test_list_recordset_history_success(shared_zone_test_context):
     check_change_history_response(response, fqdn, type, recordChanges=True, startFrom=False, nextId=False)
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_paging(shared_zone_test_context):
     """
     Test paging for recordset history can use previous nextId as start key of next page
@@ -266,6 +272,7 @@ def test_list_recordset_history_paging(shared_zone_test_context):
     check_change_history_response(response_2, fqdn, type, recordChanges=True, nextId=True, startFrom=response_1["nextId"], maxItems=1)
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_returning_no_changes(shared_zone_test_context):
     """
     Pass in startFrom of "2000" should return empty list because start key exceeded number of recordset change history
@@ -279,6 +286,7 @@ def test_list_recordset_history_returning_no_changes(shared_zone_test_context):
     assert_that(response["maxItems"], is_(100))
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_default_max_items(shared_zone_test_context):
     """
     Test default max items is 100
@@ -291,6 +299,7 @@ def test_list_recordset_history_default_max_items(shared_zone_test_context):
     check_change_history_response(response, fqdn, type, recordChanges=True, startFrom=False, nextId=False, maxItems=100)
 
 
+@pytest.mark.skip(reason="since record change history route is temporarily removed")
 def test_list_recordset_history_max_items_boundaries(shared_zone_test_context):
     """
     Test 0 < max_items <= 100

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -910,33 +910,6 @@ class RecordSetRoutingSpec
     }
   }
 
-  "GET recordset change history" should {
-    "return the recordset change" in {
-      Get(s"/recordsetchange/history?fqdn=rs1.ok.&recordType=A") ~> recordSetRoute ~> check {
-        val response = responseAs[ListRecordSetHistoryResponse]
-
-        response.zoneId shouldBe Some(okZone.id)
-        (response.recordSetChanges.map(_.id) should contain)
-          .only(rsChange1.id)
-      }
-    }
-
-    "return an error when the record fqdn and type is not defined" in {
-      Get(s"/recordsetchange/history") ~> recordSetRoute ~> check {
-        status shouldBe StatusCodes.BadRequest
-      }
-    }
-
-    "return a Bad Request when maxItems is out of Bounds" in {
-      Get(s"/recordsetchange/history?maxItems=101") ~> recordSetRoute ~> check {
-        status shouldBe StatusCodes.BadRequest
-      }
-      Get(s"/recordsetchange/history?maxItems=0") ~> recordSetRoute ~> check {
-        status shouldBe StatusCodes.BadRequest
-      }
-    }
-  }
-
   "GET failed record set changes" should {
     "return the failed record set changes" in {
       val rsChangeFailed1 = rsChange1.copy(status = RecordSetChangeStatus.Failed)

--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -166,7 +166,6 @@
                             @if(meta.sharedDisplayEnabled) {
                                 <th>Owner Group Name</th>
                             }
-                            <th ng-if="rootAccountCanReview || userCanAccessGroup">Record History</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -374,9 +373,6 @@
                                       title="Group with ID {{record.ownerGroupId}} no longer exists."><span class="fa fa-warning"></span> Group deleted</span>
                             </td>
                             }
-                            <td ng-if="rootAccountCanReview || (record.ownerGroupName && canAccessGroup(record.ownerGroupId))">
-                                <span><button class="btn btn-info btn-sm" ng-click="viewRecordHistory(record.fqdn, record.type)">View History</button></span>
-                            </td>
                         </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Changes in this pull request:
- Remove `change history` column from portal and `record change history` route from api to temporarily disallow the feature in PR: https://github.com/vinyldns/vinyldns/pull/1246 until the required database columns `fqdn` and `record type` are populated. Also, new record changes automatically populates the columns `fqdn` and `record type`.
