### PR TITLE
Added api for record set count and displayed in portal

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -386,7 +386,8 @@ class RecordSetService(
 
   def getRecordSetCount(zoneId: String, authPrincipal: AuthPrincipal): Result[RecordSetCount] = {
     for {
-      _ <- getZone(zoneId)
+      zone <- getZone(zoneId)
+      _ <- canSeeZone(authPrincipal, zone).toResult
       count  <- recordSetRepository.getRecordSetCount(zoneId).toResult
     } yield RecordSetCount(count)
   }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -384,6 +384,13 @@ class RecordSetService(
       groupName <- getGroupName(recordSet.ownerGroupId)
     } yield RecordSetInfo(recordSet, groupName)
 
+  def getRecordSetCount(zoneId: String, authPrincipal: AuthPrincipal): Result[RecordSetCount] = {
+    for {
+      _ <- getZone(zoneId)
+      count  <- recordSetRepository.getRecordSetCount(zoneId).toResult
+    } yield RecordSetCount(count)
+  }
+
   def getRecordSetByZone(
                           recordSetId: String,
                           zoneId: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
@@ -17,7 +17,7 @@
 package vinyldns.api.domain.record
 
 import vinyldns.api.Interfaces.Result
-import vinyldns.api.domain.zone.RecordSetInfo
+import vinyldns.api.domain.zone.{RecordSetCount, RecordSetInfo}
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.zone.ZoneCommandResult
 import vinyldns.api.route.{ListGlobalRecordSetsResponse, ListRecordSetsByZoneResponse}
@@ -124,5 +124,7 @@ trait RecordSetServiceAlgebra {
                                   startFrom: Int,
                                   maxItems: Int
                                 ): Result[ListFailedRecordSetChangesResponse]
+
+  def getRecordSetCount(zoneId: String, authPrincipal: AuthPrincipal): Result[RecordSetCount]
 
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -300,6 +300,8 @@ case class ListZonesResponse(
                               includeReverse: Boolean = true
                             )
 
+case class RecordSetCount( count: Int = 0 )
+
 // Errors
 case class InvalidRequest(msg: String) extends Throwable(msg)
 

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -187,6 +187,13 @@ class RecordSetRoute(
         }
       }
     } ~
+    path("zones" / Segment / "recordsetcount") { zoneId =>
+      (get & monitor("Endpoint.getRecordSetCount")) {
+        authenticateAndExecute(recordSetService.getRecordSetCount(zoneId, _)) { count =>
+          complete(StatusCodes.OK, count)
+        }
+      }
+    } ~
     path("zones" / Segment / "recordsets" / Segment) { (zoneId, rsId) =>
       (get & monitor("Endpoint.getRecordSetByZone")) {
         authenticateAndExecute(recordSetService.getRecordSetByZone(rsId, zoneId, _)) { rs =>

--- a/modules/api/src/test/functional/tests/recordsets/get_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/get_recordset_test.py
@@ -88,6 +88,21 @@ def test_get_recordset_doesnt_exist(shared_zone_test_context):
     client.get_recordset(shared_zone_test_context.ok_zone["id"], "123", status=404)
 
 
+def test_get_recordsetcount(shared_zone_test_context):
+    """
+    Test getting recordset count for a valid zoneid should return 200
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    client.get_recordset_count(shared_zone_test_context.ok_zone["id"],status=200)
+
+
+def test_get_recordsetcount_error(shared_zone_test_context):
+    """
+    Test getting recordset count for a invalid zoneid should return 404
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    client.get_recordset_count("999",status=404)
+
 @pytest.mark.serial
 def test_at_get_recordset(shared_zone_test_context):
     """

--- a/modules/api/src/test/functional/tests/recordsets/get_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/get_recordset_test.py
@@ -96,6 +96,14 @@ def test_get_recordset_count_status_code(shared_zone_test_context):
     client.get_recordset_count(shared_zone_test_context.ok_zone["id"],status=200)
 
 
+def test_get_recordset_count_error(shared_zone_test_context):
+    """
+    Test getting recordset count for a invalid zoneid should return 404
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    client.get_recordset_count("999",status=404)
+
+@pytest.mark.serial
 def test_get_recordset_count_by_zoneid(shared_zone_test_context):
     """
     Test getting a recordset with name @
@@ -115,25 +123,25 @@ def test_get_recordset_count_by_zoneid(shared_zone_test_context):
                 }
             ]
         }
+        result = client.create_recordset(new_rs, status=202)
+        result_rs = client.wait_until_recordset_change_status(result, "Complete")["recordSet"]
 
         # Get the recordset we just made and verify
-        result = client.get_recordset_count(result_rs["zoneId"])
-        result_rs = result["count"]
-        assert_that(get_recordset_count, is_(1))
+        result = client.get_recordset(result_rs["zoneId"], result_rs["id"])
+        result_recordset_count = client.get_recordset_count(result_rs["zoneId"],status=200)
+        result_rs = result["recordSet"]
+
+        expected_rs = new_rs
+        expected_rs["name"] = ok_zone["name"]
+        verify_recordset(result_rs, expected_rs)
+
+        assert_that(result_recordset_count, is_({'count': 10}))
     finally:
         if result_rs:
             delete_result = client.delete_recordset(result_rs["zoneId"], result_rs["id"], status=202)
             client.wait_until_recordset_change_status(delete_result, "Complete")
 
 
-def test_get_recordset_count_error(shared_zone_test_context):
-    """
-    Test getting recordset count for a invalid zoneid should return 404
-    """
-    client = shared_zone_test_context.ok_vinyldns_client
-    client.get_recordset_count("999",status=404)
-
-@pytest.mark.serial
 def test_at_get_recordset(shared_zone_test_context):
     """
     Test getting a recordset with name @

--- a/modules/api/src/test/functional/tests/recordsets/get_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/get_recordset_test.py
@@ -88,7 +88,7 @@ def test_get_recordset_doesnt_exist(shared_zone_test_context):
     client.get_recordset(shared_zone_test_context.ok_zone["id"], "123", status=404)
 
 
-def test_get_recordsetcount(shared_zone_test_context):
+def test_get_recordset_count_status_code(shared_zone_test_context):
     """
     Test getting recordset count for a valid zoneid should return 200
     """
@@ -96,7 +96,37 @@ def test_get_recordsetcount(shared_zone_test_context):
     client.get_recordset_count(shared_zone_test_context.ok_zone["id"],status=200)
 
 
-def test_get_recordsetcount_error(shared_zone_test_context):
+def test_get_recordset_count_by_zoneid(shared_zone_test_context):
+    """
+    Test getting a recordset with name @
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone = shared_zone_test_context.ok_zone
+    result_rs = None
+    try:
+        new_rs = {
+            "zoneId": ok_zone["id"],
+            "name": "@",
+            "type": "TXT",
+            "ttl": 100,
+            "records": [
+                {
+                    "text": "someText"
+                }
+            ]
+        }
+
+        # Get the recordset we just made and verify
+        result = client.get_recordset_count(result_rs["zoneId"])
+        result_rs = result["count"]
+        assert_that(get_recordset_count, is_(1))
+    finally:
+        if result_rs:
+            delete_result = client.delete_recordset(result_rs["zoneId"], result_rs["id"], status=202)
+            client.wait_until_recordset_change_status(delete_result, "Complete")
+
+
+def test_get_recordset_count_error(shared_zone_test_context):
     """
     Test getting recordset count for a invalid zoneid should return 404
     """

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -559,6 +559,17 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, "GET", self.headers, None, not_found_ok=True, **kwargs)
         return data
 
+    def get_recordset_count(self, zone_id,**kwargs):
+        """
+        Get count of record set in managed records tab
+        :param zone_id: the zone id the recordset belongs to
+        :return: the value of count
+        """
+        url = urljoin(self.index_url, "/zones/{0}/recordsetcount".format(zone_id))
+
+        response, data = self.make_request(url, "GET", self.headers, None, not_found_ok=True, **kwargs)
+        return data
+
     def get_recordset_change(self, zone_id, rs_id, change_id, **kwargs):
         """
         Gets an existing recordset change

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2123,6 +2123,15 @@ class RecordSetServiceSpec
       error shouldBe a[RecordSetChangeNotFoundError]
     }
 
+    "return Total RecordCount" in {
+      doReturn(IO.pure(10))
+        .when(mockRecordRepo).getRecordSetCount(okZone.id)
+
+      val result = underTest.getRecordSetCount(okZone.id,authPrincipal = sharedAuth).value.unsafeRunSync().toOption.get
+      result shouldBe RecordSetCount(10)
+
+    }
+
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -850,9 +850,7 @@ class RecordSetServiceSpec
       val oldRecord = aaaa.copy(zoneId = okZone.id, status = RecordSetStatus.Active)
       val newRecord = oldRecord.copy(ttl = oldRecord.ttl + 1000)
 
-      doReturn(IO.pure(Some(okZone)))
-        .when(mockZoneRepo)
-        .getZone(okZone.id)
+
       doReturn(IO.pure(Some(oldRecord)))
         .when(mockRecordRepo)
         .getRecordSet(newRecord.id)
@@ -2123,14 +2121,31 @@ class RecordSetServiceSpec
       error shouldBe a[RecordSetChangeNotFoundError]
     }
 
-    "return Total RecordCount" in {
+    "return a RecordSets Count" in {
+      doReturn(IO.pure(Some(okZone)))
+        .when(mockZoneRepo)
+        .getZone(okZone.id)
+      doReturn(IO.pure(ListUsersResults(Seq(okUser), None)))
+        .when(mockUserRepo)
+        .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
       doReturn(IO.pure(10))
         .when(mockRecordRepo).getRecordSetCount(okZone.id)
 
-      val result = underTest.getRecordSetCount(okZone.id,authPrincipal = sharedAuth).value.unsafeRunSync().toOption.get
+      val result = underTest.getRecordSetCount(okZone.id,authPrincipal = okAuth).value.unsafeRunSync().toOption.get
       result shouldBe RecordSetCount(10)
 
     }
+
+    "return a NotAuthorizedError for getRecordSetCount if the user is not authorized to access the zone" in {
+      doReturn(IO.pure(10))
+        .when(mockRecordRepo).getRecordSetCount(zoneNotAuthorized.id)
+      val error =
+        underTest.getRecordSetCount((zoneNotAuthorized.id), authPrincipal = okAuth).value.unsafeRunSync().swap.toOption.get
+
+      error shouldBe a[NotAuthorizedError]
+
+    }
+
 
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -1686,7 +1686,7 @@ class RecordSetRoutingSpec
       Get(s"/zones/${okZone.id}/recordsetcount") ~> recordSetRoute ~> check {
         status shouldBe StatusCodes.OK
         val resultRs = responseAs[RecordSetCount]
-        resultRs shouldBe RecordCount
+        resultRs shouldBe recordSetCount
       }
     }
 

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -302,6 +302,15 @@ class VinylDNS @Inject() (
     })
   }
 
+  def getRecordSetCount(zoneId : String): Action[AnyContent] = userAction.async { implicit request =>
+    val vinyldnsRequest =
+      VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"zones/$zoneId/recordsetcount")
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+  }
+
   def getAuthenticatedUserData(): Action[AnyContent] = userAction.async { implicit request =>
     Future {
       Ok(Json.toJson(VinylDNS.UserInfo.fromUser(request.user)))

--- a/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/manageRecords.scala.html
@@ -61,7 +61,7 @@
     <div class="panel-heading">
         <div class="row">
             <div class="col-md-10">
-                <span class="panel-title bolder-font-weight">Records</span>
+                <span class="panel-title bolder-font-weight">Records - {{recordSetCount}}</span>
             </div>
             <div class="col-md-2 pull-right">
                 <form class="input-group remove-bottom-margin" ng-submit="refreshRecords()">

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -43,6 +43,7 @@ DELETE        /api/zones/:zid/recordsets/:rid    @controllers.VinylDNS.deleteRec
 PUT           /api/zones/:zid/recordsets/:rid    @controllers.VinylDNS.updateRecordSet(zid: String, rid:String)
 
 GET           /api/zones/:id/recordsetchanges    @controllers.VinylDNS.listRecordSetChanges(id: String)
+GET           /api/zones/:zid/recordsetcount     @controllers.VinylDNS.getRecordSetCount(zid: String)
 GET           /api/recordsetchange/history       @controllers.VinylDNS.listRecordSetChangeHistory
 
 GET           /api/groups                        @controllers.VinylDNS.getGroups

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -510,7 +510,7 @@ angular.module('controller.records', [])
                  return $scope.recordSetCount = response.data.count
              }
              return recordsService
-                 .recordSetCount($scope.zoneId)
+                 .getRecordSetCount($scope.zoneId)
                  .then(success)
                  .catch(function (error) {
                      handleError(error, 'groupsService::getRecordSetsCount-failure');

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -51,6 +51,7 @@ angular.module('controller.records', [])
     $scope.currentRecord = {};
     $scope.zoneInfo = {};
     $scope.profile = {};
+    $scope.recordSetCount = 0;
 
     var loadZonesPromise;
     var loadRecordsPromise;
@@ -494,6 +495,7 @@ angular.module('controller.records', [])
                     newRecords.push(recordsService.toDisplayRecord(record, $scope.zoneInfo.name));
                 });
                 $scope.records = newRecords;
+                $scope.getRecordSetCount();
                 if($scope.records.length > 0) {
                   $("td.dataTables_empty").hide();
                 } else {
@@ -501,6 +503,19 @@ angular.module('controller.records', [])
                 }
             });
     };
+
+    $scope.getRecordSetCount = function getRecordSetsCount() {
+        function success(response) {
+                 $log.debug('RecordService::getRecordSetsCount-success',  response.data);
+                 return $scope.recordSetCount = response.data.count
+             }
+             return recordsService
+                 .recordSetCount($scope.zoneId)
+                 .then(success)
+                 .catch(function (error) {
+                     handleError(error, 'groupsService::getRecordSetsCount-failure');
+                 });
+    }
 
     /**
      * Recordset paging

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -91,7 +91,7 @@ describe('Controller: RecordsController', function () {
 
     it('deleteSshfp should keep at least one sshfp object', function() {
         this.scope.currentRecord.sshfpItems = [{algorithm: '1', type: '', fingerprint: ''},
-            {algorithm: '2', type: '', fideleteSshfpngerprint: ''}];
+            {algorithm: '2', type: '', fingerprint: ''}];
         this.scope.deleteSshfp(0);
         this.scope.deleteSshfp(0);
         expect(this.scope.currentRecord.sshfpItems).toEqual([{algorithm: '', type: '', fingerprint: ''}]);

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -91,7 +91,7 @@ describe('Controller: RecordsController', function () {
 
     it('deleteSshfp should keep at least one sshfp object', function() {
         this.scope.currentRecord.sshfpItems = [{algorithm: '1', type: '', fingerprint: ''},
-            {algorithm: '2', type: '', fingerprint: ''}];
+            {algorithm: '2', type: '', fideleteSshfpngerprint: ''}];
         this.scope.deleteSshfp(0);
         this.scope.deleteSshfp(0);
         expect(this.scope.currentRecord.sshfpItems).toEqual([{algorithm: '', type: '', fingerprint: ''}]);
@@ -136,11 +136,6 @@ describe('Controller: RecordsController', function () {
         expect(this.scope.zoneInfo).toEqual(mockZone);
         expect(this.scope.isZoneAdmin).toBe(true);
     });
-
-    it('display the recordset count', function() {
-           this.scope.getRecordSetCount();
-           expect(this.scope.getRecordSetCount).toEqual(0);
-        });
 
     it('refreshZone updates zoneInfo and isZoneAdmin when user is not in admin group', function() {
         mockZone = {

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -137,6 +137,11 @@ describe('Controller: RecordsController', function () {
         expect(this.scope.isZoneAdmin).toBe(true);
     });
 
+    it('display the recordset count', function() {
+           this.scope.getRecordSetCount();
+           expect(this.scope.getRecordSetCount).toEqual(0);
+        });
+
     it('refreshZone updates zoneInfo and isZoneAdmin when user is not in admin group', function() {
         mockZone = {
             name: "dummy.",

--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -100,7 +100,7 @@ angular.module('service.records', [])
             return $http.get("/api/zones/"+zid);
         };
 
-        this.recordSetCount = function (zid) {
+        this.getRecordSetCount = function (zid) {
         return $http.get("/api/zones/"+zid+"/recordsetcount");
         };
 

--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -100,6 +100,10 @@ angular.module('service.records', [])
             return $http.get("/api/zones/"+zid);
         };
 
+        this.recordSetCount = function (zid) {
+        return $http.get("/api/zones/"+zid+"/recordsetcount");
+        };
+
         this.getCommonZoneDetails = function (zid) {
             return $http.get("/api/zones/"+zid+"/details");
         };

--- a/modules/portal/public/lib/services/records/service.records.spec.js
+++ b/modules/portal/public/lib/services/records/service.records.spec.js
@@ -95,6 +95,15 @@ describe('Service: recordsService', function () {
         this.$httpBackend.flush();
     });
 
+    it('http backend gets called properly when getting record sets count', function () {
+        this.$httpBackend.expectGET('/api/zones/zoneid/recordsetcount').respond('success');
+        this.recordsService.getRecordSetCount('zoneid')
+            .then(function(response) {
+                expect(response.data).toBe('success');
+            });
+        this.$httpBackend.flush();
+    });
+
     it('have toVinylRecord return a valid sshfp record', function() {
         sentRecord = {
             "id": 'recordId',

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -2362,6 +2362,59 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
       }
     }
 
+    ".getRecordSetCount" should {
+      "return a not found (404) if the zone does not exist" in new WithApplication(app) {
+        val client = MockWS {
+          case (GET, u) if u == s"http://localhost:9001/zones/not-hobbits/recordsetcount" =>
+            defaultActionBuilder {
+              Results.NotFound
+            }
+        }
+        val mockUserAccessor = mock[UserAccountAccessor]
+        mockUserAccessor.get(anyString).returns(IO.pure(Some(frodoUser)))
+        mockUserAccessor.getUserByKey(anyString).returns(IO.pure(Some(frodoUser)))
+        val underTest = withClient(client)
+        val result =
+          underTest.getRecordSetCount("not-hobbits")(
+            FakeRequest(GET, "/zones/not-hobbits/recordsetcount")
+              .withSession("username" -> frodoUser.userName, "accessKey" -> frodoUser.accessKey)
+          )
+
+        status(result) must beEqualTo(NOT_FOUND)
+        hasCacheHeaders(result)
+      }
+
+      "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
+        val client = mock[WSClient]
+        val underTest = withClient(client)
+        val result =
+          underTest.getRecordSetCount(hobbitZoneId)(
+            FakeRequest(GET, s"/api/zones/$hobbitZoneId/recordsetcount")
+          )
+
+        status(result) mustEqual 401
+        hasCacheHeaders(result)
+        contentAsString(result) must beEqualTo("You are not logged in. Please login to continue.")
+      }
+
+      "return forbidden (403) if user account is locked" in new WithApplication(app) {
+        val client = mock[WSClient]
+        val underTest = withLockedClient(client)
+        val result = underTest.getRecordSetCount(hobbitZoneId)(
+          FakeRequest(GET, s"/api/zones/$hobbitZoneId/recordsetcount").withSession(
+            "username" -> lockedFrodoUser.userName,
+            "accessKey" -> lockedFrodoUser.accessKey
+          )
+        )
+
+        status(result) mustEqual 403
+        hasCacheHeaders(result)
+        contentAsString(result) must beEqualTo(
+          s"User account for `${lockedFrodoUser.userName}` is locked."
+        )
+      }
+    }
+
     ".listBatchChanges" should {
       "return unauthorized (401) if requesting user is not logged in" in new WithApplication(app) {
         val client = mock[WSClient]


### PR DESCRIPTION
Fixes #1244.

Changes in this pull request:
- Added api for record set count and displayed in portal

Steps: 
Login to the vinyldns 
zones > manage records
<img width="126" alt="image" src="https://github.com/vinyldns/vinyldns/assets/88772914/4a678baf-de6d-4bf7-a595-5c107de29717">
