### PR TITLE
Remove record change history route

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -242,33 +242,6 @@ class RecordSetRoute(
         }
       }
     } ~
-    path("recordsetchange" / "history") {
-      (get & monitor("Endpoint.listRecordSetChangeHistory")) {
-        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS), "fqdn".as[String].?, "recordType".as[String].?) {
-          (startFrom: Option[Int], maxItems: Int, fqdn: Option[String], recordType: Option[String]) =>
-            handleRejections(invalidQueryHandler) {
-              val errorMessage = if(fqdn.isEmpty || recordType.isEmpty) {
-                "recordType and fqdn cannot be empty"
-              } else {
-                s"maxItems was $maxItems, maxItems must be between 0 exclusive " +
-                  s"and $DEFAULT_MAX_ITEMS inclusive"
-              }
-              val isValid = (0 < maxItems && maxItems <= DEFAULT_MAX_ITEMS) && (fqdn.nonEmpty && recordType.nonEmpty)
-              validate(
-                check = isValid,
-                errorMsg = errorMessage
-              ){
-                authenticateAndExecute(
-                  recordSetService
-                    .listRecordSetChangeHistory(None, startFrom, maxItems, fqdn, RecordType.find(recordType.get), _)
-                ) { changes =>
-                  complete(StatusCodes.OK, changes)
-                }
-              }
-            }
-        }
-      }
-    } ~
     path("metrics" / "health" / "zones" / Segment / "recordsetchangesfailure") {zoneId =>
       (get & monitor("Endpoint.listFailedRecordSetChanges")) {
         parameters("startFrom".as[Int].?(0), "maxItems".as[Int].?(DEFAULT_MAX_ITEMS)) {


### PR DESCRIPTION
Changes in this pull request:
- Remove record change history route from api so that no one can access. Previously removed, but was added back by a merge to main branch. This route should not be accessible until record change columns are populated.
