### PR TITLE
Updated record set ownergroup id as none when zone is private

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -145,7 +145,7 @@ class RecordSetService(
       _ <- unchangedZoneId(existing, recordSet).toResult
       change <- RecordSetChangeGenerator.forUpdate(existing, recordSet, zone, Some(auth)).toResult
       // because changes happen to the RS in forUpdate itself, converting 1st and validating on that
-      rsForValidations = change.recordSet
+      rsForValidations = if(!zone.shared) change.recordSet.copy(ownerGroupId = None) else change.recordSet
       superUserCanUpdateOwnerGroup = canSuperUserUpdateOwnerGroup(existing, recordSet, zone, auth)
       _ <- isNotHighValueDomain(recordSet, zone, highValueDomainConfig).toResult
       _ <- canUpdateRecordSet(auth, existing.name, existing.typ, zone, existing.ownerGroupId, superUserCanUpdateOwnerGroup).toResult
@@ -184,6 +184,7 @@ class RecordSetService(
       ).toResult
       _ <- if(existing.name == rsForValidations.name) ().toResult else if(allowedZoneList.contains(zone.name)) checkAllowedDots(allowedDotsLimit, rsForValidations, zone).toResult else ().toResult
       _ <- if(allowedZoneList.contains(zone.name)) isNotApexEndsWithDot(rsForValidations, zone).toResult else ().toResult
+
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
 


### PR DESCRIPTION
Fixes #1317.

Changes in this pull request:
- Updated record set owner group id as none when zone is private
-
