### PR TITLE
Fix record change history view in portal

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -609,13 +609,12 @@ class RecordSetService(
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetHistoryResponse] =
     for {
+      zone <- getZone(zoneId.get)
+      _ <- canSeeZone(authPrincipal, zone).toResult
       recordSetChangesResults <- recordChangeRepository
         .listRecordSetChanges(zoneId, startFrom, maxItems, fqdn, recordType)
         .toResult[ListRecordSetChangesResults]
       recordSetChangesInfo <- buildRecordSetChangeInfo(recordSetChangesResults.items)
-      zoneId = if(recordSetChangesResults.items.nonEmpty) Some(recordSetChangesResults.items.map(x => x.zone.id).head) else None
-      zone <- getZone(zoneId.get)
-      _ <- canSeeZone(authPrincipal, zone).toResult
     } yield ListRecordSetHistoryResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
 
   def listFailedRecordSetChanges(

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -613,8 +613,9 @@ class RecordSetService(
         .listRecordSetChanges(zoneId, startFrom, maxItems, fqdn, recordType)
         .toResult[ListRecordSetChangesResults]
       recordSetChangesInfo <- buildRecordSetChangeInfo(recordSetChangesResults.items)
-      _ <- if(recordSetChangesResults.items.nonEmpty) canSeeZone(authPrincipal, recordSetChangesInfo.map(_.zone).head).toResult else ().toResult
       zoneId = if(recordSetChangesResults.items.nonEmpty) Some(recordSetChangesResults.items.map(x => x.zone.id).head) else None
+      zone <- getZone(zoneId.get)
+      _ <- canSeeZone(authPrincipal, zone).toResult
     } yield ListRecordSetHistoryResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
 
   def listFailedRecordSetChanges(

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -251,23 +251,23 @@ class RecordSetRoute(
     } ~
     path("recordsetchange" / "history") {
       (get & monitor("Endpoint.listRecordSetChangeHistory")) {
-        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS), "fqdn".as[String].?, "recordType".as[String].?) {
-          (startFrom: Option[Int], maxItems: Int, fqdn: Option[String], recordType: Option[String]) =>
+        parameters("zoneId".as[String].?, "startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS), "fqdn".as[String].?, "recordType".as[String].?) {
+          (zoneId: Option[String], startFrom: Option[Int], maxItems: Int, fqdn: Option[String], recordType: Option[String]) =>
             handleRejections(invalidQueryHandler) {
-              val errorMessage = if(fqdn.isEmpty || recordType.isEmpty) {
-                "recordType and fqdn cannot be empty"
+              val errorMessage = if(fqdn.isEmpty || recordType.isEmpty || zoneId.isEmpty) {
+                "recordType, fqdn and zoneId cannot be empty"
               } else {
                 s"maxItems was $maxItems, maxItems must be between 0 exclusive " +
                   s"and $DEFAULT_MAX_ITEMS inclusive"
               }
-              val isValid = (0 < maxItems && maxItems <= DEFAULT_MAX_ITEMS) && (fqdn.nonEmpty && recordType.nonEmpty)
+              val isValid = (0 < maxItems && maxItems <= DEFAULT_MAX_ITEMS) && (fqdn.nonEmpty && recordType.nonEmpty && zoneId.nonEmpty)
               validate(
                 check = isValid,
                 errorMsg = errorMessage
               ){
                 authenticateAndExecute(
                   recordSetService
-                    .listRecordSetChangeHistory(None, startFrom, maxItems, fqdn, RecordType.find(recordType.get), _)
+                    .listRecordSetChangeHistory(zoneId, startFrom, maxItems, fqdn, RecordType.find(recordType.get), _)
                 ) { changes =>
                   complete(StatusCodes.OK, changes)
                 }

--- a/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/list_recordset_changes_test.py
@@ -214,9 +214,10 @@ def test_list_recordset_history_no_authorization(shared_zone_test_context):
     Test that recordset history without authorization fails
     """
     client = shared_zone_test_context.history_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
-    client.list_recordset_change_history(fqdn, type, sign_request=False, status=401)
+    client.list_recordset_change_history(zone_id, fqdn, type, sign_request=False, status=401)
 
 
 def test_list_recordset_history_member_auth_success(shared_zone_test_context):
@@ -224,9 +225,10 @@ def test_list_recordset_history_member_auth_success(shared_zone_test_context):
     Test recordset history succeeds with membership auth for member of admin group
     """
     client = shared_zone_test_context.history_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
-    response = client.list_recordset_change_history(fqdn, type, status=200)
+    response = client.list_recordset_change_history(zone_id, fqdn, type, status=200)
     check_change_history_response(response, fqdn, type, recordChanges=True, startFrom=False, nextId=False)
 
 
@@ -235,9 +237,10 @@ def test_list_recordset_history_member_auth_no_access(shared_zone_test_context):
     Test recordset history fails for user not in admin group with no acl rules
     """
     client = shared_zone_test_context.ok_vinyldns_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
-    client.list_recordset_change_history(fqdn, type, status=403)
+    client.list_recordset_change_history(zone_id, fqdn, type, status=403)
 
 
 def test_list_recordset_history_success(shared_zone_test_context):
@@ -245,9 +248,10 @@ def test_list_recordset_history_success(shared_zone_test_context):
     Test recordset history succeeds with membership auth for member of admin group
     """
     client = shared_zone_test_context.history_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
-    response = client.list_recordset_change_history(fqdn, type, status=200)
+    response = client.list_recordset_change_history(zone_id, fqdn, type, status=200)
     check_change_history_response(response, fqdn, type, recordChanges=True, startFrom=False, nextId=False)
 
 
@@ -257,11 +261,12 @@ def test_list_recordset_history_paging(shared_zone_test_context):
     """
     client = shared_zone_test_context.history_client
 
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
 
-    response_1 = client.list_recordset_change_history(fqdn, type, start_from=None, max_items=1)
-    response_2 = client.list_recordset_change_history(fqdn, type, start_from=response_1["nextId"], max_items=1)
+    response_1 = client.list_recordset_change_history(zone_id, fqdn, type, start_from=None, max_items=1)
+    response_2 = client.list_recordset_change_history(zone_id, fqdn, type, start_from=response_1["nextId"], max_items=1)
 
     check_change_history_response(response_1, fqdn, type, recordChanges=True, nextId=True, startFrom=False, maxItems=1)
     check_change_history_response(response_2, fqdn, type, recordChanges=True, nextId=True, startFrom=response_1["nextId"], maxItems=1)
@@ -272,9 +277,10 @@ def test_list_recordset_history_returning_no_changes(shared_zone_test_context):
     Pass in startFrom of "2000" should return empty list because start key exceeded number of recordset change history
     """
     client = shared_zone_test_context.history_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
-    response = client.list_recordset_change_history(fqdn, type, start_from=2000, max_items=None)
+    response = client.list_recordset_change_history(zone_id, fqdn, type, start_from=2000, max_items=None)
     assert_that(response["recordSetChanges"], has_length(0))
     assert_that(response["startFrom"], is_(2000))
     assert_that(response["maxItems"], is_(100))
@@ -285,10 +291,11 @@ def test_list_recordset_history_default_max_items(shared_zone_test_context):
     Test default max items is 100
     """
     client = shared_zone_test_context.history_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
 
-    response = client.list_recordset_change_history(fqdn, type, start_from=None, max_items=None)
+    response = client.list_recordset_change_history(zone_id, fqdn, type, start_from=None, max_items=None)
     check_change_history_response(response, fqdn, type, recordChanges=True, startFrom=False, nextId=False, maxItems=100)
 
 
@@ -297,11 +304,12 @@ def test_list_recordset_history_max_items_boundaries(shared_zone_test_context):
     Test 0 < max_items <= 100
     """
     client = shared_zone_test_context.history_client
+    zone_id = shared_zone_test_context.history_zone["id"]
     fqdn = "test-create-cname-ok.system-test-history1."
     type = "CNAME"
 
-    too_large = client.list_recordset_change_history(fqdn, type, start_from=None, max_items=101, status=400)
-    too_small = client.list_recordset_change_history(fqdn, type, start_from=None, max_items=0, status=400)
+    too_large = client.list_recordset_change_history(zone_id, fqdn, type, start_from=None, max_items=101, status=400)
+    too_small = client.list_recordset_change_history(zone_id, fqdn, type, start_from=None, max_items=0, status=400)
 
     assert_that(too_large, is_("maxItems was 101, maxItems must be between 0 exclusive and 100 inclusive"))
     assert_that(too_small, is_("maxItems was 0, maxItems must be between 0 exclusive and 100 inclusive"))

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -460,9 +460,10 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, "GET", self.headers, not_found_ok=True, **kwargs)
         return data
 
-    def list_recordset_change_history(self, fqdn, record_type, start_from=None, max_items=None, **kwargs):
+    def list_recordset_change_history(self, zone_id, fqdn, record_type, start_from=None, max_items=None, **kwargs):
         """
-        Gets the record's change history for the given record fqdn and record type
+        Gets the record's change history for the given zone, record fqdn and record type
+        :param zone_id: the id of the zone to retrieve
         :param fqdn: the record's fqdn
         :param record_type: the record's type
         :param start_from: the start key of the page
@@ -474,6 +475,7 @@ class VinylDNSClient(object):
             args.append("startFrom={0}".format(start_from))
         if max_items is not None:
             args.append("maxItems={0}".format(max_items))
+        args.append("zoneId={0}".format(zone_id))
         args.append("fqdn={0}".format(fqdn))
         args.append("recordType={0}".format(record_type))
         url = urljoin(self.index_url, "recordsetchange/history") + "?" + "&".join(args)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -1963,6 +1963,9 @@ class RecordSetServiceSpec
         List(pendingCreateAAAA, completeCreateAAAA)
       val zoneId = filteredRecordSetChanges.head.zoneId
 
+      doReturn(IO.pure(Some(okZone)))
+        .when(mockZoneRepo)
+        .getZone(zoneId)
       doReturn(IO.pure(ListRecordSetChangesResults(filteredRecordSetChanges)))
         .when(mockRecordChangeRepo)
         .listRecordSetChanges(zoneId = None, startFrom = None, maxItems = 100, fqdn = Some("aaaa.ok.zone.recordsets."), recordType = Some(RecordType.AAAA))

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -1968,13 +1968,13 @@ class RecordSetServiceSpec
         .getZone(zoneId)
       doReturn(IO.pure(ListRecordSetChangesResults(filteredRecordSetChanges)))
         .when(mockRecordChangeRepo)
-        .listRecordSetChanges(zoneId = None, startFrom = None, maxItems = 100, fqdn = Some("aaaa.ok.zone.recordsets."), recordType = Some(RecordType.AAAA))
+        .listRecordSetChanges(zoneId = Some(zoneId), startFrom = None, maxItems = 100, fqdn = Some("aaaa.ok.zone.recordsets."), recordType = Some(RecordType.AAAA))
       doReturn(IO.pure(ListUsersResults(Seq(okUser), None)))
         .when(mockUserRepo)
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListRecordSetHistoryResponse =
-        underTest.listRecordSetChangeHistory(None, fqdn = Some("aaaa.ok.zone.recordsets."), recordType = Some(RecordType.AAAA), authPrincipal = okAuth).value.unsafeRunSync().toOption.get
+        underTest.listRecordSetChangeHistory(zoneId = Some(zoneId), fqdn = Some("aaaa.ok.zone.recordsets."), recordType = Some(RecordType.AAAA), authPrincipal = okAuth).value.unsafeRunSync().toOption.get
       val changesWithName =
         filteredRecordSetChanges.map(change => RecordSetChangeInfo(change, Some("ok")))
       val expectedResults = ListRecordSetHistoryResponse(

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -924,7 +924,7 @@ class RecordSetRoutingSpec
 
   "GET recordset change history" should {
     "return the recordset change" in {
-      Get(s"/recordsetchange/history?fqdn=rs1.ok.&recordType=A") ~> recordSetRoute ~> check {
+      Get(s"/recordsetchange/history?zoneId=${okZone.id}&fqdn=rs1.ok.&recordType=A") ~> recordSetRoute ~> check {
         val response = responseAs[ListRecordSetHistoryResponse]
 
         response.zoneId shouldBe Some(okZone.id)

--- a/modules/docs/src/main/mdoc/api/get-recordset-change-history.md
+++ b/modules/docs/src/main/mdoc/api/get-recordset-change-history.md
@@ -10,12 +10,13 @@ Gets the history of all the changes that has been made to a recordset
 
 #### HTTP REQUEST
 
-> GET /recordsetchange/history?fqdn={recordsetFqdn}&recordType={recordsetType}&startFrom={response.nextId}&maxItems={1 - 100}
+> GET /recordsetchange/history?zoneId={zoneId}&fqdn={recordsetFqdn}&recordType={recordsetType}&startFrom={response.nextId}&maxItems={1 - 100}
 
 #### HTTP REQUEST PARAMS
 
 name          | type          | required?   | description |
  ------------ | ------------- | ----------- | :---------- |
+zoneId        | string        | yes         | The id of the zone where the recordset is present |
 fqdn          | string        | yes         | The fqdn of the recordset whose history will be returned |
 recordType    | string        | yes         | The record type of the recordset |
 startFrom     | int           | no          | In order to advance through pages of results, the startFrom is set to the `nextId` that is returned on the previous response.  It is up to the client to maintain previous pages if the client wishes to advance forward and backward.   If not specified, will return the first page of results |

--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -169,7 +169,7 @@
                             @if(meta.sharedDisplayEnabled) {
                                 <th>Owner Group Name</th>
                             }
-                            <th ng-if="rootAccountCanReview || userCanAccessGroup">Record History</th>
+                            <th>Record History</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -377,8 +377,8 @@
                                       title="Group with ID {{record.ownerGroupId}} no longer exists."><span class="fa fa-warning"></span> Group deleted</span>
                             </td>
                             }
-                            <td ng-if="rootAccountCanReview || (record.ownerGroupName && canAccessGroup(record.ownerGroupId))">
-                                <span><button class="btn btn-info btn-sm" ng-click="viewRecordHistory(record.fqdn, record.type)">View History</button></span>
+                            <td>
+                                <span><button class="btn btn-info btn-sm" ng-disabled="(record.ownerGroupName && !canAccessGroup(record.ownerGroupId))" ng-click="viewRecordHistory(record.fqdn, record.type)">View History</button></span>
                             </td>
                         </tr>
                         </tbody>

--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -378,7 +378,7 @@
                             </td>
                             }
                             <td>
-                                <span><button class="btn btn-info btn-sm" ng-disabled="(record.ownerGroupName && !canAccessGroup(record.ownerGroupId))" ng-click="viewRecordHistory(record.fqdn, record.type)">View History</button></span>
+                                <span><button class="btn btn-info btn-sm" ng-disabled="(record.ownerGroupName && !canAccessGroup(record.ownerGroupId))" ng-click="viewRecordHistory(record.fqdn, record.type, record.zoneId)">View History</button></span>
                             </td>
                         </tr>
                         </tbody>

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -184,7 +184,6 @@
                     newRecords.push(recordsService.toDisplayRecord(record, ''));
                 });
                 $scope.records = newRecords;
-                $log.log("$scope.records: ",  $scope.records);
                 for(var i = 0; i < $scope.records.length; i++) {
                   if (!$scope.records[i].zoneShared){
                     getZone($scope.records[i].zoneId, i);

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -113,10 +113,10 @@
                           .append("<div>" + recordSet + "</div>")
                           .appendTo(ul); };
 
-            $scope.viewRecordHistory = function(recordFqdn, recordType) {
+            $scope.viewRecordHistory = function(recordFqdn, recordType, zoneId) {
                $scope.recordFqdn = recordFqdn;
                $scope.recordType = recordType;
-               $scope.refreshRecordChangeHistory($scope.recordFqdn, $scope.recordType);
+               $scope.refreshRecordChangeHistory($scope.recordFqdn, $scope.recordType, zoneId);
                $("#record_history_modal").modal("show");
             };
 
@@ -184,6 +184,7 @@
                     newRecords.push(recordsService.toDisplayRecord(record, ''));
                 });
                 $scope.records = newRecords;
+                $log.log("$scope.records: ",  $scope.records);
                 for(var i = 0; i < $scope.records.length; i++) {
                   if (!$scope.records[i].zoneShared){
                     getZone($scope.records[i].zoneId, i);
@@ -245,7 +246,7 @@
                     });
             };
 
-            $scope.refreshRecordChangeHistory = function(recordFqdn, recordType) {
+            $scope.refreshRecordChangeHistory = function(recordFqdn, recordType, zoneId) {
                 changePaging = pagingService.resetPaging(changePaging);
                 function success(response) {
                     $scope.zoneId = response.data.zoneId;
@@ -254,7 +255,7 @@
                     updateChangeDisplay(response.data.recordSetChanges)
                 }
                 return recordsService
-                    .listRecordSetChangeHistory(changePaging.maxItems, undefined, recordFqdn, recordType)
+                    .listRecordSetChangeHistory(zoneId, changePaging.maxItems, undefined, recordFqdn, recordType)
                     .then(success)
                     .catch(function (error){
                         handleError(error, 'recordsService::getRecordSetChangeHistory-failure');

--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -124,9 +124,10 @@ angular.module('service.records', [])
             return $http.get(url);
         };
 
-        this.listRecordSetChangeHistory = function (maxItems, startFrom, fqdn, recordType) {
+        this.listRecordSetChangeHistory = function (zoneId, maxItems, startFrom, fqdn, recordType) {
             var url = '/api/recordsetchange/history';
             var params = {
+                "zoneId": zoneId,
                 "maxItems": maxItems,
                 "startFrom": startFrom,
                 "fqdn": fqdn,


### PR DESCRIPTION
Fixes #1337.

Changes in this pull request:
- Fixed the column name by making it permanent. 
- Allowed every users to view the history of unowned records.
- For records in the private zones, only the users who belong to the owning group can view the history.
- The button will be disabled if the users don't have the right permissions.
