### PR TITLE
Remove unnecessary parameters from "listRecordSetChanges"

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -584,21 +584,19 @@ class RecordSetService(
     } yield change
 
   def listRecordSetChanges(
-                            zoneId: Option[String] = None,
+                            zoneId: String,
                             startFrom: Option[Int] = None,
                             maxItems: Int = 100,
-                            fqdn: Option[String] = None,
-                            recordType: Option[RecordType] = None,
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetChangesResponse] =
       for {
-        zone <- getZone(zoneId.get)
+        zone <- getZone(zoneId)
         _ <- canSeeZone(authPrincipal, zone).toResult
         recordSetChangesResults <- recordChangeRepository
-          .listRecordSetChanges(Some(zone.id), startFrom, maxItems, fqdn, recordType)
+          .listRecordSetChanges(Some(zone.id), startFrom, maxItems, None, None)
           .toResult[ListRecordSetChangesResults]
         recordSetChangesInfo <- buildRecordSetChangeInfo(recordSetChangesResults.items)
-      } yield ListRecordSetChangesResponse(zoneId.get, recordSetChangesResults, recordSetChangesInfo)
+      } yield ListRecordSetChangesResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
 
   def listRecordSetChangeHistory(
                             zoneId: Option[String] = None,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
@@ -101,11 +101,9 @@ trait RecordSetServiceAlgebra {
                         ): Result[RecordSetChange]
 
   def listRecordSetChanges(
-                            zoneId: Option[String],
+                            zoneId: String,
                             startFrom: Option[Int],
                             maxItems: Int,
-                            fqdn: Option[String],
-                            recordType: Option[RecordType],
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetChangesResponse]
 

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -230,8 +230,8 @@ class RecordSetRoute(
     } ~
     path("zones" / Segment / "recordsetchanges") { zoneId =>
       (get & monitor("Endpoint.listRecordSetChanges")) {
-        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS), "fqdn".as[String].?, "recordType".as[String].?) {
-          (startFrom: Option[Int], maxItems: Int, fqdn: Option[String], _: Option[String]) =>
+        parameters("startFrom".as[Int].?, "maxItems".as[Int].?(DEFAULT_MAX_ITEMS)) {
+          (startFrom: Option[Int], maxItems: Int) =>
             handleRejections(invalidQueryHandler) {
               validate(
                 check = 0 < maxItems && maxItems <= DEFAULT_MAX_ITEMS,
@@ -240,7 +240,7 @@ class RecordSetRoute(
               ) {
                 authenticateAndExecute(
                   recordSetService
-                    .listRecordSetChanges(Some(zoneId), startFrom, maxItems, fqdn, None, _)
+                    .listRecordSetChanges(zoneId, startFrom, maxItems, _)
                 ) { changes =>
                   complete(StatusCodes.OK, changes)
                 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -1937,19 +1937,22 @@ class RecordSetServiceSpec
       val completeRecordSetChanges: List[RecordSetChange] =
         List(pendingCreateAAAA, pendingCreateCNAME, completeCreateAAAA, completeCreateCNAME)
 
+      doReturn(IO.pure(Some(zoneActive)))
+        .when(mockZoneRepo)
+        .getZone(zoneActive.id)
       doReturn(IO.pure(ListRecordSetChangesResults(completeRecordSetChanges)))
         .when(mockRecordChangeRepo)
-        .listRecordSetChanges(zoneId = Some(okZone.id), startFrom = None, maxItems = 100, fqdn = None, recordType = None)
+        .listRecordSetChanges(zoneId = Some(zoneActive.id), startFrom = None, maxItems = 100, fqdn = None, recordType = None)
       doReturn(IO.pure(ListUsersResults(Seq(okUser), None)))
         .when(mockUserRepo)
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListRecordSetChangesResponse =
-        underTest.listRecordSetChanges(Some(okZone.id), authPrincipal = okAuth).value.unsafeRunSync().toOption.get
+        underTest.listRecordSetChanges(zoneActive.id, authPrincipal = okAuth).value.unsafeRunSync().toOption.get
       val changesWithName =
         completeRecordSetChanges.map(change => RecordSetChangeInfo(change, Some("ok")))
       val expectedResults = ListRecordSetChangesResponse(
-        zoneId = okZone.id,
+        zoneId = zoneActive.id,
         recordSetChanges = changesWithName,
         nextId = None,
         startFrom = None,
@@ -1996,7 +1999,7 @@ class RecordSetServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListRecordSetChangesResponse =
-        underTest.listRecordSetChanges(Some(okZone.id), authPrincipal = okAuth).value.unsafeRunSync().toOption.get
+        underTest.listRecordSetChanges(okZone.id, authPrincipal = okAuth).value.unsafeRunSync().toOption.get
       val expectedResults = ListRecordSetChangesResponse(
         zoneId = okZone.id,
         recordSetChanges = List(),
@@ -2062,7 +2065,7 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError" in {
       val error =
-        underTest.listRecordSetChanges(Some(zoneNotAuthorized.id), authPrincipal = okAuth).value.unsafeRunSync().swap.toOption.get
+        underTest.listRecordSetChanges(zoneNotAuthorized.id, authPrincipal = okAuth).value.unsafeRunSync().swap.toOption.get
 
       error shouldBe a[NotAuthorizedError]
     }
@@ -2079,7 +2082,7 @@ class RecordSetServiceSpec
         .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
 
       val result: ListRecordSetChangesResponse =
-        underTest.listRecordSetChanges(Some(okZone.id), authPrincipal = okAuth).value.unsafeRunSync().toOption.get
+        underTest.listRecordSetChanges(okZone.id, authPrincipal = okAuth).value.unsafeRunSync().toOption.get
       val changesWithName =
         List(RecordSetChangeInfo(rsChange2, Some("ok")), RecordSetChangeInfo(rsChange1, Some("ok")))
       val expectedResults = ListRecordSetChangesResponse(

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -758,16 +758,14 @@ class RecordSetRoutingSpec
     }.toResult
 
     def listRecordSetChanges(
-                              zoneId: Option[String],
+                              zoneId: String,
                               startFrom: Option[Int],
                               maxItems: Int,
-                              fqdn: Option[String],
-                              recordType: Option[RecordType],
                               authPrincipal: AuthPrincipal
                             ): Result[ListRecordSetChangesResponse] = {
       zoneId match {
-        case Some(zoneNotFound.id) => Left(ZoneNotFoundError(s"$zoneId"))
-        case Some(notAuthorizedZone.id) => Left(NotAuthorizedError("no way"))
+        case zoneNotFound.id => Left(ZoneNotFoundError(s"$zoneId"))
+        case notAuthorizedZone.id => Left(NotAuthorizedError("no way"))
         case _ => Right(listRecordSetChangesResponse)
       }
     }.toResult

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordChangeRepository.scala
@@ -23,7 +23,7 @@ import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record._
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
-import vinyldns.mysql.repository.MySqlRecordSetRepository.fromRecordType
+import vinyldns.mysql.repository.MySqlRecordSetRepository.{fromRecordType, toFQDN}
 import vinyldns.proto.VinylDNSProto
 
 class MySqlRecordChangeRepository
@@ -103,7 +103,7 @@ class MySqlRecordChangeRepository
                   change.zoneId,
                   change.created.toEpochMilli,
                   fromChangeType(change.changeType),
-                  if(change.recordSet.name == change.zone.name) change.zone.name else change.recordSet.name + "." + change.zone.name,
+                  toFQDN(change.zone.name, change.recordSet.name),
                   fromRecordType(change.recordSet.typ),
                   toPB(change).toByteArray,
                 )


### PR DESCRIPTION
Fixes #1356.

Changes in this pull request:
- Removed the parameters `fqdn` and `recordType` from the `listRecordSetChanges` route as the only parameters in this route are `startFrom` and `maxItems`. The `fqdn` and `recordType` parameters are only used in `listRecordSetChangeHistory` route.
- Reuse `toFqdn` method to save the fqdn to database.
