### PR TITLE
fixed deleted zone access issue in portal

### DIFF
--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -487,7 +487,7 @@
 }
 
 @plugins = {
-<script type='text/javascript' src='/public/js/ui.js'></script>
+    <script type='text/javascript' src='/public/js/ui.js'></script>
 }
 
 @main(rootAccountName)("ZonesController")("Zones")(content)(plugins)

--- a/modules/portal/app/views/zones/zones.scala.html
+++ b/modules/portal/app/views/zones/zones.scala.html
@@ -370,7 +370,7 @@
                                                                 {{deletedZone.userName}}
                                                             </td>
                                                             @if(meta.sharedDisplayEnabled) {
-                                                            <td>{{zone.shared ? "Shared" : "Private"}}</td>
+                                                            <td>{{deletedZone.zoneChange.zone.shared ? "Shared" : "Private"}}</td>
                                                             }
                                                         </tr>
                                                         </tbody>
@@ -449,7 +449,7 @@
                                                                 {{deletedZone.userName}}
                                                             </td>
                                                             @if(meta.sharedDisplayEnabled) {
-                                                            <td>{{zone.shared ? "Shared" : "Private"}}</td>
+                                                            <td>{{deletedZone.zoneChange.zone.shared ? "Shared" : "Private"}}</td>
                                                             }
                                                         </tr>
                                                         </tbody>


### PR DESCRIPTION
Fixes #1359 .

Changes in this pull request:
- Fixed deleted zone `access` issue in portal. Previously, they appeared as `private` even though they were `shared` zones
