### PR TITLE
Removed docker compose version since no more use

### DIFF
--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "19004:19004"
 
-  # Integration image hosting r53, sns, sqs, bind, and mysql
+  # Integration image hosting r53, sns, sqs, bind and mysql
   integration:
     container_name: "vinyldns-api-integration"
     hostname: "vinyldns-integration"

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
 
   # LDAP container hosting example users


### PR DESCRIPTION
Fixes #1373 .

Changes in this pull request:
- Removed docker compose version since no more use. [Reference](https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313)
-
