### PR TITLE
Fix for latency issue in batch change upload

### DIFF
--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -350,6 +350,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
+    request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/build/docker/api/application.conf
+++ b/build/docker/api/application.conf
@@ -350,7 +350,10 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-    request-timeout = 60s
+
+    # A default request timeout is applied globally to all routes and can be configured using the
+    # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+    # request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -347,7 +347,9 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-    request-timeout = 60s
+    # A default request timeout is applied globally to all routes and can be configured using the
+    # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+    # request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -347,6 +347,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
+    request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/api/src/it/resources/application.conf
+++ b/modules/api/src/it/resources/application.conf
@@ -347,6 +347,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
+
     # A default request timeout is applied globally to all routes and can be configured using the
     # akka.http.server.request-timeout setting (which defaults to 20 seconds).
     # request-timeout = 60s

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -19,7 +19,7 @@ vinyldns {
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 
   # Batch change settings
-  batch-change-limit = 1000
+  batch-change-limit = 100
   batch-change-limit = ${?BATCH_CHANGE_LIMIT}
   manual-batch-review-enabled = true
   manual-batch-review-enabled = ${?MANUAL_BATCH_REVIEW_ENABLED}

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -366,6 +366,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
+    request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -19,7 +19,7 @@ vinyldns {
   shared-approved-types = ["A", "AAAA", "CNAME", "PTR", "TXT"]
 
   # Batch change settings
-  batch-change-limit = 100
+  batch-change-limit = 1000
   batch-change-limit = ${?BATCH_CHANGE_LIMIT}
   manual-batch-review-enabled = true
   manual-batch-review-enabled = ${?MANUAL_BATCH_REVIEW_ENABLED}
@@ -366,7 +366,10 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-    request-timeout = 60s
+
+    # A default request timeout is applied globally to all routes and can be configured using the
+    # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+    # request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -351,7 +351,10 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-    request-timeout = 60s
+
+    # A default request timeout is applied globally to all routes and can be configured using the
+    # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+    # request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/api/src/universal/conf/application.conf
+++ b/modules/api/src/universal/conf/application.conf
@@ -351,6 +351,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
+    request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -990,6 +990,7 @@ dotted-hosts = {
         # The time period within which the TCP binding process must be completed.
         # Set to `infinite` to disable.
         bind-timeout = 5s
+        request-timeout = 60s
       
         # Show verbose error messages back to the client
         verbose-error-messages = on

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -990,8 +990,10 @@ dotted-hosts = {
         # The time period within which the TCP binding process must be completed.
         # Set to `infinite` to disable.
         bind-timeout = 5s
-        request-timeout = 60s
-      
+        # A default request timeout is applied globally to all routes and can be configured using the 
+        # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+        # request-timeout = 60s      
+  
         # Show verbose error messages back to the client
         verbose-error-messages = on
      }

--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -32,7 +32,7 @@ object Meta {
     Meta(
       config.getOptional[String]("vinyldns.version").getOrElse("unknown"),
       config.getOptional[Boolean]("shared-display-enabled").getOrElse(false),
-      config.getOptional[Int]("api.limits.batchchange-routing-max-items-limit").getOrElse(100),
+      config.getOptional[Int]("api.limits.batchchange-routing-max-items-limit").getOrElse(1000),
       config.getOptional[Long]("default-ttl").getOrElse(7200L),
       config.getOptional[Boolean]("manual-batch-review-enabled").getOrElse(false),
       config.getOptional[Boolean]("scheduled-changes-enabled").getOrElse(false),

--- a/modules/portal/app/models/Meta.scala
+++ b/modules/portal/app/models/Meta.scala
@@ -32,7 +32,7 @@ object Meta {
     Meta(
       config.getOptional[String]("vinyldns.version").getOrElse("unknown"),
       config.getOptional[Boolean]("shared-display-enabled").getOrElse(false),
-      config.getOptional[Int]("batch-change-limit").getOrElse(1000),
+      config.getOptional[Int]("api.limits.batchchange-routing-max-items-limit").getOrElse(100),
       config.getOptional[Long]("default-ttl").getOrElse(7200L),
       config.getOptional[Boolean]("manual-batch-review-enabled").getOrElse(false),
       config.getOptional[Boolean]("scheduled-changes-enabled").getOrElse(false),

--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -329,7 +329,7 @@
                                 <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" ng-change="uploadCSV(createBatchChangeForm.batchChangeCsv.$viewValue, batchChangeLimit )" batch-change-file>
                                 <p><a href="https://www.vinyldns.io/portal/dns-changes#dns-change-csv-import" target="_blank" rel="noopener noreferrer">See documentation for sample CSV</a></p>
                             </div>
-                            <p ng-if="newBatch.changes.length > batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per DNS change.</p>
+                            <p ng-if="newBatch.changes.length >= batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per DNS change.</p>
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">

--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -329,7 +329,7 @@
                                 <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" ng-change="uploadCSV(createBatchChangeForm.batchChangeCsv.$viewValue, batchChangeLimit )" batch-change-file>
                                 <p><a href="https://www.vinyldns.io/portal/dns-changes#dns-change-csv-import" target="_blank" rel="noopener noreferrer">See documentation for sample CSV</a></p>
                             </div>
-                            <p ng-if="newBatch.changes.length >= batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per DNS change.</p>
+                            <p ng-if="newBatch.changes.length > batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per DNS change.</p>
                         </div>
                         <div class="panel-footer clearfix">
                             <div ng-if="formStatus=='pendingSubmit'" class="pull-right">

--- a/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeNew.scala.html
@@ -326,7 +326,7 @@
                                 <label class="batch-change-csv-label btn btn-default" for="batchChangeCsv" id="batchChangeCsvImportLabel">
                                     <span><span class="glyphicon glyphicon-import"></span> Import CSV</span>
                                 </label>
-                                <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" ng-change="uploadCSV(createBatchChangeForm.batchChangeCsv.$viewValue)" batch-change-file>
+                                <input type="file" id="batchChangeCsv" ng-model="csvInput" name="batchChangeCsv" class="batchChangeCsv" ng-change="uploadCSV(createBatchChangeForm.batchChangeCsv.$viewValue, batchChangeLimit )" batch-change-file>
                                 <p><a href="https://www.vinyldns.io/portal/dns-changes#dns-change-csv-import" target="_blank" rel="noopener noreferrer">See documentation for sample CSV</a></p>
                             </div>
                             <p ng-if="newBatch.changes.length >= batchChangeLimit">Limit reached. Cannot add more than {{batchChangeLimit}} records per DNS change.</p>
@@ -336,6 +336,9 @@
                                 <button type="button" id="create-batch-changes-button" class="btn btn-primary" ng-click="submitChange(manualReviewEnabled)">Submit</button>
                             </div>
                             <div ng-if="formStatus=='pendingConfirm'" class="pull-right">
+                                <div class="modal fade" id="loader" tabindex="-1" role="dialog" >
+                                    <div class="spinner" ></div>
+                                </div>
                                 <span ng-if="!batchChangeErrors">{{ confirmationPrompt }}</span>
                                 <span ng-if="batchChangeErrors" class="batch-change-error-help">There were errors, please review the highlighted rows and then proceed.</span>
                                 <button class="btn btn-default" ng-click="cancelSubmit()">Cancel</button>

--- a/modules/portal/public/lib/dns-change/dns-change-new.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-new.controller.js
@@ -165,7 +165,7 @@
             $scope.uploadCSV = function(file, batchChangeLimit) {
                 parseFile(file, batchChangeLimit).then(function(dataLength){
 
-                    $scope.alerts.push({type: 'success', content: 'Successfully imported ' + dataLength + ' changes.' });
+                    $scope.alerts.push({type: 'success', content: 'Successfully imported ' + dataLength + ' DNS changes.' });
 
                 }, function(error) {
                     $scope.alerts.push({type: 'danger', content: error});
@@ -180,10 +180,10 @@
                       var reader = new FileReader();
                       reader.onload = function(e) {
                         var rows = e.target.result.split("\n");
-                        $log.log(rows.length , batchChangeLimit)
-                        if(rows.length >= batchChangeLimit)
+                        if(rows.length - 1  > batchChangeLimit)
                         {reject("Import failed. Cannot add more than " + batchChangeLimit + " records per DNS change.");
-                        } else if (rows[0].trim() == "Change Type,Record Type,Input Name,TTL,Record Data") {
+                        } else {
+                        if (rows[0].trim() == "Change Type,Record Type,Input Name,TTL,Record Data") {
                           $scope.newBatch.changes = [];
                           for(var i = 1; i < rows.length; i++) {
                             var lengthCheck = rows[i].replace(/,+/g, '').trim().length
@@ -195,7 +195,7 @@
                         }  else {
                           reject("Import failed. CSV header must be: Change Type,Record Type,Input Name,TTL,Record Data");
                         }
-                      }
+                      }}
                       reader.readAsText(file);
                     }
                   });

--- a/modules/portal/public/lib/dns-change/dns-change-new.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-new.controller.js
@@ -164,9 +164,7 @@
 
             $scope.uploadCSV = function(file, batchChangeLimit) {
                 parseFile(file, batchChangeLimit).then(function(dataLength){
-
                     $scope.alerts.push({type: 'success', content: 'Successfully imported ' + dataLength + ' DNS changes.' });
-
                 }, function(error) {
                     $scope.alerts.push({type: 'danger', content: error});
                 });

--- a/modules/portal/public/lib/dns-change/dns-change-new.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-new.controller.js
@@ -44,6 +44,7 @@
             $scope.manualReviewEnabled;
             $scope.naptrFlags = ["U", "S", "A", "P"];
 
+
             $scope.addSingleChange = function() {
                 $scope.newBatch.changes.push({changeType: "Add", type: "A+PTR"});
                 var changesLength = $scope.newBatch.changes.length;
@@ -161,14 +162,16 @@
                 $scope.alerts.push(alert);
             }
 
-            $scope.uploadCSV = function(file) {
-                parseFile(file).then(function(dataLength){
+            $scope.uploadCSV = function(file, batchChangeLimit) {
+                parseFile(file, batchChangeLimit).then(function(dataLength){
+
                     $scope.alerts.push({type: 'success', content: 'Successfully imported ' + dataLength + ' changes.' });
+
                 }, function(error) {
                     $scope.alerts.push({type: 'danger', content: error});
                 });
 
-                function parseFile(file) {
+                function parseFile(file, batchChangeLimit) {
                   return $q(function(resolve, reject) {
                     if (!file.name.endsWith('.csv')) {
                       reject("Import failed. File should be of ‘.csv’ type.");
@@ -177,7 +180,10 @@
                       var reader = new FileReader();
                       reader.onload = function(e) {
                         var rows = e.target.result.split("\n");
-                        if (rows[0].trim() == "Change Type,Record Type,Input Name,TTL,Record Data") {
+                        $log.log(rows.length , batchChangeLimit)
+                        if(rows.length >= batchChangeLimit)
+                        {reject("Import failed. Cannot add more than " + batchChangeLimit + " records per DNS change.");
+                        } else if (rows[0].trim() == "Change Type,Record Type,Input Name,TTL,Record Data") {
                           $scope.newBatch.changes = [];
                           for(var i = 1; i < rows.length; i++) {
                             var lengthCheck = rows[i].replace(/,+/g, '').trim().length
@@ -186,7 +192,7 @@
                           }
                           $scope.$apply()
                           resolve($scope.newBatch.changes.length);
-                        } else {
+                        }  else {
                           reject("Import failed. CSV header must be: Change Type,Record Type,Input Name,TTL,Record Data");
                         }
                       }

--- a/modules/portal/public/lib/dns-change/dns-change.service.js
+++ b/modules/portal/public/lib/dns-change/dns-change.service.js
@@ -30,7 +30,6 @@
                     "allowManualReview": allowManualReview
                 }
                 var url = utilityService.urlBuilder('/api/dnschanges', params);
-                return $http.post(url, data, {headers: utilityService.getCsrfHeader()});
                 let loader = $("#loader");
                              loader.modal({
                                            backdrop: "static",

--- a/modules/portal/public/lib/dns-change/dns-change.service.js
+++ b/modules/portal/public/lib/dns-change/dns-change.service.js
@@ -31,6 +31,17 @@
                 }
                 var url = utilityService.urlBuilder('/api/dnschanges', params);
                 return $http.post(url, data, {headers: utilityService.getCsrfHeader()});
+                let loader = $("#loader");
+                             loader.modal({
+                                           backdrop: "static",
+                                           keyboard: false, //remove option to close with keyboard
+                                           show: true //Display loader!
+                                          })
+                let promis =  $http.post(url, data, {headers: utilityService.getCsrfHeader()});
+                    // Hide loader when api gets response
+                    promis.then(()=>loader.modal("hide"))
+                          .catch(()=>loader.modal("hide"))
+                return promis
             };
 
             this.getBatchChanges = function (maxItems, startFrom, ignoreAccess, approvalStatus, userName, dateTimeRangeStart, dateTimeRangeEnd) {

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -34,12 +34,12 @@ class MetaSpec extends Specification with Mockito {
       Meta(Configuration.from(config)).sharedDisplayEnabled must beTrue
     }
     "get the batch-change-limit value in config" in {
-      val config = Map("batch-change-limit" -> 21)
+      val config = Map("api.limits.batchchange-routing-max-items-limit" -> 21)
       Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(21)
     }
     "default to 1000 if batch-change-limit is not found" in {
       val config = Map("vinyldns.version" -> "foo-bar")
-      Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(1000)
+      Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(100)
     }
     "get the default-ttl value in config" in {
       val config = Map("default-ttl" -> 7210)

--- a/modules/portal/test/models/MetaSpec.scala
+++ b/modules/portal/test/models/MetaSpec.scala
@@ -39,7 +39,7 @@ class MetaSpec extends Specification with Mockito {
     }
     "default to 1000 if batch-change-limit is not found" in {
       val config = Map("vinyldns.version" -> "foo-bar")
-      Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(100)
+      Meta(Configuration.from(config)).batchChangeLimit must beEqualTo(1000)
     }
     "get the default-ttl value in config" in {
       val config = Map("default-ttl" -> 7210)

--- a/test/api/functional/application.conf
+++ b/test/api/functional/application.conf
@@ -301,6 +301,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
+    request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/test/api/functional/application.conf
+++ b/test/api/functional/application.conf
@@ -301,7 +301,10 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-    request-timeout = 60s
+
+    # A default request timeout is applied globally to all routes and can be configured using the
+    # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+    # request-timeout = 60s
 
     # Show verbose error messages back to the client
     verbose-error-messages = on

--- a/test/api/integration/application.conf
+++ b/test/api/integration/application.conf
@@ -359,7 +359,7 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-
+    request-timeout = 60s
     # Show verbose error messages back to the client
     verbose-error-messages = on
   }

--- a/test/api/integration/application.conf
+++ b/test/api/integration/application.conf
@@ -359,7 +359,11 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     # Set to `infinite` to disable.
     bind-timeout = 5s
-    request-timeout = 60s
+
+    # A default request timeout is applied globally to all routes and can be configured using the
+    # akka.http.server.request-timeout setting (which defaults to 20 seconds).
+    # request-timeout = 60s
+
     # Show verbose error messages back to the client
     verbose-error-messages = on
   }


### PR DESCRIPTION
Fixes #1375.

Changes in this pull request:
- Fix for latency issue in batch change upload.

Root Cause:
Since the batch upload will take much time to give response from the SQL side, our akka server gets `503 timeout`, but in backend we gets the successful response.

Fix: 
Increased the akka http timeout to `60seconds` (default is 20s) and keeps the portal in loading state untill we gets the response from api.
