### PR TITLE
Update Hikari Log Level

### DIFF
--- a/build/docker/api/logback.xml
+++ b/build/docker/api/logback.xml
@@ -14,7 +14,7 @@
 
     <logger name="scalikejdbc.StatementExecutor$$anon$1" level="OFF"/>
 
-    <logger name="com.zaxxer.hikari" level="TRACE">
+    <logger name="com.zaxxer.hikari" level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </logger>
 

--- a/build/docker/portal/logback.xml
+++ b/build/docker/portal/logback.xml
@@ -15,7 +15,7 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
-  <logger name="com.zaxxer.hikari" level="TRACE">
+  <logger name="com.zaxxer.hikari" level="ERROR">
     <appender-ref ref="CONSOLE"/>
   </logger>
 

--- a/modules/api/src/main/resources/logback.xml
+++ b/modules/api/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="com.zaxxer.hikari" level="TRACE">
+    <logger name="com.zaxxer.hikari" level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </logger>
 

--- a/modules/api/src/universal/conf/logback.xml
+++ b/modules/api/src/universal/conf/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="com.zaxxer.hikari" level="TRACE">
+    <logger name="com.zaxxer.hikari" level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </logger>
 

--- a/modules/portal/conf/logback.xml
+++ b/modules/portal/conf/logback.xml
@@ -15,7 +15,7 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
-  <logger name="com.zaxxer.hikari" level="TRACE">
+  <logger name="com.zaxxer.hikari" level="ERROR">
     <appender-ref ref="CONSOLE"/>
   </logger>
 


### PR DESCRIPTION
Changes in this pull request:
- Update the hikari log level to ERROR so that we only capture and output messages at the ERROR level or higher (FATAL). This makes us easier to debug other issues while only capturing events that may have an impact from hikari side. We can revert back to TRACE level logs when necessary.
