### PR TITLE
Revert "Update info messages"

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -38,7 +38,6 @@ object RecordSetChangeHandler extends TransactionProvider {
   private val outOfSyncFailureMessage: String = "This record set is out of sync with the DNS backend; sync this zone before attempting to update this record set."
   private val incompatibleRecordFailureMessage: String = "Incompatible record in DNS."
   private val syncZoneMessage: String = "This record set is out of sync with the DNS backend. Sync this zone before attempting to update this record set."
-  private val wrongRecordDataMessage: String = "The record data entered doesn't exist. Please enter the correct record data or leave the field empty if it's a delete operation."
   private val recordConflictMessage: String = "Conflict due to the record having the same name as an NS record in the same zone. Please create the record using the DNS service the NS record has been delegated to (ex. AWS r53), or use a different record name."
 
   final case class Requeue(change: RecordSetChange) extends Throwable
@@ -393,16 +392,10 @@ object RecordSetChangeHandler extends TransactionProvider {
       case AlreadyApplied(_) => Completed(change.successful)
       case ReadyToApply(_) => Validated(change)
       case Failure(_, message) =>
-        if(message == outOfSyncFailureMessage){
+        if(message == outOfSyncFailureMessage || message == incompatibleRecordFailureMessage){
           Completed(
             change.failed(
               syncZoneMessage
-            )
-          )
-        } else if (message == incompatibleRecordFailureMessage) {
-          Completed(
-            change.failed(
-              wrongRecordDataMessage
             )
           )
         } else if (message == "referral") {


### PR DESCRIPTION
Reverts vinyldns/vinyldns#1361

Since we already display a message when record data entered does not exist `ℹ️ Record data entered does not exist. No further action is required.`, I don't think we need this here. As this is not the right place to display this message and should only display message we might get from DNS servers (like zone out of sync, record conflict, etc). 