### PR TITLE
Fix batch delete

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -28,6 +28,7 @@ import vinyldns.api.domain.batch.BatchChangeInterfaces._
 import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain.zone.ZoneRecordValidations.isStringInRegexList
 import vinyldns.api.domain.zone.ZoneRecordValidations
+import vinyldns.core.Messages.{nonExistentRecordDataDeleteMessage, nonExistentRecordDeleteMessage}
 import vinyldns.core.domain.DomainHelpers.omitTrailingDot
 import vinyldns.core.domain.record._
 import vinyldns.core.domain._
@@ -350,9 +351,6 @@ class BatchChangeValidations(
       isApproved: Boolean
   ): SingleValidation[ChangeForValidation] = {
 
-    val nonExistentRecordDeleteMessage = "This record does not exist. No further action is required."
-    val nonExistentRecordDataDeleteMessage = "Record data entered does not exist. No further action is required."
-
     val recordData = change match {
       case AddChangeForValidation(_, _, inputChange, _, _) => inputChange.record.toString
       case DeleteRRSetChangeForValidation(_, _, inputChange) => inputChange.record.map(_.toString).getOrElse("")
@@ -424,9 +422,6 @@ class BatchChangeValidations(
       auth: AuthPrincipal,
       isApproved: Boolean
   ): SingleValidation[ChangeForValidation] = {
-
-    val nonExistentRecordDeleteMessage = "This record does not exist. No further action is required."
-    val nonExistentRecordDataDeleteMessage = "Record data entered does not exist. No further action is required."
 
     // To handle add and delete for the record with same record data is present in the batch
     val recordData = change match {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -251,7 +251,7 @@ object BatchTransformations {
         case (false, true) =>
           if (existingRecords == deleteChangeSet) {
             LogicalChangeType.FullDelete
-          } else if (deleteChangeSet.exists(existingRecords.contains)) {
+          } else if (existingRecords.nonEmpty) {
             LogicalChangeType.Update
           } else {
             LogicalChangeType.OutOfSync

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -26,6 +26,7 @@ import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain.batch.BatchTransformations.LogicalChangeType._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.api.repository._
+import vinyldns.core.Messages.nonExistentRecordDeleteMessage
 import vinyldns.core.TestMembershipData.okUser
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData.{okZone, _}
@@ -37,8 +38,6 @@ import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
 
 class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
-  private val nonExistentRecordDeleteMessage: String = "This record does not exist. " +
-    "No further action is required."
 
   private def makeSingleAddChange(
                                    name: String,

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeConverterSpec.scala
@@ -26,7 +26,7 @@ import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain.batch.BatchTransformations.LogicalChangeType._
 import vinyldns.api.engine.TestMessageQueue
 import vinyldns.api.repository._
-import vinyldns.core.Messages.nonExistentRecordDeleteMessage
+import vinyldns.core.Messages.{nonExistentRecordDataDeleteMessage, nonExistentRecordDeleteMessage}
 import vinyldns.core.TestMembershipData.okUser
 import vinyldns.core.TestRecordSetData._
 import vinyldns.core.TestZoneData.{okZone, _}
@@ -168,6 +168,14 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
 
   private val changeForValidationOneDelete = List(
     makeDeleteRRSetChangeForValidation("DoesNotExistToDelete", A, Some(nonExistentRecordDeleteMessage))
+  )
+
+  private val singleChangesOneDataDelete = List(
+    makeSingleDeleteRRSetChange("DataDoesNotExistToDelete", A, okZone, Some(nonExistentRecordDataDeleteMessage))
+  )
+
+  private val changeForValidationOneDataDelete = List(
+    makeDeleteRRSetChangeForValidation("DataDoesNotExistToDelete", A, Some(nonExistentRecordDataDeleteMessage))
   )
 
   private val singleChangesOneBad = List(
@@ -573,6 +581,41 @@ class BatchChangeConverterSpec extends AnyWordSpec with Matchers {
       receivedChange.recordChangeId shouldBe None
       receivedChange.systemMessage shouldBe Some(nonExistentRecordDeleteMessage)
       returnedBatch.changes(0) shouldBe singleChangesOneDelete(0).copy(systemMessage = Some(nonExistentRecordDeleteMessage), status = SingleChangeStatus.Pending)
+
+      // check the update has been made in the DB
+      val savedBatch: Option[BatchChange] =
+        batchChangeRepo.getBatchChange(batchWithBadChange.id).unsafeRunSync()
+      savedBatch shouldBe Some(returnedBatch)
+    }
+
+    "set status to pending when deleting a record data that does not exist" in {
+      val batchWithBadChange =
+        BatchChange(
+          okUser.id,
+          okUser.userName,
+          None,
+          Instant.now.truncatedTo(ChronoUnit.MILLIS),
+          singleChangesOneDataDelete,
+          approvalStatus = BatchChangeApprovalStatus.AutoApproved
+        )
+      val result =
+        underTest
+          .sendBatchForProcessing(
+            batchWithBadChange,
+            existingZones,
+            ChangeForValidationMap(changeForValidationOneDataDelete.map(_.validNel), existingRecordSets),
+            None
+          )
+          .value.unsafeRunSync().toOption.get
+
+      val returnedBatch = result.batchChange
+
+      // validate completed status returned
+      val receivedChange = returnedBatch.changes(0)
+      receivedChange.status shouldBe SingleChangeStatus.Pending
+      receivedChange.recordChangeId shouldBe None
+      receivedChange.systemMessage shouldBe Some(nonExistentRecordDataDeleteMessage)
+      returnedBatch.changes(0) shouldBe singleChangesOneDataDelete(0).copy(systemMessage = Some(nonExistentRecordDataDeleteMessage), status = SingleChangeStatus.Pending)
 
       // check the update has been made in the DB
       val savedBatch: Option[BatchChange] =

--- a/modules/core/src/main/scala/vinyldns/core/Messages.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Messages.scala
@@ -84,4 +84,8 @@ object Messages {
   val InvalidEmailValidationErrorMsg = "Please enter a valid Email."
 
   val DotsValidationErrorMsg = "Please enter a valid Email. Number of dots allowed after @ is"
+
+  val nonExistentRecordDeleteMessage = "This record does not exist. No further action is required."
+
+  val nonExistentRecordDataDeleteMessage = "Record data entered does not exist. No further action is required."
 }


### PR DESCRIPTION
Changes in this pull request:
- When there is a record that exist in Vinyl and we issue a batch change with Delete for that record with a non-existing record data, it throws `out of sync` error. But it should not throw any error and process with info `Record data does not exist. No action is required`. Fixed that in this PR.