### PR TITLE
Rearranged the DNS change export csv column

### DIFF
--- a/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
@@ -157,7 +157,6 @@
                 csv.push(row.join(","));
               }
               var csvFile = new Blob([csv.join("\n")], { type: "text/csv" });
-
               // link to export csv
               var downloadBatchChanges = document.createElement("a");
               downloadBatchChanges.download = filename;

--- a/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
@@ -143,21 +143,24 @@
               var csv = [];
               var changes = document.querySelectorAll("table tr");
               $log.debug(batchId)
-              for (var i = 0; i < changes.length; i++) {
-                var row = [], cols = changes[i].querySelectorAll("td, th");
+              var colOrder = [0, 4, 1, 6, 5, 2, 3, 7, 8];
 
-                for (var j = 0; j < cols.length; j++) {
-                  row.push('"' + cols[j].innerText + '"');
-                }
+                for (var i = 0; i < changes.length; i++) {
+                    var row = [], cols = changes[i].querySelectorAll("td, th");
+
+                    for (var j = 0; j < colOrder.length; j++) {
+                        var colIndex = colOrder[j];
+                        if (cols[colIndex]) {
+                            row.push('"' + cols[colIndex].innerText + '"');
+                        }
+                    }
                 csv.push(row.join(","));
               }
               var csvFile = new Blob([csv.join("\n")], { type: "text/csv" });
 
-              // Create a link to download it
+              // link to export csv
               var downloadBatchChanges = document.createElement("a");
               downloadBatchChanges.download = filename;
-
-              // Create a URL for the link
               downloadBatchChanges.href = window.URL.createObjectURL(csvFile);
               document.body.appendChild(downloadBatchChanges);
               downloadBatchChanges.click();


### PR DESCRIPTION
Fixes #1406 .

Changes in this pull request:
- Rearranged the DNS change export csv column

Column order:
Change Type, Record Type, Input Name, TTL, Record Data, Recordset Name, Zone Name, Status, Additional Info
