### PR TITLE
Ownership transfer bugfix

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/domain/record/RecordSetServiceIntegrationSpec.scala
@@ -128,7 +128,10 @@ class RecordSetServiceIntegrationSpec
     RecordSetStatus.Active,
     Instant.now.truncatedTo(ChronoUnit.MILLIS),
     None,
-    List(AAAAData("fd69:27cc:fe91::60"))
+    List(AAAAData("fd69:27cc:fe91::60")),
+    recordSetGroupChange =
+      Some(OwnerShipTransfer(ownerShipTransferStatus = OwnerShipTransferStatus.None,
+        requestedOwnerGroupId = None))
   )
   private val subTestRecordA = RecordSet(
     zone.id,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -27,6 +27,7 @@ import vinyldns.core.domain.zone.{Zone, ZoneCommandResult, ZoneRepository}
 import vinyldns.core.queue.MessageQueue
 import cats.data._
 import cats.effect.IO
+import org.slf4j.{Logger, LoggerFactory}
 import org.xbill.DNS.ReverseMap
 import vinyldns.api.config.{ZoneAuthConfigs, DottedHostsConfig, HighValueDomainConfig}
 import vinyldns.api.domain.DomainValidations.{validateIpv4Address, validateIpv6Address}
@@ -94,6 +95,8 @@ class RecordSetService(
   import RecordSetValidations._
   import accessValidation._
 
+  val logger: Logger = LoggerFactory.getLogger(classOf[RecordSetService])
+
   val approverOwnerShipTransferStatus = List(OwnerShipTransferStatus.ManuallyApproved , OwnerShipTransferStatus.AutoApproved, OwnerShipTransferStatus.ManuallyRejected)
   val requestorOwnerShipTransferStatus = List(OwnerShipTransferStatus.Cancelled , OwnerShipTransferStatus.Requested, OwnerShipTransferStatus.PendingReview)
 
@@ -155,8 +158,12 @@ class RecordSetService(
         && !auth.isSuper && !auth.isGroupMember(existing.ownerGroupId.getOrElse("None")))
         unchangedRecordSet(existing, recordSet).toResult else ().toResult
       _ <- if(existing.recordSetGroupChange.map(_.ownerShipTransferStatus).getOrElse("<none>") == OwnerShipTransferStatus.Cancelled
-        && !auth.isSuper)
-        recordSetOwnerShipApproveStatus(recordSet).toResult else ().toResult
+        && !auth.isSuper) {
+        recordSetOwnerShipApproveStatus(recordSet).toResult
+      } else ().toResult
+      _ = logger.debug(s"updated recordsetgroupchange: ${recordSet.recordSetGroupChange}")
+      _ = logger.debug(s"existing recordsetgroupchange: ${existing.recordSetGroupChange}")
+//      recordSet <- if(zone.shared) updateRecordSetGroupChangeStatus(recordSet, existing, zone)
       recordSet <- updateRecordSetGroupChangeStatus(recordSet, existing, zone)
       change <- RecordSetChangeGenerator.forUpdate(existing, recordSet, zone, Some(auth)).toResult
       // because changes happen to the RS in forUpdate itself, converting 1st and validating on that

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -161,9 +161,8 @@ class RecordSetService(
         && !auth.isSuper) {
         recordSetOwnerShipApproveStatus(recordSet).toResult
       } else ().toResult
-      _ = logger.debug(s"updated recordsetgroupchange: ${recordSet.recordSetGroupChange}")
-      _ = logger.debug(s"existing recordsetgroupchange: ${existing.recordSetGroupChange}")
-//      recordSet <- if(zone.shared) updateRecordSetGroupChangeStatus(recordSet, existing, zone)
+      _ = logger.info(s"updated recordsetgroupchange: ${recordSet.recordSetGroupChange}")
+      _ = logger.info(s"existing recordsetgroupchange: ${existing.recordSetGroupChange}")
       recordSet <- updateRecordSetGroupChangeStatus(recordSet, existing, zone)
       change <- RecordSetChangeGenerator.forUpdate(existing, recordSet, zone, Some(auth)).toResult
       // because changes happen to the RS in forUpdate itself, converting 1st and validating on that

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -495,7 +495,7 @@ object RecordSetValidations {
                                          existing: RecordSet
                                        ): Either[Throwable, Unit] =
     Either.cond(
-      updates.recordSetGroupChange == existing.recordSetGroupChange,
+      updates.recordSetGroupChange == existing.recordSetGroupChange || existing.recordSetGroupChange.isEmpty,
       (),
       InvalidRequest("Cannot update RecordSet OwnerShip Status when zone is not shared.")
     )

--- a/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
@@ -303,7 +303,7 @@ def test_update_recordset_replace_2_records_with_1_different_record(shared_zone_
             ]
         }
         result = client.create_recordset(new_rs, status=202)
-        
+
         assert_that(result["changeType"], is_("Create"))
         assert_that(result["status"], is_("Pending"))
         assert_that(result["created"], is_not(none()))
@@ -373,7 +373,7 @@ def test_update_existing_record_set_add_record(shared_zone_test_context):
             ]
         }
         result = client.create_recordset(new_rs, status=202)
-        
+
         assert_that(result["changeType"], is_("Create"))
         assert_that(result["status"], is_("Pending"))
         assert_that(result["created"], is_not(none()))
@@ -2432,9 +2432,17 @@ def test_update_owner_group_transfer_on_non_shared_zones_in_fails(shared_zone_te
     update_rs = None
 
     try:
-        record_json = create_recordset(ok_zone, "test_update_success", "A", [{"address": "1.1.1.1"}])
-        record_json["recordSetGroupChange"] = {"ownerShipTransferStatus": None,
-                                               "requestedOwnerGroupId": None}
+        record_json = {
+            "zoneId": ok_zone,
+            "name": "test_update_success",
+            "type": "A",
+            "ttl": 38400,
+            "records": [
+                {"address": "1.1.1.1"}
+            ],
+            "recordSetGroupChange": {"ownerShipTransferStatus": None,
+                                     "requestedOwnerGroupId": None}
+        }
 
         create_response = ok_client.create_recordset(record_json, status=202)
         update = ok_client.wait_until_recordset_change_status(create_response, "Complete")["recordSet"]

--- a/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
@@ -2433,6 +2433,8 @@ def test_update_owner_group_transfer_on_non_shared_zones_in_fails(shared_zone_te
 
     try:
         record_json = create_recordset(ok_zone, "test_update_success", "A", [{"address": "1.1.1.1"}])
+        record_json["recordSetGroupChange"] = {"ownerShipTransferStatus": None,
+                                               "requestedOwnerGroupId": None}
 
         create_response = ok_client.create_recordset(record_json, status=202)
         update = ok_client.wait_until_recordset_change_status(create_response, "Complete")["recordSet"]

--- a/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
@@ -2432,8 +2432,9 @@ def test_update_owner_group_transfer_on_non_shared_zones_in_fails(shared_zone_te
     update_rs = None
 
     try:
+        # record_json = create_recordset(ok_zone, "test_update_success", "A", [{"address": "1.1.1.1"}], recordSetGroupChange={"ownerShipTransferStatus": None, "requestedOwnerGroupId": None})
         record_json = {
-            "zoneId": ok_zone,
+            "zoneId": ok_zone["id"],
             "name": "test_update_success",
             "type": "A",
             "ttl": 38400,

--- a/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/update_recordset_test.py
@@ -2441,7 +2441,7 @@ def test_update_owner_group_transfer_on_non_shared_zones_in_fails(shared_zone_te
             "records": [
                 {"address": "1.1.1.1"}
             ],
-            "recordSetGroupChange": {"ownerShipTransferStatus": None,
+            "recordSetGroupChange": {"ownerShipTransferStatus": "None",
                                      "requestedOwnerGroupId": None}
         }
 


### PR DESCRIPTION
Bug: as of version 0.21.1, when a user tries to update a record in a private zone from the zone view, it fails with a `422: Cannot update RecordSet OwnerShip Status when zone is not shared.` error.

This can be worked around by updating the record via batch change. Also, once that particular record has been updated via batch change, it can be updated in the zone view as well from then on.

It seems like the issue is that in a private zone, the existing record's recordSetGroupChange is simply set to `None`, whereas the updated record's is set to `Some(OwnerShipTransfer: [ownerShipTransferStatus=\"None\"; requestedOwnerGroupId=\"None\"])`.  This causes the unchangedRecordSetOwnershipStatus check to fail. I have updated the check to pass when the existing record's recordSetGroupChange is set to `None`, since that seems to apply only in this case. 

Once the record is successfully updated, then on future updates both the existing and updated records recordSetGroupChange value will be set to `Some(OwnerShipTransfer: [ownerShipTransferStatus=\"None\"; requestedOwnerGroupId=\"None\"])`, so the `updates.recordSetGroupChange == existing.recordSetGroupChange` check will pass as expected.