### PR TITLE
Updated validation for ownership transfer status in api

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -147,7 +147,7 @@ class RecordSetService(
       _ <- messageQueue.send(change).toResult[Unit]
     } yield change
 
-  def updateRecordSet(recordSet: RecordSet, auth: AuthPrincipal): Result[ZoneCommandResult] = {
+  def updateRecordSet(recordSet: RecordSet, auth: AuthPrincipal): Result[ZoneCommandResult] =
     for {
       zone <- getZone(recordSet.zoneId)
       existing <- getRecordSet(recordSet.id)
@@ -224,7 +224,6 @@ class RecordSetService(
         notifiers.notify(Notification(change)).toResult
       else ().toResult
     } yield change
-  }
 
   def deleteRecordSet(
                        recordSetId: String,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -400,11 +400,26 @@ object RecordSetValidations {
     (ownerGroupId, group) match {
       case (None, _) => ().asRight
       case (Some(groupId), None) =>
-        InvalidGroupError(s"""Record owner group with id "$groupId" not found""").asLeft
+          InvalidGroupError(s"""Record owner group with id "$groupId" not found""").asLeft
       case (Some(groupId), Some(_)) =>
         if (authPrincipal.isSuper || authPrincipal.isGroupMember(groupId)) ().asRight
         else InvalidRequest(s"""User not in record owner group with id "$groupId"""").asLeft
     }
+
+  def isAlreadyOwnerGroupMember(
+                                 ownerGroupId: String
+                      ): Either[Throwable, Unit] =
+    InvalidRequest(s"""Record owner group with id "$ownerGroupId" already owns the record, new request is not needed"""").asLeft
+
+  def inValidOwnerShipTransferStatus(
+                                      ownerShipTransferStatus: Option[String],
+                               ): Either[Throwable, Unit] =
+  Either.cond(
+    ownerShipTransferStatus.get == OwnerShipTransferStatus.PendingReview,
+    (),
+    InvalidRequest(s"Invalid Ownership transfer status:git ${ownerShipTransferStatus.get}")
+  )
+
 
   def unchangedRecordName(
       existing: RecordSet,

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSet.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSet.scala
@@ -38,8 +38,8 @@ object OwnerShipTransferStatus extends Enumeration {
   type OwnerShipTransferStatus = Value
   val AutoApproved, Cancelled, ManuallyApproved, ManuallyRejected, Requested, PendingReview, None = Value
 
-  def isStatus(value: String): Boolean =
-    OwnerShipTransferStatus.values.find(v => v.toString == value).isDefined
+  def isStatus(status: String): Boolean =
+    OwnerShipTransferStatus.values.find(value => value.toString == status).isDefined
 }
 
 import RecordSetStatus._

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSet.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSet.scala
@@ -19,7 +19,6 @@ package vinyldns.core.domain.record
 import vinyldns.core.domain.record.OwnerShipTransferStatus.OwnerShipTransferStatus
 
 import java.util.UUID
-
 import java.time.Instant
 
 object RecordType extends Enumeration {
@@ -37,7 +36,10 @@ object RecordSetStatus extends Enumeration {
 
 object OwnerShipTransferStatus extends Enumeration {
   type OwnerShipTransferStatus = Value
-  val AutoApproved, Cancelled, ManuallyApproved, ManuallyRejected, Requested, PendingReview, None  = Value
+  val AutoApproved, Cancelled, ManuallyApproved, ManuallyRejected, Requested, PendingReview, None = Value
+
+  def isStatus(value: String): Boolean =
+    OwnerShipTransferStatus.values.find(v => v.toString == value).isDefined
 }
 
 import RecordSetStatus._
@@ -89,7 +91,6 @@ case class OwnerShipTransfer(
                               ownerShipTransferStatus: OwnerShipTransferStatus,
                               requestedOwnerGroupId: Option[String] = None
                             ){
-
   override def toString: String = {
     val sb = new StringBuilder
     sb.append("OwnerShipTransfer: [")


### PR DESCRIPTION
Fixes #.

Changes in this pull request:
Changes in API
- User cannot able to submit "pending review" in Ownership transfer status
- If requested owner group already a member of ownergroup, cannot submit the request again.
- User cannot able to submit "invalid status" in Ownership transfer status
