### PR TITLE
Users to update record owner group in a recordset.

### DIFF
--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -339,11 +339,8 @@ angular.module('controller.records', [])
     $scope.submitUpdateRecord = function () {
         var record = angular.copy($scope.currentRecord);
         if(record.recordSetGroupChange.requestedOwnerGroupId != undefined){
-             if (record.ownerGroupId != $scope.recordModal.previous.ownerGroupId && $scope.isZoneAdmin){
-                    record.recordSetGroupChange.requestedOwnerGroupId = angular.copy(record.ownerGroupId);
-                    record.recordSetGroupChange.ownerShipTransferStatus = angular.copy("ManuallyApproved");
-             }
-        } else {record.recordSetGroupChange.requestedOwnerGroupId = angular.copy(record.ownerGroupId);}
+            record.recordSetGroupChange.requestedOwnerGroupId = angular.copy(record.ownerGroupId);
+        }
         record['onlyFour'] = true;
         if ($scope.addRecordForm.$valid) {
             updateRecordSet(record);


### PR DESCRIPTION
Fixes #1460.

Changes in this pull request:
- Normal users can now assign an owner group when creating or updating unowned records.
- Superusers can now assign or update the owner group of any record within a recordset.
