### PR TITLE
Fix for validating recordSetId in Get RecordSet Change API

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -689,14 +689,14 @@ class RecordSetService(
                             maxItems: Int = 100,
                             authPrincipal: AuthPrincipal
                           ): Result[ListRecordSetChangesResponse] =
-      for {
-        zone <- getZone(zoneId)
-        _ <- canSeeZone(authPrincipal, zone).toResult
-        recordSetChangesResults <- recordChangeRepository
-          .listRecordSetChanges(Some(zone.id), startFrom, maxItems, None, None)
-          .toResult[ListRecordSetChangesResults]
-        recordSetChangesInfo <- buildRecordSetChangeInfo(recordSetChangesResults.items)
-      } yield ListRecordSetChangesResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
+    for {
+      zone <- getZone(zoneId)
+      _ <- canSeeZone(authPrincipal, zone).toResult
+      recordSetChangesResults <- recordChangeRepository
+        .listRecordSetChanges(Some(zone.id), startFrom, maxItems, None, None)
+        .toResult[ListRecordSetChangesResults]
+      recordSetChangesInfo <- buildRecordSetChangeInfo(recordSetChangesResults.items)
+    } yield ListRecordSetChangesResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
 
   def listRecordSetChangeHistory(
                             zoneId: Option[String] = None,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -653,11 +653,13 @@ class RecordSetService(
 
   def getRecordSetChange(
                           zoneId: String,
+                          rsId: String,
                           changeId: String,
                           authPrincipal: AuthPrincipal
                         ): Result[RecordSetChange] =
     for {
       zone <- getZone(zoneId)
+      _ <-getRecordSet(rsId)
       change <- recordChangeRepository
         .getRecordSetChange(zone.id, changeId)
         .orFail(

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -666,8 +666,7 @@ class RecordSetService(
           RecordSetChangeNotFoundError(
             s"Unable to find record set change with id $changeId in zone ${zone.name}"
           )
-        )
-        .toResult[RecordSetChange]
+        ).toResult[RecordSetChange]
       _ <- canViewRecordSet(
         authPrincipal,
         change.recordSet.name,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -659,7 +659,7 @@ class RecordSetService(
                         ): Result[RecordSetChange] =
     for {
       zone <- getZone(zoneId)
-      _ <-getRecordSet(rsId)
+      _ <- getRecordSet(rsId)
       change <- recordChangeRepository
         .getRecordSetChange(zone.id, changeId)
         .orFail(
@@ -667,6 +667,13 @@ class RecordSetService(
             s"Unable to find record set change with id $changeId in zone ${zone.name}"
           )
         ).toResult[RecordSetChange]
+      _ <- if (change.recordSet.id == rsId) {
+        ().toResult
+      } else {
+        Left(RecordSetNotFoundError(
+          s"RecordSet with id $rsId does not exist."
+        )).toResult
+      }
       _ <- canViewRecordSet(
         authPrincipal,
         change.recordSet.name,

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -659,6 +659,7 @@ class RecordSetService(
                         ): Result[RecordSetChange] =
     for {
       zone <- getZone(zoneId)
+      _ <- getRecordSet(rsId)
       change <- recordChangeRepository
         .getRecordSetChange(zone.id, changeId)
         .orFail(

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -659,7 +659,6 @@ class RecordSetService(
                         ): Result[RecordSetChange] =
     for {
       zone <- getZone(zoneId)
-      _ <- getRecordSet(rsId)
       change <- recordChangeRepository
         .getRecordSetChange(zone.id, changeId)
         .orFail(

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetServiceAlgebra.scala
@@ -96,6 +96,7 @@ trait RecordSetServiceAlgebra {
 
   def getRecordSetChange(
                           zoneId: String,
+                          rsId: String,
                           changeId: String,
                           authPrincipal: AuthPrincipal
                         ): Result[RecordSetChange]

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -220,9 +220,9 @@ class RecordSetRoute(
         }
     } ~
     path("zones" / Segment / "recordsets" / Segment / "changes" / Segment) {
-      (zoneId, _, changeId) =>
+      (zoneId, rsId, changeId) =>
         (get & monitor("Endpoint.getRecordSetChange")) {
-          authenticateAndExecute(recordSetService.getRecordSetChange(zoneId, changeId, _)) {
+          authenticateAndExecute(recordSetService.getRecordSetChange(zoneId, rsId, changeId, _)) {
             change =>
               complete(StatusCodes.OK, change)
           }

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2112,33 +2112,63 @@ class RecordSetServiceSpec
 
   "getRecordSetChange" should {
     "return the record set change if it is found" in {
+      doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
+      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
-        .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
+        .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
 
       val actual: RecordSetChange =
-        underTest.getRecordSetChange(okZone.id, aaaa.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().toOption.get
+        underTest.getRecordSetChange(zoneActive.id, pendingCreateAAAA.recordSet.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().toOption.get
       actual shouldBe pendingCreateAAAA
     }
 
     "return the record set change if the user is in the record owner group in a shared zone" in {
+      doReturn(IO.pure(Some(pendingCreateSharedRecord.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateSharedRecord.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecord)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id)
 
       val actual: RecordSetChange =
-          underTest.getRecordSetChange(sharedZone.id, aaaa.id, pendingCreateSharedRecord.id, okAuth).value.unsafeRunSync().toOption.get
+          underTest.getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.recordSet.id, pendingCreateSharedRecord.id, okAuth).value.unsafeRunSync().toOption.get
 
       actual shouldBe pendingCreateSharedRecord
     }
 
     "return a RecordSetChangeNotFoundError if it is not found" in {
+      doReturn(IO.pure(Some(aaaa)))
+        .when(mockRecordRepo)
+        .getRecordSet(aaaa.id)
       doReturn(IO.pure(None))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
       val error =
         underTest.getRecordSetChange(okZone.id, aaaa.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[RecordSetChangeNotFoundError]
+    }
+
+    "return a RecordSetNotFoundError if the change belongs to a different record set" in {
+      val differentRsId = "different-rs-id"
+      doReturn(IO.pure(Some(aaaa.copy(id = differentRsId))))
+        .when(mockRecordRepo)
+        .getRecordSet(differentRsId)
+      doReturn(IO.pure(Some(pendingCreateAAAA)))
+        .when(mockRecordChangeRepo)
+        .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
+      
+      val error = underTest
+        .getRecordSetChange(okZone.id, differentRsId, pendingCreateAAAA.id, okAuth)
+        .value
+        .unsafeRunSync()
+        .swap
+        .toOption
+        .get
+      
+      error shouldBe a[RecordSetNotFoundError]
     }
 
     "return a RecordSets Count" in {
@@ -2169,18 +2199,24 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
+      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
 
       val error =
-        underTest.getRecordSetChange(zoneActive.id, aaaa.id, pendingCreateAAAA.id, dummyAuth).value.unsafeRunSync().swap.toOption.get
+        underTest.getRecordSetChange(zoneActive.id, pendingCreateAAAA.recordSet.id, pendingCreateAAAA.id, dummyAuth).value.unsafeRunSync().swap.toOption.get
 
       error shouldBe a[NotAuthorizedError]
     }
 
     "return a NotAuthorizedError if the user is in the record owner group but the zone is not shared" in {
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(zoneNotAuthorized.id)
+      doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateSharedRecordNotSharedZone.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneNotAuthorized.id, pendingCreateSharedRecordNotSharedZone.id)
@@ -2189,7 +2225,7 @@ class RecordSetServiceSpec
         underTest
           .getRecordSetChange(
             zoneNotAuthorized.id,
-            notSharedZoneRecordWithOwnerGroup.id,
+            pendingCreateSharedRecordNotSharedZone.recordSet.id,
             pendingCreateSharedRecordNotSharedZone.id,
             okAuth
           )

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2117,7 +2117,7 @@ class RecordSetServiceSpec
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
 
       val actual: RecordSetChange =
-        underTest.getRecordSetChange(okZone.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().toOption.get
+        underTest.getRecordSetChange(okZone.id, aaaa.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().toOption.get
       actual shouldBe pendingCreateAAAA
     }
 
@@ -2127,7 +2127,7 @@ class RecordSetServiceSpec
         .getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id)
 
       val actual: RecordSetChange =
-          underTest.getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id, okAuth).value.unsafeRunSync().toOption.get
+          underTest.getRecordSetChange(sharedZone.id, aaaa.id, pendingCreateSharedRecord.id, okAuth).value.unsafeRunSync().toOption.get
 
       actual shouldBe pendingCreateSharedRecord
     }
@@ -2137,7 +2137,7 @@ class RecordSetServiceSpec
         .when(mockRecordChangeRepo)
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
       val error =
-        underTest.getRecordSetChange(okZone.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().swap.toOption.get
+        underTest.getRecordSetChange(okZone.id, aaaa.id, pendingCreateAAAA.id, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe a[RecordSetChangeNotFoundError]
     }
 
@@ -2174,7 +2174,7 @@ class RecordSetServiceSpec
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
 
       val error =
-        underTest.getRecordSetChange(zoneActive.id, pendingCreateAAAA.id, dummyAuth).value.unsafeRunSync().swap.toOption.get
+        underTest.getRecordSetChange(zoneActive.id, aaaa.id, pendingCreateAAAA.id, dummyAuth).value.unsafeRunSync().swap.toOption.get
 
       error shouldBe a[NotAuthorizedError]
     }
@@ -2189,6 +2189,7 @@ class RecordSetServiceSpec
         underTest
           .getRecordSetChange(
             zoneNotAuthorized.id,
+            notSharedZoneRecordWithOwnerGroup.id,
             pendingCreateSharedRecordNotSharedZone.id,
             okAuth
           )

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2113,9 +2113,6 @@ class RecordSetServiceSpec
   "getRecordSetChange" should {
     "return the record set change if it is found" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
-      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
@@ -2126,9 +2123,6 @@ class RecordSetServiceSpec
     }
 
     "return the record set change if the user is in the record owner group in a shared zone" in {
-      doReturn(IO.pure(Some(sharedZoneRecord.copy(status = RecordSetStatus.Active))))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateSharedRecord.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecord)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id)
@@ -2150,9 +2144,6 @@ class RecordSetServiceSpec
 
     "return a RecordSetNotFoundError if the change belongs to a different record set" in {
       val differentRsId = "different-rs-id"
-      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet.copy(id = differentRsId))))
-        .when(mockRecordRepo)
-        .getRecordSet(differentRsId)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
@@ -2195,9 +2186,6 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
-      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
@@ -2210,9 +2198,6 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is in the record owner group but the zone is not shared" in {
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(zoneNotAuthorized.id)
-      doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateSharedRecordNotSharedZone.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneNotAuthorized.id, pendingCreateSharedRecordNotSharedZone.id)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2170,7 +2170,6 @@ class RecordSetServiceSpec
 
       val result = underTest.getRecordSetCount(okZone.id,authPrincipal = okAuth).value.unsafeRunSync().toOption.get
       result shouldBe RecordSetCount(10)
-
     }
 
     "return a NotAuthorizedError for getRecordSetCount if the user is not authorized to access the zone" in {

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2113,6 +2113,9 @@ class RecordSetServiceSpec
   "getRecordSetChange" should {
     "return the record set change if it is found" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
+      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
@@ -2123,6 +2126,9 @@ class RecordSetServiceSpec
     }
 
     "return the record set change if the user is in the record owner group in a shared zone" in {
+      doReturn(IO.pure(Some(sharedZoneRecord.copy(status = RecordSetStatus.Active))))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateSharedRecord.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecord)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id)
@@ -2144,6 +2150,9 @@ class RecordSetServiceSpec
 
     "return a RecordSetNotFoundError if the change belongs to a different record set" in {
       val differentRsId = "different-rs-id"
+      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet.copy(id = differentRsId))))
+        .when(mockRecordRepo)
+        .getRecordSet(differentRsId)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
@@ -2186,6 +2195,9 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
+      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
@@ -2198,6 +2210,9 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is in the record owner group but the zone is not shared" in {
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(zoneNotAuthorized.id)
+      doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone.recordSet)))
+        .when(mockRecordRepo)
+        .getRecordSet(pendingCreateSharedRecordNotSharedZone.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneNotAuthorized.id, pendingCreateSharedRecordNotSharedZone.id)

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2167,7 +2167,6 @@ class RecordSetServiceSpec
         .swap
         .toOption
         .get
-      
       error shouldBe a[RecordSetNotFoundError]
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2113,9 +2113,6 @@ class RecordSetServiceSpec
   "getRecordSetChange" should {
     "return the record set change if it is found" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
-      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
@@ -2126,9 +2123,6 @@ class RecordSetServiceSpec
     }
 
     "return the record set change if the user is in the record owner group in a shared zone" in {
-      doReturn(IO.pure(Some(pendingCreateSharedRecord.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateSharedRecord.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecord)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(sharedZone.id, pendingCreateSharedRecord.id)
@@ -2140,9 +2134,6 @@ class RecordSetServiceSpec
     }
 
     "return a RecordSetChangeNotFoundError if it is not found" in {
-      doReturn(IO.pure(Some(aaaa)))
-        .when(mockRecordRepo)
-        .getRecordSet(aaaa.id)
       doReturn(IO.pure(None))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
@@ -2153,9 +2144,6 @@ class RecordSetServiceSpec
 
     "return a RecordSetNotFoundError if the change belongs to a different record set" in {
       val differentRsId = "different-rs-id"
-      doReturn(IO.pure(Some(aaaa.copy(id = differentRsId))))
-        .when(mockRecordRepo)
-        .getRecordSet(differentRsId)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(okZone.id, pendingCreateAAAA.id)
@@ -2198,9 +2186,6 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is not authorized to access the zone" in {
       doReturn(IO.pure(Some(zoneActive))).when(mockZoneRepo).getZone(zoneActive.id)
-      doReturn(IO.pure(Some(pendingCreateAAAA.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateAAAA.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateAAAA)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneActive.id, pendingCreateAAAA.id)
@@ -2213,9 +2198,6 @@ class RecordSetServiceSpec
 
     "return a NotAuthorizedError if the user is in the record owner group but the zone is not shared" in {
       doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZone(zoneNotAuthorized.id)
-      doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone.recordSet)))
-        .when(mockRecordRepo)
-        .getRecordSet(pendingCreateSharedRecordNotSharedZone.recordSet.id)
       doReturn(IO.pure(Some(pendingCreateSharedRecordNotSharedZone)))
         .when(mockRecordChangeRepo)
         .getRecordSetChange(zoneNotAuthorized.id, pendingCreateSharedRecordNotSharedZone.id)

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -735,12 +735,14 @@ class RecordSetRoutingSpec
 
     def getRecordSetChange(
                             zoneId: String,
+                            rsId: String,
                             changeId: String,
                             authPrincipal: AuthPrincipal
                           ): Result[RecordSetChange] = {
       changeId match {
         case "changeNotFound" => Left(RecordSetChangeNotFoundError(""))
         case "zoneNotFound" => Left(ZoneNotFoundError(""))
+        case "recordSetNotFound" => Left(RecordSetNotFoundError(""))
         case "forbidden" => Left(NotAuthorizedError(""))
         case _ => Right(rsChange1)
       }

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -790,7 +790,6 @@ class RecordSetRoutingSpec
         case _ => Right(listRecordSetChangeHistoryResponse)
       }
     }.toResult
-
   }
 
   val recordSetService: RecordSetServiceAlgebra = new TestService

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -742,9 +742,13 @@ class RecordSetRoutingSpec
       changeId match {
         case "changeNotFound" => Left(RecordSetChangeNotFoundError(""))
         case "zoneNotFound" => Left(ZoneNotFoundError(""))
-        case "recordSetNotFound" => Left(RecordSetNotFoundError(""))
         case "forbidden" => Left(NotAuthorizedError(""))
-        case _ => Right(rsChange1)
+        case _ =>
+          if (rsId == "test") {
+            Right(rsChange1)
+          } else {
+            Left(RecordSetNotFoundError(s"RecordSet with id $rsId does not exist."))
+          }
       }
     }.toResult
 
@@ -878,6 +882,12 @@ class RecordSetRoutingSpec
 
     "return a 404 Not Found when the change doesn't exist" in {
       Get(s"/zones/${okZone.id}/recordsets/test/changes/changeNotFound") ~> recordSetRoute ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    "return a 404 Not Found when the change exists for a different record set" in {
+      Get(s"/zones/${okZone.id}/recordsets/differentRecordSetId/changes/good") ~> recordSetRoute ~> check {
         status shouldBe StatusCodes.NotFound
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -790,7 +790,8 @@ class RecordSetRoutingSpec
         case _ => Right(listRecordSetChangeHistoryResponse)
       }
     }.toResult
-  }
+
+}
 
   val recordSetService: RecordSetServiceAlgebra = new TestService
 


### PR DESCRIPTION
VDNS-248
Fixes #1475.
Changes in this pull request:
- This PR fixes an inconsistency in the Get RecordSet Change API:
GET /zones/{zoneId}/recordsets/{recordSetId}/changes/{recordChangeId}
- Verifies the record set exists, returning appropriate errors when it doesn't.
