### PR TITLE
Added Export to CSV Option for RecordSet Search Results

### DIFF
--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -108,6 +108,17 @@
                             </div>
                         </div>
                     </div>
+                    <div class="dropdown export-dropdown" ng-show="isRecordSearchTriggered" ng-click="$event.stopPropagation()">
+                        <button class="btn btn-primary dropdown-toggle" ng-click="toggleExportOptions($event)">
+                            Export CSV ▾
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-export" ng-if="showExportOptions" ng-click="$event.stopPropagation()">
+                            <label ng-repeat="(key, label) in HEADER_MAP">
+                            <input type="checkbox" ng-model="selectedFields[key]"> {{label}}
+                            </label>
+                            <button class="btn btn-success btn-sm" ng-click="exportWithSelection()">Download</button>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -73,7 +73,7 @@
         <!-- START RECORD TABLE -->
         <div class="panel panel-default">
             <div class="panel-heading">
-                <div class="row">
+                <div class="row" style="display: flex;">
                     <div class="col-md-10">
                         <span class="panel-title bolder-font-weight">Records</span>
                     </div>

--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -2,8 +2,9 @@
 
 @content = {
     <!-- PAGE CONTENT -->
+    
     <div class="right_col" role="main">
-
+        
         <!-- START BREADCRUMB -->
         <ul class="breadcrumb">
             <li><a href="/">Home</a></li>
@@ -73,7 +74,7 @@
         <!-- START RECORD TABLE -->
         <div class="panel panel-default">
             <div class="panel-heading">
-                <div class="row" style="display: flex;">
+                <div class="row">
                     <div class="col-md-10">
                         <span class="panel-title bolder-font-weight">Records</span>
                     </div>
@@ -107,16 +108,28 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="dropdown export-dropdown" ng-show="isRecordSearchTriggered" ng-click="$event.stopPropagation()">
-                        <button class="btn btn-primary dropdown-toggle" ng-click="toggleExportOptions($event)">
-                            Export CSV ▾
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-export" ng-if="showExportOptions" ng-click="$event.stopPropagation()">
-                            <label ng-repeat="(key, label) in HEADER_MAP">
-                            <input type="checkbox" ng-model="selectedFields[key]"> {{label}}
-                            </label>
-                            <button class="btn btn-success btn-sm" ng-click="exportWithSelection()">Download</button>
+                        <div class="dropdown export-dropdown" ng-show="isRecordSearchTriggered && records && records.length > 0">
+                            <a class="btn btn-primary dropdown-toggle" id="exportDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Export CSV <span class="caret"></span>
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="exportDropdown" style="padding: 0 4.5px;">
+                                <div class="dropdown-item"> 
+                                    <input type="checkbox" ng-model="exportOptions.selectAll" ng-change="toggleAllFields()">
+                                    <strong>Select All</strong>
+                                </div>
+                                <div class="dropdown-divider"></div>
+                                <div class="dropdown-item" ng-repeat="(key, label) in HEADER_MAP">
+                                    <input type="checkbox" ng-model="selectedFields[key]" ng-change="updateSelectAllState()">
+                                       {{label}}
+                                </div>
+                                <div class="dropdown-divider"></div>
+                                <div class="dropdown-item">
+                                    <button class="btn btn-success btn-sm btn-block"
+                                            ng-click="exportToCSV()">
+                                        Download
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -147,6 +160,9 @@
                     <!-- MODAL BEGIN -->
                     <div class="modal fade" id="loader" tabindex="-1" role="dialog">
                         <div class="spinner" ></div>
+                    </div>
+                    <div class="modal fade" id="csvLoaderModal" tabindex="-1" role="dialog">
+                        <div class="spinner"></div>
                     </div>
 
                     <div class="modal fade" id="ShowNoRec" tabindex="-1" role="dialog">

--- a/modules/portal/app/views/recordsets/recordSets.scala.html
+++ b/modules/portal/app/views/recordsets/recordSets.scala.html
@@ -413,7 +413,6 @@
                         </tbody>
                     </table>
 
-
                     <!-- PAGINATION -->
                     <div class="dataTables_paginate vinyldns_paginate">
                         <span class="vinyldns_page_number">{{ getRecordPageTitle() }}</span>

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -138,6 +138,22 @@ a.action-link {
     margin-left: 10px;
 }
 
+.export-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-menu-export{
+    display:block;
+    padding:5px;
+    min-width: auto;
+}
+
+.export-dropdown label {
+    display: block;
+    margin-bottom: 5px;
+}
+
 .form-control.zone-edit {
     background: #F9F9F9;
     color:#555;

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -143,17 +143,6 @@ a.action-link {
     display: inline-block;
 }
 
-.dropdown-menu-export{
-    display:block;
-    padding:5px;
-    min-width: auto;
-}
-
-.export-dropdown label {
-    display: block;
-    margin-bottom: 5px;
-}
-
 .form-control.zone-edit {
     background: #F9F9F9;
     color:#555;

--- a/modules/portal/public/lib/controllers/controller.recordsets.spec.js
+++ b/modules/portal/public/lib/controllers/controller.recordsets.spec.js
@@ -24,16 +24,24 @@ describe('Controller: RecordSetsController', function () {
         module('recordset')
     });
 
-    beforeEach(inject(function ($rootScope, $controller, $q, recordsService, groupsService) {
+    beforeEach(inject(function ($rootScope, $controller, $q, $timeout, recordsService, groupsService) {
         this.rootScope = $rootScope;
         this.controllerFactory = $controller;
+        this.recordsService = recordsService;
+        this.groupsService = groupsService;
+        this.q = $q;
+        this.timeout = $timeout;
 
         recordsService.listRecordSetData = function() {
             return $q.when({data: {recordSets: []}});
         };
 
-        groupsService.getGroupsAbridged = function() {
+        groupsService.getGroups = function() {
             return $q.when({data: {groups: []}});
+        };
+
+        groupsService.getGroupsStored = function() {
+            return $q.when({groups: []});
         };
     }));
 
@@ -55,6 +63,62 @@ describe('Controller: RecordSetsController', function () {
         expect(rendered.find('div').text()).toBe('<img src=x onerror=alert(1)>Team');
         expect(rendered.find('b').text()).toBe('Team');
 
+        document.body.innerHTML = '';
+    });
+
+    it('getRecordData returns SPF record data from text field', function () {
+        document.body.innerHTML = '<input id="record-search-text" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('RecordSetsController', {'$scope': scope});
+
+        var spfText = 'v=spf1 include:mail.example.com ~all';
+        var result = scope.getRecordData([{ text: spfText }], 'SPF');
+
+        expect(result).toBe(spfText);
+        document.body.innerHTML = '';
+    });
+
+    it('shouldLoadPrivateZoneOwners returns false when ownerGroupName field is deselected', function () {
+        document.body.innerHTML = '<input id="record-search-text" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('RecordSetsController', {'$scope': scope});
+
+        scope.selectedFields.ownerGroupName = false;
+
+        expect(scope.shouldLoadPrivateZoneOwners()).toBe(false);
+        document.body.innerHTML = '';
+    });
+
+    it('shouldLoadPrivateZoneOwners returns true when ownerGroupName field is selected', function () {
+        document.body.innerHTML = '<input id="record-search-text" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('RecordSetsController', {'$scope': scope});
+
+        scope.selectedFields.ownerGroupName = true;
+
+        expect(scope.shouldLoadPrivateZoneOwners()).toBe(true);
+        document.body.innerHTML = '';
+    });
+
+    it('getPrivateZoneIdsToLoad returns only unique unresolved private zone ids', function () {
+        document.body.innerHTML = '<input id="record-search-text" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('RecordSetsController', {'$scope': scope});
+
+        var zoneIds = scope.getPrivateZoneIdsToLoad([
+            { zoneShared: false, zoneId: 'zone-a' },
+            { zoneShared: false, zoneId: 'zone-a' },
+            { zoneShared: true, zoneId: 'zone-shared' },
+            { zoneShared: false, zoneId: 'unknown' },
+            { zoneShared: false, zoneId: 'zone-owned', ownerGroupName: 'group-x' },
+            { zoneShared: false, zoneId: 'zone-b' }
+        ]);
+
+        expect(zoneIds).toEqual(['zone-a', 'zone-b']);
         document.body.innerHTML = '';
     });
 });

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -60,6 +60,20 @@
                 CONFIRM_DELETE: 4,
                 VIEW_DETAILS: 5
             };
+            $scope.showExportOptions = false;
+            $scope.HEADER_MAP = {
+            fqdn: 'FQDN',
+            name: 'Name',
+            type: 'Type',
+            ttl: 'TTL',
+            records: 'Record Data',
+            zoneName: 'Zone',
+            zoneId: 'Zone ID',
+            zoneShared: 'Zone Access Type',
+            ownerGroupName: 'Owner Group Name',
+            created: 'Created Date'
+            };
+            $scope.selectedFields = {};
 
             // Function to copy the Record ID to clipboard
             $scope.copyToClipboard = function(type) {
@@ -105,6 +119,77 @@
                 $('[data-toggle="tooltip"]').tooltip();
             });
 
+            document.addEventListener('click', function () {
+                $scope.$apply(function () {
+                    $scope.showExportOptions = false;
+                });
+            });
+            
+            $scope.toggleExportOptions = function(event) {
+                event.stopPropagation();
+                $scope.showExportOptions = !$scope.showExportOptions;
+            };
+
+            $scope.exportWithSelection = function() {
+                $scope.showExportOptions = false;
+                $scope.exportToCSV();
+            };
+            
+            function getRecordData(records, type) {
+                if (!records || !records.length) return '';
+
+                switch (type) {
+                    case 'A':
+                    case 'AAAA':
+                    return records.map(r => r.address).join('\n');
+
+                    case 'CNAME':
+                    return records.map(r => r.cname).join('\n');
+
+                    case 'TXT':
+                    return records.map(r => r.text).join('\n');
+
+                    case 'NS':
+                    return records.map(r => r.nsdname).join('\n'); 
+
+                    case 'PTR':
+                    return records.map(r => r.ptrdname).join('\n');
+
+                    case 'MX':
+                    return records.map(r =>
+                        `preference=${r.preference}, exchange=${r.exchange}`
+                    ).join('\n');
+
+                    case 'SOA':
+                    return records.map(r =>
+                        `mname=${r.mname}, rname=${r.rname}, serial=${r.serial}, refresh=${r.refresh}, retry=${r.retry}, expire=${r.expire}, minimum=${r.minimum}`
+                    ).join('\n');
+
+                    case 'DS':
+                    return records.map(r =>
+                        `keyTag=${r.keytag}, algorithm=${r.algorithm}, digestType=${r.digestType}, digest=${r.digest}`
+                    ).join('\n');
+
+                    case 'SRV':
+                    return records.map(r =>
+                        `priority=${r.priority}, weight=${r.weight}, port=${r.port}, target=${r.target}`
+                    ).join('\n');
+
+                    case 'NAPTR':
+                    return records.map(r =>
+                        `order=${r.order}, preference=${r.preference}, flags=${r.flags}, service=${r.service}, regexp=${r.regexp}, replacement=${r.replacement}`
+                    ).join('\n');
+
+                    case 'SSHFP':
+                    return records.map(r =>
+                        `algorithm=${r.algorithm}, type=${r.type}, fingerprint=${r.fingerprint}`
+                    ).join('\n');
+
+                    default:
+                    return '';
+                }
+            };
+            
             $( "#record-search-text" ).autocomplete({
               source: function( request, response ) {
                 $.ajax({
@@ -204,7 +289,71 @@
                 }
             };
 
+            $scope.exportToCSV = function () {
+                if (!$scope.isRecordSearchTriggered) {
+                    return;
+                }
+                let recordName, recordType;
 
+                if ($scope.query && $scope.query.includes("|")) {
+                    const queryRecord = $scope.query.split('|');
+                    recordName = queryRecord[0].trim();
+                    recordType = queryRecord[1].trim();
+                } else {
+                    recordName = $scope.query || '';
+                    recordType = ($scope.selectedRecordTypes || []).toString();
+                }
+
+                const filename = `${recordName} - recordsets.csv`;
+                const csv = [];
+                function buildHeaders() {
+                    return Object.keys($scope.HEADER_MAP)
+                        .filter(key => $scope.selectedFields[key])
+                        .map(key => $scope.HEADER_MAP[key])
+                        .join(',');
+                }
+                function buildRow(r) {
+                return Object.keys($scope.HEADER_MAP)
+                    .filter(key => $scope.selectedFields[key])
+                    .map(key => {
+                    if (key === 'records') return `"${getRecordData(r.records, r.type)}"`;
+                    if (key === 'zoneShared') return `"${r.zoneShared ? 'Shared' : 'Private'}"`;
+                    if (key === 'created') return `"${r.created ? new Date(r.created).toISOString() : ''}"`;
+                    return `"${r[key] || ''}"`;
+                    }).join(',');
+                }
+                recordsService.listRecordSetData(
+                    recordsPaging.maxItems,
+                    undefined,
+                    recordName,
+                    recordType,
+                    $scope.nameSort,
+                    $scope.ownerGroupFilter
+                    )
+                .then(function (response) {
+                    const recordSets = response.data.recordSets || [];
+                    if (!recordSets.length) return;
+
+                    csv.push(buildHeaders());
+
+                    recordSets.forEach(function (r) {
+                        csv.push(buildRow(r));
+                    });
+
+                    const csvFile = new Blob([csv.join('\n')], { type: 'text/csv' });
+                    const link = document.createElement('a');
+
+                    link.href = window.URL.createObjectURL(csvFile);
+                    link.download = filename;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                })
+                .catch(function (error) {
+                    handleError(error, 'recordExport-failure');
+                });
+            };
+            
             function updateRecordDisplay(records) {
                 var newRecords = [];
                 angular.forEach(records, function(record) {

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -60,6 +60,7 @@
                 CONFIRM_DELETE: 4,
                 VIEW_DETAILS: 5
             };
+            $scope.isRecordSearchTriggered = false;
             $scope.showExportOptions = false;
             $scope.HEADER_MAP = {
             fqdn: 'FQDN',
@@ -233,6 +234,7 @@
             };
 
             $scope.refreshRecords = function() {
+            $scope.isRecordSearchTriggered = true;
             if($scope.query.includes("|")) {
                 const queryRecord = $scope.query.split('|');
                 recordName = queryRecord[0].trim();

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -61,9 +61,9 @@
                 VIEW_DETAILS: 5
             };
             $scope.isRecordSearchTriggered = false;
-            $scope.showExportOptions = false;
             $scope.HEADER_MAP = {
             fqdn: 'FQDN',
+            id: 'Record ID',
             name: 'Name',
             type: 'Type',
             ttl: 'TTL',
@@ -75,7 +75,10 @@
             created: 'Created Date'
             };
             $scope.selectedFields = {};
-
+            angular.forEach($scope.HEADER_MAP, function(label, key) {
+                $scope.selectedFields[key] = true;
+            });
+            
             // Function to copy the Record ID to clipboard
             $scope.copyToClipboard = function(type) {
                 let valueToCopy = '';
@@ -114,28 +117,27 @@
             var recordsPaging = pagingService.getNewPagingParams(100);
             var recordType = [];
             var recordName = [];
+            $scope.exportOptions = { selectAll: true };
 
+            $scope.toggleAllFields = function () {
+                angular.forEach($scope.HEADER_MAP, function (label, key) {
+                    $scope.selectedFields[key] = $scope.exportOptions.selectAll;
+                });
+            };
+
+            $scope.updateSelectAllState = function () {
+                var allSelected = true;
+                angular.forEach($scope.selectedFields, function (value) {
+                    if (!value) allSelected = false;
+                });
+                $scope.exportOptions.selectAll = allSelected;
+            };
+            
             // Initialize Bootstrap tooltips
             $(document).ready(function() {
                 $('[data-toggle="tooltip"]').tooltip();
             });
 
-            document.addEventListener('click', function () {
-                $scope.$apply(function () {
-                    $scope.showExportOptions = false;
-                });
-            });
-            
-            $scope.toggleExportOptions = function(event) {
-                event.stopPropagation();
-                $scope.showExportOptions = !$scope.showExportOptions;
-            };
-
-            $scope.exportWithSelection = function() {
-                $scope.showExportOptions = false;
-                $scope.exportToCSV();
-            };
-            
             function getRecordData(records, type) {
                 if (!records || !records.length) return '';
 
@@ -290,71 +292,172 @@
                     $scope.selectedRecordTypes.push(recordType);
                 }
             };
-
+            
             $scope.exportToCSV = function () {
-                if (!$scope.isRecordSearchTriggered) {
-                    return;
-                }
-                let recordName, recordType;
 
-                if ($scope.query && $scope.query.includes("|")) {
-                    const queryRecord = $scope.query.split('|');
-                    recordName = queryRecord[0].trim();
-                    recordType = queryRecord[1].trim();
-                } else {
-                    recordName = $scope.query || '';
-                    recordType = ($scope.selectedRecordTypes || []).toString();
-                }
+                if (!$scope.isRecordSearchTriggered) return;
 
-                const filename = `${recordName} - recordsets.csv`;
-                const csv = [];
-                function buildHeaders() {
-                    return Object.keys($scope.HEADER_MAP)
-                        .filter(key => $scope.selectedFields[key])
-                        .map(key => $scope.HEADER_MAP[key])
-                        .join(',');
-                }
-                function buildRow(r) {
-                return Object.keys($scope.HEADER_MAP)
-                    .filter(key => $scope.selectedFields[key])
-                    .map(key => {
-                    if (key === 'records') return `"${getRecordData(r.records, r.type)}"`;
-                    if (key === 'zoneShared') return `"${r.zoneShared ? 'Shared' : 'Private'}"`;
-                    if (key === 'created') return `"${r.created ? new Date(r.created).toISOString() : ''}"`;
-                    return `"${r[key] || ''}"`;
-                    }).join(',');
-                }
-                recordsService.listRecordSetData(
-                    recordsPaging.maxItems,
-                    undefined,
-                    recordName,
-                    recordType,
-                    $scope.nameSort,
-                    $scope.ownerGroupFilter
-                    )
-                .then(function (response) {
-                    const recordSets = response.data.recordSets || [];
-                    if (!recordSets.length) return;
-
-                    csv.push(buildHeaders());
-
-                    recordSets.forEach(function (r) {
-                        csv.push(buildRow(r));
-                    });
-
-                    const csvFile = new Blob([csv.join('\n')], { type: 'text/csv' });
-                    const link = document.createElement('a');
-
-                    link.href = window.URL.createObjectURL(csvFile);
-                    link.download = filename;
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
-                })
-                .catch(function (error) {
-                    handleError(error, 'recordExport-failure');
+                let loader = $("#csvLoaderModal");
+                loader.modal({
+                    backdrop: "static",
+                    keyboard: false,
+                    show: true
                 });
+
+                function hideLoader() {
+                    loader.modal("hide");
+                    $('.modal-backdrop').remove();
+                    $('body').removeClass('modal-open');
+                }
+
+                $timeout(function () {
+
+                    let recordName, recordType;
+                    const pageSize = 100;
+                    const zoneMap = {};
+                    const allRecords = [];
+                    let csvContent = '';
+
+                    if ($scope.query && $scope.query.includes("|")) {
+                        const queryRecord = $scope.query.split('|');
+                        recordName = queryRecord[0].trim();
+                        recordType = queryRecord[1].trim();
+                    } else {
+                        recordName = $scope.query || '';
+                        recordType = ($scope.selectedRecordTypes || []).toString();
+                    }
+
+                    function buildHeaders() {
+                        return Object.keys($scope.HEADER_MAP)
+                            .filter(key => $scope.selectedFields[key])
+                            .map(key => $scope.HEADER_MAP[key])
+                            .join(',');
+                    }
+
+                    function buildRow(r) {
+                        return Object.keys($scope.HEADER_MAP)
+                            .filter(key => $scope.selectedFields[key])
+                            .map(key => {
+                                if (key === 'records')
+                                    return toCSVCell(getRecordData(r.records, r.type));
+                                if (key === 'zoneShared')
+                                    return toCSVCell(r.zoneShared ? 'Shared' : 'Private');
+                                if (key === 'created')
+                                    return toCSVCell(r.created ? new Date(r.created).toISOString() : '');
+                                if (key === 'ownerGroupName') {
+                                    if (r.zoneShared)
+                                        return toCSVCell(r.ownerGroupName || 'Unowned');
+                                    return toCSVCell(zoneMap[r.zoneId] || 'Unowned');
+                                }
+                                return toCSVCell(r[key] || '');
+                            }).join(',');
+                    }
+
+                    let visitedNextIds = new Set();
+
+                    function fetchAllPages(nextId = null) {
+                        return recordsService.listRecordSetData(
+                            pageSize,
+                            nextId,
+                            recordName,
+                            recordType,
+                            $scope.nameSort,
+                            $scope.ownerGroupFilter,
+                            true 
+                        ).then(function (response) {
+
+                            const recordSets = response.data.recordSets || [];
+                            const newNextId = response.data.nextId;
+
+                            if (!recordSets.length) return;
+
+                            allRecords.push(...recordSets);
+
+                            if (!newNextId || visitedNextIds.has(newNextId)) return;
+
+                            visitedNextIds.add(newNextId);
+
+                            return fetchAllPages(newNextId);
+                        });
+                    }
+
+                    function loadPrivateZoneOwners() {
+                        const privateZoneIds = [
+                            ...new Set(
+                                allRecords
+                                    .filter(r => !r.zoneShared && r.zoneId && r.zoneId !== "unknown")
+                                    .map(r => r.zoneId)
+                            )
+                        ];
+                        const promises = privateZoneIds.map(zoneId =>
+                            recordsService.getCommonZoneDetails(zoneId)
+                                .then(function (res) {
+                                    zoneMap[zoneId] = res.data.zone.adminGroupName;
+                                })
+                                .catch(function () {
+                                    zoneMap[zoneId] = "Unowned";
+                                })
+                        );
+                        return Promise.all(promises);
+                    }
+
+                    function downloadCsv() {
+                        if (!allRecords.length) {
+                            hideLoader();
+                            return;
+                        }
+
+                        let filename;
+                        if (recordType) {
+                            const safeRecordName = (recordName || '')
+                                .replace(/\*/g, '')
+                                .replace(/[^a-zA-Z0-9.-]/g, '_');
+                            filename = safeRecordName
+                                ? `${safeRecordName} - recordset.csv`
+                                : `recordsets.csv`;
+                        } else {
+                            const safeRecordName = (recordName || '')
+                                .replace(/\*/g, '')
+                                .replace(/[^a-zA-Z0-9.-]/g, '_');
+                            filename = safeRecordName
+                                ? `${safeRecordName} - recordsets.csv`
+                                : `recordsets.csv`;
+                        }
+
+                        const rows = [];
+                        rows.push(buildHeaders());
+
+                        allRecords.forEach(r => {
+                            rows.push(buildRow(r));
+                        });
+                        csvContent = rows.join('\n');
+
+                        const blob = new Blob([csvContent], { type: 'text/csv' });
+                        const link = document.createElement('a');
+                        link.href = URL.createObjectURL(blob);
+                        link.download = filename;
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+
+                        hideLoader();
+                    }
+
+                    fetchAllPages()
+                        .then(loadPrivateZoneOwners)
+                        .then(downloadCsv)
+                        .catch(function (error) {
+                            if (error && Object.keys(error).length > 0) {
+                                handleError(error, 'recordExport-failure');
+                            }
+                            hideLoader();
+                        });
+                }, 0);
             };
+            
+            function toCSVCell(value) {
+                return '"' + String(value == null ? '' : value).replace(/"/g, '""') + '"';
+            }
             
             function updateRecordDisplay(records) {
                 var newRecords = [];

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -192,7 +192,7 @@
                 }
             };
             
-            $( "#record-search-text" ).autocomplete({
+            var recordSearchAutocomplete = $( "#record-search-text" ).autocomplete({
               source: function( request, response ) {
                 $.ajax({
                   url: "/api/recordsets?maxItems=100",

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -407,22 +407,13 @@
                             return;
                         }
 
-                        let filename;
-                        if (recordType) {
-                            const safeRecordName = (recordName || '')
-                                .replace(/\*/g, '')
-                                .replace(/[^a-zA-Z0-9.-]/g, '_');
-                            filename = safeRecordName
-                                ? `${safeRecordName} - recordset.csv`
-                                : `recordsets.csv`;
-                        } else {
-                            const safeRecordName = (recordName || '')
-                                .replace(/\*/g, '')
-                                .replace(/[^a-zA-Z0-9.-]/g, '_');
-                            filename = safeRecordName
-                                ? `${safeRecordName} - recordsets.csv`
-                                : `recordsets.csv`;
-                        }
+                        const safeRecordName = (recordName || '')
+                            .replace(/\*/g, '')
+                            .replace(/[^a-zA-Z0-9.-]/g, '_');
+                        const recordLabel = recordType ? 'recordset' : 'recordsets';
+                        const filename = safeRecordName
+                            ? `${safeRecordName} - ${recordLabel}.csv`
+                            : 'recordsets.csv';
 
                         const rows = [];
                         rows.push(buildHeaders());
@@ -430,7 +421,7 @@
                         allRecords.forEach(r => {
                             rows.push(buildRow(r));
                         });
-                        csvContent = rows.join('\n');
+                        csvContent = '\uFEFF' + rows.join('\n');
 
                         const blob = new Blob([csvContent], { type: 'text/csv' });
                         const link = document.createElement('a');
@@ -447,7 +438,7 @@
                         .then(loadPrivateZoneOwners)
                         .then(downloadCsv)
                         .catch(function (error) {
-                            if (error && Object.keys(error).length > 0) {
+                            if (error) {
                                 handleError(error, 'recordExport-failure');
                             }
                             hideLoader();
@@ -456,9 +447,13 @@
             };
             
             function toCSVCell(value) {
-                return '"' + String(value == null ? '' : value).replace(/"/g, '""') + '"';
+                let str = String(value == null ? '' : value);
+                if (/^[=+\-@\t\r]/.test(str)) {
+                    str = "'" + str;
+                }
+                return '"' + str.replace(/"/g, '""') + '"';
             }
-            
+
             function updateRecordDisplay(records) {
                 var newRecords = [];
                 angular.forEach(records, function(record) {

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -140,7 +140,6 @@
 
             function getRecordData(records, type) {
                 if (!records || !records.length) return '';
-
                 switch (type) {
                     case 'A':
                     case 'AAAA':

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -365,18 +365,12 @@
                             $scope.ownerGroupFilter,
                             true 
                         ).then(function (response) {
-
                             const recordSets = response.data.recordSets || [];
                             const newNextId = response.data.nextId;
-
                             if (!recordSets.length) return;
-
                             allRecords.push(...recordSets);
-
                             if (!newNextId || visitedNextIds.has(newNextId)) return;
-
                             visitedNextIds.add(newNextId);
-
                             return fetchAllPages(newNextId);
                         });
                     }

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -418,7 +418,6 @@
                         document.body.appendChild(link);
                         link.click();
                         document.body.removeChild(link);
-
                         hideLoader();
                     }
 

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -194,7 +194,6 @@
             };
 
             $scope.getRecordData = getRecordData;
-            
             var recordSearchAutocomplete = $( "#record-search-text" ).autocomplete({
               source: function( request, response ) {
                 $.ajax({

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -149,6 +149,7 @@
                     return records.map(r => r.cname).join('\n');
 
                     case 'TXT':
+                    case 'SPF':
                     return records.map(r => r.text).join('\n');
 
                     case 'NS':
@@ -191,6 +192,8 @@
                     return '';
                 }
             };
+
+            $scope.getRecordData = getRecordData;
             
             var recordSearchAutocomplete = $( "#record-search-text" ).autocomplete({
               source: function( request, response ) {
@@ -341,7 +344,7 @@
                                 if (key === 'ownerGroupName') {
                                     if (r.zoneShared)
                                         return toCSVCell(r.ownerGroupName || 'Unowned');
-                                    return toCSVCell(zoneMap[r.zoneId] || 'Unowned');
+                                    return toCSVCell(zoneMap[r.zoneId] || r.ownerGroupName || 'Unowned');
                                 }
                                 return toCSVCell(r[key] || '');
                             }).join(',');
@@ -370,13 +373,15 @@
                     }
 
                     function loadPrivateZoneOwners() {
-                        const privateZoneIds = [
-                            ...new Set(
-                                allRecords
-                                    .filter(r => !r.zoneShared && r.zoneId && r.zoneId !== "unknown")
-                                    .map(r => r.zoneId)
-                            )
-                        ];
+                        if (!shouldLoadPrivateZoneOwners()) {
+                            return Promise.resolve();
+                        }
+
+                        const privateZoneIds = getPrivateZoneIdsToLoad(allRecords, zoneMap);
+                        if (!privateZoneIds.length) {
+                            return Promise.resolve();
+                        }
+
                         const promises = privateZoneIds.map(zoneId =>
                             recordsService.getCommonZoneDetails(zoneId)
                                 .then(function (res) {
@@ -440,6 +445,36 @@
                 }
                 return '"' + str.replace(/"/g, '""') + '"';
             }
+
+            function shouldLoadPrivateZoneOwners() {
+                return !!$scope.selectedFields.ownerGroupName;
+            }
+
+            function getPrivateZoneIdsToLoad(records, zoneMap) {
+                const privateZoneIds = new Set();
+
+                records.forEach(function (record) {
+                    if (!record || record.zoneShared || !record.zoneId || record.zoneId === 'unknown') {
+                        return;
+                    }
+
+                    if (record.ownerGroupName) {
+                        zoneMap[record.zoneId] = record.ownerGroupName;
+                        return;
+                    }
+
+                    if (!zoneMap[record.zoneId]) {
+                        privateZoneIds.add(record.zoneId);
+                    }
+                });
+
+                return Array.from(privateZoneIds);
+            }
+
+            $scope.shouldLoadPrivateZoneOwners = shouldLoadPrivateZoneOwners;
+            $scope.getPrivateZoneIdsToLoad = function (records) {
+                return getPrivateZoneIdsToLoad(records || [], {});
+            };
 
             function updateRecordDisplay(records) {
                 var newRecords = [];

--- a/modules/portal/public/lib/services/records/service.records.js
+++ b/modules/portal/public/lib/services/records/service.records.js
@@ -19,7 +19,7 @@
 angular.module('service.records', [])
     .service('recordsService', function ($http, utilityService) {
 
-        this.listRecordSetData = function (limit, startFrom, nameFilter, typeFilter, nameSort, ownerGroupFilter) {
+        this.listRecordSetData = function (limit, startFrom, nameFilter, typeFilter, nameSort, ownerGroupFilter, skipLoader) {
             if (typeFilter == "") {
                 typeFilter = null;
             }
@@ -40,18 +40,18 @@ angular.module('service.records', [])
                 "recordOwnerGroupFilter": ownerGroupFilter
             };
             var url = utilityService.urlBuilder("/api/recordsets", params);
-
+            let promis = $http.get(url);
+            
 
             let loader = $("#loader");
-            loader.modal({
-                             backdrop: "static", //remove ability to close modal with click
-                             keyboard: false, //remove option to close with keyboard
-                             show: true //Display loader!
-                             });
-            let promis = $http.get(url);
-            // What?
-            promis.then(()=>loader.modal("hide"), ()=>loader.modal("hide"))
-
+            if (!skipLoader) {
+                loader.modal({
+                                backdrop: "static", //remove ability to close modal with click
+                                keyboard: false, //remove option to close with keyboard
+                                show: true //Display loader!
+                                });
+                promis.then(()=>loader.modal("hide"), ()=>loader.modal("hide"))
+            }
             return promis
         };
 


### PR DESCRIPTION
VDNS-273

Fixes #1410.

Enhanced the Global RecordSet Search to support CSV export enabling users to download all matching records with configurable fields, formatting and optional additional details via a selectable checklist making audits and bulk CSV uploads easier for UI users.