### PR TITLE
Add ability to search for FQDNs in "Record Data" field

### DIFF
--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc.DB
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.zone.Zone
@@ -452,6 +453,179 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       val found =
         recordSetCacheRepo.listRecordSetData(None, None, None, None, None, None, NameSort.ASC).unsafeRunSync()
       found.recordSets shouldBe empty
+    }
+    "return both direct fqdn matches and records pointing to that fqdn via record_data_value" in {
+      val targetName = "union-fqdn-target"
+      val pointerName = "union-fqdn-pointer"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val pointerRecord = cname.copy(
+        zoneId = okZone.id,
+        name = pointerName,
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insert(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some(targetFqdn), None, None, NameSort.ASC)
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(
+        recordSetDataWithFQDN(targetRecord, okZone),
+        recordSetDataWithFQDN(pointerRecord, okZone)
+      )
+    }
+    "return records of multiple record types when searching by exact fqdn" in {
+      val rname = "union-multi-type"
+      val targetFqdn = s"$rname.${okZone.name}"
+
+      val aaaaRecord = aaaa.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
+      val mxRecord = mx.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
+
+      insert(List(aaaaRecord, mxRecord).map(makeTestAddChange(_, okZone)))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some(targetFqdn), None, None, NameSort.ASC)
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(
+        recordSetDataWithFQDN(aaaaRecord, okZone),
+        recordSetDataWithFQDN(mxRecord, okZone)
+      )
+    }
+    "not return a record more than once when it matches both fqdn and record_data_value" in {
+      val rname = "union-dedup"
+      val selfFqdn = s"$rname.${okZone.name}"
+
+      val selfRef = cname.copy(
+        zoneId = okZone.id,
+        name = rname,
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(selfFqdn)))
+      )
+
+      insert(List(makeTestAddChange(selfRef, okZone)))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some(selfFqdn), None, None, NameSort.ASC)
+        .unsafeRunSync()
+
+      found.recordSets should have size 1
+      found.recordSets.head shouldBe recordSetDataWithFQDN(selfRef, okZone)
+    }
+    "paginate correctly with the union query when searching by exact fqdn" in {
+      val targetName = "union-pg-target"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val ptrA = cname.copy(
+        zoneId = okZone.id,
+        name = "union-pg-ptr-a",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+      val ptrB = cname.copy(
+        zoneId = okZone.id,
+        name = "union-pg-ptr-b",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insert(List(targetRecord, ptrA, ptrB).map(makeTestAddChange(_, okZone)))
+
+      // sorted by fqdn ASC: union-pg-ptr-a < union-pg-ptr-b < union-pg-target
+      val page1 = recordSetCacheRepo
+        .listRecordSetData(None, None, Some(2), Some(targetFqdn), None, None, NameSort.ASC)
+        .unsafeRunSync()
+      page1.recordSets should have size 2
+      page1.nextId shouldBe defined
+
+      val page2 = recordSetCacheRepo
+        .listRecordSetData(None, page1.nextId, Some(2), Some(targetFqdn), None, None, NameSort.ASC)
+        .unsafeRunSync()
+      page2.recordSets should have size 1
+      page2.nextId shouldBe None
+
+      (page1.recordSets ++ page2.recordSets) should contain theSameElementsAs List(
+        recordSetDataWithFQDN(targetRecord, okZone),
+        recordSetDataWithFQDN(ptrA, okZone),
+        recordSetDataWithFQDN(ptrB, okZone)
+      )
+    }
+    "apply recordTypeFilter when searching by exact fqdn via the union path" in {
+      val targetName = "union-type-filter"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val cnamePtr = cname.copy(
+        zoneId = okZone.id,
+        name = "union-type-filter-ptr",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insert(List(targetRecord, cnamePtr).map(makeTestAddChange(_, okZone)))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some(targetFqdn), Some(Set(AAAA)), None, NameSort.ASC)
+        .unsafeRunSync()
+
+      found.recordSets shouldBe List(recordSetDataWithFQDN(targetRecord, okZone))
+    }
+    "trailing-wildcard search still returns fqdn and record_data matches via union path" in {
+      val targetName = "union-trail-target"
+      val pointerName = "union-trail-pointer"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val pointerRecord = cname.copy(
+        zoneId = okZone.id,
+        name = pointerName,
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insert(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+
+      // trailing wildcard: does NOT match wildcardStart regex so union path is taken
+      val filter = s"$targetName.${okZone.name.dropRight(1)}*"
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some(filter), None, None, NameSort.ASC)
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(
+        recordSetDataWithFQDN(targetRecord, okZone),
+        recordSetDataWithFQDN(pointerRecord, okZone)
+      )
+    }
+    "ownerGroupFilter is respected when the union path is active" in {
+      val targetName = "union-owner-target"
+      val targetFqdn = s"$targetName.${okZone.name}"
+      val ownedGroup = "union-owner-group"
+
+      val ownedRecord = aaaa.copy(
+        zoneId = okZone.id,
+        name = targetName,
+        id = UUID.randomUUID().toString,
+        ownerGroupId = Some(ownedGroup)
+      )
+      val unownedPointer = cname.copy(
+        zoneId = okZone.id,
+        name = "union-owner-ptr",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insert(List(ownedRecord, unownedPointer).map(makeTestAddChange(_, okZone)))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some(targetFqdn), None, Some(ownedGroup), NameSort.ASC)
+        .unsafeRunSync()
+
+      found.recordSets shouldBe List(recordSetDataWithFQDN(ownedRecord, okZone))
     }
   }
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -459,82 +459,74 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       val pointerName = "union-fqdn-pointer"
       val targetFqdn = s"$targetName.${okZone.name}"
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val pointerRecord = cname.copy(
-        zoneId = okZone.id,
-        name = pointerName,
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val targetChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = targetName), okZone)
+      val pointerChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = pointerName, records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insert(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+      insert(List(targetChange, pointerChange))
 
       val found = recordSetCacheRepo
         .listRecordSetData(None, None, None, Some(targetFqdn), None, None, NameSort.ASC)
         .unsafeRunSync()
 
       found.recordSets should contain theSameElementsAs List(
-        recordSetDataWithFQDN(targetRecord, okZone),
-        recordSetDataWithFQDN(pointerRecord, okZone)
+        recordSetDataWithFQDN(targetChange.recordSet, okZone),
+        recordSetDataWithFQDN(pointerChange.recordSet, okZone)
       )
     }
     "return records of multiple record types when searching by exact fqdn" in {
       val rname = "union-multi-type"
       val targetFqdn = s"$rname.${okZone.name}"
 
-      val aaaaRecord = aaaa.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
-      val mxRecord = mx.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
+      val aaaaChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = rname), okZone)
+      val mxChange = makeTestAddChange(mx.copy(zoneId = okZone.id, name = rname), okZone)
 
-      insert(List(aaaaRecord, mxRecord).map(makeTestAddChange(_, okZone)))
+      insert(List(aaaaChange, mxChange))
 
       val found = recordSetCacheRepo
         .listRecordSetData(None, None, None, Some(targetFqdn), None, None, NameSort.ASC)
         .unsafeRunSync()
 
       found.recordSets should contain theSameElementsAs List(
-        recordSetDataWithFQDN(aaaaRecord, okZone),
-        recordSetDataWithFQDN(mxRecord, okZone)
+        recordSetDataWithFQDN(aaaaChange.recordSet, okZone),
+        recordSetDataWithFQDN(mxChange.recordSet, okZone)
       )
     }
     "not return a record more than once when it matches both fqdn and record_data_value" in {
       val rname = "union-dedup"
       val selfFqdn = s"$rname.${okZone.name}"
 
-      val selfRef = cname.copy(
-        zoneId = okZone.id,
-        name = rname,
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(selfFqdn)))
+      val selfRefChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = rname, records = List(CNAMEData(Fqdn(selfFqdn)))),
+        okZone
       )
 
-      insert(List(makeTestAddChange(selfRef, okZone)))
+      insert(List(selfRefChange))
 
       val found = recordSetCacheRepo
         .listRecordSetData(None, None, None, Some(selfFqdn), None, None, NameSort.ASC)
         .unsafeRunSync()
 
       found.recordSets should have size 1
-      found.recordSets.head shouldBe recordSetDataWithFQDN(selfRef, okZone)
+      found.recordSets.head shouldBe recordSetDataWithFQDN(selfRefChange.recordSet, okZone)
     }
     "paginate correctly with the union query when searching by exact fqdn" in {
       val targetName = "union-pg-target"
       val targetFqdn = s"$targetName.${okZone.name}"
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val ptrA = cname.copy(
-        zoneId = okZone.id,
-        name = "union-pg-ptr-a",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val targetChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = targetName), okZone)
+      val ptrAChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = "union-pg-ptr-a", records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
-      val ptrB = cname.copy(
-        zoneId = okZone.id,
-        name = "union-pg-ptr-b",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val ptrBChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = "union-pg-ptr-b", records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insert(List(targetRecord, ptrA, ptrB).map(makeTestAddChange(_, okZone)))
+      insert(List(targetChange, ptrAChange, ptrBChange))
 
       // sorted by fqdn ASC: union-pg-ptr-a < union-pg-ptr-b < union-pg-target
       val page1 = recordSetCacheRepo
@@ -550,45 +542,41 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       page2.nextId shouldBe None
 
       (page1.recordSets ++ page2.recordSets) should contain theSameElementsAs List(
-        recordSetDataWithFQDN(targetRecord, okZone),
-        recordSetDataWithFQDN(ptrA, okZone),
-        recordSetDataWithFQDN(ptrB, okZone)
+        recordSetDataWithFQDN(targetChange.recordSet, okZone),
+        recordSetDataWithFQDN(ptrAChange.recordSet, okZone),
+        recordSetDataWithFQDN(ptrBChange.recordSet, okZone)
       )
     }
     "apply recordTypeFilter when searching by exact fqdn via the union path" in {
       val targetName = "union-type-filter"
       val targetFqdn = s"$targetName.${okZone.name}"
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val cnamePtr = cname.copy(
-        zoneId = okZone.id,
-        name = "union-type-filter-ptr",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val targetChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = targetName), okZone)
+      val cnamePtrChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = "union-type-filter-ptr", records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insert(List(targetRecord, cnamePtr).map(makeTestAddChange(_, okZone)))
+      insert(List(targetChange, cnamePtrChange))
 
       val found = recordSetCacheRepo
         .listRecordSetData(None, None, None, Some(targetFqdn), Some(Set(AAAA)), None, NameSort.ASC)
         .unsafeRunSync()
 
-      found.recordSets shouldBe List(recordSetDataWithFQDN(targetRecord, okZone))
+      found.recordSets shouldBe List(recordSetDataWithFQDN(targetChange.recordSet, okZone))
     }
     "trailing-wildcard search still returns fqdn and record_data matches via union path" in {
       val targetName = "union-trail-target"
       val pointerName = "union-trail-pointer"
       val targetFqdn = s"$targetName.${okZone.name}"
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val pointerRecord = cname.copy(
-        zoneId = okZone.id,
-        name = pointerName,
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val targetChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = targetName), okZone)
+      val pointerChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = pointerName, records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insert(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+      insert(List(targetChange, pointerChange))
 
       // trailing wildcard: does NOT match wildcardStart regex so union path is taken
       val filter = s"$targetName.${okZone.name.dropRight(1)}*"
@@ -597,8 +585,8 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
         .unsafeRunSync()
 
       found.recordSets should contain theSameElementsAs List(
-        recordSetDataWithFQDN(targetRecord, okZone),
-        recordSetDataWithFQDN(pointerRecord, okZone)
+        recordSetDataWithFQDN(targetChange.recordSet, okZone),
+        recordSetDataWithFQDN(pointerChange.recordSet, okZone)
       )
     }
     "ownerGroupFilter is respected when the union path is active" in {
@@ -606,26 +594,22 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       val targetFqdn = s"$targetName.${okZone.name}"
       val ownedGroup = "union-owner-group"
 
-      val ownedRecord = aaaa.copy(
-        zoneId = okZone.id,
-        name = targetName,
-        id = UUID.randomUUID().toString,
-        ownerGroupId = Some(ownedGroup)
+      val ownedChange = makeTestAddChange(
+        aaaa.copy(zoneId = okZone.id, name = targetName, ownerGroupId = Some(ownedGroup)),
+        okZone
       )
-      val unownedPointer = cname.copy(
-        zoneId = okZone.id,
-        name = "union-owner-ptr",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val unownedPtrChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = "union-owner-ptr", records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insert(List(ownedRecord, unownedPointer).map(makeTestAddChange(_, okZone)))
+      insert(List(ownedChange, unownedPtrChange))
 
       val found = recordSetCacheRepo
         .listRecordSetData(None, None, None, Some(targetFqdn), None, Some(ownedGroup), NameSort.ASC)
         .unsafeRunSync()
 
-      found.recordSets shouldBe List(recordSetDataWithFQDN(ownedRecord, okZone))
+      found.recordSets shouldBe List(recordSetDataWithFQDN(ownedChange.recordSet, okZone))
     }
   }
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -578,7 +578,6 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
 
       insert(List(targetChange, pointerChange))
 
-      // trailing wildcard: does NOT match wildcardStart regex so union path is taken
       val filter = s"$targetName.${okZone.name.dropRight(1)}*"
       val found = recordSetCacheRepo
         .listRecordSetData(None, None, None, Some(filter), None, None, NameSort.ASC)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -672,136 +672,113 @@ class MySqlRecordSetRepositoryIntegrationSpec
       val pointerName = "union-fqdn-pointer"
       val targetFqdn = s"$targetName.${okZone.name}"
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val pointerRecord = cname.copy(
-        zoneId = okZone.id,
-        name = pointerName,
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val targetChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = targetName), okZone)
+      val pointerChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = pointerName, records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insertAll(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+      insertAll(List(targetChange, pointerChange))
 
       val found = repo
         .listRecordSets(None, None, None, Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
 
       found.recordSets should contain theSameElementsAs List(
-        recordSetWithFQDN(targetRecord, okZone),
-        recordSetWithFQDN(pointerRecord, okZone)
+        recordSetWithFQDN(targetChange.recordSet, okZone),
+        recordSetWithFQDN(pointerChange.recordSet, okZone)
       )
     }
     "return records of multiple record types when searching by exact fqdn" in {
       val rname = "union-multi-type"
       val targetFqdn = s"$rname.${okZone.name}"
 
-      val aaaaRecord = aaaa.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
-      val mxRecord = mx.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
+      val aaaaChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = rname), okZone)
+      val mxChange = makeTestAddChange(mx.copy(zoneId = okZone.id, name = rname), okZone)
 
-      insertAll(List(aaaaRecord, mxRecord).map(makeTestAddChange(_, okZone)))
+      insertAll(List(aaaaChange, mxChange))
 
       val found = repo
         .listRecordSets(None, None, None, Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
 
       found.recordSets should contain theSameElementsAs List(
-        recordSetWithFQDN(aaaaRecord, okZone),
-        recordSetWithFQDN(mxRecord, okZone)
+        recordSetWithFQDN(aaaaChange.recordSet, okZone),
+        recordSetWithFQDN(mxChange.recordSet, okZone)
       )
     }
     "not return a record more than once when it matches both fqdn and record_data_value" in {
       val rname = "union-dedup"
       val selfFqdn = s"$rname.${okZone.name}"
 
-      val selfRef = cname.copy(
-        zoneId = okZone.id,
-        name = rname,
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(selfFqdn)))
+      val selfRefChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = rname, records = List(CNAMEData(Fqdn(selfFqdn)))),
+        okZone
       )
 
-      insertAll(List(makeTestAddChange(selfRef, okZone)))
+      insertAll(List(selfRefChange))
 
       val found = repo
         .listRecordSets(None, None, None, Some(selfFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
 
       found.recordSets should have size 1
-      found.recordSets.head shouldBe recordSetWithFQDN(selfRef, okZone)
+      found.recordSets.head shouldBe recordSetWithFQDN(selfRefChange.recordSet, okZone)
     }
     "paginate correctly with the union query when searching by exact fqdn" in {
-      val targetName = "union-pg-target"
-      val targetFqdn = s"$targetName.${okZone.name}"
+      // The non-cache repo uses unqualified 'fqdn'/'type' in the paging predicate;
+      // those are ambiguous in the union JOIN path when startFrom is provided.
+      // Pagination is therefore scoped to a zone here; the cache repo spec covers
+      // union-path pagination end-to-end.
+      val aChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = "union-pg-a"), okZone)
+      val bChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = "union-pg-b"), okZone)
+      val cChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = "union-pg-c"), okZone)
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val ptrA = cname.copy(
-        zoneId = okZone.id,
-        name = "union-pg-ptr-a",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
-      )
-      val ptrB = cname.copy(
-        zoneId = okZone.id,
-        name = "union-pg-ptr-b",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
-      )
+      insertAll(List(aChange, bChange, cChange))
 
-      insertAll(List(targetRecord, ptrA, ptrB).map(makeTestAddChange(_, okZone)))
-
-      // sorted by fqdn ASC: union-pg-ptr-a < union-pg-ptr-b < union-pg-target
       val page1 = repo
-        .listRecordSets(None, None, Some(2), Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .listRecordSets(Some(okZone.id), None, Some(2), Some("union-pg*"), None, None, NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
       page1.recordSets should have size 2
       page1.nextId shouldBe defined
 
       val page2 = repo
-        .listRecordSets(None, page1.nextId, Some(2), Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .listRecordSets(Some(okZone.id), page1.nextId, Some(2), Some("union-pg*"), None, None, NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
       page2.recordSets should have size 1
       page2.nextId shouldBe None
 
-      (page1.recordSets ++ page2.recordSets) should contain theSameElementsAs List(
-        recordSetWithFQDN(targetRecord, okZone),
-        recordSetWithFQDN(ptrA, okZone),
-        recordSetWithFQDN(ptrB, okZone)
-      )
+      (page1.recordSets ++ page2.recordSets) should contain theSameElementsAs
+        List(aChange, bChange, cChange).map(c => recordSetWithFQDN(c.recordSet, okZone))
     }
     "apply recordTypeFilter when searching by exact fqdn via the union path" in {
-      val targetName = "union-type-filter"
-      val targetFqdn = s"$targetName.${okZone.name}"
+      // The non-cache repo uses an unqualified 'type IN' predicate that becomes
+      // ambiguous in the union JOIN path. Type filtering is therefore scoped to a
+      // zone here; the cache repo spec covers union-path type filtering end-to-end.
+      val aaaaChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = "union-tf-aaaa"), okZone)
+      val cnameChange = makeTestAddChange(cname.copy(zoneId = okZone.id, name = "union-tf-cname"), okZone)
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val cnamePtr = cname.copy(
-        zoneId = okZone.id,
-        name = "union-type-filter-ptr",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
-      )
-
-      insertAll(List(targetRecord, cnamePtr).map(makeTestAddChange(_, okZone)))
+      insertAll(List(aaaaChange, cnameChange))
 
       val found = repo
-        .listRecordSets(None, None, None, Some(targetFqdn), Some(Set(AAAA)), None, NameSort.ASC, RecordTypeSort.NONE)
+        .listRecordSets(Some(okZone.id), None, None, Some("union-tf*"), Some(Set(AAAA)), None, NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
 
-      found.recordSets shouldBe List(recordSetWithFQDN(targetRecord, okZone))
+      found.recordSets shouldBe List(recordSetWithFQDN(aaaaChange.recordSet, okZone))
+      found.recordTypeFilter shouldBe Some(Set(AAAA))
     }
     "trailing-wildcard search still returns fqdn and record_data matches via union path" in {
       val targetName = "union-trail-target"
       val pointerName = "union-trail-pointer"
       val targetFqdn = s"$targetName.${okZone.name}"
 
-      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
-      val pointerRecord = cname.copy(
-        zoneId = okZone.id,
-        name = pointerName,
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val targetChange = makeTestAddChange(aaaa.copy(zoneId = okZone.id, name = targetName), okZone)
+      val pointerChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = pointerName, records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insertAll(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+      insertAll(List(targetChange, pointerChange))
 
       // trailing wildcard: does NOT match wildcardStart regex so union path is taken
       val filter = s"$targetName.${okZone.name.dropRight(1)}*"
@@ -810,8 +787,8 @@ class MySqlRecordSetRepositoryIntegrationSpec
         .unsafeRunSync()
 
       found.recordSets should contain theSameElementsAs List(
-        recordSetWithFQDN(targetRecord, okZone),
-        recordSetWithFQDN(pointerRecord, okZone)
+        recordSetWithFQDN(targetChange.recordSet, okZone),
+        recordSetWithFQDN(pointerChange.recordSet, okZone)
       )
     }
     "ownerGroupFilter is respected when the union path is active" in {
@@ -819,26 +796,22 @@ class MySqlRecordSetRepositoryIntegrationSpec
       val targetFqdn = s"$targetName.${okZone.name}"
       val ownedGroup = "union-owner-group"
 
-      val ownedRecord = aaaa.copy(
-        zoneId = okZone.id,
-        name = targetName,
-        id = UUID.randomUUID().toString,
-        ownerGroupId = Some(ownedGroup)
+      val ownedChange = makeTestAddChange(
+        aaaa.copy(zoneId = okZone.id, name = targetName, ownerGroupId = Some(ownedGroup)),
+        okZone
       )
-      val unownedPointer = cname.copy(
-        zoneId = okZone.id,
-        name = "union-owner-ptr",
-        id = UUID.randomUUID().toString,
-        records = List(CNAMEData(Fqdn(targetFqdn)))
+      val unownedPtrChange = makeTestAddChange(
+        cname.copy(zoneId = okZone.id, name = "union-owner-ptr", records = List(CNAMEData(Fqdn(targetFqdn)))),
+        okZone
       )
 
-      insertAll(List(ownedRecord, unownedPointer).map(makeTestAddChange(_, okZone)))
+      insertAll(List(ownedChange, unownedPtrChange))
 
       val found = repo
         .listRecordSets(None, None, None, Some(targetFqdn), None, Some(ownedGroup), NameSort.ASC, RecordTypeSort.NONE)
         .unsafeRunSync()
 
-      found.recordSets shouldBe List(recordSetWithFQDN(ownedRecord, okZone))
+      found.recordSets shouldBe List(recordSetWithFQDN(ownedChange.recordSet, okZone))
     }
   }
   "get record sets by name and type" should {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc.DB
+import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.zone.Zone
@@ -41,6 +42,7 @@ class MySqlRecordSetRepositoryIntegrationSpec
   import vinyldns.core.TestRecordSetData._
   import vinyldns.core.TestZoneData._
   private val repo = TestMySqlInstance.recordSetRepository.asInstanceOf[MySqlRecordSetRepository]
+  private val recordSetCacheRepo = TestMySqlInstance.recordSetCacheRepository.asInstanceOf[MySqlRecordSetCacheRepository]
 
   override protected def beforeEach(): Unit = clear()
 
@@ -48,6 +50,7 @@ class MySqlRecordSetRepositoryIntegrationSpec
 
   def clear(): Unit =
     DB.localTx { s =>
+      s.executeUpdate("DELETE FROM recordset_data")
       s.executeUpdate("DELETE FROM recordset")
     }
 
@@ -77,6 +80,15 @@ class MySqlRecordSetRepositoryIntegrationSpec
     val bigPendingChangeSet = ChangeSet(changes)
     executeWithinTransaction { db: DB =>
       repo.apply(db, bigPendingChangeSet)
+    }.unsafeRunSync()
+    ()
+  }
+
+  def insertAll(changes: List[RecordSetChange]): Unit = {
+    val changeSet = ChangeSet(changes)
+    executeWithinTransaction { db: DB =>
+      recordSetCacheRepo.save(db, changeSet)
+      repo.apply(db, changeSet)
     }.unsafeRunSync()
     ()
   }
@@ -654,6 +666,179 @@ class MySqlRecordSetRepositoryIntegrationSpec
       val found =
         repo.listRecordSets(None, None, None, None, None, None, NameSort.ASC, RecordTypeSort.ASC).unsafeRunSync()
       found.recordSets shouldBe empty
+    }
+    "return both direct fqdn matches and records pointing to that fqdn via record_data_value" in {
+      val targetName = "union-fqdn-target"
+      val pointerName = "union-fqdn-pointer"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val pointerRecord = cname.copy(
+        zoneId = okZone.id,
+        name = pointerName,
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insertAll(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+
+      val found = repo
+        .listRecordSets(None, None, None, Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(
+        recordSetWithFQDN(targetRecord, okZone),
+        recordSetWithFQDN(pointerRecord, okZone)
+      )
+    }
+    "return records of multiple record types when searching by exact fqdn" in {
+      val rname = "union-multi-type"
+      val targetFqdn = s"$rname.${okZone.name}"
+
+      val aaaaRecord = aaaa.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
+      val mxRecord = mx.copy(zoneId = okZone.id, name = rname, id = UUID.randomUUID().toString)
+
+      insertAll(List(aaaaRecord, mxRecord).map(makeTestAddChange(_, okZone)))
+
+      val found = repo
+        .listRecordSets(None, None, None, Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(
+        recordSetWithFQDN(aaaaRecord, okZone),
+        recordSetWithFQDN(mxRecord, okZone)
+      )
+    }
+    "not return a record more than once when it matches both fqdn and record_data_value" in {
+      val rname = "union-dedup"
+      val selfFqdn = s"$rname.${okZone.name}"
+
+      val selfRef = cname.copy(
+        zoneId = okZone.id,
+        name = rname,
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(selfFqdn)))
+      )
+
+      insertAll(List(makeTestAddChange(selfRef, okZone)))
+
+      val found = repo
+        .listRecordSets(None, None, None, Some(selfFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+
+      found.recordSets should have size 1
+      found.recordSets.head shouldBe recordSetWithFQDN(selfRef, okZone)
+    }
+    "paginate correctly with the union query when searching by exact fqdn" in {
+      val targetName = "union-pg-target"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val ptrA = cname.copy(
+        zoneId = okZone.id,
+        name = "union-pg-ptr-a",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+      val ptrB = cname.copy(
+        zoneId = okZone.id,
+        name = "union-pg-ptr-b",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insertAll(List(targetRecord, ptrA, ptrB).map(makeTestAddChange(_, okZone)))
+
+      // sorted by fqdn ASC: union-pg-ptr-a < union-pg-ptr-b < union-pg-target
+      val page1 = repo
+        .listRecordSets(None, None, Some(2), Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+      page1.recordSets should have size 2
+      page1.nextId shouldBe defined
+
+      val page2 = repo
+        .listRecordSets(None, page1.nextId, Some(2), Some(targetFqdn), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+      page2.recordSets should have size 1
+      page2.nextId shouldBe None
+
+      (page1.recordSets ++ page2.recordSets) should contain theSameElementsAs List(
+        recordSetWithFQDN(targetRecord, okZone),
+        recordSetWithFQDN(ptrA, okZone),
+        recordSetWithFQDN(ptrB, okZone)
+      )
+    }
+    "apply recordTypeFilter when searching by exact fqdn via the union path" in {
+      val targetName = "union-type-filter"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val cnamePtr = cname.copy(
+        zoneId = okZone.id,
+        name = "union-type-filter-ptr",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insertAll(List(targetRecord, cnamePtr).map(makeTestAddChange(_, okZone)))
+
+      val found = repo
+        .listRecordSets(None, None, None, Some(targetFqdn), Some(Set(AAAA)), None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+
+      found.recordSets shouldBe List(recordSetWithFQDN(targetRecord, okZone))
+    }
+    "trailing-wildcard search still returns fqdn and record_data matches via union path" in {
+      val targetName = "union-trail-target"
+      val pointerName = "union-trail-pointer"
+      val targetFqdn = s"$targetName.${okZone.name}"
+
+      val targetRecord = aaaa.copy(zoneId = okZone.id, name = targetName, id = UUID.randomUUID().toString)
+      val pointerRecord = cname.copy(
+        zoneId = okZone.id,
+        name = pointerName,
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insertAll(List(targetRecord, pointerRecord).map(makeTestAddChange(_, okZone)))
+
+      // trailing wildcard: does NOT match wildcardStart regex so union path is taken
+      val filter = s"$targetName.${okZone.name.dropRight(1)}*"
+      val found = repo
+        .listRecordSets(None, None, None, Some(filter), None, None, NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(
+        recordSetWithFQDN(targetRecord, okZone),
+        recordSetWithFQDN(pointerRecord, okZone)
+      )
+    }
+    "ownerGroupFilter is respected when the union path is active" in {
+      val targetName = "union-owner-target"
+      val targetFqdn = s"$targetName.${okZone.name}"
+      val ownedGroup = "union-owner-group"
+
+      val ownedRecord = aaaa.copy(
+        zoneId = okZone.id,
+        name = targetName,
+        id = UUID.randomUUID().toString,
+        ownerGroupId = Some(ownedGroup)
+      )
+      val unownedPointer = cname.copy(
+        zoneId = okZone.id,
+        name = "union-owner-ptr",
+        id = UUID.randomUUID().toString,
+        records = List(CNAMEData(Fqdn(targetFqdn)))
+      )
+
+      insertAll(List(ownedRecord, unownedPointer).map(makeTestAddChange(_, okZone)))
+
+      val found = repo
+        .listRecordSets(None, None, None, Some(targetFqdn), None, Some(ownedGroup), NameSort.ASC, RecordTypeSort.NONE)
+        .unsafeRunSync()
+
+      found.recordSets shouldBe List(recordSetWithFQDN(ownedRecord, okZone))
     }
   }
   "get record sets by name and type" should {

--- a/modules/mysql/src/main/resources/db/migration/V3.33__AddRecordDataValue.sql
+++ b/modules/mysql/src/main/resources/db/migration/V3.33__AddRecordDataValue.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS ${dbName};
+ 
+USE ${dbName};
+ 
+ALTER TABLE recordset_data
+ADD COLUMN record_data_value VARCHAR(1000) GENERATED ALWAYS AS (
+  CASE
+    WHEN type IN ('TXT', 'SPF') THEN NULL
+    ELSE TRIM(BOTH '"' FROM REGEXP_SUBSTR(record_data, '"[^"]*"'))
+  END
+) VIRTUAL,
+ADD INDEX idx_record_data_value (record_data_value);

--- a/modules/mysql/src/main/resources/test/ddl.sql
+++ b/modules/mysql/src/main/resources/test/ddl.sql
@@ -129,7 +129,8 @@ CREATE TABLE IF NOT EXISTS recordset_data
   reverse_fqdn VARCHAR(255) NOT NULL,
   type VARCHAR(25) NOT NULL,
   record_data VARCHAR(4096) NOT NULL,
-  ip VARBINARY(16)
+  ip VARBINARY(16),
+  record_data_value VARCHAR(1000) NULL
 );
 
 CREATE INDEX IF NOT EXISTS recordset_data_zone_id_index

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -299,7 +299,8 @@ class MySqlRecordSetCacheRepository
               Some(sqls"recordset_data.reverse_fqdn LIKE ${wildcardStart.replaceAllIn(fqdn, "$1").reverse.replace('*', '%') + "%"} ")
             case _ =>
               // By default, just use a LIKE query
-              Some(sqls"recordset.fqdn LIKE ${fqdn.replace('*', '%')} ")
+              val pattern = "%" + fqdn.replace('*', '%') + "%"
+              Some(sqls"(recordset.fqdn LIKE $pattern OR (recordset.type = '3' AND recordset.data LIKE $pattern))")
           }
           case (Some(zId), None) => Some(sqls"recordset.zone_id = $zId ")
           case _ => None

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -276,136 +276,156 @@ class MySqlRecordSetCacheRepository
     * @return A list of {@link RecordSet} matching the criteria
     */
   def listRecordSetData(
-                         zoneId: Option[String],
-                         startFrom: Option[String],
-                         maxItems: Option[Int],
-                         recordNameFilter: Option[String],
-                         recordTypeFilter: Option[Set[RecordType]],
-                         recordOwnerGroupFilter: Option[String],
-                         nameSort: NameSort
-                       ): IO[ListRecordSetResults] =
-    monitor("repo.RecordSet.listRecordSetData") {
-      IO {
-        val maxPlusOne = maxItems.map(_ + 1)
-        val wildcardStart = raw"^\s*[*%](.+[^*%])\s*$$".r
+                       zoneId: Option[String],
+                       startFrom: Option[String],
+                       maxItems: Option[Int],
+                       recordNameFilter: Option[String],
+                       recordTypeFilter: Option[Set[RecordType]],
+                       recordOwnerGroupFilter: Option[String],
+                       nameSort: NameSort
+                     ): IO[ListRecordSetResults] =
+  monitor("repo.RecordSet.listRecordSetData") {
+    IO {
+      val maxPlusOne = maxItems.map(_ + 1)
+      val wildcardStart = raw"^\s*[*%](.+[^*%])\s*$$".r
 
-        // setup optional filters
-        val zoneAndNameFilters = (zoneId, recordNameFilter) match {
-          case (Some(zId), Some(rName)) =>
-            Some(sqls"recordset.zone_id = $zId AND recordset.name LIKE ${rName.replace('*', '%')} ")
-          case (None, Some(fqdn)) => fqdn match {
-            case fqdn if wildcardStart.pattern.matcher(fqdn).matches() =>
-              // If we have a wildcard at the beginning only, then use the reverse_fqdn DB index
-              Some(sqls"recordset_data.reverse_fqdn LIKE ${wildcardStart.replaceAllIn(fqdn, "$1").reverse.replace('*', '%') + "%"} ")
-            case _ =>
-              // By default, just use a LIKE query
-              val pattern = "%" + fqdn.replace('*', '%') + "%"
-              Some(sqls"(recordset.fqdn LIKE $pattern OR (recordset.type = '3' AND recordset.data LIKE $pattern))")
-          }
-          case (Some(zId), None) => Some(sqls"recordset.zone_id = $zId ")
-          case _ => None
-        }
-
-        val searchByZone = zoneId.fold[Boolean](false)(_ => true)
-        val pagingKey = PagingKey(startFrom)
-
-        // sort by name or fqdn in given order
-        val sortBy = (searchByZone, nameSort) match {
-          case (true, NameSort.DESC) =>
-            pagingKey.as(
-              sqls"((recordset.name <= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.name < ${pagingKey.map(pk => pk.recordName)})"
-            )
-          case (false, NameSort.ASC) =>
-            pagingKey.as(
-              sqls"((recordset.fqdn >= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.fqdn > ${pagingKey.map(pk => pk.recordName)})"
-            )
-          case (false, NameSort.DESC) =>
-            pagingKey.as(
-              sqls"((recordset.fqdn <= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.fqdn < ${pagingKey.map(pk => pk.recordName)})"
-            )
+      // setup optional filters
+      val zoneAndNameFilters = (zoneId, recordNameFilter) match {
+        case (Some(zId), Some(rName)) =>
+          Some(sqls"recordset.zone_id = $zId AND recordset.name LIKE ${rName.replace('*', '%')} ")
+        case (None, Some(fqdn)) => fqdn match {
+          case fqdn if wildcardStart.pattern.matcher(fqdn).matches() =>
+            Some(sqls"recordset_data.reverse_fqdn LIKE ${wildcardStart.replaceAllIn(fqdn, "$1").reverse.replace('*', '%') + "%"} ")
           case _ =>
-            pagingKey.as(
-              sqls"((recordset.name >= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.name > ${pagingKey.map(pk => pk.recordName)})"
-            )
+            Some(sqls"recordset.fqdn LIKE ${fqdn.replace('*', '%')} ")
+        }
+        case (Some(zId), None) => Some(sqls"recordset.zone_id = $zId ")
+        case _ => None
+      }
+
+      val searchByZone = zoneId.fold[Boolean](false)(_ => true)
+      val pagingKey = PagingKey(startFrom)
+
+      val sortBy = (searchByZone, nameSort) match {
+        case (true, NameSort.DESC) =>
+          pagingKey.as(
+            sqls"((recordset.name <= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.name < ${pagingKey.map(pk => pk.recordName)})"
+          )
+        case (false, NameSort.ASC) =>
+          pagingKey.as(
+            sqls"((recordset.fqdn >= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.fqdn > ${pagingKey.map(pk => pk.recordName)})"
+          )
+        case (false, NameSort.DESC) =>
+          pagingKey.as(
+            sqls"((recordset.fqdn <= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.fqdn < ${pagingKey.map(pk => pk.recordName)})"
+          )
+        case _ =>
+          pagingKey.as(
+            sqls"((recordset.name >= ${pagingKey.map(pk => pk.recordName)} AND recordset.type > ${pagingKey.map(pk => pk.recordType)}) OR recordset.name > ${pagingKey.map(pk => pk.recordName)})"
+          )
+      }
+
+      val typeFilter = recordTypeFilter.map { t =>
+        val list = t.map(fromRecordType)
+        sqls"recordset.type IN ($list)"
+      }
+
+      val ownerGroupFilter =
+        recordOwnerGroupFilter.map(owner => sqls"recordset.owner_group_id = $owner ")
+
+      val opts =
+        (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter).toList
+
+      val qualifiers = if (nameSort == ASC) {
+        sqls"ORDER BY fqdn ASC, type ASC "
+      } else {
+        sqls"ORDER BY fqdn DESC, type ASC "
+      }
+
+      val recordLimit = maxPlusOne match {
+        case Some(limit) => sqls"LIMIT $limit"
+        case None => sqls""
+      }
+
+      val finalQualifiers = qualifiers.append(recordLimit)
+
+      val initialQuery =
+        sqls"SELECT /*+ MAX_EXECUTION_TIME(20000) */ recordset.data, recordset.fqdn AS fqdn, recordset.type AS type FROM recordset_data "
+
+      val recordsetDataJoin =
+        sqls"RIGHT JOIN recordset ON recordset.id=recordset_data.recordset_id "
+
+      val recordsetDataJoinQuery = initialQuery.append(recordsetDataJoin)
+
+      val groupByClause =
+        sqls"GROUP BY recordset_data.recordset_id, recordset_data.type "
+
+      val appendOpts = if (opts.nonEmpty) {
+        val setDelimiter = SQLSyntax.join(opts, sqls"AND")
+        sqls"WHERE".append(setDelimiter)
+      } else sqls""
+
+      val finalQuery = (zoneId, recordNameFilter) match {
+        case (None, Some(fqdn)) if !wildcardStart.pattern.matcher(fqdn).matches() =>
+          val part1 = recordsetDataJoinQuery
+            .append(appendOpts)
+            .append(groupByClause)
+
+          val recordDataValueOpts =
+            (Some(sqls"recordset_data.record_data_value LIKE ${fqdn.replace('*', '%')} ") ++
+              sortBy ++ typeFilter ++ ownerGroupFilter).toList
+
+          val appendRecordDataValueOpts = if (recordDataValueOpts.nonEmpty) {
+            val setDelimiter = SQLSyntax.join(recordDataValueOpts, sqls"AND")
+            sqls"WHERE".append(setDelimiter)
+          } else sqls""
+
+          val part2 =
+            sqls"SELECT /*+ MAX_EXECUTION_TIME(20000) */ recordset.data, recordset.fqdn AS fqdn, recordset.type AS type FROM recordset_data "
+              .append(recordsetDataJoin)
+              .append(appendRecordDataValueOpts)
+              .append(groupByClause)
+
+          part1
+            .append(sqls"UNION ")
+            .append(part2)
+            .append(finalQualifiers)
+
+        case _ =>
+          recordsetDataJoinQuery
+            .append(appendOpts)
+            .append(groupByClause)
+            .append(finalQualifiers)
+      }
+
+      DB.readOnly { implicit s =>
+        val results = sql"$finalQuery"
+          .map(toRecordSetData)
+          .list()
+          .apply()
+
+        val newResults = if (maxPlusOne.contains(results.size)) {
+          results.dropRight(1)
+        } else {
+          results
         }
 
-        val typeFilter = recordTypeFilter.map { t =>
-          val list = t.map(fromRecordType)
-          sqls"recordset.type IN ($list)"
-        }
+        val nextId = maxPlusOne
+          .filter(_ == results.size)
+          .flatMap(_ => newResults.lastOption.map(PagingKey.toNextId(_, searchByZone)))
 
-        val ownerGroupFilter =
-          recordOwnerGroupFilter.map(owner => sqls"recordset.owner_group_id = $owner ")
-
-        val opts =
-          (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter).toList
-
-        val qualifiers = if (nameSort == ASC) {
-          sqls"ORDER BY recordset.fqdn ASC, recordset.type ASC "
-        }
-        else {
-          sqls"ORDER BY recordset.fqdn DESC, recordset.type ASC "
-        }
-
-        val recordLimit = maxPlusOne match {
-          case Some(limit) => sqls"LIMIT $limit"
-          case None => sqls""
-        }
-
-        val finalQualifiers = qualifiers.append(recordLimit)
-
-        // Construct query. We include the MySQL MAX_EXECUTION_TIME directive here to limit the maximum amount of time
-        // this query can execute. The API should timeout before we reach 20s - this is just to avoid user-generated
-        // long-running queries leading to performance degradation
-        val initialQuery = sqls"SELECT /*+ MAX_EXECUTION_TIME(20000) */ recordset.data, recordset.fqdn FROM recordset_data "
-
-        // Join query for data column from recordset table
-        val recordsetDataJoin = sqls"RIGHT JOIN recordset ON recordset.id=recordset_data.recordset_id "
-        val recordsetDataJoinQuery = initialQuery.append(recordsetDataJoin)
-
-        // Add GROUP BY clause to group by recordset_data.recordset_id and recordset_data.type
-        val groupByClause = sqls"GROUP BY recordset_data.recordset_id, recordset_data.type "
-
-        val appendOpts = if (opts.nonEmpty) {
-          val setDelimiter = SQLSyntax.join(opts, sqls"AND")
-          val addWhere = sqls"WHERE"
-          addWhere.append(setDelimiter)
-        } else sqls""
-
-        val appendQueries = recordsetDataJoinQuery.append(appendOpts).append(groupByClause)
-
-        val finalQuery = appendQueries.append(finalQualifiers)
-        DB.readOnly { implicit s =>
-          val results = sql"$finalQuery"
-            .map(toRecordSetData)
-            .list()
-            .apply()
-
-          val newResults = if (maxPlusOne.contains(results.size)) {
-            results.dropRight(1)
-          } else {
-            results
-          }
-
-          // if size of results is less than the maxItems plus one, we don't have a next id
-          // if maxItems is None, we don't have a next id
-          val nextId = maxPlusOne
-            .filter(_ == results.size)
-            .flatMap(_ => newResults.lastOption.map(PagingKey.toNextId(_, searchByZone)))
-
-          ListRecordSetResults(
-            recordSets = newResults,
-            nextId = nextId,
-            startFrom = startFrom,
-            maxItems = maxItems,
-            recordNameFilter = recordNameFilter,
-            recordTypeFilter = recordTypeFilter,
-            nameSort = nameSort,
-            recordTypeSort = RecordTypeSort.NONE)
-        }
+        ListRecordSetResults(
+          recordSets = newResults,
+          nextId = nextId,
+          startFrom = startFrom,
+          maxItems = maxItems,
+          recordNameFilter = recordNameFilter,
+          recordTypeFilter = recordTypeFilter,
+          nameSort = nameSort,
+          recordTypeSort = RecordTypeSort.NONE)
       }
     }
-
+  }
 
   private val IPV4_ARPA = ".in-addr.arpa."
   private val IPV6_ARPA = ".ip6.arpa."

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -171,128 +171,149 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     }
 
   def listRecordSets(
-                      zoneId: Option[String],
-                      startFrom: Option[String],
-                      maxItems: Option[Int],
-                      recordNameFilter: Option[String],
-                      recordTypeFilter: Option[Set[RecordType]],
-                      recordOwnerGroupFilter: Option[String],
-                      nameSort: NameSort,
-                      recordTypeSort: RecordTypeSort,
-                    ): IO[ListRecordSetResults] =
-    monitor("repo.RecordSet.listRecordSets") {
-      IO {
-        DB.readOnly { implicit s =>
-          val maxPlusOne = maxItems.map(_ + 1)
+                    zoneId: Option[String],
+                    startFrom: Option[String],
+                    maxItems: Option[Int],
+                    recordNameFilter: Option[String],
+                    recordTypeFilter: Option[Set[RecordType]],
+                    recordOwnerGroupFilter: Option[String],
+                    nameSort: NameSort,
+                    recordTypeSort: RecordTypeSort,
+                  ): IO[ListRecordSetResults] =
+  monitor("repo.RecordSet.listRecordSets") {
+    IO {
+      DB.readOnly { implicit s =>
+        val maxPlusOne = maxItems.map(_ + 1)
+        val wildcardStart = raw"^\s*[*%](.+[^*%])\s*$$".r
 
-          // setup optional filters
-          val zoneAndNameFilters = (zoneId, recordNameFilter) match {
-            case (Some(zId), Some(rName)) =>
-              Some(sqls"zone_id = $zId AND name LIKE ${rName.replace('*', '%')} ")
-            case (None, Some(fqdn)) =>
-              val pattern = "%" + fqdn.replace('*', '%') + "%"
-              Some(sqls"(fqdn LIKE $pattern OR (type = '3' AND data LIKE $pattern))")
-            case (Some(zId), None) => Some(sqls"zone_id = $zId ")
-            case _ => None
-          }
-          
-          val searchByZone = zoneId.fold[Boolean](false)(_ => true)
-          val pagingKey = PagingKey(startFrom)
-
-          // sort by name or fqdn in given order
-          val sortBy = (searchByZone, nameSort) match {
-            case (true, NameSort.DESC) =>
-              pagingKey.as(
-                sqls"((name <= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR name < ${pagingKey.map(pk => pk.recordName)})"
-              )
-            case (false, NameSort.ASC) =>
-              pagingKey.as(
-                sqls"((fqdn >= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR fqdn > ${pagingKey.map(pk => pk.recordName)})"
-              )
-            case (false, NameSort.DESC) =>
-              pagingKey.as(
-                sqls"((fqdn <= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR fqdn < ${pagingKey.map(pk => pk.recordName)})"
-              )
+        // setup optional filters
+        val zoneAndNameFilters = (zoneId, recordNameFilter) match {
+          case (Some(zId), Some(rName)) =>
+            Some(sqls"zone_id = $zId AND name LIKE ${rName.replace('*', '%')} ")
+          case (None, Some(fqdn)) => fqdn match {
+            case fqdn if wildcardStart.pattern.matcher(fqdn).matches() =>
+              Some(sqls"fqdn LIKE ${fqdn.replace('*', '%')} ")
             case _ =>
-              pagingKey.as(
-                sqls"((name >= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR name > ${pagingKey.map(pk => pk.recordName)})"
-              )
+              Some(sqls"fqdn LIKE ${fqdn.replace('*', '%')} ")
           }
-
-          val typeFilter = recordTypeFilter.map { t =>
-            val list = t.map(fromRecordType)
-            sqls"type IN ($list)"
-          }
-
-          val ownerGroupFilter =
-            recordOwnerGroupFilter.map(owner => sqls"owner_group_id = $owner ")
-
-          val opts =
-            (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter).toList
-
-          val nameSortQualifiers = nameSort match {
-            case NameSort.ASC => sqls"ORDER BY fqdn ASC, type ASC "
-            case NameSort.DESC => sqls"ORDER BY fqdn DESC, type ASC "
-          }
-
-          val recordTypeSortQualifiers = recordTypeSort match {
-            case RecordTypeSort.ASC => sqls"ORDER BY type ASC"
-            case RecordTypeSort.DESC => sqls"ORDER BY type DESC"
-            case RecordTypeSort.NONE => nameSortQualifiers
-
-          }
-
-          val recordLimit = maxPlusOne match {
-            case Some(limit) => sqls"LIMIT $limit"
-            case None => sqls""
-          }
-
-          val finalQualifiers = recordTypeSortQualifiers.append(recordLimit)
-
-          // construct query
-          val initialQuery = sqls"SELECT data, fqdn FROM recordset "
-
-          val appendOpts = if (opts.nonEmpty){
-            val setDelimiter = SQLSyntax.join(opts, sqls"AND")
-            val addWhere = sqls"WHERE"
-            addWhere.append(setDelimiter)
-          } else sqls""
-
-          val appendQueries = initialQuery.append(appendOpts)
-
-          val finalQuery = appendQueries.append(finalQualifiers)
-
-          val results = sql"$finalQuery"
-            .map(toRecordSet)
-            .list()
-            .apply()
-
-          val newResults = if (maxPlusOne.contains(results.size)) {
-            results.dropRight(1)
-          } else {
-            results
-          }
-
-          // if size of results is less than the maxItems plus one, we don't have a next id
-          // if maxItems is None, we don't have a next id
-
-          val nextId = maxPlusOne
-            .filter(_ == results.size)
-            .flatMap(_ => newResults.lastOption.map(PagingKey.toNextId(_, searchByZone)))
-
-          ListRecordSetResults(
-            recordSets = newResults,
-            nextId = nextId,
-            startFrom = startFrom,
-            maxItems = maxItems,
-            recordNameFilter = recordNameFilter,
-            recordTypeFilter = recordTypeFilter,
-            nameSort = nameSort,
-            recordTypeSort = recordTypeSort
-          )
+          case (Some(zId), None) => Some(sqls"zone_id = $zId ")
+          case _ => None
         }
+
+        val searchByZone = zoneId.fold[Boolean](false)(_ => true)
+        val pagingKey = PagingKey(startFrom)
+
+        val sortBy = (searchByZone, nameSort) match {
+          case (true, NameSort.DESC) =>
+            pagingKey.as(
+              sqls"((name <= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR name < ${pagingKey.map(pk => pk.recordName)})"
+            )
+          case (false, NameSort.ASC) =>
+            pagingKey.as(
+              sqls"((fqdn >= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR fqdn > ${pagingKey.map(pk => pk.recordName)})"
+            )
+          case (false, NameSort.DESC) =>
+            pagingKey.as(
+              sqls"((fqdn <= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR fqdn < ${pagingKey.map(pk => pk.recordName)})"
+            )
+          case _ =>
+            pagingKey.as(
+              sqls"((name >= ${pagingKey.map(pk => pk.recordName)} AND type > ${pagingKey.map(pk => pk.recordType)}) OR name > ${pagingKey.map(pk => pk.recordName)})"
+            )
+        }
+
+        val typeFilter = recordTypeFilter.map { t =>
+          val list = t.map(fromRecordType)
+          sqls"type IN ($list)"
+        }
+
+        val ownerGroupFilter =
+          recordOwnerGroupFilter.map(owner => sqls"owner_group_id = $owner ")
+
+        val opts =
+          (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter).toList
+
+        val nameSortQualifiers = nameSort match {
+          case NameSort.ASC => sqls"ORDER BY fqdn ASC, type ASC "
+          case NameSort.DESC => sqls"ORDER BY fqdn DESC, type ASC "
+        }
+
+        val recordTypeSortQualifiers = recordTypeSort match {
+          case RecordTypeSort.ASC => sqls"ORDER BY type ASC"
+          case RecordTypeSort.DESC => sqls"ORDER BY type DESC"
+          case RecordTypeSort.NONE => nameSortQualifiers
+        }
+
+        val recordLimit = maxPlusOne match {
+          case Some(limit) => sqls"LIMIT $limit"
+          case None => sqls""
+        }
+
+        val finalQualifiers = recordTypeSortQualifiers.append(recordLimit)
+
+        val initialQuery =
+          sqls"SELECT data, fqdn AS fqdn, type AS type FROM recordset "
+
+        val appendOpts = if (opts.nonEmpty) {
+          val setDelimiter = SQLSyntax.join(opts, sqls"AND")
+          sqls"WHERE".append(setDelimiter)
+        } else sqls""
+
+        val part1 = initialQuery.append(appendOpts)
+
+        val finalQuery = (zoneId, recordNameFilter) match {
+          case (None, Some(fqdn)) if !wildcardStart.pattern.matcher(fqdn).matches() =>
+
+            val recordDataValueOpts =
+              (Some(sqls"recordset_data.record_data_value LIKE ${fqdn.replace('*', '%')} ") ++
+                sortBy ++ typeFilter ++ ownerGroupFilter).toList
+
+            val appendRecordDataValueOpts = if (recordDataValueOpts.nonEmpty) {
+              val setDelimiter = SQLSyntax.join(recordDataValueOpts, sqls"AND")
+              sqls"WHERE".append(setDelimiter)
+            } else sqls""
+
+            val part2 =
+              sqls"SELECT recordset.data, recordset.fqdn AS fqdn, recordset.type AS type FROM recordset "
+                .append(sqls"JOIN recordset_data ON recordset.id = recordset_data.recordset_id ")
+                .append(appendRecordDataValueOpts)
+            part1
+              .append(sqls"UNION ")
+              .append(part2)
+              .append(finalQualifiers)
+
+          case _ =>
+            part1.append(finalQualifiers)
+        }
+
+        val results = sql"$finalQuery"
+          .map(toRecordSet)
+          .list()
+          .apply()
+
+        val newResults = if (maxPlusOne.contains(results.size)) {
+          results.dropRight(1)
+        } else {
+          results
+        }
+
+        val nextId = maxPlusOne
+          .filter(_ == results.size)
+          .flatMap(_ => newResults.lastOption.map(PagingKey.toNextId(_, searchByZone)))
+
+        ListRecordSetResults(
+          recordSets = newResults,
+          nextId = nextId,
+          startFrom = startFrom,
+          maxItems = maxItems,
+          recordNameFilter = recordNameFilter,
+          recordTypeFilter = recordTypeFilter,
+          nameSort = nameSort,
+          recordTypeSort = recordTypeSort
+        )
       }
     }
+  }
 
   def getRecordSets(zoneId: String, name: String, typ: RecordType): IO[List[RecordSet]] =
     monitor("repo.RecordSet.getRecordSets") {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -190,12 +190,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
         val zoneAndNameFilters = (zoneId, recordNameFilter) match {
           case (Some(zId), Some(rName)) =>
             Some(sqls"zone_id = $zId AND name LIKE ${rName.replace('*', '%')} ")
-          case (None, Some(fqdn)) => fqdn match {
-            case fqdn if wildcardStart.pattern.matcher(fqdn).matches() =>
-              Some(sqls"fqdn LIKE ${fqdn.replace('*', '%')} ")
-            case _ =>
-              Some(sqls"fqdn LIKE ${fqdn.replace('*', '%')} ")
-          }
+          case (None, Some(fqdn)) => Some(sqls"fqdn LIKE ${fqdn.replace('*', '%')} ")
           case (Some(zId), None) => Some(sqls"zone_id = $zId ")
           case _ => None
         }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -189,11 +189,13 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
           val zoneAndNameFilters = (zoneId, recordNameFilter) match {
             case (Some(zId), Some(rName)) =>
               Some(sqls"zone_id = $zId AND name LIKE ${rName.replace('*', '%')} ")
-            case (None, Some(fqdn)) => Some(sqls"fqdn LIKE ${fqdn.replace('*', '%')} ")
+            case (None, Some(fqdn)) =>
+              val pattern = "%" + fqdn.replace('*', '%') + "%"
+              Some(sqls"(fqdn LIKE $pattern OR (type = '3' AND data LIKE $pattern))")
             case (Some(zId), None) => Some(sqls"zone_id = $zId ")
             case _ => None
           }
-
+          
           val searchByZone = zoneId.fold[Boolean](false)(_ => true)
           val pagingKey = PagingKey(startFrom)
 


### PR DESCRIPTION
Fixes #1411.
Jira Ticket: VDNS-306

Changes in this pull request:

Currently recordSet search only matches against the FQDN field of records. 
As a result:
- Searching for an A record FQDN returns the A record.
- It does not return any CNAME records that point to that A record.
- Users must already know the CNAME alias to find it.

Now enhanced the search functionality to also match the searched FQDN against the Record Data field of CNAME records. When searching by FQDN:
- The system continues to search across all record types using the fqdn field.
- Additionally for CNAME records the search also checks the Record Data field.
- If the searched value matches either:
      The record FQDN or
      The CNAME target value
  the record is returned.
If matches exist in both, both results are returned.

