### PR TITLE
Properly parse and display multi-value TXT records in batch changes

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -128,7 +128,9 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr ng-repeat="change in batch.changes|filter:query" ng-class="{changeError: change.outstandingErrors}">
+                            <tr ng-repeat="change in batch.changes|filter:query" 
+                                ng-hide="change.type=='TXT' && $index > 0 && batch.changes[$index - 1].zoneId === change.zoneId && batch.changes[$index - 1].recordName === change.recordName && batch.changes[$index - 1].type === change.type"
+                                ng-class="{changeError: change.outstandingErrors}">
                                 <td ng-bind="change.changeType"></td>
                                 <td class="wrap-long-text">{{change.inputName}}</td>
                                 <td class="wrap-long-text">{{change.recordName}}</td>
@@ -145,7 +147,14 @@
                                         {{change.record.ptrdname}}
                                     </td>
                                     <td ng-if="change.type=='TXT'" class="wrap-long-text">
-                                        {{change.record.text}}
+                                        <ul class="table-cell-list">
+                                        <li class="wrap-long-text"ng-repeat="c in batch.changes | filter:query" 
+                                            ng-if="c.zoneId === change.zoneId && 
+                                                    c.recordName === change.recordName && 
+                                                    c.type === change.type">
+                                            {{c.record.text}}
+                                        </li>
+                                        </ul>
                                     </td>
                                     <td ng-if="change.type=='MX'">
                                         <ul>

--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -129,7 +129,8 @@
                             </thead>
                             <tbody>
                             <tr ng-repeat="change in batch.changes|filter:query" 
-                                ng-hide="change.type=='TXT' && $index > 0 && batch.changes[$index - 1].zoneId === change.zoneId && batch.changes[$index - 1].recordName === change.recordName && batch.changes[$index - 1].type === change.type"
+                                ng-hide="change.type=='TXT' && $index > 0 && batch.changes[$index - 1].zoneId === change.zoneId && batch.changes[$index - 1].recordName === change.recordName
+                                 && batch.changes[$index - 1].type === change.type && batch.changes[$index - 1].changeType === change.changeType"
                                 ng-class="{changeError: change.outstandingErrors}">
                                 <td ng-bind="change.changeType"></td>
                                 <td class="wrap-long-text">{{change.inputName}}</td>
@@ -151,7 +152,9 @@
                                         <li class="wrap-long-text"ng-repeat="c in batch.changes | filter:query" 
                                             ng-if="c.zoneId === change.zoneId && 
                                                     c.recordName === change.recordName && 
-                                                    c.type === change.type">
+                                                    c.type === change.type &&
+                                                    c.changeType === change.changeType &&
+                                                    c.record && c.record.text">
                                             {{c.record.text}}
                                         </li>
                                         </ul>

--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -128,9 +128,9 @@
                             </tr>
                             </thead>
                             <tbody>
-                            <tr ng-repeat="change in batch.changes|filter:query" 
-                                ng-hide="change.type=='TXT' && $index > 0 && batch.changes[$index - 1].zoneId === change.zoneId && batch.changes[$index - 1].recordName === change.recordName
-                                 && batch.changes[$index - 1].type === change.type && batch.changes[$index - 1].changeType === change.changeType"
+                            <tr ng-repeat="change in batch.changes|filter:query as filteredChanges" 
+                                ng-hide="change.type=='TXT' && $index > 0 && filteredChanges[$index - 1].zoneId === change.zoneId && filteredChanges[$index - 1].recordName === change.recordName
+                                 && filteredChanges[$index - 1].type === change.type && filteredChanges[$index - 1].changeType === change.changeType"
                                 ng-class="{changeError: change.outstandingErrors}">
                                 <td ng-bind="change.changeType"></td>
                                 <td class="wrap-long-text">{{change.inputName}}</td>
@@ -149,13 +149,8 @@
                                     </td>
                                     <td ng-if="change.type=='TXT'" class="wrap-long-text">
                                         <ul class="table-cell-list">
-                                        <li class="wrap-long-text"ng-repeat="c in batch.changes | filter:query" 
-                                            ng-if="c.zoneId === change.zoneId && 
-                                                    c.recordName === change.recordName && 
-                                                    c.type === change.type &&
-                                                    c.changeType === change.changeType &&
-                                                    c.record && c.record.text">
-                                            {{c.record.text}}
+                                        <li class="wrap-long-text" ng-repeat="text in txtRecordGroups[getTxtGroupKey(change)] track by $index">
+                                            {{text}}
                                         </li>
                                         </ul>
                                     </td>

--- a/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
@@ -21,10 +21,30 @@
         .controller('DnsChangeDetailController', function($scope, $log, $location, $timeout, dnsChangeService, utilityService){
 
             $scope.batch = {};
+            $scope.txtRecordGroups = {};
             $scope.alerts = [];
             $scope.reviewComment;
             $scope.reviewConfirmationMsg;
             $scope.reviewType;
+
+            function getTxtGroupKey(change) {
+                return [change.zoneId, change.recordName, change.type, change.changeType].join('||');
+            }
+
+            function buildTxtRecordGroups(changes) {
+                var groups = {};
+                angular.forEach(changes, function(change) {
+                    if (change && change.type === 'TXT' && change.record && change.record.text) {
+                        var key = getTxtGroupKey(change);
+                        if (!groups[key]) {
+                            groups[key] = [];
+                        }
+                        groups[key].push(change.record.text);
+                    }
+                });
+                return groups;
+            }
+            $scope.getTxtGroupKey = getTxtGroupKey;
 
             // Initialize Bootstrap tooltips
             $(document).ready(function() {
@@ -42,6 +62,7 @@
             $scope.getBatchChange = function(batchChangeId) {
                 function success(response) {
                     $scope.batch = response.data;
+                    $scope.txtRecordGroups = buildTxtRecordGroups($scope.batch.changes || []);
                     $scope.batch.createdTimestamp = utilityService.formatDateTime(response.data.createdTimestamp);
                     if (response.data.scheduledTime) {
                         $scope.batch.scheduledTime = utilityService.formatDateTime(response.data.scheduledTime);

--- a/modules/portal/public/lib/dns-change/dns-change-new.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-new.controller.js
@@ -76,9 +76,7 @@
             $scope.createBatchChange = function() {
                 //flag to prevent multiple clicks until previous promise has resolved.
                 $scope.processing = true;
-
                 var payload = $scope.newBatch;
-                
                 function formatData(payload) {
                     if (!$scope.newBatch.ownerGroupId) {
                          delete payload.ownerGroupId
@@ -103,7 +101,7 @@
                                 payload.changes[i] = newEntry;
                             }
                         }
-                        if(entry.type == 'TXT'){
+                        if(entry.type == 'TXT' && entry.record && entry.record.text){
                             var splitValues = entry.record.text
                                 .split(/\r?\n/)
                                 .map(function(v) { return v.trim(); })
@@ -119,6 +117,7 @@
                                         record: { text: splitValues[j] }
                                     });
                                 }
+                                i += (splitValues.length - 1);
                             }
                         }
                         if(entry.changeType == 'DeleteRecordSet' && entry.record) {
@@ -134,7 +133,6 @@
                         }
                     }
                 }
-
                 function success(response) {
                     var alert = utilityService.success('Successfully created DNS Change', response, 'createBatchChange: createBatchChange successful');
                     $scope.alerts.push(alert);

--- a/modules/portal/public/lib/dns-change/dns-change-new.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-new.controller.js
@@ -78,7 +78,7 @@
                 $scope.processing = true;
 
                 var payload = $scope.newBatch;
-
+                
                 function formatData(payload) {
                     if (!$scope.newBatch.ownerGroupId) {
                          delete payload.ownerGroupId
@@ -101,6 +101,24 @@
                             if(entry.record.regexp == undefined){
                                 var newEntry = {changeType: entry.changeType, type: "NAPTR", ttl: entry.ttl, inputName: entry.inputName, record: {order: entry.record.order, preference: entry.record.preference, flags: entry.record.flags, service: entry.record.service, regexp: '', replacement: entry.record.replacement}}
                                 payload.changes[i] = newEntry;
+                            }
+                        }
+                        if(entry.type == 'TXT'){
+                            var splitValues = entry.record.text
+                                .split(/\r?\n/)
+                                .map(function(v) { return v.trim(); })
+                                .filter(function(v) { return v.length > 0; });
+                            if (splitValues.length > 1) {
+                                entry.record.text = splitValues[0];
+                                for (var j = 1; j < splitValues.length; j++) {
+                                    payload.changes.splice(i + j, 0, {
+                                        changeType: entry.changeType,
+                                        type: 'TXT',
+                                        ttl: entry.ttl,
+                                        inputName: entry.inputName,
+                                        record: { text: splitValues[j] }
+                                    });
+                                }
                             }
                         }
                         if(entry.changeType == 'DeleteRecordSet' && entry.record) {
@@ -127,7 +145,6 @@
                 }
 
                 formatData(payload);
-
                 return dnsChangeService.createBatchChange(payload, true)
                     .then(success)
                     .catch(function (error){


### PR DESCRIPTION
Fixes #1482.
Jira Ticket: VDNS-259

Changes in this pull request:

When submitting multi-value TXT records in batch changes with newline-separated values the system did not properly expand them into separate records so it appeared like: ANSWER SECTION:
txttest.shared. 7200 IN TXT ""thisisoneline",\010"thisistwoline",\010thing=value,\010thing2=anotherthing,".

The issue has been fixed by:
- Adding TXT record expansion logic to split multiline input into separate batch change entries before submission.
- Updating the HTML template to group multiple TXT values of the same record into a single row and display them as bullet-pointed values.
