### PR TITLE
Validate zoneId in Create RecordSet API

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -40,6 +40,7 @@ trait DnsJsonProtocol extends JsonValidation {
   val dnsSerializers = Seq(
     CreateZoneInputSerializer,
     UpdateZoneInputSerializer,
+    CreateRecordSetInputSerializer,
     ZoneConnectionSerializer,
     AlgorithmSerializer,
     EncryptedSerializer,
@@ -140,6 +141,61 @@ trait DnsJsonProtocol extends JsonValidation {
         (js \ "scheduleRequestor").optional[String],
         (js \ "backendId").optional[String],
         ).mapN(UpdateZoneInput.apply)
+  }
+
+  case object CreateRecordSetInputSerializer extends ValidationSerializer[vinyldns.api.route.CreateRecordSetInput] {
+    import RecordType._
+    override def fromJson(js: JValue): ValidatedNel[String, vinyldns.api.route.CreateRecordSetInput] = {
+      val recordType = (js \ "type").required(RecordType, "Missing RecordSet.type")
+      val recordTypeGet: RecordType = recordType.getOrElse(A)
+      val createInputResult = (
+        (js \ "zoneId").optional[String],
+        (js \ "name")
+          .required[String]("Missing RecordSet.name")
+          .check(
+            "Record name must not exceed 255 characters" -> checkDomainNameLen,
+            "Record name cannot contain spaces" -> nameDoesNotContainSpaces
+          ),
+        recordType,
+        (js \ "ttl")
+          .required[Long]("Missing RecordSet.ttl")
+          .check(
+            "RecordSet.ttl must be a positive signed 32 bit number" -> (_ <= 2147483647),
+            "RecordSet.ttl must be a positive signed 32 bit number greater than or equal to 30" -> (_ >= 30)
+          ),
+        (js \ "status").default(RecordSetStatus, RecordSetStatus.Pending),
+        (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
+        (js \ "updated").optional[Instant],
+        recordType.andThen(extractRecords(_, js \ "records")),
+        (js \ "id").default[String](UUID.randomUUID().toString),
+        (js \ "account").default[String]("system"),
+        (js \ "ownerGroupId").optional[String],
+        (js \ "recordSetGroupChange").optional[OwnershipTransfer],
+        (js \ "fqdn").optional[String]
+        ).mapN(vinyldns.api.route.CreateRecordSetInput.apply)
+
+      // Put additional record set level checks below
+      createInputResult.checkIf(recordTypeGet == RecordType.CNAME)(
+        "CNAME record sets cannot contain multiple records" -> { crs =>
+          crs.records.length <= 1
+        }
+      )
+    }
+
+    override def toJson(crs: vinyldns.api.route.CreateRecordSetInput): JValue =
+      ("type" -> Extraction.decompose(crs.typ)) ~
+        ("zoneId" -> crs.zoneId) ~
+        ("name" -> crs.name) ~
+        ("ttl" -> crs.ttl) ~
+        ("status" -> Extraction.decompose(crs.status)) ~
+        ("created" -> Extraction.decompose(crs.created)) ~
+        ("updated" -> Extraction.decompose(crs.updated)) ~
+        ("records" -> Extraction.decompose(crs.records)) ~
+        ("id" -> crs.id) ~
+        ("account" -> crs.account) ~
+        ("ownerGroupId" -> crs.ownerGroupId) ~
+        ("recordSetGroupChange" -> Extraction.decompose(crs.recordSetGroupChange)) ~
+        ("fqdn" -> crs.fqdn)
   }
 
   case object AlgorithmSerializer extends ValidationSerializer[Algorithm] {

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -29,6 +29,7 @@ import vinyldns.core.domain.DomainHelpers.ensureTrailingDot
 import vinyldns.core.domain.DomainHelpers.removeWhitespace
 import vinyldns.core.domain.{EncryptFromJson, Encrypted, Fqdn}
 import vinyldns.core.domain.record._
+import vinyldns.core.domain.record.RecordSetStatus.RecordSetStatus
 import vinyldns.core.domain.zone._
 import vinyldns.core.Messages._
 import vinyldns.core.domain.record.OwnershipTransferStatus
@@ -36,6 +37,51 @@ import vinyldns.core.domain.record.OwnershipTransferStatus.OwnershipTransferStat
 
 trait DnsJsonProtocol extends JsonValidation {
   import vinyldns.core.domain.record.RecordType._
+
+  private type CommonRecordSetInputFields =
+    (
+      String,
+      RecordType,
+      Long,
+      RecordSetStatus,
+      Instant,
+      Option[Instant],
+      List[RecordData],
+      String,
+      String,
+      Option[String],
+      Option[OwnershipTransfer],
+      Option[String]
+    )
+
+  private def commonRecordSetInputFields(
+      js: JValue,
+      recordType: ValidatedNel[String, RecordType]
+  ): ValidatedNel[String, CommonRecordSetInputFields] =
+    (
+      (js \ "name")
+        .required[String]("Missing RecordSet.name")
+        .check(
+          "Record name must not exceed 255 characters" -> checkDomainNameLen,
+          "Record name cannot contain spaces" -> nameDoesNotContainSpaces
+        ),
+      recordType,
+      (js \ "ttl")
+        .required[Long]("Missing RecordSet.ttl")
+        .check(
+          "RecordSet.ttl must be a positive signed 32 bit number" -> (_ <= 2147483647),
+          "RecordSet.ttl must be a positive signed 32 bit number greater than or equal to 30" -> (_ >= 30)
+        ),
+      (js \ "status").default(RecordSetStatus, RecordSetStatus.Pending),
+      (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
+      (js \ "updated").optional[Instant],
+      recordType.andThen(extractRecords(_, js \ "records")),
+      (js \ "id").default[String](UUID.randomUUID().toString),
+      (js \ "account").default[String]("system"),
+      (js \ "ownerGroupId").optional[String],
+      (js \ "recordSetGroupChange").optional[OwnershipTransfer],
+      (js \ "fqdn").optional[String]
+    ).tupled
 
   val dnsSerializers = Seq(
     CreateZoneInputSerializer,
@@ -143,36 +189,19 @@ trait DnsJsonProtocol extends JsonValidation {
         ).mapN(UpdateZoneInput.apply)
   }
 
-  case object CreateRecordSetInputSerializer extends ValidationSerializer[vinyldns.api.route.CreateRecordSetInput] {
+  case object CreateRecordSetInputSerializer extends ValidationSerializer[CreateRecordSetInput] {
     import RecordType._
-    override def fromJson(js: JValue): ValidatedNel[String, vinyldns.api.route.CreateRecordSetInput] = {
+    override def fromJson(js: JValue): ValidatedNel[String, CreateRecordSetInput] = {
       val recordType = (js \ "type").required(RecordType, "Missing RecordSet.type")
       val recordTypeGet: RecordType = recordType.getOrElse(A)
+
       val createInputResult = (
         (js \ "zoneId").optional[String],
-        (js \ "name")
-          .required[String]("Missing RecordSet.name")
-          .check(
-            "Record name must not exceed 255 characters" -> checkDomainNameLen,
-            "Record name cannot contain spaces" -> nameDoesNotContainSpaces
-          ),
-        recordType,
-        (js \ "ttl")
-          .required[Long]("Missing RecordSet.ttl")
-          .check(
-            "RecordSet.ttl must be a positive signed 32 bit number" -> (_ <= 2147483647),
-            "RecordSet.ttl must be a positive signed 32 bit number greater than or equal to 30" -> (_ >= 30)
-          ),
-        (js \ "status").default(RecordSetStatus, RecordSetStatus.Pending),
-        (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
-        (js \ "updated").optional[Instant],
-        recordType.andThen(extractRecords(_, js \ "records")),
-        (js \ "id").default[String](UUID.randomUUID().toString),
-        (js \ "account").default[String]("system"),
-        (js \ "ownerGroupId").optional[String],
-        (js \ "recordSetGroupChange").optional[OwnershipTransfer],
-        (js \ "fqdn").optional[String]
-        ).mapN(vinyldns.api.route.CreateRecordSetInput.apply)
+        commonRecordSetInputFields(js, recordType)
+      ).mapN {
+        case (zoneId, (name, typ, ttl, status, created, updated, records, id, account, ownerGroupId, recordSetGroupChange, fqdn)) =>
+          CreateRecordSetInput(zoneId, name, typ, ttl, status, created, updated, records, id, account, ownerGroupId, recordSetGroupChange, fqdn)
+      }
 
       // Put additional record set level checks below
       createInputResult.checkIf(recordTypeGet == RecordType.CNAME)(
@@ -182,7 +211,7 @@ trait DnsJsonProtocol extends JsonValidation {
       )
     }
 
-    override def toJson(crs: vinyldns.api.route.CreateRecordSetInput): JValue =
+    override def toJson(crs: CreateRecordSetInput): JValue =
       ("type" -> Extraction.decompose(crs.typ)) ~
         ("zoneId" -> crs.zoneId) ~
         ("name" -> crs.name) ~
@@ -270,31 +299,11 @@ trait DnsJsonProtocol extends JsonValidation {
       val recordTypeGet: RecordType = recordType.getOrElse(A)
       val recordSetResult = (
         (js \ "zoneId").required[String]("Missing RecordSet.zoneId"),
-        (js \ "name")
-          .required[String]("Missing RecordSet.name")
-          .check(
-            "Record name must not exceed 255 characters" -> checkDomainNameLen,
-            "Record name cannot contain spaces" -> nameDoesNotContainSpaces
-          ),
-        recordType,
-        (js \ "ttl")
-          .required[Long]("Missing RecordSet.ttl")
-          .check(
-            // RFC 1035.2.3.4 and  RFC 2181.8
-            "RecordSet.ttl must be a positive signed 32 bit number" -> (_ <= 2147483647),
-            "RecordSet.ttl must be a positive signed 32 bit number greater than or equal to 30" -> (_ >= 30)
-          ),
-        (js \ "status").default(RecordSetStatus, RecordSetStatus.Pending),
-        (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
-        (js \ "updated").optional[Instant],
-        recordType
-          .andThen(extractRecords(_, js \ "records")),
-        (js \ "id").default[String](UUID.randomUUID().toString),
-        (js \ "account").default[String]("system"),
-        (js \ "ownerGroupId").optional[String],
-        (js \ "recordSetGroupChange").optional[OwnershipTransfer],
-        (js \ "fqdn").optional[String]
-        ).mapN(RecordSet.apply)
+        commonRecordSetInputFields(js, recordType)
+      ).mapN {
+        case (zoneId, (name, typ, ttl, status, created, updated, records, id, account, ownerGroupId, recordSetGroupChange, fqdn)) =>
+          RecordSet(zoneId, name, typ, ttl, status, created, updated, records, id, account, ownerGroupId, recordSetGroupChange, fqdn)
+      }
 
       // Put additional record set level checks below
       recordSetResult.checkIf(recordTypeGet == RecordType.CNAME)(

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -32,6 +32,7 @@ import vinyldns.core.domain.zone.ZoneCommandResult
 import akka.http.scaladsl.model.HttpEntity
 import spray.json._
 
+
 import scala.concurrent.duration._
 
 case class GetRecordSetResponse(recordSet: RecordSetInfo)
@@ -92,7 +93,14 @@ class RecordSetRoute(
   val recordSetRoute: Route = path("zones" / Segment / "recordsets") { zoneId =>
     (post & monitor("Endpoint.addRecordSet")) {
       authenticateAndExecuteWithEntity[ZoneCommandResult, RecordSet](
-        (authPrincipal, recordSet) => recordSetService.addRecordSet(recordSet, authPrincipal)
+        (authPrincipal, recordSet) => {
+          if (recordSet.zoneId.nonEmpty && recordSet.zoneId != zoneId) {
+            Left(RecordSetValidation("zoneId in URI and body must match")).toResult
+          } else {
+            val updatedRecordSet = recordSet.copy(zoneId = zoneId)
+            recordSetService.addRecordSet(updatedRecordSet, authPrincipal)
+          }
+        }
       ) { rc =>
         complete(StatusCodes.Accepted, rc)
       }

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -93,14 +93,14 @@ class RecordSetRoute(
   val recordSetRoute: Route = path("zones" / Segment / "recordsets") { zoneId =>
     (post & monitor("Endpoint.addRecordSet")) {
       authenticateAndExecuteWithEntity[ZoneCommandResult, RecordSet](
-        (authPrincipal, recordSet) => {
-          if (recordSet.zoneId.nonEmpty && recordSet.zoneId != zoneId) {
-            Left(RecordSetValidation("zoneId in URI and body must match")).toResult
-          } else {
-            val updatedRecordSet = recordSet.copy(zoneId = zoneId)
-            recordSetService.addRecordSet(updatedRecordSet, authPrincipal)
+        (authPrincipal, recordSet) =>   
+          recordSet match {
+            case badRs if badRs.zoneId.nonEmpty && badRs.zoneId != zoneId =>
+              Left(InvalidRequest("zoneId in URI and body must match")).toResult
+            case goodRs =>
+              val updatedRecordSet = goodRs.copy(zoneId = zoneId)
+              recordSetService.addRecordSet(updatedRecordSet, authPrincipal)
           }
-        }
       ) { rc =>
         complete(StatusCodes.Accepted, rc)
       }

--- a/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/RecordSetRouting.scala
@@ -27,10 +27,13 @@ import vinyldns.api.domain.zone._
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.RecordTypeSort.RecordTypeSort
-import vinyldns.core.domain.record.{NameSort, OwnershipTransferStatus, RecordSet, RecordType, RecordTypeSort}
+import vinyldns.core.domain.record.RecordSetStatus.RecordSetStatus
+import vinyldns.core.domain.record.{NameSort, OwnershipTransferStatus, RecordSet, RecordType, RecordTypeSort, RecordData, RecordSetStatus, OwnershipTransfer}
 import vinyldns.core.domain.zone.ZoneCommandResult
 import akka.http.scaladsl.model.HttpEntity
 import spray.json._
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 
 import scala.concurrent.duration._
@@ -59,6 +62,22 @@ case class ListRecordSetsByZoneResponse(
                                          nameSort: NameSort,
                                          recordTypeSort: RecordTypeSort
                                        )
+
+case class CreateRecordSetInput(
+                                 zoneId: Option[String] = None,
+                                 name: String,
+                                 typ: RecordType,
+                                 ttl: Long,
+                                 status: RecordSetStatus = RecordSetStatus.Pending,
+                                 created: Instant = Instant.now.truncatedTo(ChronoUnit.MILLIS),
+                                 updated: Option[Instant] = None,
+                                 records: List[RecordData] = List.empty,
+                                 id: String,
+                                 account: String = "system",
+                                 ownerGroupId: Option[String] = None,
+                                 recordSetGroupChange: Option[OwnershipTransfer] = None,
+                                 fqdn: Option[String] = None
+                               )
 
 class RecordSetRoute(
                       recordSetService: RecordSetServiceAlgebra,
@@ -92,14 +111,28 @@ class RecordSetRoute(
 
   val recordSetRoute: Route = path("zones" / Segment / "recordsets") { zoneId =>
     (post & monitor("Endpoint.addRecordSet")) {
-      authenticateAndExecuteWithEntity[ZoneCommandResult, RecordSet](
-        (authPrincipal, recordSet) =>   
-          recordSet match {
-            case badRs if badRs.zoneId.nonEmpty && badRs.zoneId != zoneId =>
-              Left(InvalidRequest("zoneId in URI and body must match")).toResult
-            case goodRs =>
-              val updatedRecordSet = goodRs.copy(zoneId = zoneId)
-              recordSetService.addRecordSet(updatedRecordSet, authPrincipal)
+      authenticateAndExecuteWithEntity[ZoneCommandResult, CreateRecordSetInput](
+        (authPrincipal, createInput) =>
+          createInput.zoneId match {
+            case Some(bodyZoneId) if bodyZoneId != zoneId =>
+              Left(RecordSetValidation("zoneId in URI and body must match")).toResult
+            case _ =>
+              val recordSet = RecordSet(
+                zoneId = zoneId,
+                name = createInput.name,
+                typ = createInput.typ,
+                ttl = createInput.ttl,
+                status = createInput.status,
+                created = createInput.created,
+                updated = createInput.updated,
+                records = createInput.records,
+                id = createInput.id,
+                account = createInput.account,
+                ownerGroupId = createInput.ownerGroupId,
+                recordSetGroupChange = createInput.recordSetGroupChange,
+                fqdn = createInput.fqdn
+              )
+              recordSetService.addRecordSet(recordSet, authPrincipal)
           }
       ) { rc =>
         complete(StatusCodes.Accepted, rc)

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -75,10 +75,7 @@ def test_create_recordset_zoneid_mismatch(shared_zone_test_context):
             {"address": "10.1.1.1"}
         ]
     }
-    url = urljoin(
-        client.index_url,
-        "/zones/{0}/recordsets".format(zone["id"]) 
-    )
+    url = urljoin(client.index_url, "/zones/{0}/recordsets".format(zone["id"]))
     response, error = client.make_request(
         url,
         "POST",

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.test_data import TestData
 from utils import *
+from urllib.parse import urljoin
 
 
 def test_create_recordset_with_dns_verify(shared_zone_test_context):
@@ -57,6 +58,36 @@ def test_create_recordset_with_dns_verify(shared_zone_test_context):
                 traceback.print_exc()
                 pass
 
+def test_create_recordset_zoneid_mismatch(shared_zone_test_context):
+    """
+    Test creating a record set where the zoneId in the body does not match the URI zoneId returns 422
+    """
+
+    client = shared_zone_test_context.ok_vinyldns_client
+    zone = shared_zone_test_context.shared_zone
+
+    new_rs = {
+        "zoneId": shared_zone_test_context.dummy_zone["id"],
+        "name": "test-create-recordset-zoneid-mismatch",
+        "type": "A",
+        "ttl": 100,
+        "records": [
+            {"address": "10.1.1.1"}
+        ]
+    }
+    url = urljoin(
+        client.index_url,
+        "/zones/{0}/recordsets".format(zone["id"]) 
+    )
+    response, error = client.make_request(
+        url,
+        "POST",
+        client.headers,
+        json.dumps(new_rs),
+        status=422
+    )
+
+    assert_that(error, is_("zoneId in URI and body must match"))
 
 def test_create_naptr_origin_record(shared_zone_test_context):
     """

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -60,7 +60,7 @@ def test_create_recordset_with_dns_verify(shared_zone_test_context):
 
 def test_create_recordset_zoneid_mismatch(shared_zone_test_context):
     """
-    Test creating a record set where the zoneId in the body does not match the URI zoneId returns 422
+    Test creating a record set where the zoneId in the body does not match the URI zoneId returns 400
     """
 
     client = shared_zone_test_context.ok_vinyldns_client
@@ -81,10 +81,38 @@ def test_create_recordset_zoneid_mismatch(shared_zone_test_context):
         "POST",
         client.headers,
         json.dumps(new_rs),
-        status=422
+        status=400
     )
 
     assert_that(error, is_("zoneId in URI and body must match"))
+
+def test_create_recordset_omitted_zoneid(shared_zone_test_context):
+    """
+    Test creating a record set where zoneId is omitted from the body uses the URI zoneId
+    """
+
+    client = shared_zone_test_context.ok_vinyldns_client
+    zone = shared_zone_test_context.shared_zone
+
+    new_rs = {
+        "name": "test-create-recordset-omitted-zoneid",
+        "type": "A",
+        "ttl": 100,
+        "records": [
+            {"address": "10.1.1.2"}
+        ]
+    }
+    url = urljoin(client.index_url, "/zones/{0}/recordsets".format(zone["id"]))
+    response, rs = client.make_request(
+        url,
+        "POST",
+        client.headers,
+        json.dumps(new_rs),
+        status=202
+    )
+
+    assert_that(rs["recordSet"]["zoneId"], is_(zone["id"]))
+    assert_that(rs["recordSet"]["name"], is_("test-create-recordset-omitted-zoneid"))
 
 def test_create_naptr_origin_record(shared_zone_test_context):
     """

--- a/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
+++ b/modules/api/src/test/functional/tests/recordsets/create_recordset_test.py
@@ -65,26 +65,29 @@ def test_create_recordset_zoneid_mismatch(shared_zone_test_context):
 
     client = shared_zone_test_context.ok_vinyldns_client
     zone = shared_zone_test_context.shared_zone
+    result_rs = None
 
-    new_rs = {
-        "zoneId": shared_zone_test_context.dummy_zone["id"],
-        "name": "test-create-recordset-zoneid-mismatch",
-        "type": "A",
-        "ttl": 100,
-        "records": [
-            {"address": "10.1.1.1"}
-        ]
-    }
-    url = urljoin(client.index_url, "/zones/{0}/recordsets".format(zone["id"]))
-    response, error = client.make_request(
-        url,
-        "POST",
-        client.headers,
-        json.dumps(new_rs),
-        status=400
-    )
+    try:
+        new_rs = {
+            "zoneId": shared_zone_test_context.dummy_zone["id"],
+            "name": "test-create-recordset-zoneid-mismatch",
+            "type": "A",
+            "ttl": 100,
+            "records": [
+                {"address": "10.1.1.1"}
+            ]
+        }
+        error = client.create_recordset(new_rs, uri_zone_id=zone["id"], status=400)
 
-    assert_that(error, is_("zoneId in URI and body must match"))
+        assert_that(error, is_("zoneId in URI and body must match"))
+    finally:
+        if result_rs:
+            try:
+                delete_result = client.delete_recordset(result_rs["zoneId"], result_rs["id"], status=202)
+                client.wait_until_recordset_change_status(delete_result, "Complete")
+            except Exception:
+                traceback.print_exc()
+                pass
 
 def test_create_recordset_omitted_zoneid(shared_zone_test_context):
     """
@@ -93,26 +96,31 @@ def test_create_recordset_omitted_zoneid(shared_zone_test_context):
 
     client = shared_zone_test_context.ok_vinyldns_client
     zone = shared_zone_test_context.shared_zone
+    result_rs = None
 
-    new_rs = {
-        "name": "test-create-recordset-omitted-zoneid",
-        "type": "A",
-        "ttl": 100,
-        "records": [
-            {"address": "10.1.1.2"}
-        ]
-    }
-    url = urljoin(client.index_url, "/zones/{0}/recordsets".format(zone["id"]))
-    response, rs = client.make_request(
-        url,
-        "POST",
-        client.headers,
-        json.dumps(new_rs),
-        status=202
-    )
+    try:
+        new_rs = {
+            "name": "test-create-recordset-omitted-zoneid",
+            "type": "A",
+            "ttl": 100,
+            "records": [
+                {"address": "10.1.1.2"}
+            ]
+        }
+        rs = client.create_recordset(new_rs, uri_zone_id=zone["id"], status=202)
 
-    assert_that(rs["recordSet"]["zoneId"], is_(zone["id"]))
-    assert_that(rs["recordSet"]["name"], is_("test-create-recordset-omitted-zoneid"))
+        result_rs = client.wait_until_recordset_change_status(rs, "Complete")["recordSet"]
+
+        assert_that(result_rs["zoneId"], is_(zone["id"]))
+        assert_that(result_rs["name"], is_("test-create-recordset-omitted-zoneid"))
+    finally:
+        if result_rs:
+            try:
+                delete_result = client.delete_recordset(result_rs["zoneId"], result_rs["id"], status=202)
+                client.wait_until_recordset_change_status(delete_result, "Complete")
+            except Exception:
+                traceback.print_exc()
+                pass
 
 def test_create_naptr_origin_record(shared_zone_test_context):
     """

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -513,16 +513,18 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, "GET", self.headers, **kwargs)
         return data
 
-    def create_recordset(self, recordset, **kwargs):
+    def create_recordset(self, recordset, uri_zone_id=None, **kwargs):
         """
         Creates a new recordset
         :param recordset: the recordset to be created
+        :param uri_zone_id: optional zone id to use in request URI when different from body or omitted in body
         :return: the content of the response
         """
         if recordset and "name" in recordset:
             recordset["name"] = recordset["name"].replace("_", "-")
 
-        url = urljoin(self.index_url, "/zones/{0}/recordsets".format(recordset["zoneId"]))
+        zone_id = uri_zone_id if uri_zone_id is not None else recordset["zoneId"]
+        url = urljoin(self.index_url, "/zones/{0}/recordsets".format(zone_id))
         response, data = self.make_request(url, "POST", self.headers, json.dumps(recordset), **kwargs)
         return data
 

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -56,6 +56,7 @@ class RecordSetRoutingSpec
   private val notAuthorizedZone = Zone("notAuth", "test@test.com")
   private val syncingZone = Zone("syncing", "test@test.com")
   private val invalidChangeZone = Zone("invalidChange", "test@test.com")
+  private val mismatchedZone = Zone("mismatch", "test@test.com")
   private val recordSetCount = RecordSetCount(5)
 
   private val rsAlreadyExists = RecordSet(
@@ -1305,6 +1306,22 @@ class RecordSetRoutingSpec
     "return 202 Accepted when the the recordset is created" in {
       post(rsOk) ~> recordSetRoute ~> check {
         status shouldBe StatusCodes.Accepted
+      }
+    }
+
+    "return a 422 Unprocessable Entity if the zoneId in the body does not match the one in the URI" in {
+      Post(s"/zones/${okZone.id}/recordsets")
+        .withEntity(
+          HttpEntity(
+            ContentTypes.`application/json`,
+            rsJson(rsOk.copy(zoneId = mismatchedZone.id))
+        )   
+      ) ~>
+      recordSetRoute ~> check {
+        
+        status shouldBe StatusCodes.UnprocessableEntity
+        val error = responseAs[String]
+        error shouldBe "zoneId in URI and body must match"
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/RecordSetRoutingSpec.scala
@@ -1309,7 +1309,7 @@ class RecordSetRoutingSpec
       }
     }
 
-    "return a 422 Unprocessable Entity if the zoneId in the body does not match the one in the URI" in {
+    "return a 400 Bad Request if the zoneId in the body does not match the one in the URI" in {
       Post(s"/zones/${okZone.id}/recordsets")
         .withEntity(
           HttpEntity(
@@ -1319,10 +1319,30 @@ class RecordSetRoutingSpec
       ) ~>
       recordSetRoute ~> check {
         
-        status shouldBe StatusCodes.UnprocessableEntity
+        status shouldBe StatusCodes.BadRequest
         val error = responseAs[String]
         error shouldBe "zoneId in URI and body must match"
       }
+    }
+
+    "return 202 Accepted when zoneId is omitted from the body and uses the URI value" in {
+      val createInput = compact(render(
+        ("type" -> "A") ~~
+        ("id" -> rsOk.id) ~
+        ("name" -> "test-omitted-zoneid") ~~
+        ("ttl" -> 300) ~~
+        ("records" -> List(Map("address" -> "1.2.3.4")))
+      ))
+      Post(s"/zones/${okZone.id}/recordsets")
+        .withEntity(HttpEntity(ContentTypes.`application/json`, createInput)) ~>
+        recordSetRoute ~> check {
+          status shouldBe StatusCodes.Accepted
+          val change = responseAs[RecordSetChange]
+          change.changeType shouldBe RecordSetChangeType.Create
+          change.status shouldBe RecordSetChangeStatus.Complete
+          change.recordSet.zoneId shouldBe okZone.id
+          change.recordSet.name shouldBe rsOk.name
+        }
     }
 
     "return a 404 NOT FOUND if the zone does not exist" in {
@@ -1365,7 +1385,6 @@ class RecordSetRoutingSpec
     "return appropriate errors for missing information" in {
       validateErrors(
         rsMissingData,
-        "Missing RecordSet.zoneId",
         "Missing RecordSet.name",
         "Missing RecordSet.type",
         "Missing RecordSet.ttl"


### PR DESCRIPTION
VDNS-307

Fixes #1490.

This PR fixes an issue in the Create RecordSet API (POST /zones/{zoneId}/recordsets) where the zoneId provided in the request body was used without validating it against the zoneId specified in the URI.

Changes in this pull request:
- The zoneId from the URI is used for processing the request.
- If a zoneId is provided in the request body and it does not match the URI zoneId, the API returns a 400 Bad Request error.

