### PR TITLE
Consolidate messages and make them configurable

### DIFF
--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -33,10 +33,24 @@ vinyldns {
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = false
   load-test-data = ${?LOAD_TEST_DATA}
-  # should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  # Should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
+  # Should be set to true only on a single server/instance else automated sync will be performed at every server/instance
   is-zone-sync-schedule-allowed = true
-  # should be set to true only on a single server/instance else automated sync will be performed at every server/instance
   is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
+
+  # Configure Messages. Override existing messages with new messages. Refer Messages.scala file for existing messages
+  # Have a look on placeholders while making changes, else you may face errors
+  messages = [
+    # Place the existing message present at Messages.scala file in 'text' and the new message in 'override-text'
+    {
+      text = "Dummy message."
+      override-text = "Replacing dummy message with this."
+    },
+    {
+      text = "Cannot create group. A group, %s, is already associated with the email address %s. Please contact %s to be added to the group."
+      override-text = "Cannot create group. A group, %s, is already associated with the email address %s. Please contact %s to be added to the group. Visit FAQ for more information."
+    }
+  ]
 
   # configured backend providers
   backend {

--- a/modules/api/src/main/resources/application.conf
+++ b/modules/api/src/main/resources/application.conf
@@ -33,12 +33,13 @@ vinyldns {
   use-recordset-cache = ${?USE_RECORDSET_CACHE}
   load-test-data = false
   load-test-data = ${?LOAD_TEST_DATA}
-  # Should be true while running locally or when we have only one api server/instance, for zone sync scheduler to work
-  # Should be set to true only on a single server/instance else automated sync will be performed at every server/instance
+  # Enable only for local or single api server/instance to allow zone sync scheduler to run.
   is-zone-sync-schedule-allowed = true
+  # In multi-instance setups, keep this false to avoid duplicate automated sync across instances.
   is-zone-sync-schedule-allowed = ${?IS_ZONE_SYNC_SCHEDULE_ALLOWED}
 
-  # Configure Messages. Override existing messages with new messages. Refer Messages.scala file for existing messages
+  # Configure Messages. Override existing messages with new messages.
+  # Refer to path: vinyldns/modules/core/src/main/scala/vinyldns/core/Messages.scala file for existing messages.
   # Have a look on placeholders while making changes, else you may face errors
   messages = [
     # Place the existing message present at Messages.scala file in 'text' and the new message in 'override-text'

--- a/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/access/AccessValidations.scala
@@ -19,6 +19,7 @@ package vinyldns.api.domain.access
 import vinyldns.api.Interfaces.ensuring
 import vinyldns.api.domain.ReverseZoneHelpers
 import vinyldns.api.domain.zone._
+import vinyldns.core.Messages._
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.{RecordData, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
@@ -32,7 +33,7 @@ class AccessValidations(
 
   def canSeeZone(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =
     ensuring(
-      NotAuthorizedError(s"User ${auth.signedInUser.userName} cannot access zone '${zone.name}'")
+      NotAuthorizedError(CannotAccessZoneErrorMsg.format(auth.signedInUser.userName, zone.name))
     )(
       auth.isSystemAdmin || zone.shared || auth
         .isGroupMember(zone.adminGroupId) || userHasAclRules(auth, zone)
@@ -40,7 +41,7 @@ class AccessValidations(
 
   def canSeeZoneChange(auth: AuthPrincipal, zone: Zone): Either[Throwable, Unit] =
     ensuring(
-      NotAuthorizedError(s"User ${auth.signedInUser.userName} cannot access zone '${zone.name}' changes")
+      NotAuthorizedError(CannotAccessZoneChangeErrorMsg.format(auth.signedInUser.userName, zone.name))
     )(
       auth.isSystemAdmin || zone.shared || auth.isGroupMember(zone.adminGroupId)
     )
@@ -52,8 +53,9 @@ class AccessValidations(
   ): Either[Throwable, Unit] =
     ensuring(
       NotAuthorizedError(
-        s"""User '${auth.signedInUser.userName}' cannot create or modify zone '$zoneName' because
-           |they are not in the Zone Admin Group '$zoneAdminGroupId'""".stripMargin
+        CannotChangeZoneErrorMsg
+          .format(auth.signedInUser.userName, zoneName, zoneAdminGroupId)
+          .stripMargin
           .replace("\n", " ")
       )
     )(auth.isSuper || auth.isGroupMember(zoneAdminGroupId))
@@ -68,8 +70,7 @@ class AccessValidations(
     val accessLevel = getAccessLevel(auth, recordName, recordType, zone, None, recordData)
     ensuring(
       NotAuthorizedError(
-        s"User ${auth.signedInUser.userName} does not have access to create " +
-          s"$recordName.${zone.name}"
+        CannotAddRecordErrorMsg.format(auth.signedInUser.userName, recordName, zone.name)
       )
     )(accessLevel == AccessLevel.Delete || accessLevel == AccessLevel.Write)
   }
@@ -88,8 +89,7 @@ class AccessValidations(
     }
     ensuring(
       NotAuthorizedError(
-        s"User ${auth.signedInUser.userName} does not have access to update " +
-          s"$recordName.${zone.name}"
+        CannotUpdateRecordErrorMsg.format(auth.signedInUser.userName, recordName, zone.name)
       )
     )(accessLevel == AccessLevel.Delete || accessLevel == AccessLevel.Write || superUserCanUpdateOwnerGroup)
   }
@@ -103,10 +103,7 @@ class AccessValidations(
       existingRecordData: List[RecordData] = List.empty
   ): Either[Throwable, Unit] =
     ensuring(
-      NotAuthorizedError(
-        s"User ${auth.signedInUser.userName} does not have access to delete " +
-          s"$recordName.${zone.name}"
-      )
+      NotAuthorizedError(CannotDeleteRecordErrorMsg.format(auth.signedInUser.userName, recordName, zone.name))
     )(
       getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId, existingRecordData) == AccessLevel.Delete
     )
@@ -120,10 +117,7 @@ class AccessValidations(
       recordData: List[RecordData] = List.empty
   ): Either[Throwable, Unit] =
     ensuring(
-      NotAuthorizedError(
-        s"User ${auth.signedInUser.userName} does not have access to view " +
-          s"$recordName.${zone.name}"
-      )
+      NotAuthorizedError(CannotViewRecordErrorMsg.format(auth.signedInUser.userName, recordName, zone.name))
     )(
       getAccessLevel(auth, recordName, recordType, zone, recordOwnerGroupId, recordData) != AccessLevel.NoAccess
     )

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeErrors.scala
@@ -16,11 +16,13 @@
 
 package vinyldns.api.domain.batch
 
-import java.time.Instant
 import vinyldns.api.domain.batch.BatchChangeInterfaces.ValidatedBatch
 import vinyldns.api.domain.batch.BatchTransformations.ChangeForValidation
+import vinyldns.core.Messages._
 import vinyldns.core.domain.DomainValidationError
 import vinyldns.core.domain.batch.{BatchChange, SingleChange}
+import java.time.Instant
+
 
 /* Error response options */
 sealed trait BatchChangeErrorResponse
@@ -37,44 +39,37 @@ final case class BatchChangeFailedApproval(batchChange: BatchChange)
     extends BatchChangeErrorResponse
 
 final case class BatchChangeNotFound(id: String) extends BatchChangeErrorResponse {
-  def message: String = s"Batch change with id $id cannot be found"
+  def message: String = BatchChangeNotFoundErrorMsg.format(id)
 }
 final case class UserNotAuthorizedError(itemId: String) extends BatchChangeErrorResponse {
-  def message: String = s"User does not have access to item $itemId"
+  def message: String = UserNotAuthorizedErrorMsg.format(itemId)
 }
 final case class BatchConversionError(change: SingleChange) extends BatchChangeErrorResponse {
-  def message: String =
-    s"""Batch conversion for processing failed to convert change with name "${change.inputName}"
-       |and type "${change.typ}"""".stripMargin
+  def message: String = BatchConversionErrorMsg.format(change.inputName, change.typ).stripMargin
 }
 final case class UnknownConversionError(message: String) extends BatchChangeErrorResponse
 
 final case class BatchChangeNotPendingReview(id: String) extends BatchChangeErrorResponse {
-  def message: String =
-    s"""Batch change $id is not pending review, so it cannot be rejected."""
+  def message: String = BatchChangeNotPendingReviewErrorMsg.format(id)
 }
 
 final case class BatchRequesterNotFound(userId: String, userName: String)
     extends BatchChangeErrorResponse {
-  def message: String =
-    s"The requesting user with id $userId and name $userName cannot be found in VinylDNS"
+  def message: String = BatchRequesterNotFoundErrorMsg.format(userId, userName)
 }
 
 case object ScheduledChangesDisabled extends BatchChangeErrorResponse {
-  val message: String =
-    "Cannot create a scheduled change, as it is currently disabled on this VinylDNS instance."
+  val message: String = ScheduledChangesDisabledErrorMsg
 }
 
 case object ScheduledTimeMustBeInFuture extends BatchChangeErrorResponse {
-  val message: String = "Scheduled time must be in the future."
+  val message: String = ScheduledTimeMustBeInFutureErrorMsg
 }
 
 final case class ScheduledChangeNotDue(scheduledTime: Instant) extends BatchChangeErrorResponse {
-  val message: String =
-    s"Cannot process scheduled change as it is not past the scheduled date of $scheduledTime"
+  val message: String = ScheduledChangeNotDueErrorMsg.format(scheduledTime)
 }
 
 case object ManualReviewRequiresOwnerGroup extends BatchChangeErrorResponse {
-  val message: String =
-    "Batch change requires owner group for manual review."
+  val message: String = ManualReviewRequiresOwnerGroupErrorMsg
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -154,7 +154,7 @@ class BatchChangeService(
           case e: UserIsNotAuthorizedError =>
             val group = groups.find(_.id == e.ownerGroupId)
             val updatedError = UserIsNotAuthorizedError(
-              e.userName,
+              e.recordName,
               e.ownerGroupId,
               e.ownerType,
               group.map(_.email),

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -609,7 +609,7 @@ class BatchChangeValidations(
       .leftMap(
         _ =>
           UserIsNotAuthorizedError(
-            authPrincipal.signedInUser.userName,
+            input.recordName,
             input.zone.adminGroupId,
             OwnerType.Zone,
             Some(input.zone.email)
@@ -639,10 +639,10 @@ class BatchChangeValidations(
         _ =>
           ownerGroupId match {
             case Some(id) if input.zone.shared =>
-              UserIsNotAuthorizedError(authPrincipal.signedInUser.userName, id, OwnerType.Record)
+              UserIsNotAuthorizedError(input.recordName, id, OwnerType.Record)
             case _ =>
               UserIsNotAuthorizedError(
-                authPrincipal.signedInUser.userName,
+                input.recordName,
                 input.zone.adminGroupId,
                 OwnerType.Zone,
                 Some(input.zone.email)
@@ -672,10 +672,10 @@ class BatchChangeValidations(
         _ =>
           ownerGroupId match {
             case Some(id) if input.zone.shared =>
-              UserIsNotAuthorizedError(authPrincipal.signedInUser.userName, id, OwnerType.Record)
+              UserIsNotAuthorizedError(input.recordName, id, OwnerType.Record)
             case _ =>
               UserIsNotAuthorizedError(
-                authPrincipal.signedInUser.userName,
+                input.recordName,
                 input.zone.adminGroupId,
                 OwnerType.Zone,
                 Some(input.zone.email)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipValidations.scala
@@ -19,6 +19,7 @@ package vinyldns.api.domain.membership
 import vinyldns.api.Interfaces.ensuring
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.api.domain.zone.NotAuthorizedError
+import vinyldns.core.Messages._
 import vinyldns.core.domain.membership.{Group, GroupChange}
 
 object MembershipValidations {
@@ -26,32 +27,32 @@ object MembershipValidations {
   private val canViewGroupDetails = true
 
   def hasMembersAndAdmins(group: Group): Either[Throwable, Unit] =
-    ensuring(InvalidGroupError("Group must have at least one member and one admin")) {
+    ensuring(InvalidGroupError(hasNoMembersAndAdminsErrorMsg)) {
       group.memberIds.nonEmpty && group.adminUserIds.nonEmpty
     }
 
   def canEditGroup(group: Group, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    ensuring(NotAuthorizedError("Not authorized")) {
+    ensuring(NotAuthorizedError(NoAuthorizationErrorMsg)) {
       authPrincipal.isGroupAdmin(group) || authPrincipal.isSuper
     }
 
   def isSuperAdmin(authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    ensuring(NotAuthorizedError("Not authorized")) {
+    ensuring(NotAuthorizedError(NoAuthorizationErrorMsg)) {
       authPrincipal.isSuper
     }
 
   def canSeeGroup(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    ensuring(NotAuthorizedError("Not authorized")) {
+    ensuring(NotAuthorizedError(NoAuthorizationErrorMsg)) {
       authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin || canViewGroupDetails
     }
 
   def canSeeGroupChange(groupId: String, authPrincipal: AuthPrincipal): Either[Throwable, Unit] =
-    ensuring(NotAuthorizedError("Not authorized")) {
+    ensuring(NotAuthorizedError(NoAuthorizationErrorMsg)) {
       authPrincipal.isGroupMember(groupId) || authPrincipal.isSystemAdmin
     }
 
   def isGroupChangePresent(groupChange: Option[GroupChange]): Either[Throwable, Unit] =
-    ensuring(InvalidGroupRequestError("Invalid Group Change ID")) {
+    ensuring(InvalidGroupRequestError(InvalidGroupChangeIdErrorMsg)) {
       groupChange.isDefined
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetValidations.scala
@@ -40,26 +40,23 @@ object RecordSetValidations {
     recordSet.typ match {
       case CNAME | SOA | TXT | NS | DS => ().asRight
       case PTR =>
-        ensuring(InvalidRequest("PTR is not valid in forward lookup zone"))(zone.isReverse)
+        ensuring(InvalidRequest(InvalidPtrErrorMsg))(zone.isReverse)
       case _ =>
-        ensuring(InvalidRequest(s"${recordSet.typ} is not valid in reverse lookup zone."))(
+        ensuring(InvalidRequest(ReverseLookupErrorMsg.format(recordSet.typ)))(
           !zone.isReverse
         )
     }
 
   def validRecordNameLength(recordSet: RecordSet, zone: Zone): Either[Throwable, Unit] = {
     val absoluteName = recordSet.name + "." + zone.name
-    ensuring(InvalidRequest(s"record set name ${recordSet.name} is too long")) {
+    ensuring(InvalidRequest(RecordNameLengthErrorMsg.format(recordSet.name))) {
       absoluteName.length < 256 || isOriginRecord(recordSet.name, zone.name)
     }
   }
 
   def notPending(recordSet: RecordSet): Either[Throwable, Unit] =
     ensuring(
-      PendingUpdateError(
-        s"RecordSet with id ${recordSet.id}, name ${recordSet.name} and type ${recordSet.typ} " +
-          s"currently has a pending change"
-      )
+      PendingUpdateError(PendingUpdateErrorMsg.format(recordSet.id, recordSet.name, recordSet.typ))
     )(
       !recordSet.isPending
     )
@@ -70,10 +67,7 @@ object RecordSetValidations {
       zone: Zone
   ): Either[Throwable, Unit] =
     ensuring(
-      RecordSetAlreadyExists(
-        s"RecordSet with name ${newRecordSet.name} and type CNAME already " +
-          s"exists in zone ${zone.name}"
-      )
+      RecordSetAlreadyExists(RecordSetCnameExistsErrorMsg.format(newRecordSet.name, zone.name))
     )(
       !existingRecordsWithName.exists(rs => rs.id != newRecordSet.id && rs.typ == CNAME)
     )
@@ -85,8 +79,7 @@ object RecordSetValidations {
   ): Either[Throwable, Unit] =
     ensuring(
       RecordSetAlreadyExists(
-        s"RecordSet with name ${newRecordSet.name} and type ${newRecordSet.typ} already " +
-          s"exists in zone ${zone.name}"
+        RecordSetAlreadyExistsErrorMsg.format(newRecordSet.name, newRecordSet.typ, zone.name)
       )
     )(
       !existingRecordsWithName.exists(rs => rs.id != newRecordSet.id && rs.typ == newRecordSet.typ)
@@ -130,10 +123,7 @@ object RecordSetValidations {
      isRecordTypeAndUserAllowed: Boolean
   ): Either[Throwable, Unit] =
     ensuring(
-      InvalidRequest(
-        s"Record with fqdn '${newRecordSet.name}.${zone.name}' cannot be created. " +
-          s"Please check if a record with the same FQDN and type already exist and make the change there."
-      )
+      InvalidRequest(InvalidRequestErrorMsg.format(newRecordSet.name, zone.name))
     )(
       (newRecordSet.name != zone.name || existingRecordSet.exists(_.name == newRecordSet.name)) && recordFqdnDoesNotExist && isRecordTypeAndUserAllowed
     )
@@ -147,9 +137,7 @@ object RecordSetValidations {
      isRecordTypeAndUserAllowed: Boolean
   ): Either[Throwable, Unit] =
     ensuring(
-      InvalidRequest(
-        s"Record type is not allowed or the user is not authorized to create a dotted host in the zone '${zone.name}'"
-      )
+      InvalidRequest(RtypeOrUserNotAllowedErrorMsg.format(zone.name))
     )(
       (newRecordSet.name != zone.name || existingRecordSet.exists(_.name == newRecordSet.name)) && recordFqdnDoesNotExist && isRecordTypeAndUserAllowed
     )
@@ -161,10 +149,7 @@ object RecordSetValidations {
       existingRecordSet: Option[RecordSet] = None
   ): Either[Throwable, Unit] =
     ensuring(
-      InvalidRequest(
-        s"Record with name ${newRecordSet.name} and type ${newRecordSet.typ} is a dotted host which" +
-          s" is not allowed in zone ${zone.name}"
-      )
+      InvalidRequest(DottedHostErrorMsg.format(newRecordSet.name, newRecordSet.typ, zone.name))
     )(
       newRecordSet.name == zone.name || !newRecordSet.name.contains(".") ||
         existingRecordSet.exists(_.name == newRecordSet.name)
@@ -198,9 +183,9 @@ object RecordSetValidations {
         isNotOrigin(
           recordSet,
           zone,
-          s"Record with name ${recordSet.name} is an NS record at apex and cannot be edited"
+          NSApexEditErrorMsg.format(recordSet.name)
         )
-      case SOA => InvalidRequest("SOA records cannot be deleted").asLeft
+      case SOA => InvalidRequest(SOADeleteErrorMsg).asLeft
       case _ => ().asRight
     }
 
@@ -218,10 +203,7 @@ object RecordSetValidations {
     // cannot create a cname record if a record with the same exists
     val noRecordWithName = {
       ensuring(
-        RecordSetAlreadyExists(
-          s"RecordSet with name ${newRecordSet.name} already " +
-            s"exists in zone ${zone.name}, CNAME record cannot use duplicate name"
-        )
+        RecordSetAlreadyExists(CnameDuplicateErrorMsg.format(newRecordSet.name, zone.name))
       )(
         existingRecordsWithName.forall(_.id == newRecordSet.id)
       )
@@ -230,9 +212,7 @@ object RecordSetValidations {
     // cname recordset data cannot contain more than one sequential '.'
     val RDataWithConsecutiveDots = {
       ensuring(
-        RecordSetValidation(
-          s"RecordSet Data cannot contain consecutive 'dot' character. RData: '${newRecordSet.records.head.toString}'"
-        )
+          RecordSetValidation(RDataWithConsecutiveDotsErrorMsg.format(newRecordSet.records.head.toString))
       )(
         noConsecutiveDots(newRecordSet.records.head.toString)
       )
@@ -240,9 +220,7 @@ object RecordSetValidations {
 
     val isNotIPv4inCname = {
       ensuring(
-        RecordSetValidation(
-          s"""Invalid CNAME: ${newRecordSet.records.head.toString.dropRight(1)}, valid CNAME record data cannot be an IP address."""
-        )
+          RecordSetValidation(IPv4inCnameErrorMsg.format(newRecordSet.records.head.toString.dropRight(1)))
       )(
         validateIpv4Address(newRecordSet.records.head.toString.dropRight(1)).isInvalid
       )
@@ -252,7 +230,7 @@ object RecordSetValidations {
       _ <- isNotOrigin(
         newRecordSet,
         zone,
-        "CNAME RecordSet cannot have name '@' because it points to zone origin"
+        InvalidCnameErrorMsg
       )
       _ <- noRecordWithName
       _ <- isNotIPv4inCname
@@ -275,10 +253,7 @@ object RecordSetValidations {
     val nsChecks = existingRecordsWithName.find(_.typ == NS) match {
       case Some(_) => ().asRight
       case None =>
-        InvalidRequest(
-          s"DS record [${newRecordSet.name}] is invalid because there is no NS record with that " +
-            s"name in the zone [${zone.name}]"
-        ).asLeft
+        InvalidRequest(DSInvalidErrorMsg.format(newRecordSet.name, zone.name)).asLeft
     }
 
     for {
@@ -286,7 +261,7 @@ object RecordSetValidations {
       _ <- isNotOrigin(
         newRecordSet,
         zone,
-        s"Record with name [${newRecordSet.name}] is an DS record at apex and cannot be added"
+        DSApexErrorMsg.format(newRecordSet.name)
       )
       _ <- nsChecks
     } yield ()
@@ -310,7 +285,7 @@ object RecordSetValidations {
       _ <- isNotOrigin(
         newRecordSet,
         zone,
-        s"Record with name ${newRecordSet.name} is an NS record at apex and cannot be added"
+        NSApexErrorMsg.format(newRecordSet.name)
       )
       _ <- containsApprovedNameServers(newRecordSet, approvedNameServers)
       _ <- oldRecordSet
@@ -318,7 +293,7 @@ object RecordSetValidations {
           isNotOrigin(
             rs,
             zone,
-            s"Record with name ${newRecordSet.name} is an NS record at apex and cannot be edited"
+            NSApexEditErrorMsg.format(newRecordSet.name)
           )
         }
         .getOrElse(().asRight)
@@ -372,10 +347,7 @@ object RecordSetValidations {
 
   def checkAllowedDots(allowedDotsLimit: Int, recordSet: RecordSet, zone: Zone): Either[Throwable, Unit] = {
     ensuring(
-      InvalidRequest(
-        s"RecordSet with name ${recordSet.name} has more dots than that is allowed in config for this zone " +
-          s"which is, 'dots-limit = $allowedDotsLimit'."
-      )
+      InvalidRequest(MoreDotsThanAllowedErrorMsg.format(recordSet.name, allowedDotsLimit))
     )(
       recordSet.name.count(_ == '.') <= allowedDotsLimit || (recordSet.name.count(_ == '.') == 1 &&
         recordSet.name.takeRight(1) == ".") || recordSet.name == zone.name ||
@@ -385,9 +357,7 @@ object RecordSetValidations {
 
   def isNotApexEndsWithDot(recordSet: RecordSet, zone: Zone): Either[Throwable, Unit] = {
     ensuring(
-      InvalidRequest(
-        "RecordSet name cannot end with a dot, unless it's an apex record."
-      )
+      InvalidRequest(InvalidEndingErrorMsg)
     )(
       recordSet.name.endsWith(zone.name) || !recordSet.name.endsWith(".")
     )
@@ -401,11 +371,11 @@ object RecordSetValidations {
     (ownerGroupId, group) match {
       case (None, _) => ().asRight
       case (Some(groupId), None) => {
-        InvalidGroupError(s"""Record owner group with id "$groupId" not found""").asLeft
+        InvalidGroupError(RecordOwnerGroupNotFoundErrorMsg.format(groupId)).asLeft
       }
       case (Some(groupId), Some(_)) =>
         if (authPrincipal.isSuper || authPrincipal.isGroupMember(groupId)) ().asRight
-        else InvalidRequest(s"""User not in record owner group with id "$groupId"""").asLeft
+        else InvalidRequest(UserNotInOwnerGroupErrorMsg.format(groupId)).asLeft
     }
 
   def isAlreadyOwnerGroupMember(
@@ -416,7 +386,7 @@ object RecordSetValidations {
       recordSet.recordSetGroupChange.exists(change =>
         existing.ownerGroupId != change.requestedOwnerGroupId || change.ownershipTransferStatus == OwnershipTransferStatus.Cancelled),
       (),
-      InvalidRequest(s"""Record owner group with id ${existing.ownerGroupId.getOrElse("<none>")} already owns the record, new request is not needed"""")
+      InvalidRequest(OwnershipTransferAlreadyOwnedErrorMsg.format(existing.ownerGroupId.getOrElse("<none>")))
     )
 
   def isValidOwnershipTransferStatusPendingReview(
@@ -425,7 +395,7 @@ object RecordSetValidations {
     Either.cond(
       !ownershipTransfer.exists(_.ownershipTransferStatus == OwnershipTransferStatus.PendingReview),
       (),
-      InvalidRequest(s"Invalid Ownership transfer status: ${ownershipTransfer.map(_.ownershipTransferStatus).getOrElse("none")}")
+      InvalidRequest(OwnershipTransferInvalidPendingReviewErrorMsg.format(ownershipTransfer.map(_.ownershipTransferStatus).getOrElse("none")))
     )
 
   def isValidOwnershipTransferStatusApprove(
@@ -443,7 +413,7 @@ object RecordSetValidations {
     Either.cond(
       !(isInvalidApproval && (existingStatus == OwnershipTransferStatus.None || existingStatus == OwnershipTransferStatus.Cancelled)),
       (),
-      InvalidRequest(s"Unable to $requestedStatus the Ownership transfer status for the record: None")
+      InvalidRequest(OwnershipTransferInvalidApprovalErrorMsg.format(requestedStatus))
     )
   }
 
@@ -463,7 +433,7 @@ object RecordSetValidations {
       !isCancelRequest || canCancel,
       (),
       InvalidRequest(
-        s"Unable to cancel the Ownership transfer. Current status: $exitingOwnershipTransferStatus"
+        OwnershipTransferInvalidCancelErrorMsg.format(exitingOwnershipTransferStatus)
       )
     )
   }
@@ -478,7 +448,7 @@ object RecordSetValidations {
           authPrincipal.isSuper ||
           authPrincipal.isGroupMember(owt.requestedOwnerGroupId.getOrElse("none"))},
       (),
-      InvalidRequest("Unauthorised to Cancel the ownership transfer")
+      InvalidRequest(OwnershipTransferUnauthorisedCancelErrorMsg)
     )
 
   def canChangeFromPendingReview(
@@ -488,7 +458,7 @@ object RecordSetValidations {
 
     val currentOwnershipTransferStatus = recordSet.recordSetGroupChange.map(_.ownershipTransferStatus).getOrElse(OwnershipTransferStatus.None)
     ensuring(
-      NotAuthorizedError(s"Unauthorized to change ownership transfer status to '$currentOwnershipTransferStatus'")
+      NotAuthorizedError(OwnershipTransferUnauthorizedChangeErrorMsg.format(currentOwnershipTransferStatus))
     )(authPrincipal.isSuper || authPrincipal.isGroupMember(recordSet.ownerGroupId.getOrElse("none")))
   }
 
@@ -500,7 +470,7 @@ object RecordSetValidations {
     updates.name.toLowerCase == existing.name.toLowerCase
       || (updates.name == "@" && existing.name.toLowerCase == zone.name.toLowerCase),
     (),
-    InvalidRequest("Cannot update RecordSet's name.")
+    InvalidRequest(UnchangedRecordNameErrorMsg)
   )
 
   def unchangedRecordType(
@@ -510,7 +480,7 @@ object RecordSetValidations {
     Either.cond(
       updates.typ == existing.typ,
       (),
-      InvalidRequest("Cannot update RecordSet's record type.")
+      InvalidRequest(UnchangedRecordTypeErrorMsg)
     )
 
   def unchangedZoneId(
@@ -520,7 +490,7 @@ object RecordSetValidations {
     Either.cond(
       updates.zoneId == existing.zoneId,
       (),
-      InvalidRequest("Cannot update RecordSet's zone ID.")
+      InvalidRequest(UnchangedZoneIdErrorMsg)
     )
 
   /**
@@ -544,7 +514,7 @@ object RecordSetValidations {
     )
 
   def validRecordNameFilterLength(recordNameFilter: String): Either[Throwable, Unit] =
-    ensuring(onError = InvalidRequest(RecordNameFilterError)) {
+    ensuring(onError = InvalidRequest(RecordNameFilterErrorMsg)) {
       val searchRegex = "[a-zA-Z0-9].*[a-zA-Z0-9]+".r
       val wildcardRegex = raw"^\s*[*%].*[*%]\s*$$".r
       searchRegex.findFirstIn(recordNameFilter).isDefined && wildcardRegex.findFirstIn(recordNameFilter).isEmpty
@@ -563,7 +533,7 @@ object RecordSetValidations {
         updates.ownerGroupId == existing.ownerGroupId &&
         updates.ttl == existing.ttl,
       (),
-      InvalidRequest("Cannot update RecordSet's if user not a member of ownership group. User can only request for ownership transfer")
+      InvalidRequest(OwnershipTransferUpdateErrorMsg)
     )
 
   def recordSetOwnershipApproveStatus(
@@ -574,7 +544,7 @@ object RecordSetValidations {
         updates.recordSetGroupChange.map(_.ownershipTransferStatus).getOrElse("<none>") != OwnershipTransferStatus.AutoApproved &&
         updates.recordSetGroupChange.map(_.ownershipTransferStatus).getOrElse("<none>") != OwnershipTransferStatus.ManuallyRejected,
       (),
-      InvalidRequest("Cannot update RecordSet Ownership Status when request is cancelled.")
+      InvalidRequest(OwnershipTransferCancelledRequestErrorMsg)
     )
 
   def unchangedRecordSetOwnershipStatus(
@@ -584,6 +554,6 @@ object RecordSetValidations {
     Either.cond(
       updates.recordSetGroupChange == existing.recordSetGroupChange || existing.recordSetGroupChange.isEmpty,
       (),
-      InvalidRequest("Cannot update RecordSet Ownership Status when zone is not shared.")
+      InvalidRequest(OwnershipTransferZoneNotSharedErrorMsg)
     )
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneRecordValidations.scala
@@ -18,6 +18,7 @@ package vinyldns.api.domain.zone
 
 import cats.implicits._
 import cats.data._
+import vinyldns.core.Messages._
 import com.comcast.ip4s.IpAddress
 import vinyldns.core.domain.{DomainHelpers, DomainValidationError, HighValueDomainError, RecordRequiresManualReview}
 import vinyldns.core.domain.record.{NSData, RecordSet}
@@ -45,7 +46,7 @@ object ZoneRecordValidations {
     if (isStringInRegexList(approvedServerList, nsData.nsdname.fqdn)) {
       nsData.validNel[String]
     } else {
-      s"Name Server ${nsData.nsdname.fqdn} is not an approved name server.".invalidNel[NSData]
+      ApprovedNameServerMsg.format(nsData.nsdname.fqdn).invalidNel[NSData]
     }
 
   /* Inspects each record in the rdata, returning back the record set itself or all ns records that are not approved */

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -21,6 +21,7 @@ import com.comcast.ip4s.Cidr
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import vinyldns.api.Interfaces.ensuring
+import vinyldns.core.Messages._ 
 import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record.RecordType
 import vinyldns.core.domain.zone.{ACLRule, Zone, ZoneACL}
@@ -32,7 +33,7 @@ class ZoneValidations(syncDelayMillis: Int) {
   def outsideSyncDelay(zone: Zone): Either[Throwable, Unit] =
     zone.latestSync match {
       case Some(time) if Instant.now.truncatedTo(ChronoUnit.MILLIS).toEpochMilli - time.toEpochMilli < syncDelayMillis => {
-        RecentSyncError(s"Zone ${zone.name} was recently synced. Cannot complete sync").asLeft
+        RecentSyncError(RecentSyncErrorMsg.format(zone.name)).asLeft
       }
       case _ => Right(())
     }
@@ -50,7 +51,7 @@ class ZoneValidations(syncDelayMillis: Int) {
     } yield ()
 
   def isUserOrGroupRule(rule: ACLRule): Either[Throwable, Unit] =
-    ensuring(InvalidRequest("Invalid ACL rule: ACL rules must have a group or user id")) {
+    ensuring(InvalidRequest(InvalidACLRuleErrorMsg)) {
       (rule.groupId ++ rule.userId).size == 1
     }
 
@@ -60,21 +61,21 @@ class ZoneValidations(syncDelayMillis: Int) {
         Try(Cidr.fromString(mask).get) match {
           case Success(_) => Right(())
           case Failure(_) =>
-            InvalidRequest(s"PTR types must have no mask or a valid CIDR mask: Invalid CIDR block").asLeft
+            InvalidRequest(CIDRErrorMsg).asLeft
         }
       case Some(_) if rule.recordTypes.contains(RecordType.PTR) =>
-        InvalidRequest("Multiple record types including PTR must have no mask").asLeft
+        InvalidRequest(PTRNoMaskErrorMsg).asLeft
       case Some(mask) =>
         Try("string".matches(mask)) match {
           case Success(_) => ().asRight
-          case Failure(_) => InvalidRequest(s"record mask $mask is an invalid regex").asLeft
+          case Failure(_) => InvalidRequest(InvalidRegexErrorMsg.format(mask)).asLeft
         }
       case None => ().asRight
     }
 
   // Validates that the zone is either not shared or shared and the user is a super or support user
   def validateSharedZoneAuthorized(zoneShared: Boolean, user: User): Either[Throwable, Unit] =
-    ensuring(NotAuthorizedError("Not authorized to create shared zones."))(
+    ensuring(NotAuthorizedError(CreateSharedZoneErrorMsg))(
       !zoneShared || user.isSuper || user.isSupport
     )
 
@@ -86,7 +87,7 @@ class ZoneValidations(syncDelayMillis: Int) {
   ): Either[Throwable, Unit] =
     ensuring(
       NotAuthorizedError(
-        s"Not authorized to update zone shared status from $currentShared to $updateShared."
+        UpdateSharedZoneErrorMsg.format(currentShared, updateShared)
       )
     )(currentShared == updateShared || user.isSuper || user.isSupport)
 }

--- a/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/RecordSetChangeHandler.scala
@@ -28,6 +28,7 @@ import vinyldns.core.domain.backend.{Backend, BackendResponse}
 import vinyldns.core.domain.batch.{BatchChangeRepository, SingleChange}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.zone.Zone
+import vinyldns.core.Messages._
 import vinyldns.mysql.TransactionProvider
 
 object RecordSetChangeHandler extends TransactionProvider {
@@ -35,11 +36,6 @@ object RecordSetChangeHandler extends TransactionProvider {
   private val logger = LoggerFactory.getLogger("vinyldns.api.engine.RecordSetChangeHandler")
   private implicit val cs: ContextShift[IO] =
     IO.contextShift(scala.concurrent.ExecutionContext.global)
-
-  private val outOfSyncFailureMessage: String = "This record set is out of sync with the DNS backend; sync this zone before attempting to update this record set."
-  private val incompatibleRecordFailureMessage: String = "Incompatible record in DNS."
-  private val syncZoneMessage: String = "This record set is out of sync with the DNS backend. Sync this zone before attempting to update this record set."
-  private val recordConflictMessage: String = "Conflict due to the record having the same name as an NS record in the same zone. Please create the record using the DNS service the NS record has been delegated to (ex. AWS r53), or use a different record name."
 
   final case class Requeue(change: RecordSetChange) extends Throwable
 
@@ -189,7 +185,7 @@ object RecordSetChangeHandler extends TransactionProvider {
           if (existingRecords.isEmpty) ReadyToApply(change)
           else if (isDnsMatch(existingRecords, change.recordSet, change.zone.name))
             AlreadyApplied(change)
-          else Failure(change, incompatibleRecordFailureMessage)
+          else Failure(change, IncompatibleRecordFailureMessage)
 
         case RecordSetChangeType.Update =>
           if (isDnsMatch(existingRecords, change.recordSet, change.zone.name))
@@ -203,7 +199,7 @@ object RecordSetChangeHandler extends TransactionProvider {
             else
               Failure(
                 change,
-                outOfSyncFailureMessage
+                OutOfSyncFailureMessage
               )
           }
 
@@ -215,7 +211,7 @@ object RecordSetChangeHandler extends TransactionProvider {
           if (existingRecords.nonEmpty) {
             Failure(
               change,
-              outOfSyncFailureMessage
+              OutOfSyncFailureMessage
             )
           } else {
             AlreadyApplied(change)
@@ -419,22 +415,22 @@ object RecordSetChangeHandler extends TransactionProvider {
       case AlreadyApplied(_) => Completed(change.successful)
       case ReadyToApply(_) => Validated(change)
       case Failure(_, message) =>
-        if(message == outOfSyncFailureMessage || message == incompatibleRecordFailureMessage){
+        if(message == OutOfSyncFailureMessage || message == IncompatibleRecordFailureMessage){
           Completed(
             change.failed(
-              syncZoneMessage
+              SyncZoneMessage
             )
           )
         } else if (message == "referral") {
           Completed(
             change.failed(
-              recordConflictMessage
+              RecordConflictMessage
             )
           )
         } else {
           Completed(
             change.failed(
-              s"""Failed validating update to DNS for change "${change.id}": "${change.recordSet.name}": """ + message
+              UpdateValidateMsg.format(change.id, change.recordSet.name, message)
             )
           )
         }
@@ -451,7 +447,7 @@ object RecordSetChangeHandler extends TransactionProvider {
       case Left(error) =>
         Completed(
           change.failed(
-            s"Failed applying update to DNS for change ${change.id}:${change.recordSet.name}: ${error.getMessage}"
+            UpdateApplyMsg.format(change.id, change.recordSet.name, error.getMessage)
           )
         )
     }
@@ -475,7 +471,7 @@ object RecordSetChangeHandler extends TransactionProvider {
       case Failure(_, message) =>
         Completed(
           change.failed(
-            s"""Failed verifying update to DNS for change "${change.id}":"${change.recordSet.name}": $message"""
+            UpdateVerifyMsg.format(change.id, change.recordSet.name, message)
           )
         )
       case _ => Retrying(change)

--- a/modules/api/src/main/scala/vinyldns/api/route/ACLJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ACLJsonProtocol.scala
@@ -18,6 +18,7 @@ package vinyldns.api.route
 
 import org.json4s.JValue
 import cats.data._, cats.implicits._
+import vinyldns.core.Messages._
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.zone.{ACLRule, ACLRuleInfo, AccessLevel}
 
@@ -33,7 +34,7 @@ trait ACLJsonProtocol extends JsonValidation {
   case object ACLRuleInfoSerializer extends ValidationSerializer[ACLRuleInfo] {
     override def fromJson(js: JValue): ValidatedNel[String, ACLRuleInfo] = {
       val deserialized = (
-        (js \ "accessLevel").required(AccessLevel, "Missing ACLRule.accessLevel"),
+        (js \ "accessLevel").required(AccessLevel, ACLAccessLevelMsg),
         (js \ "description").optional[String],
         (js \ "userId").optional[String],
         (js \ "groupId").optional[String],
@@ -43,7 +44,7 @@ trait ACLJsonProtocol extends JsonValidation {
       ).mapN(ACLRuleInfo.apply)
 
       deserialized.check(
-        ("Cannot specify both a userId and a groupId", { rule =>
+        (DeserializeCheckErrorMsg, { rule =>
           !(rule.userId.isDefined && rule.groupId.isDefined)
         })
       )

--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -79,10 +79,10 @@ trait DnsJsonProtocol extends JsonValidation {
   case object RecordSetChangeSerializer extends ValidationSerializer[RecordSetChange] {
     override def fromJson(js: JValue): ValidatedNel[String, RecordSetChange] =
       (
-        (js \ "zone").required[Zone]("Missing RecordSetChange.zone"),
-        (js \ "recordSet").required[RecordSet]("Missing RecordSetChange.recordSet"),
-        (js \ "userId").required[String]("Missing RecordSetChange.userId"),
-        (js \ "changeType").required(RecordSetChangeType, "Missing RecordSetChange.changeType"),
+        (js \ "zone").required[Zone](MissingRecordSetZoneMsg),
+        (js \ "recordSet").required[RecordSet](MissingRecordSetMsg),
+        (js \ "userId").required[String](MissingRecordSetUserIdMsg),
+        (js \ "changeType").required(RecordSetChangeType, MissingRecordSetChangeTypeMsg),
         (js \ "status").default(RecordSetChangeStatus, RecordSetChangeStatus.Pending),
         (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
         (js \ "systemMessage").optional[String],
@@ -108,15 +108,15 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, CreateZoneInput] =
       (
         (js \ "name")
-          .required[String]("Missing Zone.name")
+          .required[String](MissingZoneNameMsg)
           .map(removeWhitespace)
           .map(name => if (name.endsWith(".")) name else s"$name."),
-        (js \ "email").required[String]("Missing Zone.email"),
+        (js \ "email").required[String](MissingZoneEmailMsg),
         (js \ "connection").optional[ZoneConnection],
         (js \ "transferConnection").optional[ZoneConnection],
         (js \ "shared").default[Boolean](false),
         (js \ "acl").default[ZoneACL](ZoneACL()),
-        (js \ "adminGroupId").required[String]("Missing Zone.adminGroupId"),
+        (js \ "adminGroupId").required[String](MissingZoneGroupIdMsg),
         (js \ "backendId").optional[String],
         (js \ "recurrenceSchedule").optional[String],
         (js \ "scheduleRequestor").optional[String],
@@ -126,16 +126,16 @@ trait DnsJsonProtocol extends JsonValidation {
   case object UpdateZoneInputSerializer extends ValidationSerializer[UpdateZoneInput] {
     override def fromJson(js: JValue): ValidatedNel[String, UpdateZoneInput] =
       (
-        (js \ "id").required[String]("Missing Zone.id"),
+        (js \ "id").required[String](MissingZoneIdMsg),
         (js \ "name")
-          .required[String]("Missing Zone.name")
+          .required[String](MissingZoneNameMsg)
           .map(ensureTrailingDot),
-        (js \ "email").required[String]("Missing Zone.email"),
+        (js \ "email").required[String](MissingZoneEmailMsg),
         (js \ "connection").optional[ZoneConnection],
         (js \ "transferConnection").optional[ZoneConnection],
         (js \ "shared").default[Boolean](false),
         (js \ "acl").default[ZoneACL](ZoneACL()),
-        (js \ "adminGroupId").required[String]("Missing Zone.adminGroupId"),
+        (js \ "adminGroupId").required[String](MissingZoneGroupIdMsg),
         (js \ "recurrenceSchedule").optional[String],
         (js \ "scheduleRequestor").optional[String],
         (js \ "backendId").optional[String],
@@ -146,7 +146,7 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, Algorithm] =
       js match {
         case JString(value) => Algorithm.fromString(value).toValidatedNel
-        case _ => "Unsupported type for key algorithm, must be a string".invalidNel
+        case _ => UnsupportedKeyAlgorithmMsg.invalidNel
       }
 
     override def toJson(a: Algorithm): JValue = JString(a.name)
@@ -156,7 +156,7 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, Encrypted] =
       js match {
         case JString(value) => EncryptFromJson.fromString(value).toValidatedNel
-        case _ => "Unsupported type for zone connection key, must be a string".invalidNel
+        case _ => UnsupportedEncryptedTypeErrorMsg.invalidNel
       }
 
     override def toJson(a: Encrypted): JValue = JString(a.value)
@@ -165,10 +165,10 @@ trait DnsJsonProtocol extends JsonValidation {
   case object ZoneConnectionSerializer extends ValidationSerializer[ZoneConnection] {
     override def fromJson(js: JValue): ValidatedNel[String, ZoneConnection] =
       (
-        (js \ "name").required[String]("Missing ZoneConnection.name"),
-        (js \ "keyName").required[String]("Missing ZoneConnection.keyName"),
-        (js \ "key").required[Encrypted]("Missing ZoneConnection.key"),
-        (js \ "primaryServer").required[String]("Missing ZoneConnection.primaryServer"),
+        (js \ "name").required[String](MissingZoneConnectionNameMsg),
+        (js \ "keyName").required[String](MissingZoneConnectionKeyNameMsg),
+        (js \ "key").required[Encrypted](MissingZoneConnectionKeyMsg),
+        (js \ "primaryServer").required[String](MissingZoneConnectionServer),
         (js \ "algorithm").default[Algorithm](Algorithm.HMAC_MD5)
         ).mapN(ZoneConnection.apply)
   }
@@ -208,25 +208,25 @@ trait DnsJsonProtocol extends JsonValidation {
   case object RecordSetSerializer extends ValidationSerializer[RecordSet] {
     import RecordType._
     override def fromJson(js: JValue): ValidatedNel[String, RecordSet] = {
-      val recordType = (js \ "type").required(RecordType, "Missing RecordSet.type")
+      val recordType = (js \ "type").required(RecordType, MissingRecordSetTypeMsg)
       // This variable is ONLY used for record type checks where the type is already known to be a success.
       // The "getOrElse" is only so that it will cast the type
       val recordTypeGet: RecordType = recordType.getOrElse(A)
       val recordSetResult = (
-        (js \ "zoneId").required[String]("Missing RecordSet.zoneId"),
+        (js \ "zoneId").required[String](MissingRecordSetZoneIdMsg),
         (js \ "name")
-          .required[String]("Missing RecordSet.name")
+          .required[String](MissingRecordSetNameMsg)
           .check(
-            "Record name must not exceed 255 characters" -> checkDomainNameLen,
-            "Record name cannot contain spaces" -> nameDoesNotContainSpaces
+            RecordNameLengthMsg -> checkDomainNameLen,
+            RecordContainsSpaceMsg -> nameDoesNotContainSpaces
           ),
         recordType,
         (js \ "ttl")
-          .required[Long]("Missing RecordSet.ttl")
+          .required[Long](MissingRecordSetTTL)
           .check(
             // RFC 1035.2.3.4 and  RFC 2181.8
-            "RecordSet.ttl must be a positive signed 32 bit number" -> (_ <= 2147483647),
-            "RecordSet.ttl must be a positive signed 32 bit number greater than or equal to 30" -> (_ >= 30)
+            RecordSetTTLNotPositiveMsg -> (_ <= 2147483647),
+            RecordSetTTLNotValidMsg -> (_ >= 30)
           ),
         (js \ "status").default(RecordSetStatus, RecordSetStatus.Pending),
         (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
@@ -242,7 +242,7 @@ trait DnsJsonProtocol extends JsonValidation {
 
       // Put additional record set level checks below
       recordSetResult.checkIf(recordTypeGet == RecordType.CNAME)(
-        "CNAME record sets cannot contain multiple records" -> { rs =>
+        CnameValidationMsg -> { rs =>
           rs.records.length <= 1
         }
       )
@@ -282,7 +282,7 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, RecordSetListInfo] =
       (
         RecordSetInfoSerializer.fromJson(js),
-        (js \ "accessLevel").required[AccessLevel.AccessLevel]("Missing RecordSet.zoneId")
+        (js \ "accessLevel").required[AccessLevel.AccessLevel](MissingRecordSetZoneIdMsg)
         ).mapN(RecordSetListInfo.apply)
 
     override def toJson(rs: RecordSetListInfo): JValue =
@@ -329,8 +329,8 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, RecordSetGlobalInfo] =
       (
         RecordSetSerializer.fromJson(js),
-        (js \ "zoneName").required[String]("Missing Zone.name"),
-        (js \ "zoneShared").required[Boolean]("Missing Zone.shared"),
+        (js \ "zoneName").required[String](MissingZoneNameMsg),
+        (js \ "zoneShared").required[Boolean](MissingZoneSharedMsg),
         (js \ "ownerGroupName").optional[String]
         ).mapN(RecordSetGlobalInfo.apply)
 
@@ -355,28 +355,28 @@ trait DnsJsonProtocol extends JsonValidation {
 
   def extractRecords(typ: RecordType, js: JValue): ValidatedNel[String, List[RecordData]] =
     typ match {
-      case RecordType.A => js.required[List[AData]]("Missing A Records")
-      case RecordType.AAAA => js.required[List[AAAAData]]("Missing AAAA Records")
-      case RecordType.CNAME => js.required[List[CNAMEData]]("Missing CNAME Records")
-      case RecordType.DS => js.required[List[DSData]]("Missing DS Records")
-      case RecordType.MX => js.required[List[MXData]]("Missing MX Records")
-      case RecordType.NS => js.required[List[NSData]]("Missing NS Records")
-      case RecordType.PTR => js.required[List[PTRData]]("Missing PTR Records")
-      case RecordType.SOA => js.required[List[SOAData]]("Missing SOA Records")
-      case RecordType.SPF => js.required[List[SPFData]]("Missing SPF Records")
-      case RecordType.SRV => js.required[List[SRVData]]("Missing SRV Records")
-      case RecordType.NAPTR => js.required[List[NAPTRData]]("Missing NAPTR Records")
-      case RecordType.SSHFP => js.required[List[SSHFPData]]("Missing SSHFP Records")
-      case RecordType.TXT => js.required[List[TXTData]]("Missing TXT Records")
-      case _ => s"Unsupported type $typ, valid types include ${RecordType.values}".invalidNel
+      case RecordType.A => js.required[List[AData]](MissingARecordsMsg)
+      case RecordType.AAAA => js.required[List[AAAAData]](MissingAAAARecordsMsg)
+      case RecordType.CNAME => js.required[List[CNAMEData]](MissingCnameRecordsMsg)
+      case RecordType.DS => js.required[List[DSData]](MissingDSRecordsMsg)
+      case RecordType.MX => js.required[List[MXData]](MissingMXRecordsMsg)
+      case RecordType.NS => js.required[List[NSData]](MissingNsRecordsMsg)
+      case RecordType.PTR => js.required[List[PTRData]](MissingPTRRecordsMsg)
+      case RecordType.SOA => js.required[List[SOAData]](MissingSOARecordsMsg)
+      case RecordType.SPF => js.required[List[SPFData]](MissingSPFRecordsMsg)
+      case RecordType.SRV => js.required[List[SRVData]](MissingSRVRecordsMsg)
+      case RecordType.NAPTR => js.required[List[NAPTRData]](MissingNAPTRRecordsMsg)
+      case RecordType.SSHFP => js.required[List[SSHFPData]](MissingSSHFPRecordsMsg)
+      case RecordType.TXT => js.required[List[TXTData]](MissingTXTRecordsMsg)
+      case _ => UnsupportedRecordTypeMsg.format(typ, RecordType.values).invalidNel
     }
 
   case object ASerializer extends ValidationSerializer[AData] {
     override def fromJson(js: JValue): ValidatedNel[String, AData] =
       (js \ "address")
-        .required[String]("Missing A.address")
+        .required[String](MissingAAddressMsg)
         .check(
-          "A must be a valid IPv4 Address" -> ipv4Match
+          InvalidIPv4Msg -> ipv4Match
         )
         .map(AData.apply)
   }
@@ -384,9 +384,9 @@ trait DnsJsonProtocol extends JsonValidation {
   case object AAAASerializer extends ValidationSerializer[AAAAData] {
     override def fromJson(js: JValue): ValidatedNel[String, AAAAData] =
       (js \ "address")
-        .required[String]("Missing AAAA.address")
+        .required[String](MissingAAAAAddressMsg)
         .check(
-          "AAAA must be a valid IPv6 Address" -> ipv6Match
+          InvalidIPv6Msg -> ipv6Match
         )
         .map(AAAAData.apply)
   }
@@ -394,10 +394,10 @@ trait DnsJsonProtocol extends JsonValidation {
   case object CNAMESerializer extends ValidationSerializer[CNAMEData] {
     override def fromJson(js: JValue): ValidatedNel[String, CNAMEData] =
       (js \ "cname")
-        .required[String]("Missing CNAME.cname")
+        .required[String](MissingCnameMsg)
         .check(
-          "CNAME domain name must not exceed 255 characters" -> checkDomainNameLen,
-          "CNAME data must be absolute" -> nameContainsDots
+          CnameLengthMsg -> checkDomainNameLen,
+          CnameAbsoluteMsg -> nameContainsDots
         )
         .map(Fqdn.apply)
         .map(CNAMEData.apply)
@@ -407,14 +407,14 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, MXData] =
       (
         (js \ "preference")
-          .required[Integer]("Missing MX.preference")
+          .required[Integer](MissingMXPreferenceMsg)
           .check(
-            "MX.preference must be a 16 bit integer" -> (i => i <= 65535 && i >= 0)
+            MXPreferenceValidationMsg -> (i => i <= 65535 && i >= 0)
           ),
         (js \ "exchange")
-          .required[String]("Missing MX.exchange")
+          .required[String](MissingMXExchangeMsg)
           .check(
-            "MX.exchange must be less than 255 characters" -> checkDomainNameLen
+            MXExchangeValidationMsg -> checkDomainNameLen
           )
           .map(Fqdn.apply)
         ).mapN(MXData.apply)
@@ -423,10 +423,10 @@ trait DnsJsonProtocol extends JsonValidation {
   case object NSSerializer extends ValidationSerializer[NSData] {
     override def fromJson(js: JValue): ValidatedNel[String, NSData] =
       (js \ "nsdname")
-        .required[String]("Missing NS.nsdname")
+        .required[String](MissingNSNameMsg)
         .check(
-          "NS must be less than 255 characters" -> checkDomainNameLen,
-          NSDataError -> nameContainsDots
+          NSNameValidationMsg -> checkDomainNameLen,
+          NSDataErrorMsg -> nameContainsDots
         )
         .map(Fqdn.apply)
         .map(NSData.apply)
@@ -435,9 +435,9 @@ trait DnsJsonProtocol extends JsonValidation {
   case object PTRSerializer extends ValidationSerializer[PTRData] {
     override def fromJson(js: JValue): ValidatedNel[String, PTRData] =
       (js \ "ptrdname")
-        .required[String]("Missing PTR.ptrdname")
+        .required[String](MissingPTRNameMsg)
         .check(
-          "PTR must be less than 255 characters" -> checkDomainNameLen
+          PTRNameValidationMsg -> checkDomainNameLen
         )
         .map(Fqdn.apply)
         .map(PTRData.apply)
@@ -447,41 +447,41 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, SOAData] =
       (
         (js \ "mname")
-          .required[String]("Missing SOA.mname")
+          .required[String](MissingSOAMNameMsg)
           .check(
-            "SOA.mname must be less than 255 characters" -> checkDomainNameLen
+            SOAMNameValidationMsg -> checkDomainNameLen
           )
           .map(Fqdn.apply),
         (js \ "rname")
-          .required[String]("Missing SOA.rname")
+          .required[String](MissingSOARNameMsg)
           .check(
-            "SOA.rname must be less than 255 characters" -> checkDomainNameLen
+            SOARNameValidationMsg -> checkDomainNameLen
           )
           .map(removeWhitespace),
         (js \ "serial")
-          .required[Long]("Missing SOA.serial")
+          .required[Long](MissingSOASerialMsg)
           .check(
-            "SOA.serial must be an unsigned 32 bit number" -> (i => i <= 4294967295L && i >= 0)
+            SOASerialValidationMsg -> (i => i <= 4294967295L && i >= 0)
           ),
         (js \ "refresh")
-          .required[Long]("Missing SOA.refresh")
+          .required[Long](MissingSOARefreshMsg)
           .check(
-            "SOA.refresh must be an unsigned 32 bit number" -> (i => i <= 4294967295L && i >= 0)
+            SOARefreshValidationMsg -> (i => i <= 4294967295L && i >= 0)
           ),
         (js \ "retry")
-          .required[Long]("Missing SOA.retry")
+          .required[Long](MissingSOARetryMsg)
           .check(
-            "SOA.retry must be an unsigned 32 bit number" -> (i => i <= 4294967295L && i >= 0)
+            SOARetryValidationMsg -> (i => i <= 4294967295L && i >= 0)
           ),
         (js \ "expire")
-          .required[Long]("Missing SOA.expire")
+          .required[Long](MissingSOAExpireMsg)
           .check(
-            "SOA.expire must be an unsigned 32 bit number" -> (i => i <= 4294967295L && i >= 0)
+            SOAExpireValidationMsg -> (i => i <= 4294967295L && i >= 0)
           ),
         (js \ "minimum")
-          .required[Long]("Missing SOA.minimum")
+          .required[Long](MissingSOAMinimumMsg)
           .check(
-            "SOA.minimum must be an unsigned 32 bit number" -> (i => i <= 4294967295L && i >= 0)
+            SOAMinimumValidationMsg -> (i => i <= 4294967295L && i >= 0)
           )
         ).mapN(SOAData.apply)
   }
@@ -489,9 +489,9 @@ trait DnsJsonProtocol extends JsonValidation {
   case object SPFSerializer extends ValidationSerializer[SPFData] {
     override def fromJson(js: JValue): ValidatedNel[String, SPFData] =
       (js \ "text")
-        .required[String]("Missing SPF.text")
+        .required[String](MissingSPFTextMsg)
         .check(
-          "SPF record must be less than 64764 characters" -> (_.length < 64764)
+          SPFValidationMsg -> (_.length < 64764)
         )
         .map(SPFData.apply)
   }
@@ -500,24 +500,24 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, SRVData] =
       (
         (js \ "priority")
-          .required[Integer]("Missing SRV.priority")
+          .required[Integer](MissingSRVPriorityMsg)
           .check(
-            "SRV.priority must be an unsigned 16 bit number" -> (i => i <= 65535 && i >= 0)
+            SRVPriorityValidationMsg -> (i => i <= 65535 && i >= 0)
           ),
         (js \ "weight")
-          .required[Integer]("Missing SRV.weight")
+          .required[Integer](MissingSRVWeightMsg)
           .check(
-            "SRV.weight must be an unsigned 16 bit number" -> (i => i <= 65535 && i >= 0)
+            SRVWeightValidationMsg -> (i => i <= 65535 && i >= 0)
           ),
         (js \ "port")
-          .required[Integer]("Missing SRV.port")
+          .required[Integer](MissingSRVPortMsg)
           .check(
-            "SRV.port must be an unsigned 16 bit number" -> (i => i <= 65535 && i >= 0)
+            SRVPortValidationMsg -> (i => i <= 65535 && i >= 0)
           ),
         (js \ "target")
-          .required[String]("Missing SRV.target")
+          .required[String](MissingSRVTargetMsg)
           .check(
-            "SRV.target must be less than 255 characters" -> checkDomainNameLen
+            SRVTargetValidationMsg -> checkDomainNameLen
           )
           .map(Fqdn.apply)
         ).mapN(SRVData.apply)
@@ -527,35 +527,35 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, NAPTRData] =
       (
         (js \ "order")
-          .required[Integer]("Missing NAPTR.order")
+          .required[Integer](MissingNAPTROrderMsg)
           .check(
-            "NAPTR.order must be an unsigned 16 bit number" -> (i => i <= 65535 && i >= 0)
+            NAPTROrderValidationMsg -> (i => i <= 65535 && i >= 0)
           ),
         (js \ "preference")
-          .required[Integer]("Missing NAPTR.preference")
+          .required[Integer](MissingNAPTRPreferenceMsg)
           .check(
-            "NAPTR.preference must be an unsigned 16 bit number" -> (i => i <= 65535 && i >= 0)
+            NAPTRPreferenceValidationMsg -> (i => i <= 65535 && i >= 0)
           ),
         (js \ "flags")
-          .required[String]("Missing NAPTR.flags")
+          .required[String](MissingNAPTRFlagsMsg)
           .check(
-            "Invalid NAPTR.flag. Valid NAPTR flag value must be U, S, A or P" -> validateNaptrFlag
+            NAPTRFlagsValidationMsg -> validateNaptrFlag
           ),
         (js \ "service")
-          .required[String]("Missing NAPTR.service")
+          .required[String](MissingNAPTRServiceMsg)
           .check(
-            "NAPTR.service must be less than 255 characters" -> checkDomainNameLen
+            NAPTRServiceValidationMsg -> checkDomainNameLen
           ),
         (js \ "regexp")
-          .required[String]("Missing NAPTR.regexp")
+          .required[String](MissingNAPTRRegexMsg)
           .check(
-            "Invalid NAPTR.regexp. Valid NAPTR regexp value must start and end with '!' or can be empty" -> validateNaptrRegexp
+            NAPTRRegexValidationMsg -> validateNaptrRegexp
           ),
 
         (js \ "replacement")
-          .required[String]("Missing NAPTR.replacement")
+          .required[String](MissingNAPTRReplacementMsg)
           .check(
-            "NAPTR.replacement must be less than 255 characters" -> checkDomainNameLen
+            NAPTRReplacementValidationMsg -> checkDomainNameLen
           )
           .map(Fqdn.apply)
         ).mapN(NAPTRData.apply)
@@ -565,16 +565,16 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, SSHFPData] =
       (
         (js \ "algorithm")
-          .required[Integer]("Missing SSHFP.algorithm")
+          .required[Integer](MissingSSHFPAlgorithmMsg)
           .check(
-            "SSHFP.algorithm must be an unsigned 8 bit number" -> (i => i <= 255 && i >= 0)
+            SSHFPAlgorithmValidationMsg -> (i => i <= 255 && i >= 0)
           ),
         (js \ "type")
-          .required[Integer]("Missing SSHFP.type")
+          .required[Integer](MissingSSHFPTypeMsg)
           .check(
-            "SSHFP.type must be an unsigned 8 bit number" -> (i => i <= 255 && i >= 0)
+            SSHFPTypeValidationMsg -> (i => i <= 255 && i >= 0)
           ),
-        (js \ "fingerprint").required[String]("Missing SSHFP.fingerprint")
+        (js \ "fingerprint").required[String](MissingSSHFPFingerprintMsg)
         ).mapN(SSHFPData.apply)
 
     // necessary because type != typ
@@ -588,30 +588,30 @@ trait DnsJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, DSData] =
       (
         (js \ "keytag")
-          .required[Integer]("Missing DS.keytag")
-          .check("DS.keytag must be an unsigned 16 bit number" -> (i => i <= 65535 && i >= 0)),
+          .required[Integer](MissingDSKeytagMsg)
+          .check(DSKeytagValidationMsg -> (i => i <= 65535 && i >= 0)),
         (js \ "algorithm")
-          .required[Integer]("Missing DS.algorithm")
+          .required[Integer](MissingDSAlgorithmMsg)
           .map(DnsSecAlgorithm(_))
           .andThen {
             case DnsSecAlgorithm.UnknownAlgorithm(x) =>
-              s"Algorithm $x is not a supported DNSSEC algorithm".invalidNel
+              UnsupportedDNSSECMsg.format(x).invalidNel
             case supported => supported.validNel
           },
         (js \ "digesttype")
-          .required[Integer]("Missing DS.digesttype")
+          .required[Integer](MissingDSDigestTypeMsg)
           .map(DigestType(_))
           .andThen {
             case DigestType.UnknownDigestType(x) =>
-              s"Digest Type $x is not a supported DS record digest type".invalidNel
+              UnsupportedDigestTypeMsg.format(x).invalidNel
             case supported => supported.validNel
           },
         (js \ "digest")
-          .required[String]("Missing DS.digest")
+          .required[String](MissingDSDigestMsg)
           .map(ByteVector.fromHex(_))
           .andThen {
             case Some(v) => v.validNel
-            case None => "Could not convert digest to valid hex".invalidNel
+            case None => DigestConvertMsg.invalidNel
           }
         ).mapN(DSData.apply)
 
@@ -625,9 +625,9 @@ trait DnsJsonProtocol extends JsonValidation {
   case object TXTSerializer extends ValidationSerializer[TXTData] {
     override def fromJson(js: JValue): ValidatedNel[String, TXTData] =
       (js \ "text")
-        .required[String]("Missing TXT.text")
+        .required[String](MissingTXTTextMsg)
         .check(
-          "TXT record must be less than 64764 characters" -> (_.length < 64764)
+          TXTRecordValidationMsg -> (_.length < 64764)
         )
         .map(TXTData.apply)
   }

--- a/modules/api/src/main/scala/vinyldns/api/route/JsonValidation.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/JsonValidation.scala
@@ -29,6 +29,7 @@ import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.ext._
 import org.json4s.jackson.JsonMethods._
+import vinyldns.core.Messages._
 
 import scala.reflect.ClassTag
 
@@ -165,11 +166,11 @@ trait JsonValidation extends JsonValidationSupport {
       try {
         Extraction.extract(js, TypeInfo(Class, None))(subsetFormats) match {
           case a: A => a.validNel[String]
-          case _ => "Extraction.extract returned unexpected type".invalidNel[A]
+          case _ => UnexpectedExtractionErrorMsg.invalidNel[A]
         }
       } catch {
         case _: MappingException | _: JsonParseException =>
-          s"Failed to parse ${Class.getSimpleName.replace("$", "")}".invalidNel[A]
+          JsonParseErrorMsg.format(Class.getSimpleName.replace("$", "")).invalidNel[A]
       }
 
     // use a subset of formats that does not include this class or we will StackOverflow
@@ -205,7 +206,7 @@ trait JsonValidation extends JsonValidationSupport {
                   err.invalidNel[T]
               }
             case e: JsonParseException =>
-              s"While parsing $json, received unexpected error '${e.getMessage}'".invalidNel[T]
+              UnexpectedJsonErrorMsg.format(json, e.getMessage).invalidNel[T]
           }
       }
 
@@ -213,7 +214,7 @@ trait JsonValidation extends JsonValidationSupport {
         enum: E
     )(default: => ValidatedNel[String, E#Value]): ValidatedNel[String, E#Value] = {
       lazy val invalidMsg =
-        s"Invalid ${enum.getClass.getSimpleName.replace("$", "")}".invalidNel[E#Value]
+        InvalidMsg.format(enum.getClass.getSimpleName.replace("$", "")).invalidNel[E#Value]
 
       json match {
         case JNothing | JNull => default

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipJsonProtocol.scala
@@ -25,6 +25,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import vinyldns.api.domain.membership._
 import vinyldns.core.domain.membership.{Group, GroupChangeType, GroupStatus, LockStatus}
+import vinyldns.core.Messages._
 
 object MembershipJsonProtocol {
   final case class CreateGroupInput(
@@ -63,22 +64,22 @@ trait MembershipJsonProtocol extends JsonValidation {
   case object CreateGroupInputSerializer extends ValidationSerializer[CreateGroupInput] {
     override def fromJson(js: JValue): ValidatedNel[String, CreateGroupInput] =
       (
-        (js \ "name").required[String]("Missing Group.name"),
-        (js \ "email").required[String]("Missing Group.email"),
+        (js \ "name").required[String](MissingGroupNameMsg),
+        (js \ "email").required[String](MissingGroupEmailMsg),
         (js \ "description").optional[String],
-        (js \ "members").required[Set[UserId]]("Missing Group.members"),
-        (js \ "admins").required[Set[UserId]]("Missing Group.admins")
+        (js \ "members").required[Set[UserId]](MissingGroupMembersMsg),
+        (js \ "admins").required[Set[UserId]](MissingGroupAdminsMsg)
       ).mapN(CreateGroupInput.apply)
   }
   case object UpdateGroupInputSerializer extends ValidationSerializer[UpdateGroupInput] {
     override def fromJson(js: JValue): ValidatedNel[String, UpdateGroupInput] =
       (
-        (js \ "id").required[String]("Missing Group.id"),
-        (js \ "name").required[String]("Missing Group.name"),
-        (js \ "email").required[String]("Missing Group.email"),
+        (js \ "id").required[String](MissingGroupIdMsg),
+        (js \ "name").required[String](MissingGroupNameMsg),
+        (js \ "email").required[String](MissingGroupEmailMsg),
         (js \ "description").optional[String],
-        (js \ "members").required[Set[UserId]]("Missing Group.members"),
-        (js \ "admins").required[Set[UserId]]("Missing Group.admins")
+        (js \ "members").required[Set[UserId]](MissingGroupMembersMsg),
+        (js \ "admins").required[Set[UserId]](MissingGroupAdminsMsg)
       ).mapN(UpdateGroupInput.apply)
   }
 
@@ -89,8 +90,8 @@ trait MembershipJsonProtocol extends JsonValidation {
   case object GroupSerializer extends ValidationSerializer[Group] {
     override def fromJson(js: JValue): ValidatedNel[String, Group] =
       (
-        (js \ "name").required[String]("Missing Group.name"),
-        (js \ "email").required[String]("Missing Group.email"),
+        (js \ "name").required[String](MissingGroupNameMsg),
+        (js \ "email").required[String](MissingGroupEmailMsg),
         (js \ "description").optional[String],
         (js \ "id").default[String](UUID.randomUUID().toString),
         (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
@@ -104,8 +105,8 @@ trait MembershipJsonProtocol extends JsonValidation {
     override def fromJson(js: JValue): ValidatedNel[String, GroupInfo] = {
       (
         (js \ "id").default[String](UUID.randomUUID().toString),
-        (js \ "name").required[String]("Missing Group.name"),
-        (js \ "email").required[String]("Missing Group.email"),
+        (js \ "name").required[String](MissingGroupNameMsg),
+        (js \ "email").required[String](MissingGroupEmailMsg),
         (js \ "description").optional[String],
         (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
         (js \ "status").default(GroupStatus, GroupStatus.Active),
@@ -125,17 +126,18 @@ trait MembershipJsonProtocol extends JsonValidation {
       ("admins" -> Extraction.decompose(gi.admins))
   }
 
+  // TODO: add error message
   case object GroupChangeInfoSerializer extends ValidationSerializer[GroupChangeInfo] {
     override def fromJson(js: JValue): ValidatedNel[String, GroupChangeInfo] = {
       (
-        (js \ "newGroup").required[GroupInfo]("Missing new group"),
-        (js \ "changeType").required(GroupChangeType, "Missing change type"),
-        (js \ "userId").required[String]("Missing userId"),
+        (js \ "newGroup").required[GroupInfo](MissingNewGroupMsg),
+        (js \ "changeType").required(GroupChangeType, MissingChangeTypeMsg),
+        (js \ "userId").required[String](MissingUserIdMsg),
         (js \ "oldGroup").optional[GroupInfo],
         (js \ "id").default[String](UUID.randomUUID().toString),
         (js \ "created").default[Instant](Instant.now.truncatedTo(ChronoUnit.MILLIS)),
-        (js \ "userName").required[String]("Missing userName"),
-        (js \ "groupChangeMessage").required[String]("Missing groupChangeMessage"),
+        (js \ "userName").required[String](MissingUserNameMsg),
+        (js \ "groupChangeMessage").required[String](MissingGroupChangeMsg),
       ).mapN(GroupChangeInfo.apply)
     }
 

--- a/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/VinylDNSAuthentication.scala
@@ -24,7 +24,7 @@ import vinyldns.core.crypto.CryptoAlgebra
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership.LockStatus
 import vinyldns.core.route.Monitored
-
+import vinyldns.core.Messages._
 import scala.util.matching.Regex
 
 sealed abstract class VinylDNSAuthenticationError(msg: String) extends Throwable(msg)
@@ -69,7 +69,7 @@ class ProductionVinylDNSAuthenticator(
         header.name.compareToIgnoreCase("Authorization") == 0
       }
       .map(header => IO.pure(header.value))
-      .getOrElse(IO.raiseError(AuthMissing("Authorization header not found")))
+      .getOrElse(IO.raiseError(AuthMissing(AuthMissingErrorMsg)))
 
   /**
     * Parses the auth header into an Aws Regex.Match.  If the auth header cannot be parsed, an
@@ -81,7 +81,7 @@ class ProductionVinylDNSAuthenticator(
     Aws4Authenticator
       .parseAuthHeader(header)
       .map(IO.pure)
-      .getOrElse(IO.raiseError(AuthRejected("Authorization header could not be parsed")))
+      .getOrElse(IO.raiseError(AuthRejected(AuthRejectedErrorMsg)))
 
   /**
     * Gets the access key from the request.  Normalizes the exceptions coming out of the authenticator
@@ -112,7 +112,7 @@ class ProductionVinylDNSAuthenticator(
       case auth if authenticator.authenticateReq(req, auth.subgroups, secretKey, content) =>
         IO.unit
       case _ =>
-        IO.raiseError(AuthRejected(s"Request signature could not be validated"))
+        IO.raiseError(AuthRejected(RequestSignatureErrorMsg))
     }
 
   /**
@@ -157,10 +157,10 @@ class ProductionVinylDNSAuthenticator(
       case Some(ok) =>
         if (ok.signedInUser.lockStatus == LockStatus.Locked) {
           IO.raiseError(
-            AccountLocked(s"Account with username ${ok.signedInUser.userName} is locked")
+            AccountLocked(AccountLockedErrorMsg.format(ok.signedInUser.userName))
           )
         } else IO.pure(ok)
       case None =>
-        IO.raiseError(AuthRejected(s"Account with accessKey $accessKey specified was not found"))
+        IO.raiseError(AuthRejected(AccountAccessKeyErrorMsg.format(accessKey)))
     }
 }

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -1429,6 +1429,7 @@ def test_create_batch_change_with_readonly_user_fails(shared_zone_test_context):
     ok_client = shared_zone_test_context.ok_vinyldns_client
     ok_zone_name = shared_zone_test_context.ok_zone["name"]
     ok_group_name = shared_zone_test_context.ok_group["name"]
+    ok_group_id = shared_zone_test_context.ok_group["id"]
 
     acl_rule = generate_acl_rule("Read", groupId=shared_zone_test_context.dummy_group["id"], recordMask=".*",
                                  recordTypes=["A", "AAAA"])
@@ -1457,15 +1458,15 @@ def test_create_batch_change_with_readonly_user_fails(shared_zone_test_context):
         errors = dummy_client.create_batch_change(batch_change_input, status=400)
 
         assert_failed_change_in_error_response(errors[0], input_name=f"relative.{ok_zone_name}", record_data="4.5.6.7",
-                                               error_messages=[f'User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"relative\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[1], input_name=f"delete.{ok_zone_name}", change_type="DeleteRecordSet",
                                                record_data="4.5.6.7",
-                                               error_messages=[f'User "dummy" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"delete\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[2], input_name=f"update.{ok_zone_name}", record_data="1.2.3.4",
-                                               error_messages=[f'User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"update\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[3], input_name=f"update.{ok_zone_name}", change_type="DeleteRecordSet",
                                                record_data=None,
-                                               error_messages=[f'User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"update\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_ok_acl_rules(shared_zone_test_context)
         clear_recordset_list(to_delete, ok_client)
@@ -1563,7 +1564,7 @@ def test_a_recordtype_add_checks(shared_zone_test_context):
                                                                f'Existing record with name "{existing_cname_fqdn}" and type \"CNAME\" conflicts with this record.'])
         assert_failed_change_in_error_response(response[9], input_name=f"user-add-unauthorized.{dummy_zone_name}",
                                                record_data="1.2.3.4",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -1702,16 +1703,16 @@ def test_a_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist, not authorized
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn,
                                                change_type="DeleteRecordSet",
-                                               error_messages=[f'User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn,
                                                change_type="DeleteRecordSet",
-                                               error_messages=[f'User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[13], input_name=rs_update_dummy_fqdn, ttl=300,
-                                               error_messages=[f'User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[14], input_name=rs_update_dummy_with_owner_fqdn, change_type="DeleteRecordSet",
-                                               error_messages=[f'User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{rs_dummy_with_owner_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[15], input_name=rs_update_dummy_with_owner_fqdn, ttl=300,
-                                               error_messages=[f'User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{rs_dummy_with_owner_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]
@@ -1810,7 +1811,7 @@ def test_aaaa_recordtype_add_checks(shared_zone_test_context):
                                                                f"and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[9], input_name=f"user-add-unauthorized.{dummy_zone_name}",
                                                record_type="AAAA", record_data="1::1",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -1929,13 +1930,13 @@ def test_aaaa_recordtype_update_delete_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[10], input_name=f"update-nonexistent.{ok_zone_name}", record_type="AAAA", record_data="1::1")
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn,
                                                record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn,
                                                record_type="AAAA", record_data="1::1",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[13], input_name=rs_update_dummy_fqdn,
                                                record_type="AAAA", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]
@@ -2088,7 +2089,7 @@ def test_cname_recordtype_add_checks(shared_zone_test_context):
                                                                f"Existing record with name \"{existing_reverse_fqdn}\" and type \"PTR\" conflicts with this record."])
         assert_failed_change_in_error_response(response[16], input_name=f"user-add-unauthorized.{dummy_zone_name}",
                                                record_type="CNAME", record_data="test.com.",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[17], input_name=f"invalid-ipv4-{parent_zone_name}", record_type="CNAME", record_data="1.2.3.4.",
                                                error_messages=[f'Invalid Cname: "Fqdn(1.2.3.4.)", Valid CNAME record data should not be an IP address'])
 
@@ -2223,13 +2224,13 @@ def test_cname_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_type="CNAME", record_data="test.com.")
         assert_failed_change_in_error_response(response[13], input_name=f"delete-unauthorized3.{dummy_zone_name}",
                                                record_type="CNAME", change_type="DeleteRecordSet",
-                                               error_messages=[f'User "ok" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"delete-unauthorized3\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[14], input_name=f"update-unauthorized3.{dummy_zone_name}",
                                                record_type="CNAME", change_type="DeleteRecordSet",
-                                               error_messages=[f'User "ok" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"update-unauthorized3\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[15], input_name=f"update-unauthorized3.{dummy_zone_name}",
                                                record_type="CNAME", ttl=300, record_data="test.com.",
-                                               error_messages=[f'User "ok" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"update-unauthorized3\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_successful_change_in_error_response(response[16], input_name=f"existing-cname2.{parent_zone_name}",
                                                    record_type="CNAME", change_type="DeleteRecordSet")
         assert_failed_change_in_error_response(response[17], input_name=f"existing-cname2.{parent_zone_name}",
@@ -2259,6 +2260,7 @@ def test_ptr_recordtype_auth_checks(shared_zone_test_context):
     ip4_prefix = shared_zone_test_context.ip4_classless_prefix
     ip6_prefix = shared_zone_test_context.ip6_prefix
     ok_group_name = shared_zone_test_context.ok_group["name"]
+    ok_group_id = shared_zone_test_context.ok_group["id"]
 
     no_auth_ipv4 = create_recordset(shared_zone_test_context.classless_base_zone, "25", "PTR",
                                     [{"ptrdname": "ptrdname.data."}], 200)
@@ -2287,19 +2289,19 @@ def test_ptr_recordtype_auth_checks(shared_zone_test_context):
 
         assert_failed_change_in_error_response(errors[0], input_name=f"{ip4_prefix}.5", record_type="PTR",
                                                record_data="not.authorized.ipv4.ptr.base.",
-                                               error_messages=[f"User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"5\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[1], input_name=f"{ip4_prefix}.193", record_type="PTR",
                                                record_data="not.authorized.ipv4.ptr.classless.delegation.",
-                                               error_messages=[f"User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"193\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[2], input_name=f"{ip6_prefix}:1000::1234", record_type="PTR",
                                                record_data="not.authorized.ipv6.ptr.",
-                                               error_messages=[f"User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[3], input_name=f"{ip4_prefix}.25", record_type="PTR", record_data=None,
                                                change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"25\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(errors[4], input_name=f"{ip6_prefix}:1000::1234", record_type="PTR",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"dummy\" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"4.3.2.1.0.0.0.0.0.0.0.0.0.0.0.0\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, ok_client)
 
@@ -2769,7 +2771,7 @@ def test_txt_recordtype_add_checks(shared_zone_test_context):
                                                                f"Existing record with name \"{existing_cname_fqdn}\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[7], input_name=f"user-add-unauthorized.{dummy_zone_name}",
                                                record_type="TXT", record_data="test",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -2868,11 +2870,11 @@ def test_txt_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist, not authorized
         assert_successful_change_in_error_response(response[8], input_name=f"update-nonexistent.{ok_zone_name}", record_type="TXT", record_data="test")
         assert_failed_change_in_error_response(response[9], input_name=rs_delete_dummy_fqdn, record_type="TXT", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[10], input_name=rs_update_dummy_fqdn, record_type="TXT", record_data="test",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[11], input_name=rs_update_dummy_fqdn, record_type="TXT", record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]
@@ -2974,7 +2976,7 @@ def test_mx_recordtype_add_checks(shared_zone_test_context):
                                                                f"Existing record with name \"{existing_cname_fqdn}\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[10], input_name=f"user-add-unauthorized.{dummy_zone_name}", record_type="MX",
                                                record_data={"preference": 1, "exchange": "foo.bar."},
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -3091,13 +3093,13 @@ def test_mx_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data={"preference": 1000, "exchange": "foo.bar."})
         assert_failed_change_in_error_response(response[11], input_name=rs_delete_dummy_fqdn, record_type="MX",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn, record_type="MX",
                                                record_data={"preference": 1000, "exchange": "foo.bar."},
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[13], input_name=rs_update_dummy_fqdn, record_type="MX",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]
@@ -3560,8 +3562,7 @@ def test_create_batch_delete_recordset_for_unassociated_user_not_in_owner_group_
 
         assert_failed_change_in_error_response(response[0], input_name=shared_delete_fqdn,
                                                change_type="DeleteRecordSet",
-                                               error_messages=[f'User "list-group-user" is not authorized. Contact record owner group: '
-                                                               f'{shared_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{shared_delete_name}\" is owned by the [{shared_group_name}] group(/groups/{shared_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         if create_rs:
             delete_rs = shared_client.delete_recordset(shared_zone["id"], create_rs["recordSet"]["id"], status=202)
@@ -3754,7 +3755,7 @@ def test_create_batch_with_irrelevant_global_acl_rule_applied_fails(shared_zone_
         response = test_user_client.create_batch_change(batch_change_input, status=400)
         assert_failed_change_in_error_response(response[0], input_name=a_fqdn, record_type="A",
                                                change_type="Add", record_data=f"{ip4_prefix}.45",
-                                               error_messages=['User "testuser" is not authorized. Contact record owner group: testSharedZoneGroup at email to make DNS changes.'])
+                                               error_messages=[f'The record \"{a_name}\" is owned by the [testSharedZoneGroup] group(/groups/shared-zone-group). Only members of this group may update the record. Please contact them for assistance: email.'])
     finally:
         if create_a_rs:
             delete_a_rs = shared_client.delete_recordset(shared_zone["id"], create_a_rs["recordSet"]["id"], status=202)
@@ -3863,6 +3864,7 @@ def test_create_batch_delete_record_access_checks(shared_zone_test_context):
     dummy_group_id = shared_zone_test_context.dummy_group["id"]
     ok_zone_name = shared_zone_test_context.ok_zone["name"]
     ok_group_name = shared_zone_test_context.ok_group["name"]
+    ok_group_id = shared_zone_test_context.ok_group["id"]
 
     a_delete_acl = generate_acl_rule("Delete", groupId=dummy_group_id, recordMask=".*", recordTypes=["A"])
     txt_write_acl = generate_acl_rule("Write", groupId=dummy_group_id, recordMask=".*", recordTypes=["TXT"])
@@ -3911,7 +3913,7 @@ def test_create_batch_delete_record_access_checks(shared_zone_test_context):
         assert_successful_change_in_error_response(response[3], input_name=txt_update_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecordSet")
         assert_successful_change_in_error_response(response[4], input_name=txt_update_fqdn, record_type="TXT", record_data="updated text")
         assert_failed_change_in_error_response(response[5], input_name=txt_delete_fqdn, record_type="TXT", record_data="test", change_type="DeleteRecordSet",
-                                               error_messages=[f'User "dummy" is not authorized. Contact zone owner group: {ok_group_name} at test@test.com to make DNS changes.'])
+                                               error_messages=[f'The record \"{txt_delete_name}\" is owned by the [{ok_group_name}] group(/groups/{ok_group_id}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_ok_acl_rules(shared_zone_test_context)
         clear_recordset_list(to_delete, ok_client)
@@ -4353,7 +4355,7 @@ def test_ns_recordtype_add_checks(shared_zone_test_context):
                                                error_messages=[f"Name Server unapproved.name.server. is not an approved name server."])
         assert_failed_change_in_error_response(response[8], input_name=f"user-add-unauthorized.{dummy_zone_name}",
                                                record_type="NS", record_data="ns1.parent.com.",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -4453,14 +4455,14 @@ def test_ns_recordtype_update_delete_checks(shared_zone_test_context):
         # context validation failures: record does not exist, not authorized
         assert_successful_change_in_error_response(response[8], input_name=f"update-nonexistent.{ok_zone_name}", record_type="NS", record_data="ns1.parent.com.")
         assert_failed_change_in_error_response(response[9], input_name=rs_delete_dummy_fqdn, record_type="NS", record_data="ns1.parent.com.", change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[10], input_name=rs_update_dummy_fqdn, record_type="NS", record_data="ns1.parent.com.",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[11], input_name=f"unapproved.{ok_zone_name}",
                                                record_type="NS", record_data="unapproved.name.server.",
                                                error_messages=[f"Name Server unapproved.name.server. is not an approved name server."])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn, record_type="NS", record_data="ns1.parent.com.", change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]
@@ -4557,7 +4559,7 @@ def test_naptr_recordtype_add_checks(shared_zone_test_context):
                                                                f"Existing record with name \"{existing_cname_fqdn}\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[9], input_name=f"user-add-unauthorized.{dummy_zone_name}", record_type="NAPTR",
                                                record_data={"order": 1, "preference": 1000, "flags": "U", "service": "E2U+sip", "regexp": "!.*!test.!", "replacement": "target.vinyldns."},
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -4669,13 +4671,13 @@ def test_naptr_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data={"order": 1, "preference": 1000, "flags": "U", "service": "E2U+sip", "regexp": "!.*!test.!", "replacement": "target.vinyldns."})
         assert_failed_change_in_error_response(response[10], input_name=rs_delete_dummy_fqdn, record_type="NAPTR",
                                                record_data={"order": 1, "preference": 1000, "flags": "U", "service": "E2U+sip", "regexp": "!.*!test.!", "replacement": "target.vinyldns."}, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[11], input_name=rs_update_dummy_fqdn, record_type="NAPTR",
                                                record_data={"order": 1, "preference": 1000, "flags": "U", "service": "E2U+sip", "regexp": "!.*!test.!", "replacement": "target.vinyldns."},
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn, record_type="NAPTR",
                                                record_data={"order": 1, "preference": 1000, "flags": "U", "service": "E2U+sip", "regexp": "!.*!test.!", "replacement": "target.vinyldns."}, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]
@@ -4772,7 +4774,7 @@ def test_srv_recordtype_add_checks(shared_zone_test_context):
                                                                f"Existing record with name \"{existing_cname_fqdn}\" and type \"CNAME\" conflicts with this record."])
         assert_failed_change_in_error_response(response[9], input_name=f"user-add-unauthorized.{dummy_zone_name}", record_type="SRV",
                                                record_data={"priority": 1000, "weight": 5, "port": 20, "target": "bar.foo."},
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"user-add-unauthorized\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         clear_recordset_list(to_delete, client)
 
@@ -4884,13 +4886,13 @@ def test_srv_recordtype_update_delete_checks(shared_zone_test_context):
                                                    record_data={"priority": 1000, "weight": 5, "port": 20, "target": "bar.foo."})
         assert_failed_change_in_error_response(response[10], input_name=rs_delete_dummy_fqdn, record_type="SRV",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_delete_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[11], input_name=rs_update_dummy_fqdn, record_type="SRV",
                                                record_data={"priority": 1000, "weight": 5, "port": 20, "target": "bar.foo."},
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
         assert_failed_change_in_error_response(response[12], input_name=rs_update_dummy_fqdn, record_type="SRV",
                                                record_data=None, change_type="DeleteRecordSet",
-                                               error_messages=[f"User \"ok\" is not authorized. Contact zone owner group: {dummy_group_name} at test@test.com to make DNS changes."])
+                                               error_messages=[f'The record \"{rs_update_dummy_name}\" is owned by the [{dummy_group_name}] group(/groups/{shared_zone_test_context.dummy_group["id"]}). Only members of this group may update the record. Please contact them for assistance: test@test.com.'])
     finally:
         # Clean up updates
         dummy_deletes = [rs for rs in to_delete if rs["zone"]["id"] == dummy_zone["id"]]

--- a/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
+++ b/modules/api/src/test/functional/tests/batch/create_batch_change_test.py
@@ -800,7 +800,6 @@ def test_create_batch_change_partial_failure(shared_zone_test_context):
     }
 
     to_delete = []
-
     try:
         dns_add(shared_zone_test_context.ok_zone, "direct-to-backend", 200, "A", "1.2.3.4")
         result = client.create_batch_change(batch_change_input, status=202)

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -2759,7 +2759,7 @@ class BatchChangeServiceSpec
 
   "getGroupIdsFromUnauthorizedErrors" should {
     val error =
-      UserIsNotAuthorizedError("test-user", okGroup.id, OwnerType.Zone, Some("test@example.com")).invalidNel
+      UserIsNotAuthorizedError("test-record", okGroup.id, OwnerType.Zone, Some("test@example.com")).invalidNel
 
     "combine gets for each valid record" in {
       val in = List(apexAddForVal.validNel, error)
@@ -2772,7 +2772,7 @@ class BatchChangeServiceSpec
 
   "errorGroupMapping" should {
     val error =
-      UserIsNotAuthorizedError("test-user", okGroup.id, OwnerType.Zone, Some("test@example.com")).invalidNel
+      UserIsNotAuthorizedError("test-record", okGroup.id, OwnerType.Zone, Some("test@example.com")).invalidNel
 
     "combine gets for each valid record" in {
       val in = List(error, apexAddForVal.validNel)
@@ -2781,7 +2781,7 @@ class BatchChangeServiceSpec
 
       result.head should haveInvalid[DomainValidationError](
         UserIsNotAuthorizedError(
-          "test-user",
+          "test-record",
           okGroup.id,
           OwnerType.Zone,
           Some(okGroup.email),

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeValidationsSpec.scala
@@ -1106,7 +1106,7 @@ class BatchChangeValidationsSpec
 
     result(0) should haveInvalid[DomainValidationError](
       UserIsNotAuthorizedError(
-        notAuth.signedInUser.userName,
+        addUpdateA.recordName,
         addUpdateA.zone.adminGroupId,
         OwnerType.Zone,
         Some(addUpdateA.zone.email)
@@ -1115,7 +1115,7 @@ class BatchChangeValidationsSpec
 
     result(1) should haveInvalid[DomainValidationError](
       UserIsNotAuthorizedError(
-        notAuth.signedInUser.userName,
+        deleteUpdateA.recordName,
         deleteUpdateA.zone.adminGroupId,
         OwnerType.Zone,
         Some(deleteUpdateA.zone.email)
@@ -1655,7 +1655,7 @@ class BatchChangeValidationsSpec
 
       result(0) should haveInvalid[DomainValidationError](
         UserIsNotAuthorizedError(
-          notAuth.signedInUser.userName,
+          input.recordName,
           input.zone.adminGroupId,
           OwnerType.Zone,
           Some(input.zone.email)
@@ -1850,7 +1850,7 @@ class BatchChangeValidationsSpec
 
     result(0) should haveInvalid[DomainValidationError](
       UserIsNotAuthorizedError(
-        notAuth.signedInUser.userName,
+        deleteA.recordName,
         deleteA.zone.adminGroupId,
         OwnerType.Zone,
         Some(deleteA.zone.email)
@@ -2451,7 +2451,7 @@ class BatchChangeValidationsSpec
     result(0) should
       haveInvalid[DomainValidationError](
         UserIsNotAuthorizedError(
-          dummyAuth.signedInUser.userName,
+          "shared-delete",
           sharedZoneRecord.ownerGroupId.get,
           OwnerType.Record,
           None

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetValidationsSpec.scala
@@ -689,7 +689,7 @@ class RecordSetValidationsSpec
         val invalidString = "*o*"
         val error = leftValue(validRecordNameFilterLength(invalidString))
         error shouldBe an[InvalidRequest]
-        error.getMessage() shouldBe RecordNameFilterError
+        error.getMessage() shouldBe RecordNameFilterErrorMsg
       }
     }
     

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -614,7 +614,7 @@ class VinylDNSJsonProtocolSpec
           ("records" -> data)
 
       val thrown = the[MappingException] thrownBy recordSetJValue.extract[RecordSet]
-      thrown.msg should include(NSDataError)
+      thrown.msg should include(NSDataErrorMsg)
     }
     "round trip a DS record set" in {
       val rs = RecordSet(

--- a/modules/core/src/main/scala/vinyldns/core/Messages.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Messages.scala
@@ -205,7 +205,7 @@ object Messages {
 
   val OwnershipTransferAlreadyOwnedErrorMsg: String = "Record owner group with id %s already owns the record, new request is not needed.".orConfig
 
-  val OwnershipTransferInvalidPendingReviewErrorMsg: String = "Invalid ownership transfer status: %s".orConfig
+  val OwnershipTransferInvalidPendingReviewErrorMsg: String = "Invalid Ownership transfer status: %s".orConfig
 
   val OwnershipTransferInvalidApprovalErrorMsg: String = "Unable to %s the Ownership transfer status for the record: None".orConfig
 

--- a/modules/core/src/main/scala/vinyldns/core/Messages.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Messages.scala
@@ -130,7 +130,7 @@ object Messages {
 
   val DeleteRecordDataDoesNotExistErrorMsg: String = "Record data %s does not exist for \"%s\".".orConfig
 
-  val NotAuthorizedErrorMsg: String = "User \"%s\" is not authorized. Contact %s owner group: %s at %s to make DNS changes.".orConfig
+  val NotAuthorizedErrorMsg: String = "The record \"%s\" is owned by the [%s] group(%s). Only members of this group may update the record. Please contact them for assistance: %s.".orConfig
 
   val InvalidIPv4CNameErrorMsg: String = "Invalid Cname: \"%s\", Valid CNAME record data should not be an IP address".orConfig
 
@@ -139,6 +139,13 @@ object Messages {
   val InvalidReverseCnameErrorMsg: String = "Invalid Cname: \"%s\", valid cnames must be letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.".orConfig
 
   val InvalidUpdateRequestErrorMsg: String = "Cannot perform request for the record \"%s\". Add and Delete for the record with same record data exists in the batch.".orConfig
+
+  /* Deprecated errors */
+  val ExistingMultiRecordErrorMsg: String = "RecordSet with name %s and type %s cannot be updated in a single Batch Change because it contains multiple DNS records (%s).".orConfig
+
+  val NewMultiRecordErrorMsg: String = "Multi-record recordsets are not enabled for this instance of VinylDNS. Cannot create a new record set with multiple records for inputName %s and type %s.".orConfig
+
+  val UserIsNotAuthorizedMsg: String = "User \"%s\" is not authorized.".orConfig
 
   /* RecordSetValidations.scala */
   val RecordNameFilterErrorMsg: String = "Record Name Filter field must contain at least two letters or numbers and cannot have wildcard at both the start and end.".orConfig
@@ -585,4 +592,5 @@ object Messages {
   val nonExistentRecordDeleteMessage = "This record does not exist. No further action is required."
 
   val nonExistentRecordDataDeleteMessage = "Record data entered does not exist. No further action is required."
+
 }

--- a/modules/core/src/main/scala/vinyldns/core/Messages.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Messages.scala
@@ -16,74 +16,571 @@
 
 package vinyldns.core
 
+import vinyldns.core.config.MessagesConfig._
+import vinyldns.core.config.Message
+
 object Messages {
 
-  // Error displayed when less than two letters or numbers is filled in Record Name Filter field in RecordSetSearch page
-  val RecordNameFilterError =
-    "Record Name Filter field must contain at least two letters or numbers and cannot have wildcard at both the start and end."
+  // Getting the messages present in the config file
+  val configMessages: Map[String, Message] = messages.right.toOption match {
+    case Some(value) => value.messages.map(value => value.text -> value).toMap
+    case None => Map("error" -> Message("config-not-found", "config-not-found"))
+  }
 
-  /*
-   *  Error displayed when attempting to create group with name that already exists
-   *
-   * Placeholders:
-   * 1. [string] group name
-   * 2. [string] group email address
-   */
-  val GroupAlreadyExistsErrorMsg =
-    "Group with name %s already exists. Please try a different name or contact %s to be added to the group."
+  // Checking if a message is present in config file and overriding the existing message
+  implicit class MessagesStringExtension(existingMessage: String) {
+    def orConfig: String =
+      if (configMessages.contains(existingMessage) && configMessages(existingMessage).overrideText != null && configMessages(existingMessage).overrideText != "")
+        configMessages(existingMessage).overrideText
+      else existingMessage
+  }
 
-  /*
-   *  Error displayed when deleting a group being the admin of a zone
-   *
-   * Placeholders:
-   * 1. [string] group name
-   */
-  val ZoneAdminError =
-    "%s is the admin of a zone. Cannot delete. Please transfer the ownership to another group before deleting."
+  // Messages displayed to the user and the files in which they are present
+  /* MembershipService.scala */
+  val GroupEmailExistsErrorMsg: String = "Cannot create group. A group, %s, is already associated with the email address %s. Please contact %s to be added to the group.".orConfig
 
-  /*
-   *  Error displayed when deleting a group being the owner for a record set
-   *
-   * Placeholders:
-   * 1. [string] group name
-   * 2. [string] record set id
-   */
-  val RecordSetOwnerError =
-    "%s is the owner for a record set including %s. Cannot delete. Please transfer the ownership to another group before deleting."
+  val GroupEmailExistsUpdateErrorMsg: String = "Cannot update group. A group, %s, is already associated with the email address %s. Visit FAQ for more information.".orConfig
 
-  /*
-   *  Error displayed when deleting a group which has an ACL rule for a zone
-   *
-   * Placeholders:
-   * 1. [string] group name
-   * 2. [string] zone id
-   */
-  val ACLRuleError =
-    "%s has an ACL rule for a zone including %s. Cannot delete. Please transfer the ownership to another group before deleting."
+  val UserNotFoundErrorMsg: String = "User with ID %s was not found".orConfig
 
-  // Error displayed when NSData field is not a positive integer
-  val NSDataError = "NS data must be a positive integer"
+  val GroupNotFoundErrorMsg: String = "Group with ID %s was not found".orConfig
 
-  /*
-   *  Error displayed when user is not authorized to make changes to the record
-   *
-   * Placeholders:
-   * 1. [string] user name
-   * 2. [string] owner type
-   * 3. [string] owner group name | owner group id
-   * 4. [string] contact email
-   */
-  val NotAuthorizedErrorMsg =
-    "User \"%s\" is not authorized. Contact %s owner group: %s at %s to make DNS changes."
+  val UsersNotFoundErrorMsg: String = "Users [ %s ] were not found".orConfig
 
-  // Error displayed when group name or email is empty
-  val GroupValidationErrorMsg = "Group name and email cannot be empty."
+  val UserIsNotFoundErrorMsg: String = "User %s was not found".orConfig
 
-  val EmailValidationErrorMsg = "Please enter a valid Email. Valid domains should end with"
+  val ACLRuleErrorMsg: String = "%s has an ACL rule for a zone including %s. Cannot delete. Please transfer the ownership to another group before deleting.".orConfig
 
-  val InvalidEmailValidationErrorMsg = "Please enter a valid Email."
+  val RecordSetOwnerErrorMsg: String = "%s is the owner for a record set including %s. Cannot delete. Please transfer the ownership to another group before deleting.".orConfig
 
-  val DotsValidationErrorMsg = "Please enter a valid Email. Number of dots allowed after @ is"
+  val GroupAlreadyExistsErrorMsg: String = "Group with name %s already exists. Please try a different name or contact %s to be added to the group.".orConfig
+
+  val ZoneAdminErrorMsg: String = "%s is the admin of a zone. Cannot delete. Please transfer the ownership to another group before deleting.".orConfig
+
+  val GroupValidationErrorMsg: String = "Group name and email cannot be empty.".orConfig
+
+  val EmailValidationErrorMsg: String = "Please enter a valid Email. Valid domains should end with".orConfig
+
+  val InvalidEmailValidationErrorMsg: String = "Please enter a valid Email.".orConfig
+
+  val DotsValidationErrorMsg: String = "Please enter a valid Email. Number of dots allowed after @ is".orConfig
+
+  /* DomainValidationErrors.scala */
+  val ChangeLimitExceededErrorMsg: String = "Cannot request more than %d changes in a single batch change request".orConfig
+
+  val GroupIdNotFoundErrorMsg: String = "Group with ID \"%s\" was not found".orConfig
+
+  val BatchChangeIsEmptyErrorMsg: String = "Batch change contained no changes. Batch change must have at least one change, up to a maximum of %d changes.".orConfig
+
+  val NotMemberOfGroupErrorMsg: String = "User \"%s\" must be a member of group \"%s\" to apply this group to batch changes.".orConfig
+
+  val InvalidDomainNameErrorMsg: String = "Invalid domain name: \"%s\", valid domain names must be letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.".orConfig
+
+  val InvalidLengthErrorMsg: String = "Invalid length: \"%s\", length needs to be between %d and %d characters.".orConfig
+
+  val InvalidEmailErrorMsg: String = "Invalid email address: \"%s\".".orConfig
+
+  val InvalidRecordTypeErrorMsg: String = "Invalid record type: \"%s\", valid record types include %s.".orConfig
+
+  val InvalidPortNumberErrorMsg: String = "Invalid port number: \"%s\", port must be a number between %d and %d.".orConfig
+
+  val InvalidIpv4AddressErrorMsg: String = "Invalid IPv4 address: \"%s\".".orConfig
+
+  val InvalidIpv6AddressErrorMsg: String = "Invalid IPv6 address: \"%s\".".orConfig
+
+  val InvalidIPAddressErrorMsg: String = "Invalid IP address: \"%s\".".orConfig
+
+  val InvalidTTLErrorMsg: String = "Invalid TTL: \"%s\", must be a number between %d and %d.".orConfig
+
+  val InvalidMxPreferenceErrorMsg: String = "Invalid MX Preference: \"%s\", must be a number between %d and %d.".orConfig
+
+  val InvalidMX_NAPTR_SRVDataErrorMsg: String = "Invalid %s %s: \"%s\", must be a number between %d and %d.".orConfig
+
+  val InvalidNaptrFlagErrorMsg: String = "Invalid NAPTR flag value: '%s'. Valid NAPTR flag value must be U, S, A or P.".orConfig
+
+  val InvalidNaptrRegexpErrorMsg: String = "Invalid NAPTR regexp value: '%s'. Valid NAPTR regexp value must start and end with '!'.".orConfig
+
+  val InvalidBatchRequestErrorMsg: String = "%s".orConfig
+
+  val NotApprovedNSErrorMsg: String = "Name Server %s is not an approved name server.".orConfig
+
+  val InvalidBatchRecordTypeErrorMsg: String = "Invalid Batch Record Type: \"%s\", valid record types for batch changes include %s.".orConfig
+
+  val ZoneDiscoveryErrorMsg: String = "Zone Discovery Failed: zone for \"%s\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS.".orConfig
+
+  val RecordAlreadyExistsErrorMsg: String = "RecordName \"%s\" already exists. If you intended to update this record, submit a DeleteRecordSet entry followed by an Add.".orConfig
+
+  val RecordDoesNotExistErrorMsg: String = "Record \"%s\" Does Not Exist: cannot delete a record that does not exist.".orConfig
+
+  val CnameIsNotUniqueErrorMsg: String = "CNAME Conflict: CNAME record names must be unique. Existing record with name \"%s\" and type \"%s\" conflicts with this record.".orConfig
+
+  val RecordNameNotUniqueInBatchErrorMsg: String = "Record Name \"%s\" Not Unique In Batch Change: cannot have multiple \"%s\" records with the same name.".orConfig
+
+  val RecordInReverseZoneErrorMsg: String = "Invalid Record Type In Reverse Zone: record with name \"%s\" and type \"%s\" is not allowed in a reverse zone.".orConfig
+
+  val HighValueDomainErrorMsg: String = "Record name \"%s\" is configured as a High Value Domain, so it cannot be modified.".orConfig
+
+  val MissingOwnerGroupIdErrorMsg: String = "Zone \"%s\" is a shared zone, so owner group ID must be specified for record \"%s\".".orConfig
+
+  val CnameAtZoneApexErrorMsg: String = "CNAME cannot be the same name as zone \"%s\".".orConfig
+
+  val RecordManualReviewErrorMsg: String = "Record set with name \"%s\" requires manual review.".orConfig
+
+  val UnsupportedOperationErrorMsg: String = "%s is not yet implemented/supported in VinylDNS.".orConfig
+
+  val DeleteRecordDataDoesNotExistErrorMsg: String = "Record data %s does not exist for \"%s\".".orConfig
+
+  val NotAuthorizedErrorMsg: String = "User \"%s\" is not authorized. Contact %s owner group: %s at %s to make DNS changes.".orConfig
+
+  val InvalidIPv4CNameErrorMsg: String = "Invalid Cname: \"%s\", Valid CNAME record data should not be an IP address".orConfig
+
+  val InvalidForwardCnameErrorMsg: String = "Invalid Cname: \"%s\", valid cnames must be letters, numbers, slashes, underscores, and hyphens, joined by dots, and terminated with a dot.".orConfig
+
+  val InvalidReverseCnameErrorMsg: String = "Invalid Cname: \"%s\", valid cnames must be letters, numbers, underscores, and hyphens, joined by dots, and terminated with a dot.".orConfig
+
+  val InvalidUpdateRequestErrorMsg: String = "Cannot perform request for the record \"%s\". Add and Delete for the record with same record data exists in the batch.".orConfig
+
+  /* RecordSetValidations.scala */
+  val RecordNameFilterErrorMsg: String = "Record Name Filter field must contain at least two letters or numbers and cannot have wildcard at both the start and end.".orConfig
+
+  val UnchangedZoneIdErrorMsg: String = "Cannot update RecordSet's zone ID.".orConfig
+
+  val UnchangedRecordTypeErrorMsg: String = "Cannot update RecordSet's record type.".orConfig
+
+  val UnchangedRecordNameErrorMsg: String = "Cannot update RecordSet's name.".orConfig
+
+  val RecordOwnerGroupNotFoundErrorMsg: String = "Record owner group with id \"%s\" not found".orConfig
+
+  val UserNotInOwnerGroupErrorMsg: String = "User not in record owner group with id \"%s\"".orConfig
+
+  val NSApexErrorMsg: String = "Record with name %s is an NS record at apex and cannot be added".orConfig
+
+  val NSApexEditErrorMsg: String = "Record with name %s is an NS record at apex and cannot be edited".orConfig
+
+  val DSTTLErrorMsg: String = "DS record [%s] must have TTL matching its linked NS (%d)".orConfig
+
+  val DSInvalidErrorMsg: String = "DS record [%s] is invalid because there is no NS record with that name in the zone [%s]".orConfig
+
+  val DSApexErrorMsg: String = "Record with name [%s] is an DS record at apex and cannot be added".orConfig
+
+  val CnameDuplicateErrorMsg: String = "RecordSet with name %s already exists in zone %s, CNAME record cannot use duplicate name".orConfig
+
+  val InvalidCnameErrorMsg: String = "CNAME RecordSet cannot have name '@' because it points to zone origin".orConfig
+
+  val SOADeleteErrorMsg: String = "SOA records cannot be deleted".orConfig
+
+  val DottedHostErrorMsg: String = "Record with name %s and type %s is a dotted host which is not allowed in zone %s".orConfig
+
+  val RecordSetAlreadyExistsErrorMsg: String = "RecordSet with name %s and type %s already exists in zone %s".orConfig
+
+  val RecordSetCnameExistsErrorMsg: String = "RecordSet with name %s and type CNAME already exists in zone %s".orConfig
+
+  val PendingUpdateErrorMsg: String = "RecordSet with id %s, name %s and type %s currently has a pending change".orConfig
+
+  val RecordNameLengthErrorMsg: String = "record set name %s is too long".orConfig
+
+  val ReverseLookupErrorMsg: String = "%s is not valid in reverse lookup zone.".orConfig
+
+  val InvalidPtrErrorMsg: String = "PTR is not valid in forward lookup zone".orConfig
+
+  val InvalidRequestErrorMsg: String = "Record with fqdn '%s.%s' cannot be created. " +
+    "Please check if a record with the same FQDN and type already exist and make the change there.".orConfig
+
+  val RtypeOrUserNotAllowedErrorMsg: String = "Record type is not allowed or the user is not authorized to create a dotted host in the zone '%s'".orConfig
+
+  val RDataWithConsecutiveDotsErrorMsg: String = "RecordSet Data cannot contain consecutive 'dot' character. RData: '%s'".orConfig
+
+  val IPv4inCnameErrorMsg: String = "Invalid CNAME: %s, valid CNAME record data cannot be an IP address.".orConfig
+
+  val MoreDotsThanAllowedErrorMsg: String = "RecordSet with name %s has more dots than that is allowed in config for this zone " +
+    "which is, 'dots-limit = %s'.".orConfig
+
+  val InvalidEndingErrorMsg: String = "RecordSet name cannot end with a dot, unless it's an apex record.".orConfig
+
+  val OwnershipTransferUpdateErrorMsg: String = "Cannot update RecordSet's if user not a member of ownership group. User can only request for ownership transfer".orConfig
+
+  val OwnershipTransferCancelledRequestErrorMsg: String = "Cannot update RecordSet Ownership Status when request is cancelled.".orConfig
+
+  val OwnershipTransferZoneNotSharedErrorMsg: String = "Cannot update RecordSet Ownership Status when zone is not shared.".orConfig
+
+  val OwnershipTransferAlreadyOwnedErrorMsg: String = "Record owner group with id %s already owns the record, new request is not needed.".orConfig
+
+  val OwnershipTransferInvalidPendingReviewErrorMsg: String = "Invalid ownership transfer status: %s. Request is already in Pending Review state.".orConfig
+
+  val OwnershipTransferInvalidApprovalErrorMsg: String = "Unable to %s the Ownership transfer status for the record: None.".orConfig
+
+  val OwnershipTransferInvalidCancelErrorMsg: String = "Unable to cancel the ownership transfer. Current status: %s".orConfig
+
+  val OwnershipTransferUnauthorisedCancelErrorMsg: String = "Unauthorised to Cancel the ownership transfer".orConfig
+
+  val OwnershipTransferUnauthorizedChangeErrorMsg: String = "Unauthorized to change ownership transfer status to '%s'".orConfig
+
+
+
+  /* BatchChangeErrors.scala */
+  val BatchChangeNotFoundErrorMsg: String = "Batch change with id %s cannot be found".orConfig
+
+  val UserNotAuthorizedErrorMsg: String = "User does not have access to item %s".orConfig
+
+  val BatchConversionErrorMsg: String = "Batch conversion for processing failed to convert change with name \"%s\" and type \"%s\"".orConfig
+
+  val BatchChangeNotPendingReviewErrorMsg: String = "Batch change %s is not pending review, so it cannot be rejected.".orConfig
+
+  val BatchRequesterNotFoundErrorMsg: String = "The requesting user with id %s and name %s cannot be found in VinylDNS".orConfig
+
+  val ScheduledChangesDisabledErrorMsg: String = "Cannot create a scheduled change, as it is currently disabled on this VinylDNS instance.".orConfig
+
+  val ScheduledTimeMustBeInFutureErrorMsg: String = "Scheduled time must be in the future.".orConfig
+
+  val ScheduledChangeNotDueErrorMsg: String = "Cannot process scheduled change as it is not past the scheduled date of %s".orConfig
+
+  val ManualReviewRequiresOwnerGroupErrorMsg: String = "Batch change requires owner group for manual review.".orConfig
+
+  /* DnsJsonProtocol.scala */
+  val MissingRecordSetZoneMsg: String = "Missing RecordSetChange.zone".orConfig
+
+  val MissingRecordSetMsg: String = "Missing RecordSetChange.recordSet".orConfig
+
+  val MissingRecordSetUserIdMsg: String = "Missing RecordSetChange.userId".orConfig
+
+  val MissingRecordSetChangeTypeMsg: String = "Missing RecordSetChange.changeType".orConfig
+
+  val MissingZoneNameMsg: String = "Missing Zone.name".orConfig
+
+  val MissingZoneEmailMsg: String = "Missing Zone.email".orConfig
+
+  val MissingZoneGroupIdMsg: String = "Missing Zone.adminGroupId".orConfig
+
+  val MissingZoneIdMsg: String = "Missing Zone.id".orConfig
+
+  val MissingZoneSharedMsg: String = "Missing Zone.shared".orConfig
+
+  val UnsupportedKeyAlgorithmMsg: String = "Unsupported type for key algorithm, must be a string".orConfig
+
+  val MissingZoneConnectionNameMsg: String = "Missing ZoneConnection.name".orConfig
+
+  val MissingZoneConnectionKeyNameMsg: String = "Missing ZoneConnection.keyName".orConfig
+
+  val MissingZoneConnectionKeyMsg: String = "Missing ZoneConnection.key".orConfig
+
+  val MissingZoneConnectionServer: String = "Missing ZoneConnection.primaryServer".orConfig
+
+  val MissingRecordSetTypeMsg: String = "Missing RecordSet.type".orConfig
+
+  val MissingRecordSetZoneIdMsg: String = "Missing RecordSet.zoneId".orConfig
+
+  val MissingRecordSetNameMsg: String = "Missing RecordSet.name".orConfig
+
+  val MissingRecordSetTTL: String = "Missing RecordSet.ttl".orConfig
+
+  val RecordNameLengthMsg: String = "Record name must not exceed 255 characters".orConfig
+
+  val RecordContainsSpaceMsg: String = "Record name cannot contain spaces".orConfig
+
+  val RecordSetTTLNotPositiveMsg: String = "RecordSet.ttl must be a positive signed 32 bit number".orConfig
+
+  val RecordSetTTLNotValidMsg: String = "RecordSet.ttl must be a positive signed 32 bit number greater than or equal to 30".orConfig
+
+  val CnameValidationMsg: String = "CNAME record sets cannot contain multiple records".orConfig
+
+  val MissingARecordsMsg: String = "Missing A Records".orConfig
+
+  val MissingAAAARecordsMsg: String = "Missing AAAA Records".orConfig
+
+  val MissingCnameRecordsMsg: String = "Missing CNAME Records".orConfig
+
+  val MissingDSRecordsMsg: String = "Missing DS Records".orConfig
+
+  val MissingMXRecordsMsg: String = "Missing MX Records".orConfig
+
+  val MissingNsRecordsMsg: String = "Missing NS Records".orConfig
+
+  val MissingPTRRecordsMsg: String = "Missing PTR Records".orConfig
+
+  val MissingSOARecordsMsg: String = "Missing SOA Records".orConfig
+
+  val MissingSPFRecordsMsg: String = "Missing SPF Records".orConfig
+
+  val MissingSRVRecordsMsg: String = "Missing SRV Records".orConfig
+
+  val MissingNAPTRRecordsMsg: String = "Missing NAPTR Records".orConfig
+
+  val MissingSSHFPRecordsMsg: String = "Missing SSHFP Records".orConfig
+
+  val MissingTXTRecordsMsg: String = "Missing TXT Records".orConfig
+
+  val UnsupportedRecordTypeMsg: String = "Unsupported type %s, valid types include %s".orConfig
+
+  val MissingAAddressMsg: String = "Missing A.address".orConfig
+
+  val InvalidIPv4Msg: String = "A must be a valid IPv4 Address".orConfig
+
+  val MissingAAAAAddressMsg: String = "Missing AAAA.address".orConfig
+
+  val InvalidIPv6Msg: String = "AAAA must be a valid IPv6 Address".orConfig
+
+  val MissingCnameMsg: String = "Missing CNAME.cname".orConfig
+
+  val CnameLengthMsg: String = "CNAME domain name must not exceed 255 characters".orConfig
+
+  val CnameAbsoluteMsg: String = "CNAME data must be absolute".orConfig
+
+  val MissingMXPreferenceMsg: String = "Missing MX.preference".orConfig
+
+  val MXPreferenceValidationMsg: String = "MX.preference must be a 16 bit integer".orConfig
+
+  val MissingMXExchangeMsg: String = "Missing MX.exchange".orConfig
+
+  val MXExchangeValidationMsg: String = "MX.exchange must be less than 255 characters".orConfig
+
+  val MissingNSNameMsg: String = "Missing NS.nsdname".orConfig
+
+  val NSNameValidationMsg: String = "NS must be less than 255 characters".orConfig
+
+  val MissingPTRNameMsg: String = "Missing PTR.ptrdname".orConfig
+
+  val PTRNameValidationMsg: String = "PTR must be less than 255 characters".orConfig
+
+  val MissingSOAMNameMsg: String = "Missing SOA.mname".orConfig
+
+  val SOAMNameValidationMsg: String = "SOA.mname must be less than 255 characters".orConfig
+
+  val MissingSOARNameMsg: String = "Missing SOA.rname".orConfig
+
+  val SOARNameValidationMsg: String = "SOA.rname must be less than 255 characters".orConfig
+
+  val MissingSOASerialMsg: String = "Missing SOA.serial".orConfig
+
+  val SOASerialValidationMsg: String = "SOA.serial must be an unsigned 32 bit number".orConfig
+
+  val MissingSOARefreshMsg: String = "Missing SOA.refresh".orConfig
+
+  val SOARefreshValidationMsg: String = "SOA.refresh must be an unsigned 32 bit number".orConfig
+
+  val MissingSOARetryMsg: String = "Missing SOA.retry".orConfig
+
+  val SOARetryValidationMsg: String = "SOA.retry must be an unsigned 32 bit number".orConfig
+
+  val MissingSOAExpireMsg: String = "Missing SOA.expire".orConfig
+
+  val SOAExpireValidationMsg: String = "SOA.expire must be an unsigned 32 bit number".orConfig
+
+  val MissingSOAMinimumMsg: String = "Missing SOA.minimum".orConfig
+
+  val SOAMinimumValidationMsg: String = "SOA.minimum must be an unsigned 32 bit number".orConfig
+
+  val MissingSPFTextMsg: String = "Missing SPF.text".orConfig
+
+  val SPFValidationMsg: String = "SPF record must be less than 64764 characters".orConfig
+
+  val MissingSRVPriorityMsg: String = "Missing SRV.priority".orConfig
+
+  val SRVPriorityValidationMsg: String = "SRV.priority must be an unsigned 16 bit number".orConfig
+
+  val MissingSRVWeightMsg: String = "Missing SRV.weight".orConfig
+
+  val SRVWeightValidationMsg: String = "SRV.weight must be an unsigned 16 bit number".orConfig
+
+  val MissingSRVPortMsg: String = "Missing SRV.port".orConfig
+
+  val SRVPortValidationMsg: String = "SRV.port must be an unsigned 16 bit number".orConfig
+
+  val MissingSRVTargetMsg: String = "Missing SRV.target".orConfig
+
+  val SRVTargetValidationMsg: String = "SRV.target must be less than 255 characters".orConfig
+
+  val MissingNAPTROrderMsg: String = "Missing NAPTR.order".orConfig
+
+  val NAPTROrderValidationMsg: String = "NAPTR.order must be an unsigned 16 bit number".orConfig
+
+  val MissingNAPTRPreferenceMsg: String = "Missing NAPTR.preference".orConfig
+
+  val NAPTRPreferenceValidationMsg: String = "NAPTR.preference must be an unsigned 16 bit number".orConfig
+
+  val MissingNAPTRFlagsMsg: String = "Missing NAPTR.flags".orConfig
+
+  val NAPTRFlagsValidationMsg: String = "Invalid NAPTR.flag. Valid NAPTR flag value must be U, S, A or P".orConfig
+
+  val MissingNAPTRServiceMsg: String = "Missing NAPTR.service".orConfig
+
+  val NAPTRServiceValidationMsg: String = "NAPTR.service must be less than 255 characters".orConfig
+
+  val MissingNAPTRRegexMsg: String = "Missing NAPTR.regexp".orConfig
+
+  val NAPTRRegexValidationMsg: String = "Invalid NAPTR.regexp. Valid NAPTR regexp value must start and end with '!' or can be empty".orConfig
+
+  val MissingNAPTRReplacementMsg: String = "Missing NAPTR.replacement".orConfig
+
+  val NAPTRReplacementValidationMsg: String = "NAPTR.replacement must be less than 255 characters".orConfig
+
+  val MissingSSHFPAlgorithmMsg: String = "Missing SSHFP.algorithm".orConfig
+
+  val SSHFPAlgorithmValidationMsg: String = "SSHFP.algorithm must be an unsigned 8 bit number".orConfig
+
+  val MissingSSHFPTypeMsg: String = "Missing SSHFP.type".orConfig
+
+  val SSHFPTypeValidationMsg: String = "SSHFP.type must be an unsigned 8 bit number".orConfig
+
+  val MissingSSHFPFingerprintMsg: String = "Missing SSHFP.fingerprint".orConfig
+
+  val MissingDSKeytagMsg: String = "Missing DS.keytag".orConfig
+
+  val DSKeytagValidationMsg: String = "DS.keytag must be an unsigned 16 bit number".orConfig
+
+  val MissingDSAlgorithmMsg: String = "Missing DS.algorithm".orConfig
+
+  val UnsupportedDNSSECMsg: String = "Algorithm %d is not a supported DNSSEC algorithm".orConfig
+
+  val MissingDSDigestTypeMsg: String = "Missing DS.digesttype".orConfig
+
+  val UnsupportedDigestTypeMsg: String = "Digest Type %d is not a supported DS record digest type".orConfig
+
+  val MissingDSDigestMsg: String = "Missing DS.digest".orConfig
+
+  val DigestConvertMsg: String = "Could not convert digest to valid hex".orConfig
+
+  val MissingTXTTextMsg: String = "Missing TXT.text".orConfig
+
+  val TXTRecordValidationMsg: String = "TXT record must be less than 64764 characters".orConfig
+
+  val NSDataErrorMsg: String = "NS data must absolute".orConfig //"NS data must be a positive integer"
+
+  val UnsupportedEncryptedTypeErrorMsg: String = "Unsupported type for zone connection key, must be a string".orConfig
+
+  /* AccessValidations.scala */
+  val CannotAccessZoneErrorMsg: String = "User %s cannot access zone '%s'".orConfig
+
+  val CannotAccessZoneChangeErrorMsg: String = "User %s cannot access zone '%s' changes".orConfig
+
+  val CannotChangeZoneErrorMsg: String = "User '%s' cannot create or modify zone '%s' because they are not in the Zone Admin Group '%s'".orConfig
+
+  val CannotAddRecordErrorMsg: String = "User %s does not have access to create %s.%s".orConfig
+
+  val CannotUpdateRecordErrorMsg: String = "User %s does not have access to update %s.%s".orConfig
+
+  val CannotDeleteRecordErrorMsg: String = "User %s does not have access to delete %s.%s".orConfig
+
+  val CannotViewRecordErrorMsg: String = "User %s does not have access to view %s.%s".orConfig
+
+  /* MembershipValidations.scala */
+  val hasNoMembersAndAdminsErrorMsg: String = "Group must have at least one member and one admin".orConfig
+
+  val NoAuthorizationErrorMsg: String = "Not authorized".orConfig
+
+  val InvalidGroupChangeIdErrorMsg: String = "Invalid Group Change ID".orConfig
+
+  /* ACLJsonProtocol.scala */
+  val ACLAccessLevelMsg: String = "Missing ACLRule.accessLevel".orConfig
+
+  val DeserializeCheckErrorMsg: String = "Cannot specify both a userId and a groupId".orConfig
+
+  /* MembershipJsonProtocol.scala */
+  val MissingGroupNameMsg: String = "Missing Group.name".orConfig
+
+  val MissingGroupEmailMsg: String = "Missing Group.email".orConfig
+
+  val MissingGroupMembersMsg: String = "Missing Group.members".orConfig
+
+  val MissingGroupAdminsMsg: String = "Missing Group.admins".orConfig
+
+  val MissingGroupIdMsg: String = "Missing Group.id".orConfig
+
+  val MissingNewGroupMsg: String = "Missing new group".orConfig
+
+  val MissingChangeTypeMsg: String = "Missing change type".orConfig
+
+  val MissingUserIdMsg: String = "Missing userId".orConfig
+
+  val MissingUserNameMsg: String = "Missing userName".orConfig
+
+  val MissingGroupChangeMsg: String = "Missing groupChangeMessage".orConfig
+
+  /* VinylDNSAuthentication.scala */
+  val AuthMissingErrorMsg: String = "Authorization header not found".orConfig
+
+  val AuthRejectedErrorMsg: String = "Authorization header could not be parsed".orConfig
+
+  val RequestSignatureErrorMsg: String = "Request signature could not be validated".orConfig
+
+  val AccountLockedErrorMsg: String = "Account with username %s is locked".orConfig
+
+  val AccountAccessKeyErrorMsg: String = "Account with accessKey %s specified was not found".orConfig
+
+  /* RecordSetChangeHandler.scala */
+  val OutOfSyncFailureMessage: String = "This record set is out of sync with the DNS backend; sync this zone before attempting to update this record set.".orConfig
+
+  val IncompatibleRecordFailureMessage: String = "Incompatible record in DNS.".orConfig
+
+  val SyncZoneMessage: String = "This record set is out of sync with the DNS backend. Sync this zone before attempting to update this record set.".orConfig
+
+  val RecordConflictMessage: String = "Conflict due to the record having the same name as an NS record in the same zone. Please create the record using the DNS service the NS record has been delegated to (ex. AWS r53), or use a different record name.".orConfig
+
+  val UpdateValidateMsg: String = "Failed validating update to DNS for change \"%s\": \"%s\": %s".orConfig
+
+  val UpdateApplyMsg: String = "Failed applying update to DNS for change %s:%s: %s".orConfig
+
+  val UpdateVerifyMsg: String = "Failed verifying update to DNS for change %s:%s: %s".orConfig
+
+  /* ZoneRecordValidations.scala */
+  val ApprovedNameServerMsg: String = "Name Server %s is not an approved name server.".orConfig
+
+  /* ZoneService.scala */
+  val UnknownGroupNameMsg: String = "Unknown group name".orConfig
+
+  val ZoneAlreadyExistsErrorMsg: String = "Zone with name %s already exists. Please contact %s to request access to the zone.".orConfig
+
+  val ZoneIdNotFoundErrorMsg: String = "Zone with id %s does not exists".orConfig
+
+  val ZoneNameNotFoundErrorMsg: String = "Zone with name %s does not exists".orConfig
+
+  val AdminGroupNotExistsErrorMsg: String = "Admin group with ID %s does not exist".orConfig
+
+  val InvalidCronStringErrorMsg: String = "Invalid cron expression. Please enter a valid cron expression in 'recurrenceSchedule'.".orConfig
+
+  val UnauthorizedSyncScheduleErrorMsg: String = "User '%s' is not authorized to schedule zone sync in this zone.".orConfig
+
+  /* ZoneValidations.scala */
+  val RecentSyncErrorMsg: String = "Zone %s was recently synced. Cannot complete sync".orConfig
+
+  val InvalidACLRuleErrorMsg: String = "Invalid ACL rule: ACL rules must have a group or user id".orConfig
+
+  val CIDRErrorMsg: String = "PTR types must have no mask or a valid CIDR mask: Invalid CIDR block".orConfig
+
+  val PTRNoMaskErrorMsg: String = "Multiple record types including PTR must have no mask".orConfig
+
+  val InvalidRegexErrorMsg: String = "record mask %s is an invalid regex".orConfig
+
+  val CreateSharedZoneErrorMsg: String = "Not authorized to create shared zones.".orConfig
+
+  val UpdateSharedZoneErrorMsg: String = "Not authorized to update zone shared status from %b to %b.".orConfig
+
+  /* JsonValidation.scala */
+  val UnexpectedExtractionErrorMsg: String = "Extraction.extract returned unexpected type".orConfig
+
+  val JsonParseErrorMsg: String = "Failed to parse %s".orConfig
+
+  val UnexpectedJsonErrorMsg: String = "While parsing %s, received unexpected error '%s'".orConfig
+
+  val InvalidMsg: String = "Invalid %s".orConfig
+
+  /* Route53Backend.scala */
+  val HostedZoneErrorMsg: String = "Unable to find hosted zone for zone name %s".orConfig
+
+  val RecordConversionErrorMsg: String = "Unable to convert record set to route 53 format for %s".orConfig
+
+  /* SqsMessage.scala */
+  val SqsParseErrorMsg: String = "Unable to parse SQS Message with ID '%s'".orConfig
+
+  val SqsBodyErrorMsg: String = "No message body found for SQS message with ID '%s'".orConfig
+
+  val SqsInvalidCommand: String = "Invalid command message type '%s'".orConfig
+
+  /* SqsMessageQueue.scala */
+  val InvalidDurationErrorMsg: String = "Invalid duration: %d seconds. Duration must be between %d-%d seconds.".orConfig
+
+  /* SqsMessageQueueProvider.scala */
+  val InvalidQueueNameErrorMsg: String = "Invalid queue name: %s. Must be 1-80 alphanumeric, hyphen or underscore characters. " +
+    "FIFO queues (queue names ending in \".fifo\") are not supported.".orConfig
 
   val nonExistentRecordDeleteMessage = "This record does not exist. No further action is required."
 

--- a/modules/core/src/main/scala/vinyldns/core/Messages.scala
+++ b/modules/core/src/main/scala/vinyldns/core/Messages.scala
@@ -205,11 +205,11 @@ object Messages {
 
   val OwnershipTransferAlreadyOwnedErrorMsg: String = "Record owner group with id %s already owns the record, new request is not needed.".orConfig
 
-  val OwnershipTransferInvalidPendingReviewErrorMsg: String = "Invalid ownership transfer status: %s. Request is already in Pending Review state.".orConfig
+  val OwnershipTransferInvalidPendingReviewErrorMsg: String = "Invalid ownership transfer status: %s".orConfig
 
-  val OwnershipTransferInvalidApprovalErrorMsg: String = "Unable to %s the Ownership transfer status for the record: None.".orConfig
+  val OwnershipTransferInvalidApprovalErrorMsg: String = "Unable to %s the Ownership transfer status for the record: None".orConfig
 
-  val OwnershipTransferInvalidCancelErrorMsg: String = "Unable to cancel the ownership transfer. Current status: %s".orConfig
+  val OwnershipTransferInvalidCancelErrorMsg: String = "Unable to cancel the Ownership transfer. Current status: %s".orConfig
 
   val OwnershipTransferUnauthorisedCancelErrorMsg: String = "Unauthorised to Cancel the ownership transfer".orConfig
 

--- a/modules/core/src/main/scala/vinyldns/core/config/MessagesConfig.scala
+++ b/modules/core/src/main/scala/vinyldns/core/config/MessagesConfig.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.config
+
+import pureconfig._
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+import pureconfig.error.ConfigReaderFailures
+
+final case class Message(text: String, overrideText: String)
+final case class MessagesConfig(messages: List[Message])
+
+object MessagesConfig {
+  val appConfigSource: ConfigObjectSource = ConfigSource.resources("application.conf")
+  val messages: Either[ConfigReaderFailures, MessagesConfig] = appConfigSource.at("vinyldns").load[MessagesConfig].map(x => x)
+}

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -17,7 +17,7 @@
 package vinyldns.core.domain
 
 import vinyldns.core.domain.batch.OwnerType.OwnerType
-import vinyldns.core.domain.record.{RecordData, RecordSet, RecordType}
+import vinyldns.core.domain.record.{RecordData, RecordType}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.Messages._
 
@@ -28,138 +28,112 @@ sealed abstract class DomainValidationError(val isFatal: Boolean = true) {
 
 // The request itself is invalid in this case, so we fail fast
 final case class ChangeLimitExceeded(limit: Int) extends DomainValidationError {
-  def message: String = s"Cannot request more than $limit changes in a single batch change request"
+  def message: String = ChangeLimitExceededErrorMsg.format(limit)
 }
 
 final case class BatchChangeIsEmpty(limit: Int) extends DomainValidationError {
-  def message: String =
-    s"Batch change contained no changes. Batch change must have at least one change, up to a maximum of $limit changes."
+  def message: String = BatchChangeIsEmptyErrorMsg.format(limit)
 }
 
 final case class GroupDoesNotExist(id: String) extends DomainValidationError {
-  def message: String = s"""Group with ID "$id" was not found"""
+  def message: String = GroupIdNotFoundErrorMsg.format(id)
 }
 
 final case class NotAMemberOfOwnerGroup(ownerGroupId: String, userName: String)
     extends DomainValidationError {
-  def message: String =
-    s"""User "$userName" must be a member of group "$ownerGroupId" to apply this group to batch changes."""
+  def message: String = NotMemberOfGroupErrorMsg.format(userName, ownerGroupId)
 }
 
 final case class InvalidDomainName(param: String) extends DomainValidationError {
-  def message: String =
-    s"""Invalid domain name: "$param", valid domain names must be letters, numbers, underscores, and hyphens, """ +
-      "joined by dots, and terminated with a dot."
+  def message: String = InvalidDomainNameErrorMsg.format(param)
 }
 
 final case class InvalidIPv4CName(param: String) extends DomainValidationError {
-  def message: String =
-    s"""Invalid Cname: "$param", Valid CNAME record data should not be an IP address"""
+  def message: String = InvalidIPv4CNameErrorMsg.format(param)
 }
 
 final case class InvalidCname(param: String, isReverseZone: Boolean) extends DomainValidationError {
   def message: String =
     isReverseZone match {
-      case true =>
-        s"""Invalid Cname: "$param", valid cnames must be letters, numbers, slashes, underscores, and hyphens, """ +
-          "joined by dots, and terminated with a dot."
-      case false =>
-        s"""Invalid Cname: "$param", valid cnames must be letters, numbers, underscores, and hyphens, """ +
-          "joined by dots, and terminated with a dot."
+      case true => InvalidForwardCnameErrorMsg.format(param)
+      case false => InvalidReverseCnameErrorMsg.format(param)
     }
 }
 
 final case class InvalidLength(param: String, minLengthInclusive: Int, maxLengthInclusive: Int)
     extends DomainValidationError {
-  def message: String =
-    s"""Invalid length: "$param", length needs to be between $minLengthInclusive and $maxLengthInclusive characters."""
+  def message: String = InvalidLengthErrorMsg.format(param, minLengthInclusive, maxLengthInclusive)
 }
 
 final case class InvalidEmail(param: String) extends DomainValidationError {
-  def message: String = s"""Invalid email address: "$param"."""
+  def message: String = InvalidEmailErrorMsg.format(param)
 }
 
 final case class InvalidRecordType(param: String) extends DomainValidationError {
-  def message: String =
-    s"""Invalid record type: "$param", valid record types include ${RecordType.values}."""
+  def message: String = InvalidRecordTypeErrorMsg.format(param, RecordType.values)
 }
 
 final case class InvalidPortNumber(param: String, minPort: Int, maxPort: Int)
     extends DomainValidationError {
-  def message: String =
-    s"""Invalid port number: "$param", port must be a number between $minPort and $maxPort."""
+  def message: String = InvalidPortNumberErrorMsg.format(param, minPort, maxPort)
 }
 
 final case class InvalidIpv4Address(param: String) extends DomainValidationError {
-  def message: String = s"""Invalid IPv4 address: "$param"."""
+  def message: String = InvalidIpv4AddressErrorMsg.format(param)
 }
 
 final case class InvalidIpv6Address(param: String) extends DomainValidationError {
-  def message: String = s"""Invalid IPv6 address: "$param"."""
+  def message: String = InvalidIpv6AddressErrorMsg.format(param)
 }
 
 final case class InvalidIPAddress(param: String) extends DomainValidationError {
-  def message: String = s"""Invalid IP address: "$param"."""
+  def message: String = InvalidIPAddressErrorMsg.format(param)
 }
 
 final case class InvalidTTL(param: Long, min: Long, max: Long) extends DomainValidationError {
-  def message: String =
-    s"""Invalid TTL: "${param.toString}", must be a number between $min and $max."""
+  def message: String = InvalidTTLErrorMsg.format(param.toString, min, max)
 }
 
 final case class InvalidMX_NAPTR_SRVData(param: Long, min: Long, max: Long, recordDataType: String, recordType: String)
     extends DomainValidationError {
-  def message: String =
-    s"""Invalid $recordType $recordDataType: "${param.toString}", must be a number between $min and $max."""
+  def message: String = InvalidMX_NAPTR_SRVDataErrorMsg.format(recordType, recordDataType, param.toString, min, max)
 }
 
 final case class InvalidNaptrFlag(value: String)
   extends DomainValidationError {
-  def message: String =
-    s"""Invalid NAPTR flag value: '$value'. Valid NAPTR flag value must be U, S, A or P."""
+  def message: String = InvalidNaptrFlagErrorMsg.format(value)
 }
 
 final case class InvalidNaptrRegexp(value: String)
   extends DomainValidationError {
-  def message: String =
-    s"""Invalid NAPTR regexp value: '$value'. Valid NAPTR regexp value must start and end with '!'."""
+  def message: String = InvalidNaptrRegexpErrorMsg.format(value)
 }
 
 final case class InvalidBatchRecordType(param: String, supported: Set[RecordType])
     extends DomainValidationError {
-  def message: String =
-    s"""Invalid Batch Record Type: "$param", valid record types for batch changes include $supported."""
+  def message: String = InvalidBatchRecordTypeErrorMsg.format(param, supported)
 }
 
 final case class ZoneDiscoveryError(name: String, fatal: Boolean = false)
     extends DomainValidationError(fatal) {
-  def message: String =
-    s"""Zone Discovery Failed: zone for "$name" does not exist in VinylDNS. """ +
-      "If zone exists, then it must be connected to in VinylDNS."
+  def message: String = ZoneDiscoveryErrorMsg.format(name)
 }
 
 final case class RecordAlreadyExists(name: String) extends DomainValidationError {
-  def message: String =
-    s"""RecordName "$name" already exists. """ +
-      "If you intended to update this record, submit a DeleteRecordSet entry followed by an Add."
+  def message: String = RecordAlreadyExistsErrorMsg.format(name)
 }
 
 final case class RecordDoesNotExist(name: String) extends DomainValidationError {
-  def message: String =
-    s"""Record "$name" Does Not Exist: cannot delete a record that does not exist."""
+  def message: String = RecordDoesNotExistErrorMsg.format(name)
 }
 
 final case class InvalidUpdateRequest(name: String) extends DomainValidationError {
-  def message: String =
-    s"""Cannot perform request for the record "$name". """ +
-      "Add and Delete for the record with same record data exists in the batch."
+  def message: String = InvalidUpdateRequestErrorMsg.format(name)
 }
 
 final case class CnameIsNotUniqueError(name: String, typ: RecordType)
     extends DomainValidationError {
-  def message: String =
-    "CNAME Conflict: CNAME record names must be unique. " +
-      s"""Existing record with name "$name" and type "$typ" conflicts with this record."""
+  def message: String = CnameIsNotUniqueErrorMsg.format(name, typ)
 }
 
 final case class UserIsNotAuthorizedError(
@@ -180,78 +154,45 @@ final case class UserIsNotAuthorizedError(
 
 final case class RecordNameNotUniqueInBatch(name: String, typ: RecordType)
     extends DomainValidationError {
-  def message: String =
-    s"""Record Name "$name" Not Unique In Batch Change: cannot have multiple "$typ" records with the same name."""
-}
+  def message: String = RecordNameNotUniqueInBatchErrorMsg.format(name, typ)}
 
 final case class RecordInReverseZoneError(name: String, typ: String) extends DomainValidationError {
-  def message: String =
-    "Invalid Record Type In Reverse Zone: record with name " +
-      s""""$name" and type "$typ" is not allowed in a reverse zone."""
+  def message: String = RecordInReverseZoneErrorMsg.format(name, typ)
 }
 
 final case class HighValueDomainError(name: String) extends DomainValidationError {
-  def message: String =
-    s"""Record name "$name" is configured as a High Value Domain, so it cannot be modified."""
+  def message: String = HighValueDomainErrorMsg.format(name)
 }
 
 final case class MissingOwnerGroupId(recordName: String, zoneName: String)
     extends DomainValidationError {
-  def message: String =
-    s"""Zone "$zoneName" is a shared zone, so owner group ID must be specified for record "$recordName"."""
+  def message: String = MissingOwnerGroupIdErrorMsg.format(zoneName, recordName)
 }
 
 final case class CnameAtZoneApexError(zoneName: String) extends DomainValidationError {
-  def message: String = s"""CNAME cannot be the same name as zone "$zoneName"."""
+  def message: String = CnameAtZoneApexErrorMsg.format(zoneName)
 }
 
 final case class RecordRequiresManualReview(fqdn: String, fatal: Boolean = false)
     extends DomainValidationError(fatal) {
-  def message: String =
-    s"""Record set with name "$fqdn" requires manual review."""
-      .replaceAll("\n", " ")
+  def message: String = RecordManualReviewErrorMsg.format(fqdn).replaceAll("\n", " ")
 }
 
 final case class InvalidBatchRequest(msg: String) extends DomainValidationError {
-  def message: String =
-    s"""$msg"""
-      .replaceAll("\n", " ")
+  def message: String = InvalidBatchRequestErrorMsg.format(msg.replaceAll("\n", " "))
 }
 
 final case class NotApprovedNSError(nsData: String) extends DomainValidationError {
-  def message: String =
-    s"Name Server $nsData is not an approved name server."
+  def message: String = NotApprovedNSErrorMsg.format(nsData)
 }
 
 final case class UnsupportedOperation(operation: String) extends DomainValidationError {
-  def message: String = s"$operation is not yet implemented/supported in VinylDNS."
+  def message: String = UnsupportedOperationErrorMsg.format(operation)
 }
 
 final case class DeleteRecordDataDoesNotExist(inputName: String, recordData: RecordData)
     extends DomainValidationError {
-  def message: String = s"""Record data $recordData does not exist for "$inputName"."""
+  def message: String = DeleteRecordDataDoesNotExistErrorMsg.format(recordData, inputName)
 }
 
-// Deprecated errors
-final case class ExistingMultiRecordError(fqdn: String, record: RecordSet)
-    extends DomainValidationError {
-  def message: String =
-    s"""RecordSet with name $fqdn and type ${record.typ.toString} cannot be updated in a single Batch Change
-       |because it contains multiple DNS records (${record.records.length}).""".stripMargin
-      .replaceAll("\n", " ")
-}
 
-final case class NewMultiRecordError(changeName: String, changeType: RecordType)
-    extends DomainValidationError {
-  def message: String =
-    s"""Multi-record recordsets are not enabled for this instance of VinylDNS.
-       |Cannot create a new record set with multiple records for inputName $changeName and
-       |type $changeType.""".stripMargin
-      .replaceAll("\n", " ")
-}
-
-// deprecated in favor of more informative error message
-final case class UserIsNotAuthorized(userName: String) extends DomainValidationError {
-  def message: String = s"""User "$userName" is not authorized."""
-}
-// $COVERAGE-ON$

--- a/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/DomainValidationErrors.scala
@@ -17,7 +17,7 @@
 package vinyldns.core.domain
 
 import vinyldns.core.domain.batch.OwnerType.OwnerType
-import vinyldns.core.domain.record.{RecordData, RecordType}
+import vinyldns.core.domain.record.{RecordData, RecordType, RecordSet}
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.Messages._
 
@@ -137,19 +137,25 @@ final case class CnameIsNotUniqueError(name: String, typ: RecordType)
 }
 
 final case class UserIsNotAuthorizedError(
-    userName: String,
+    recordName: String,
     ownerGroupId: String,
-    ownerType: OwnerType,
+    ownerType: OwnerType,              
     contactEmail: Option[String] = None,
     ownerGroupName: Option[String] = None
 ) extends DomainValidationError {
-  def message: String =
+
+  def message: String = {
+    val groupName = ownerGroupName.getOrElse(ownerGroupId)
+    val groupUrl  = s"/groups/$ownerGroupId"
+    val contact   = contactEmail.getOrElse("")
+
     NotAuthorizedErrorMsg.format(
-      userName,
-      ownerType.toString.toLowerCase,
-      ownerGroupName.getOrElse(ownerGroupId),
-      contactEmail.getOrElse("")
+      recordName,
+      groupName,
+      groupUrl,
+      contact
     )
+  }
 }
 
 final case class RecordNameNotUniqueInBatch(name: String, typ: RecordType)
@@ -195,4 +201,19 @@ final case class DeleteRecordDataDoesNotExist(inputName: String, recordData: Rec
   def message: String = DeleteRecordDataDoesNotExistErrorMsg.format(recordData, inputName)
 }
 
+// Deprecated errors
+final case class ExistingMultiRecordError(fqdn: String, record: RecordSet)
+    extends DomainValidationError {
+  def message: String = ExistingMultiRecordErrorMsg.format(fqdn, record.typ.toString, record.records.length)
+}
+
+final case class NewMultiRecordError(changeName: String, changeType: RecordType)
+    extends DomainValidationError {
+  def message: String = NewMultiRecordErrorMsg.format(changeName, changeType)
+}
+
+// deprecated in favor of more informative error message
+final case class UserIsNotAuthorized(userName: String) extends DomainValidationError {
+  def message: String = UserIsNotAuthorizedMsg.format(userName)
+}
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -35,7 +35,8 @@ object DomainValidationErrorType extends Enumeration {
   InvalidNaptrRegexp, InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
   InvalidUpdateRequest, CnameIsNotUniqueError, UserIsNotAuthorizedError, RecordNameNotUniqueInBatch,
   RecordInReverseZoneError, HighValueDomainError, MissingOwnerGroupId, CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
-  DeleteRecordDataDoesNotExist, InvalidIPv4CName, InvalidBatchRequest, NotApprovedNSError  = Value
+  DeleteRecordDataDoesNotExist, InvalidIPv4CName, InvalidBatchRequest, NotApprovedNSError,
+  NewMultiRecordError, ExistingMultiRecordError, UserIsNotAuthorized  = Value
 
   // $COVERAGE-OFF$
   def from(error: DomainValidationError): DomainValidationErrorType =
@@ -75,6 +76,10 @@ object DomainValidationErrorType extends Enumeration {
       case _: InvalidIPv4CName => InvalidIPv4CName
       case _: InvalidBatchRequest => InvalidBatchRequest
       case _: NotApprovedNSError => NotApprovedNSError
+      //Deprecated errors
+      case _: UserIsNotAuthorized => UserIsNotAuthorized
+      case _: ExistingMultiRecordError => ExistingMultiRecordError
+      case _: NewMultiRecordError => NewMultiRecordError
     }
   // $COVERAGE-ON$
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/SingleChangeError.scala
@@ -33,9 +33,8 @@ object DomainValidationErrorType extends Enumeration {
   InvalidDomainName, InvalidCname, InvalidLength, InvalidEmail, InvalidRecordType, InvalidPortNumber,
   InvalidIpv4Address, InvalidIpv6Address, InvalidIPAddress, InvalidTTL, InvalidMX_NAPTR_SRVData, InvalidNaptrFlag,
   InvalidNaptrRegexp, InvalidBatchRecordType, ZoneDiscoveryError, RecordAlreadyExists, RecordDoesNotExist,
-  InvalidUpdateRequest, CnameIsNotUniqueError, UserIsNotAuthorized, UserIsNotAuthorizedError, RecordNameNotUniqueInBatch,
-  RecordInReverseZoneError, HighValueDomainError, MissingOwnerGroupId, ExistingMultiRecordError,
-  NewMultiRecordError, CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
+  InvalidUpdateRequest, CnameIsNotUniqueError, UserIsNotAuthorizedError, RecordNameNotUniqueInBatch,
+  RecordInReverseZoneError, HighValueDomainError, MissingOwnerGroupId, CnameAtZoneApexError, RecordRequiresManualReview, UnsupportedOperation,
   DeleteRecordDataDoesNotExist, InvalidIPv4CName, InvalidBatchRequest, NotApprovedNSError  = Value
 
   // $COVERAGE-OFF$
@@ -64,14 +63,11 @@ object DomainValidationErrorType extends Enumeration {
       case _: RecordDoesNotExist => RecordDoesNotExist
       case _: InvalidUpdateRequest => InvalidUpdateRequest
       case _: CnameIsNotUniqueError => CnameIsNotUniqueError
-      case _: UserIsNotAuthorized => UserIsNotAuthorized
       case _: UserIsNotAuthorizedError => UserIsNotAuthorizedError
       case _: RecordNameNotUniqueInBatch => RecordNameNotUniqueInBatch
       case _: RecordInReverseZoneError => RecordInReverseZoneError
       case _: HighValueDomainError => HighValueDomainError
       case _: MissingOwnerGroupId => MissingOwnerGroupId
-      case _: ExistingMultiRecordError => ExistingMultiRecordError
-      case _: NewMultiRecordError => NewMultiRecordError
       case _: CnameAtZoneApexError => CnameAtZoneApexError
       case _: RecordRequiresManualReview => RecordRequiresManualReview
       case _: UnsupportedOperation => UnsupportedOperation

--- a/modules/docs/src/main/mdoc/operator/config-api.md
+++ b/modules/docs/src/main/mdoc/operator/config-api.md
@@ -660,6 +660,33 @@ v6-discovery-nibble-boundaries {
 }
 ```
 
+### Configure Messages
+The messages displayed to the users can be configured in VinylDNS. If you wish to change any existing message, you can do
+it using this configuration settings. Visit `Messages.scala` file present in `core` directory to see all the existing messages.
+Copy the existing message you want to change from `Messages.scala` and place it in `text` field. Enter the new message in
+`override-text` field. The new message in `override-text` will replace the existing message in `text` and display it to the user.
+Have a look on placeholders (`%s`, `%d` etc.) while making changes, else you may run into errors.
+
+```yaml
+# Configure Messages. Override existing messages with new messages. Refer Messages.scala file for existing messages
+# Have a look on placeholders while making changes, else you may face errors
+  messages = [
+      # Place the existing message present at Messages.scala file in 'text' and the new message in 'override-text'
+      {
+          text = "Search must contain at least two letters or numbers to perform a RecordSet Search."
+          override-text = "Record Name Filter field must contain at least two letters or numbers to perform a RecordSet Search."
+      },
+      {
+          text = "NS data must absolute"
+          override-text = "NS data must be a positive integer"
+      },
+      {
+          text = "Cannot create group. A group, %s, is already associated with the email address %s. Please contact %s to be added to the group."
+          override-text = "Cannot create group. A group, %s, is already associated with the email address %s. Please contact %s to be added to the group. Visit FAQ for more information."
+      }
+]
+```
+
 ### Dotted Hosts
 
 Configuration setting that determines the zones, users (either individual or based on group) and record types that are 

--- a/modules/r53/src/main/scala/vinyldns/route53/backend/Route53Backend.scala
+++ b/modules/r53/src/main/scala/vinyldns/route53/backend/Route53Backend.scala
@@ -25,6 +25,7 @@ import com.amazonaws.services.route53.{AmazonRoute53Async, AmazonRoute53AsyncCli
 import com.amazonaws.services.route53.model.{GetHostedZoneRequest, _}
 import com.amazonaws.{AmazonWebServiceRequest, AmazonWebServiceResult}
 import org.slf4j.LoggerFactory
+import vinyldns.core.Messages._
 import vinyldns.core.domain.Fqdn
 import vinyldns.core.domain.backend.{Backend, BackendResponse}
 import vinyldns.core.domain.record.RecordSetChangeType.RecordSetChangeType
@@ -160,16 +161,12 @@ class Route53Backend(
         case Some(x) => IO(x)
         case None =>
           IO.raiseError(
-            Route53BackendResponse.ZoneNotFoundError(
-              s"Unable to find hosted zone for zone name ${change.zone.name}"
-            )
+            Route53BackendResponse.ZoneNotFoundError(HostedZoneErrorMsg.format(change.zone.name))
           )
       }
 
       r53RecordSet <- IO.fromOption(toR53RecordSet(change.zone, change.recordSet))(
-        Route53BackendResponse.ConversionError(
-          s"Unable to convert record set to route 53 format for ${change.recordSet}"
-        )
+          Route53BackendResponse.ConversionError(RecordConversionErrorMsg.format(change.recordSet))
       )
 
       result <- r53(

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessage.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessage.scala
@@ -24,6 +24,7 @@ import vinyldns.core.domain.zone.ZoneCommand
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.queue.{CommandMessage, MessageId}
 import vinyldns.proto.VinylDNSProto
+import vinyldns.core.Messages._
 import vinyldns.sqs.queue.SqsMessageType.{
   SqsBatchChangeMessage,
   SqsRecordSetChangeMessage,
@@ -34,11 +35,11 @@ final case class SqsMessage(id: MessageId, command: ZoneCommand) extends Command
 object SqsMessage extends ProtobufConversions {
   sealed abstract class SqsMessageError(message: String) extends Throwable(message)
   final case class InvalidSqsMessageContents(messageId: String)
-      extends SqsMessageError(s"Unable to parse SQS Message with ID '$messageId'")
+      extends SqsMessageError(SqsParseErrorMsg.format(messageId))
   final case class EmptySqsMessageContents(messageId: String)
-      extends SqsMessageError(s"No message body found for SQS message with ID '$messageId'")
+      extends SqsMessageError(SqsBodyErrorMsg.format(messageId))
   final case class InvalidMessageType(className: String)
-      extends SqsMessageError(s"Invalid command message type '$className'")
+      extends SqsMessageError(SqsInvalidCommand.format(className))
 
   def parseSqsMessage(message: Message): Either[Throwable, SqsMessage] =
     for {

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueue.scala
@@ -18,7 +18,6 @@ package vinyldns.sqs.queue
 
 import java.util.Base64
 import java.util.concurrent.TimeUnit.SECONDS
-
 import cats.data._
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
@@ -27,6 +26,7 @@ import com.amazonaws.services.sqs.model._
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.{AmazonWebServiceRequest, AmazonWebServiceResult}
 import org.slf4j.LoggerFactory
+import vinyldns.core.Messages._
 import vinyldns.core.domain.batch.BatchChangeCommand
 import vinyldns.core.domain.record.RecordSetChange
 import vinyldns.core.domain.zone.{ZoneChange, ZoneCommand}
@@ -186,8 +186,8 @@ object SqsMessageQueue extends ProtobufConversions {
   sealed abstract class SqsMessageQueueError(message: String) extends Throwable(message)
   final case class InvalidMessageTimeout(duration: Long)
       extends SqsMessageQueueError(
-        s"Invalid duration: $duration seconds. Duration must be between " +
-          s"$MINIMUM_VISIBILITY_TIMEOUT-$MAXIMUM_VISIBILITY_TIMEOUT seconds."
+        InvalidDurationErrorMsg
+        .format(duration, MINIMUM_VISIBILITY_TIMEOUT, MAXIMUM_VISIBILITY_TIMEOUT)
       )
 
   // AWS limits as specified at:

--- a/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueueProvider.scala
+++ b/modules/sqs/src/main/scala/vinyldns/sqs/queue/SqsMessageQueueProvider.scala
@@ -31,7 +31,7 @@ import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
 import cats.effect.Blocker
 import vinyldns.core.queue.{MessageQueue, MessageQueueConfig, MessageQueueProvider}
-
+import vinyldns.core.Messages._ 
 import scala.util.matching.Regex
 import cats.effect.ContextShift
 
@@ -114,8 +114,7 @@ class SqsMessageQueueProvider extends MessageQueueProvider {
 object SqsMessageQueueProvider {
   final case class InvalidQueueName(queueName: String)
       extends Throwable(
-        s"Invalid queue name: $queueName. Must be 1-80 alphanumeric, hyphen or underscore characters. FIFO queues " +
-          "(queue names ending in \".fifo\") are not supported."
+        InvalidQueueNameErrorMsg.format(queueName)
       )
 
   private val logger = LoggerFactory.getLogger(classOf[SqsMessageQueueProvider])


### PR DESCRIPTION
Fixes https://github.com/vinyldns/vinyldns/issues/1292.
Jira Ticket: VDNS-405

Changes in this pull request:

- Consolidated all the messages present in the platform to a single file Messages.scala making it easier to locate any messages we want.
- Added a configuration to enable changing the existing messages without having to change the code. Open source users can change the messages displayed as per their need using this config. Also, we can change any message immediately from this config instead of changing the code and cutting a new release.