### PR TITLE
Upgrade Flyway to 9.22.3 + add flyway-mysql for modern MariaDB support (refs #1497)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,8 @@ lazy val apiAssemblySettings = Seq(
     case "simulacrum/op.class" | "simulacrum/op$.class" | "simulacrum/typeclass$.class"
          | "simulacrum/typeclass.class" | "simulacrum/noop.class" =>
       MergeStrategy.discard
+    case PathList("org", "apache", "commons", "logging", _*) =>
+      MergeStrategy.first
     case x if x.endsWith("module-info.class") => MergeStrategy.discard
     case x =>
       val oldStrategy = (assemblyMergeStrategy in assembly).value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,8 @@ object Dependencies {
     "dnsjava"                   %  "dnsjava"                        % "3.4.2",
     "org.apache.commons"        %  "commons-lang3"                  % "3.4",
     "org.apache.commons"        %  "commons-text"                   % "1.4",
-    "org.flywaydb"              %  "flyway-core"                    % "5.2.4",
+    "org.flywaydb"              %  "flyway-core"                    % "9.22.3",
+    "org.flywaydb"              %  "flyway-mysql"                   % "9.22.3",
     "org.json4s"                %% "json4s-ext"                     % "3.6.1",
     "org.json4s"                %% "json4s-jackson"                 % "3.5.3",
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
@@ -82,8 +83,9 @@ object Dependencies {
   )
 
   lazy val mysqlDependencies = Seq(
-    "org.flywaydb"              %  "flyway-core"                    % "5.2.4",
-    "org.mariadb.jdbc"          %  "mariadb-java-client"            % "2.7.13",
+    "org.flywaydb"              %  "flyway-core"                    % "9.22.3",
+    "org.flywaydb"              %  "flyway-mysql"                   % "9.22.3",
+    "org.mariadb.jdbc"          %  "mariadb-java-client"            % "3.5.1",
     "org.scalikejdbc"           %% "scalikejdbc"                    % scalikejdbcV,
     "org.scalikejdbc"           %% "scalikejdbc-config"             % scalikejdbcV,
     "com.zaxxer"                %  "HikariCP"                       % "3.2.0",


### PR DESCRIPTION
## Summary

Upgrades Flyway from 5.2.4 (Nov 2018) to 9.22.3 and adds the now-separate `flyway-mysql` artifact, fixing the hard-crash on MariaDB ≥10.5. Also bumps the matching JDBC driver `mariadb-java-client` from 2.7.13 to 3.5.1.

Refs #1497.

## Why

`flyway-core` 5.2.4 ships with an internal database-version compatibility check that hard-rejects any MariaDB version newer than ~10.4. On startup, the API logs `Unsupported Database: MariaDB <X.Y>` and exits. This makes VinylDNS 0.21.4+ unusable with any currently maintained MariaDB version, because every supported MariaDB release (10.6 LTS / 10.11 LTS / 11.x) is rejected.

The crash was introduced between 0.21.3 (which emitted a warning but proceeded) and 0.21.4 (hard fail). Issue #1497 confirms this behaviour with MariaDB 11.x; in practice the same crash hits MariaDB 10.11 LTS and 10.6 LTS too.

## Changes

- `project/Dependencies.scala`
  - `org.flywaydb:flyway-core` 5.2.4 → 9.22.3 (both occurrences — common deps and `mysqlDependencies`)
  - Add `org.flywaydb:flyway-mysql` 9.22.3 (MariaDB/MySQL driver support was moved to a separate artifact starting in Flyway 9.x — `flyway-core` alone does not include it)
  - `org.mariadb.jdbc:mariadb-java-client` 2.7.13 → 3.5.1 (matching modern driver line; 2.x is no longer maintained)
- `build.sbt`
  - Add `MergeStrategy.first` for `org/apache/commons/logging/**` in `apiAssemblySettings`. Flyway 9 transitively pulls in `org.slf4j:jcl-over-slf4j`, which provides the same class names as the existing `commons-logging` dependency and triggers a `sbt-assembly` deduplicate failure at fat-jar assembly time. Picking either implementation works — both are JCL-compatible — but a deterministic strategy is required.

## Scope and caveats

This bump covers the **Flyway 9.x line**, which supports MariaDB up to and including 10.11 LTS (next-supported MariaDB version). It does **not** add support for MariaDB 11.x, because that requires Flyway 10.x, and the 10.x line moved more drivers into separate artifacts which would expand this change. For most operators MariaDB 10.11 LTS (supported through Feb 2028) is more than adequate; if MariaDB 11.x support is desired, a follow-up PR bumping to Flyway 10.x can land on top of this.

The Flyway 9.x API surface used by `vinyldns/mysql/MySqlConnector.scala` is unchanged from 5.x: `Flyway.configure().envVars().outOfOrder(...).dataSource(...).placeholders(...).schemas(...).load().migrate()`. No code changes needed in the connector.

## Test plan

- [x] `sbt ;project api;assembly` builds clean (with the new merge strategy).
- [x] `sbt ;project portal;dist` builds clean.
- [x] Custom-built API + Portal images start against MariaDB 10.11 LTS, Flyway migrates 34 migrations clean, schema reports up-to-date.
- [x] Live testing against a real internal BIND 9.20 backend with TSIG hmac-sha512: API connects, portal LDAPS-binds against AD, stack stays healthy across multiple compose-restarts.
- [ ] Maintainer validation against the upstream CI (Linux + Docker images).
- [ ] CLA signature on first push (will be prompted by the bot automatically).

## Migration impact for existing operators

- Operators on **MariaDB 10.4 or older**: no action required, still works.
- Operators on **MariaDB 10.5–10.11**: this fixes the existing crash, no other action required.
- Operators on **MariaDB 11.x**: will see an "untested newer MariaDB" warning but should function; full 11.x support needs the follow-up Flyway 10.x PR.

