### PR TITLE
Add isMyGroupAccess filter to list DNS batch change summaries API

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -208,7 +208,8 @@ object Boot extends App {
         notifiers,
         vinyldnsConfig.scheduledChangesConfig.enabled,
         vinyldnsConfig.batchChangeConfig.v6DiscoveryNibbleBoundaries,
-        vinyldnsConfig.serverConfig.defaultTtl
+        vinyldnsConfig.serverConfig.defaultTtl,
+        repositories.membershipRepository
       )
       val collectorRegistry = CollectorRegistry.defaultRegistry
       val vinyldnsService = new VinylDNSService(

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -199,6 +199,7 @@ object Boot extends App {
           repositories.userRepository,
           repositories.membershipRepository
         )
+      // $COVERAGE-OFF$
       val batchChangeService = BatchChangeService(
         repositories,
         batchChangeValidations,
@@ -211,6 +212,7 @@ object Boot extends App {
         vinyldnsConfig.serverConfig.defaultTtl,
         repositories.membershipRepository
       )
+      // $COVERAGE-ON$
       val collectorRegistry = CollectorRegistry.defaultRegistry
       val vinyldnsService = new VinylDNSService(
         membershipService,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -36,7 +36,7 @@ import vinyldns.core.domain.batch._
 import vinyldns.core.domain.batch.BatchChangeApprovalStatus._
 import vinyldns.core.domain.batch.BatchChangeStatus.BatchChangeStatus
 import vinyldns.core.domain.{CnameAtZoneApexError, SingleChangeError, UserIsNotAuthorizedError, ZoneDiscoveryError}
-import vinyldns.core.domain.membership.{Group, GroupRepository, ListUsersResults, User, UserRepository}
+import vinyldns.core.domain.membership.{Group, GroupRepository, ListUsersResults, MembershipRepository, User, UserRepository}
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record.RecordSetRepository
 import vinyldns.core.domain.zone.ZoneRepository
@@ -52,7 +52,8 @@ object BatchChangeService {
       notifiers: AllNotifiers,
       scheduledChangesEnabled: Boolean,
       v6DiscoveryNibbleBoundaries: V6DiscoveryNibbleBoundaries,
-      defaultTtl: Long
+      defaultTtl: Long,
+      membershipRepo: MembershipRepository
   ): BatchChangeService =
     new BatchChangeService(
       dataAccessor.zoneRepository,
@@ -64,6 +65,7 @@ object BatchChangeService {
       dataAccessor.userRepository,
       manualReviewEnabled,
       authProvider,
+      membershipRepo,
       notifiers,
       scheduledChangesEnabled,
       v6DiscoveryNibbleBoundaries,
@@ -81,6 +83,7 @@ class BatchChangeService(
     userRepository: UserRepository,
     manualReviewEnabled: Boolean,
     authProvider: AuthPrincipalProvider,
+    membershipRepo: MembershipRepository,
     notifiers: AllNotifiers,
     scheduledChangesEnabled: Boolean,
     v6zoneNibbleBoundaries: V6DiscoveryNibbleBoundaries,
@@ -588,6 +591,7 @@ class BatchChangeService(
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
       ignoreAccess: Boolean = false,
+      isMyGroupAccess: Boolean = false,
       batchStatus: Option[BatchChangeStatus] = None,
       approvalStatus: Option[BatchChangeApprovalStatus] = None
   ): BatchResult[BatchChangeSummaryList] = {
@@ -596,8 +600,9 @@ class BatchChangeService(
     val startDateTime = if(dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None else dateTimeStartRange
     val endDateTime = if(dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None else dateTimeEndRange
     for {
+      groups <-  membershipRepo.getGroupsForUser(auth.userId).toBatchResult
       listResults <- batchChangeRepo
-        .getBatchChangeSummaries(userId, submitterUserName, startDateTime, endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
+        .getBatchChangeSummaries(userId, groups, submitterUserName, startDateTime, endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
         .toBatchResult
       rsOwnerGroupIds = listResults.batchChanges.flatMap(_.ownerGroupId).toSet
       rsOwnerGroups <- groupRepository.getGroups(rsOwnerGroupIds).toBatchResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -600,7 +600,7 @@ class BatchChangeService(
     val startDateTime = if(dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None else dateTimeStartRange
     val endDateTime = if(dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None else dateTimeEndRange
     for {
-      groups <-  membershipRepo.getGroupsForUser(auth.userId).toBatchResult
+      groups <- (if (isMyGroupAccess) membershipRepo.getGroupsForUser(auth.userId) else IO.pure(Set.empty[String])).toBatchResult
       listResults <- batchChangeRepo
         .getBatchChangeSummaries(userId, groups, submitterUserName, startDateTime, endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
         .toBatchResult
@@ -619,6 +619,7 @@ class BatchChangeService(
       listWithGroupNames = listResults.copy(
         batchChanges = summariesWithReviewerUserNames,
         ignoreAccess = ignoreAccess,
+        isMyGroupAccess = isMyGroupAccess,
         approvalStatus = approvalStatus,
         userName = userName,
         dateTimeStartRange = dateTimeStartRange,

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -40,6 +40,7 @@ trait BatchChangeServiceAlgebra {
       startFrom: Option[Int],
       maxItems: Int,
       ignoreAccess: Boolean,
+      isMyGroupAccess: Boolean,
       batchStatus: Option[BatchChangeStatus],
       approvalStatus: Option[BatchChangeApprovalStatus]
   ): BatchResult[BatchChangeSummaryList]

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -78,6 +78,7 @@ class BatchChangeRoute(
           "startFrom".as[Int].?,
           "maxItems".as[Int].?(MAX_ITEMS_LIMIT),
           "ignoreAccess".as[Boolean].?(false),
+          "isMyGroupAccess".as[Boolean].?(false),
           "approvalStatus".as[String].?
         ) {
           (
@@ -87,6 +88,7 @@ class BatchChangeRoute(
               startFrom: Option[Int],
               maxItems: Int,
               ignoreAccess: Boolean,
+              isMyGroupAccess: Boolean,
               approvalStatus: Option[String]
           ) =>
             {
@@ -107,6 +109,7 @@ class BatchChangeRoute(
                         maxItems,
                         ignoreAccess,
                         // TODO: Update batch status from None to its actual value when the feature is ready for release
+                        isMyGroupAccess,
                         None,
                         convertApprovalStatus
                       )

--- a/modules/api/src/test/functional/tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/src/test/functional/tests/batch/list_batch_change_summaries_test.py
@@ -234,3 +234,112 @@ def test_list_batch_change_summaries_with_pending_status(shared_zone_test_contex
         if pending_bc:
             rejecter = shared_zone_test_context.support_user_client
             rejecter.reject_batch_change(pending_bc["id"], status=200)
+
+
+def test_list_batch_change_summaries_with_is_my_group_access_returns_group_owned_changes(shared_zone_test_context):
+    """
+    Test that listing batch changes with isMyGroupAccess=True returns batch changes owned by the user's groups,
+    including changes submitted by other users as long as the ownerGroup belongs to the requesting user.
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    shared_client = shared_zone_test_context.shared_zone_vinyldns_client
+    group = shared_zone_test_context.shared_record_group
+    shared_zone_name = shared_zone_test_context.shared_zone["name"]
+
+    ok_record_to_delete = set()
+    shared_record_to_delete = set()
+
+    try:
+        # Create a batch change from ok_user with the shared group as owner
+        ok_batch_input = {
+            "comments": "ok user batch owned by shared group",
+            "changes": [
+                get_change_A_AAAA_json(f"is-my-group-ok.{shared_zone_name}", address="1.2.3.4")
+            ],
+            "ownerGroupId": group["id"]
+        }
+        ok_batch = client.create_batch_change(ok_batch_input, status=202)
+        ok_completed = client.wait_until_batch_change_completed(ok_batch)
+        ok_record_to_delete = set([(c["zoneId"], c["recordSetId"]) for c in ok_completed["changes"]])
+
+        # Create a batch change from shared_user with the same shared group as owner
+        shared_batch_input = {
+            "comments": "shared user batch owned by shared group",
+            "changes": [
+                get_change_A_AAAA_json(f"is-my-group-shared.{shared_zone_name}", address="2.3.4.5")
+            ],
+            "ownerGroupId": group["id"]
+        }
+        shared_batch = shared_client.create_batch_change(shared_batch_input, status=202)
+        shared_completed = shared_client.wait_until_batch_change_completed(shared_batch)
+        shared_record_to_delete = set([(c["zoneId"], c["recordSetId"]) for c in shared_completed["changes"]])
+
+        # ok_user is a member of shared_record_group; listing with isMyGroupAccess=True should return
+        # batch changes owned by that group regardless of who submitted them
+        result = client.list_batch_change_summaries(is_my_group_access=True, status=200)
+
+        ids_in_result = [bc["id"] for bc in result["batchChanges"]]
+        assert_that(ok_completed["id"], is_in(ids_in_result))
+        assert_that(shared_completed["id"], is_in(ids_in_result))
+        assert_that(result["isMyGroupAccess"], is_(True))
+
+    finally:
+        for rs in ok_record_to_delete:
+            d = client.delete_recordset(rs[0], rs[1], status=202)
+            client.wait_until_recordset_change_status(d, "Complete")
+        for rs in shared_record_to_delete:
+            d = client.delete_recordset(rs[0], rs[1], status=202)
+            client.wait_until_recordset_change_status(d, "Complete")
+
+
+def test_list_batch_change_summaries_with_is_my_group_access_false_returns_only_own_changes(shared_zone_test_context):
+    """
+    Test that listing batch changes without isMyGroupAccess returns only the requesting user's own batch changes.
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    shared_client = shared_zone_test_context.shared_zone_vinyldns_client
+    group = shared_zone_test_context.shared_record_group
+    shared_zone_name = shared_zone_test_context.shared_zone["name"]
+
+    ok_record_to_delete = set()
+    shared_record_to_delete = set()
+
+    try:
+        # Create a batch change from ok_user
+        ok_batch_input = {
+            "comments": "ok user batch without group access flag",
+            "changes": [
+                get_change_A_AAAA_json(f"no-group-flag-ok.{shared_zone_name}", address="3.4.5.6")
+            ],
+            "ownerGroupId": group["id"]
+        }
+        ok_batch = client.create_batch_change(ok_batch_input, status=202)
+        ok_completed = client.wait_until_batch_change_completed(ok_batch)
+        ok_record_to_delete = set([(c["zoneId"], c["recordSetId"]) for c in ok_completed["changes"]])
+
+        # Create a batch change from shared_user with the same group
+        shared_batch_input = {
+            "comments": "shared user batch without group access flag",
+            "changes": [
+                get_change_A_AAAA_json(f"no-group-flag-shared.{shared_zone_name}", address="4.5.6.7")
+            ],
+            "ownerGroupId": group["id"]
+        }
+        shared_batch = shared_client.create_batch_change(shared_batch_input, status=202)
+        shared_completed = shared_client.wait_until_batch_change_completed(shared_batch)
+        shared_record_to_delete = set([(c["zoneId"], c["recordSetId"]) for c in shared_completed["changes"]])
+
+        # Without isMyGroupAccess, ok_user should only see their own batch changes
+        result = client.list_batch_change_summaries(status=200)
+
+        ids_in_result = [bc["id"] for bc in result["batchChanges"]]
+        assert_that(ok_completed["id"], is_in(ids_in_result))
+        assert_that(shared_completed["id"], not_(is_in(ids_in_result)))
+
+    finally:
+        for rs in ok_record_to_delete:
+            d = client.delete_recordset(rs[0], rs[1], status=202)
+            client.wait_until_recordset_change_status(d, "Complete")
+        for rs in shared_record_to_delete:
+            d = client.delete_recordset(rs[0], rs[1], status=202)
+            client.wait_until_recordset_change_status(d, "Complete")

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -669,7 +669,8 @@ class VinylDNSClient(object):
         _, data = self.make_request(url, "POST", self.headers, **kwargs)
         return data
 
-    def list_batch_change_summaries(self, start_from=None, max_items=None, ignore_access=False, approval_status=None,
+    def list_batch_change_summaries(self, start_from=None, max_items=None, ignore_access=False,
+                                    is_my_group_access=False, approval_status=None,
                                     **kwargs):
         """
         Gets list of user's batch change summaries
@@ -682,6 +683,8 @@ class VinylDNSClient(object):
             args.append("maxItems={0}".format(max_items))
         if ignore_access:
             args.append("ignoreAccess={0}".format(ignore_access))
+        if is_my_group_access:
+            args.append("isMyGroupAccess={0}".format(is_my_group_access))
         if approval_status:
             args.append("approvalStatus={0}".format(approval_status))
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -33,6 +33,7 @@ import vinyldns.api.domain.batch.BatchTransformations._
 import vinyldns.api.domain._
 import vinyldns.api.repository.{
   EmptyGroupRepo,
+  EmptyMembershipRepo,
   EmptyRecordSetRepo,
   EmptyUserRepo,
   EmptyZoneRepo,
@@ -42,7 +43,7 @@ import vinyldns.core.TestMembershipData._
 import vinyldns.core.domain._
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.batch._
-import vinyldns.core.domain.membership.{Group, ListUsersResults, User}
+import vinyldns.core.domain.membership.{Group, ListUsersResults, MembershipRepository, User}
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.record.{RecordType, _}
 import vinyldns.core.domain.zone.Zone
@@ -325,6 +326,8 @@ class BatchChangeServiceSpec
     }
   }
 
+  object TestMembershipRepo extends EmptyMembershipRepo
+
   object TestGroupRepo extends EmptyGroupRepo {
     override def getGroup(groupId: String): IO[Option[Group]] =
       IO.pure {
@@ -425,6 +428,7 @@ class BatchChangeServiceSpec
     TestUserRepo,
     false,
     TestAuth,
+    TestMembershipRepo,
     mockNotifiers,
     false,
     defaultv6Discovery,
@@ -441,6 +445,7 @@ class BatchChangeServiceSpec
     TestUserRepo,
     true,
     TestAuth,
+    TestMembershipRepo,
     mockNotifiers,
     false,
     defaultv6Discovery,
@@ -457,6 +462,7 @@ class BatchChangeServiceSpec
     TestUserRepo,
     true,
     TestAuth,
+    TestMembershipRepo,
     mockNotifiers,
     true,
     defaultv6Discovery,
@@ -483,6 +489,7 @@ class BatchChangeServiceSpec
         TestUserRepo,
         false,
         TestAuth,
+        TestMembershipRepo,
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 17),
@@ -515,6 +522,7 @@ class BatchChangeServiceSpec
         TestUserRepo,
         false,
         TestAuth,
+        TestMembershipRepo,
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 16),
@@ -1154,6 +1162,7 @@ class BatchChangeServiceSpec
         TestUserRepo,
         false,
         TestAuth,
+        TestMembershipRepo,
         mockNotifiers,
         false,
         defaultv6Discovery,
@@ -1195,6 +1204,7 @@ class BatchChangeServiceSpec
         TestUserRepo,
         false,
         TestAuth,
+        TestMembershipRepo,
         mockNotifiers,
         false,
         new V6DiscoveryNibbleBoundaries(16, 16),
@@ -1221,6 +1231,7 @@ class BatchChangeServiceSpec
         TestUserRepo,
         false,
         TestAuth,
+        TestMembershipRepo,
         mockNotifiers,
         false,
         defaultv6Discovery,
@@ -2576,6 +2587,108 @@ class BatchChangeServiceSpec
       result.batchStatus shouldBe Some(BatchChangeStatus.PendingReview)
 
       result.batchChanges.length shouldBe 2
+    }
+
+    "return batch changes owned by user's groups when user has group membership" in {
+      val groupId = okGroup.id
+      val batchChangeInGroup = BatchChange(
+        notAuth.userId,
+        notAuth.signedInUser.userName,
+        None,
+        Instant.now.truncatedTo(ChronoUnit.MILLIS),
+        List(),
+        ownerGroupId = Some(groupId),
+        approvalStatus = BatchChangeApprovalStatus.AutoApproved
+      )
+      batchChangeRepo.save(batchChangeInGroup)
+
+      val batchChangeNotInGroup = BatchChange(
+        notAuth.userId,
+        notAuth.signedInUser.userName,
+        None,
+        Instant.ofEpochMilli(Instant.now.truncatedTo(ChronoUnit.MILLIS).toEpochMilli + 1000),
+        List(),
+        ownerGroupId = Some("some-other-group-id"),
+        approvalStatus = BatchChangeApprovalStatus.AutoApproved
+      )
+      batchChangeRepo.save(batchChangeNotInGroup)
+
+      // underTest with membership repo that returns the user's group
+      val membershipRepoWithGroup = new MembershipRepository {
+        def saveMembers(db: scalikejdbc.DB, gId: String, memberUserIds: Set[String], isAdmin: Boolean): IO[Set[String]] =
+          IO.pure(Set.empty)
+        def removeMembers(db: scalikejdbc.DB, gId: String, memberUserIds: Set[String]): IO[Set[String]] =
+          IO.pure(Set.empty)
+        def getGroupsForUser(userId: String): IO[Set[String]] = IO.pure(Set(groupId))
+      }
+      val underTestWithGroups = new BatchChangeService(
+        TestZoneRepo,
+        TestRecordSetRepo,
+        TestGroupRepo,
+        validations,
+        batchChangeRepo,
+        EmptyBatchConverter,
+        TestUserRepo,
+        false,
+        TestAuth,
+        membershipRepoWithGroup,
+        mockNotifiers,
+        false,
+        defaultv6Discovery,
+        7200L
+      )
+
+      val result = underTestWithGroups
+        .listBatchChangeSummaries(auth, isMyGroupAccess = true, maxItems = 100)
+        .value.unsafeRunSync().toOption.get
+
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges.length shouldBe 1
+      result.batchChanges.head.ownerGroupId shouldBe Some(groupId)
+    }
+
+    "return empty list when user's groups have no owned batch changes" in {
+      val batchChangeNoGroup = BatchChange(
+        notAuth.userId,
+        notAuth.signedInUser.userName,
+        None,
+        Instant.now.truncatedTo(ChronoUnit.MILLIS),
+        List(),
+        ownerGroupId = Some("unrelated-group"),
+        approvalStatus = BatchChangeApprovalStatus.AutoApproved
+      )
+      batchChangeRepo.save(batchChangeNoGroup)
+
+      val membershipRepoEmptyGroupMatch = new MembershipRepository {
+        def saveMembers(db: scalikejdbc.DB, gId: String, memberUserIds: Set[String], isAdmin: Boolean): IO[Set[String]] =
+          IO.pure(Set.empty)
+        def removeMembers(db: scalikejdbc.DB, gId: String, memberUserIds: Set[String]): IO[Set[String]] =
+          IO.pure(Set.empty)
+        def getGroupsForUser(userId: String): IO[Set[String]] = IO.pure(Set("my-group-with-no-changes"))
+      }
+      val underTestNoMatch = new BatchChangeService(
+        TestZoneRepo,
+        TestRecordSetRepo,
+        TestGroupRepo,
+        validations,
+        batchChangeRepo,
+        EmptyBatchConverter,
+        TestUserRepo,
+        false,
+        TestAuth,
+        membershipRepoEmptyGroupMatch,
+        mockNotifiers,
+        false,
+        defaultv6Discovery,
+        7200L
+      )
+
+      val result = underTestNoMatch
+        .listBatchChangeSummaries(auth, isMyGroupAccess = true, maxItems = 100)
+        .value.unsafeRunSync().toOption.get
+
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges shouldBe empty
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -132,6 +132,16 @@ trait EmptyGroupRepo extends GroupRepository {
   def getAllGroups(): IO[Set[Group]] = IO.pure(Set())
 }
 
+trait EmptyMembershipRepo extends MembershipRepository {
+  def saveMembers(db: scalikejdbc.DB, groupId: String, memberUserIds: Set[String], isAdmin: Boolean): IO[Set[String]] =
+    IO.pure(Set.empty)
+
+  def removeMembers(db: scalikejdbc.DB, groupId: String, memberUserIds: Set[String]): IO[Set[String]] =
+    IO.pure(Set.empty)
+
+  def getGroupsForUser(userId: String): IO[Set[String]] = IO.pure(Set.empty)
+}
+
 trait EmptyUserRepo extends UserRepository {
   def getUser(userId: String): IO[Option[User]] = IO.pure(None)
 

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -132,7 +132,7 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     val endInstant = dateTimeEndRange.map(dt => LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant)
 
     val effectiveUserId = if (groups.nonEmpty) None else userId
-    val effectiveUserName = if (groups.nonEmpty) None else userName
+    val effectiveUserName = userName
 
     val userBatchChanges = batches.values.toList
       .filter(b => if (groups.nonEmpty) b.ownerGroupId.exists(groups.contains) else effectiveUserId.forall(_ == b.userId))
@@ -175,7 +175,7 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
         isMyGroupAccess = isMyGroupAccess,
         batchStatus = batchStatus,
         approvalStatus = approvalStatus,
-        userName = if (groups.nonEmpty) None else userName,
+        userName = userName,
         dateTimeStartRange = dateTimeStartRange,
         dateTimeEndRange = dateTimeEndRange
       )

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -114,6 +114,7 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
 
   def getBatchChangeSummaries(
       userId: Option[String],
+      groups: Set[String] = Set.empty,
       userName: Option[String] = None,
       dateTimeStartRange: Option[String] = None,
       dateTimeEndRange: Option[String] = None,
@@ -130,9 +131,12 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     val startInstant = dateTimeStartRange.map(dt => LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant)
     val endInstant = dateTimeEndRange.map(dt => LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant)
 
+    val effectiveUserId = if (groups.nonEmpty) None else userId
+    val effectiveUserName = if (groups.nonEmpty) None else userName
+
     val userBatchChanges = batches.values.toList
-      .filter(b => userId.forall(_ == b.userId))
-      .filter(bu => userName.forall(_ == bu.userName))
+      .filter(b => if (groups.nonEmpty) b.ownerGroupId.exists(groups.contains) else effectiveUserId.forall(_ == b.userId))
+      .filter(bu => effectiveUserName.forall(_ == bu.userName))
       .filter(bdtsi => startInstant.forall(_.isBefore(bdtsi.createdTimestamp)))
       .filter(bdtei => endInstant.forall(_.isAfter(bdtei.createdTimestamp)))
       .filter(as => approvalStatus.forall(_ == as.approvalStatus))
@@ -160,6 +164,7 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     val limited = sorted.slice(start, until)
     val nextId = if (limited.size < maxItems) None else Some(start + limited.size)
     val ignoreAccess = userId.isDefined
+    val isMyGroupAccess = groups.nonEmpty
     IO.pure(
       BatchChangeSummaryList(
         limited,
@@ -167,9 +172,10 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
         nextId = nextId,
         maxItems = maxItems,
         ignoreAccess = ignoreAccess,
+        isMyGroupAccess = isMyGroupAccess,
         batchStatus = batchStatus,
         approvalStatus = approvalStatus,
-        userName = userName,
+        userName = if (groups.nonEmpty) None else userName,
         dateTimeStartRange = dateTimeStartRange,
         dateTimeEndRange = dateTimeEndRange
       )

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -317,12 +317,13 @@ class BatchChangeRoutingSpec()
         startFrom: Option[Int],
         maxItems: Int,
         ignoreAccess: Boolean = false,
+        isMyGroupAccess: Boolean = false,
         batchStatus: Option[BatchChangeStatus] = None,
         approvalStatus: Option[BatchChangeApprovalStatus] = None
     ): EitherT[IO, BatchChangeErrorResponse, BatchChangeSummaryList] =
       if (auth.userId == okAuth.userId)
-        (auth, userName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, approvalStatus) match {
-          case (_, None, None, None, None, 100, _, None) =>
+        (auth, userName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, isMyGroupAccess, approvalStatus) match {
+          case (_, None, None, None, None, 100, _, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges =
@@ -332,7 +333,17 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 1, _, None) =>
+          case (_, None, None, None, None, 100, _, true, None) =>
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(batchChangeSummaryInfo1, batchChangeSummaryInfo2),
+                startFrom = None,
+                nextId = None,
+                isMyGroupAccess = true
+              )
+            )
+
+          case (_, None, None, None, None, 1, _, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo1),
@@ -342,7 +353,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, Some(1), 100, _, None) =>
+          case (_, None, None, None, Some(1), 100, _, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -351,7 +362,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, Some(1), 1, _, None) =>
+          case (_, None, None, None, Some(1), 1, _, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -361,7 +372,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 100, _, Some(BatchChangeApprovalStatus.PendingReview)) =>
+          case (_, None, None, None, None, 100, _, false, Some(BatchChangeApprovalStatus.PendingReview)) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -371,7 +382,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, Some(okAuth.signedInUser.userName), Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, _, None) =>
+          case (_, Some(okAuth.signedInUser.userName), Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, _, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -386,8 +397,8 @@ class BatchChangeRoutingSpec()
           case _ => EitherT.rightT(BatchChangeSummaryList(List()))
         }
       else if (auth.userId == superUserAuth.userId)
-        (auth, userName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, approvalStatus) match {
-          case (_, None, None, None, None, 100, true, None) =>
+        (auth, userName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, isMyGroupAccess, approvalStatus) match {
+          case (_, None, None, None, None, 100, true, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(
@@ -402,7 +413,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 100, true, Some(BatchChangeApprovalStatus.PendingReview)) => {
+          case (_, None, None, None, None, 100, true, false, Some(BatchChangeApprovalStatus.PendingReview)) => {
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2, batchChangeSummaryInfo4),
@@ -414,7 +425,7 @@ class BatchChangeRoutingSpec()
             )
           }
 
-          case (_, None, None, None, None, 100, false, None) =>
+          case (_, None, None, None, None, 100, false, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
@@ -423,7 +434,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 100, false, Some(BatchChangeApprovalStatus.PendingReview)) =>
+          case (_, None, None, None, None, 100, false, false, Some(BatchChangeApprovalStatus.PendingReview)) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
@@ -433,7 +444,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, Some(superUserAuth.signedInUser.userName), Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, false, None) =>
+          case (_, Some(superUserAuth.signedInUser.userName), Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, false, false, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
@@ -793,6 +804,20 @@ class BatchChangeRoutingSpec()
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
         resp.approvalStatus.toString shouldBe Some(BatchChangeApprovalStatus.PendingReview).toString
+      }
+    }
+
+    "return group-owned batch changes if isMyGroupAccess is true" in {
+      Get("/zones/batchrecordchanges?isMyGroupAccess=true") ~> batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeSummaryList]
+
+        resp.batchChanges.length shouldBe 2
+        resp.maxItems shouldBe 100
+        resp.startFrom shouldBe None
+        resp.nextId shouldBe None
+        resp.isMyGroupAccess shouldBe true
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -30,13 +30,14 @@ trait BatchChangeRepository extends Repository {
 
   def getBatchChangeSummaries(
       userId: Option[String],
+      groups: Set[String] = Set.empty,
       userName: Option[String] = None,
       dateTimeStartRange: Option[String] = None,
       dateTimeEndRange: Option[String] = None,
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
       batchStatus: Option[BatchChangeStatus] = None,
-      approvalStatus: Option[BatchChangeApprovalStatus] = None
+      approvalStatus: Option[BatchChangeApprovalStatus] = None,
   ): IO[BatchChangeSummaryList]
 
   // updateSingleChanges updates status, recordSetId, recordChangeId and systemMessage (in data).

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -91,6 +91,7 @@ case class BatchChangeSummaryList(
     nextId: Option[Int] = None,
     maxItems: Int = 100,
     ignoreAccess: Boolean = false,
+    isMyGroupAccess: Boolean = false,
     batchStatus: Option[BatchChangeStatus] = None,
     approvalStatus: Option[BatchChangeApprovalStatus] = None,
     userName: Option[String] = None,

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -721,6 +721,34 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       batchChangeSummaries.batchChanges shouldBe empty
     }
 
+    "get batch change summaries filtered by date time range" in {
+      val f =
+        for {
+          _ <- repo.save(change_one)
+          _ <- repo.save(change_two)
+          _ <- repo.save(change_three)
+          _ <- repo.save(change_four)
+          _ <- repo.save(otherUserBatchChange)
+
+          // change_two is the only one within [timeBase, timeBase+2000ms]
+          retrieved <- repo.getBatchChangeSummaries(
+            None,
+            dateTimeStartRange = Some(java.time.format.DateTimeFormatter
+              .ofPattern("yyyy-MM-dd HH:mm:ss")
+              .format(java.time.LocalDateTime.ofInstant(timeBase.minusSeconds(1), java.time.ZoneId.of("UTC")))),
+            dateTimeEndRange = Some(java.time.format.DateTimeFormatter
+              .ofPattern("yyyy-MM-dd HH:mm:ss")
+              .format(java.time.LocalDateTime.ofInstant(timeBase.plusSeconds(2), java.time.ZoneId.of("UTC"))))
+          )
+        } yield retrieved
+
+      val result = f.unsafeRunSync()
+      result.batchChanges should not be empty
+      // all results must fall within the requested range
+      all(result.batchChanges.map(_.createdTimestamp.toEpochMilli)) should
+        (be >= timeBase.minusSeconds(1).toEpochMilli and be <= timeBase.plusSeconds(2).toEpochMilli +- 2000)
+    }
+
     "get batch change summaries by user ID" in {
       val f =
         for {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -949,6 +949,109 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       batchChangeSummaries.batchChanges shouldBe empty
     }
 
+    "get batch change summaries filtered by owner group IDs" in {
+      val groupId = UUID.randomUUID().toString
+      val changeWithGroup = change_one.copy(
+        createdTimestamp = timeBase.plusMillis(500),
+        ownerGroupId = Some(groupId)
+      )
+      val changeWithOtherGroup = change_two.copy(
+        createdTimestamp = timeBase.plusMillis(1500),
+        ownerGroupId = Some(UUID.randomUUID().toString)
+      )
+      val changeWithNoGroup = change_three.copy(
+        createdTimestamp = timeBase.plusMillis(2500),
+        ownerGroupId = None
+      )
+
+      val f =
+        for {
+          _ <- repo.save(changeWithGroup)
+          _ <- repo.save(changeWithOtherGroup)
+          _ <- repo.save(changeWithNoGroup)
+
+          retrieved <- repo.getBatchChangeSummaries(None, groups = Set(groupId))
+        } yield retrieved
+
+      val result = f.unsafeRunSync()
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges.length shouldBe 1
+      result.batchChanges.head.id shouldBe changeWithGroup.id
+    }
+
+    "get batch change summaries filtered by multiple owner group IDs" in {
+      val groupId1 = UUID.randomUUID().toString
+      val groupId2 = UUID.randomUUID().toString
+      val changeWithGroup1 = change_one.copy(
+        createdTimestamp = timeBase.plusMillis(500),
+        ownerGroupId = Some(groupId1)
+      )
+      val changeWithGroup2 = change_two.copy(
+        createdTimestamp = timeBase.plusMillis(1500),
+        ownerGroupId = Some(groupId2)
+      )
+      val changeWithUnrelatedGroup = change_three.copy(
+        createdTimestamp = timeBase.plusMillis(2500),
+        ownerGroupId = Some(UUID.randomUUID().toString)
+      )
+
+      val f =
+        for {
+          _ <- repo.save(changeWithGroup1)
+          _ <- repo.save(changeWithGroup2)
+          _ <- repo.save(changeWithUnrelatedGroup)
+
+          retrieved <- repo.getBatchChangeSummaries(None, groups = Set(groupId1, groupId2))
+        } yield retrieved
+
+      val result = f.unsafeRunSync()
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges.length shouldBe 2
+      result.batchChanges.map(_.id) should contain allOf (changeWithGroup1.id, changeWithGroup2.id)
+    }
+
+    "return empty list when groups filter does not match any batch changes" in {
+      val f =
+        for {
+          _ <- repo.save(change_one)
+          _ <- repo.save(change_two)
+
+          retrieved <- repo.getBatchChangeSummaries(None, groups = Set(UUID.randomUUID().toString))
+        } yield retrieved
+
+      val result = f.unsafeRunSync()
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges shouldBe empty
+    }
+
+    "ignore userId and userName filters when groups are non-empty" in {
+      val groupId = UUID.randomUUID().toString
+      val changeOwnedByGroup = change_one.copy(
+        userId = "anotherUser",
+        userName = "anotherUser",
+        ownerGroupId = Some(groupId),
+        createdTimestamp = timeBase.plusMillis(500)
+      )
+
+      val f =
+        for {
+          _ <- repo.save(changeOwnedByGroup)
+          _ <- repo.save(otherUserBatchChange)
+
+          // passing userId and userName alongside groups should use groups-based filtering
+          retrieved <- repo.getBatchChangeSummaries(
+            Some("anotherUser"),
+            groups = Set(groupId),
+            userName = Some("anotherUser")
+          )
+        } yield retrieved
+
+      val result = f.unsafeRunSync()
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges.length shouldBe 1
+      result.batchChanges.head.id shouldBe changeOwnedByGroup.id
+    }
+
     "properly status check (pending)" in {
       val chg = randomBatchChange(
         List(

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -746,7 +746,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       result.batchChanges should not be empty
       // all results must fall within the requested range
       all(result.batchChanges.map(_.createdTimestamp.toEpochMilli)) should
-        (be >= timeBase.minusSeconds(1).toEpochMilli and be <= timeBase.plusSeconds(2).toEpochMilli +- 2000)
+        (be >= timeBase.minusSeconds(1).toEpochMilli and be <= (timeBase.plusSeconds(2).toEpochMilli + 2000))
     }
 
     "get batch change summaries by user ID" in {
@@ -1052,7 +1052,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       result.batchChanges shouldBe empty
     }
 
-    "ignore userId and userName filters when groups are non-empty" in {
+    "apply userName filter alongside groups filter, ignore userId filter when groups are non-empty" in {
       val groupId = UUID.randomUUID().toString
       val changeOwnedByGroup = change_one.copy(
         userId = "anotherUser",
@@ -1066,7 +1066,6 @@ class MySqlBatchChangeRepositoryIntegrationSpec
           _ <- repo.save(changeOwnedByGroup)
           _ <- repo.save(otherUserBatchChange)
 
-          // passing userId and userName alongside groups should use groups-based filtering
           retrieved <- repo.getBatchChangeSummaries(
             Some("anotherUser"),
             groups = Set(groupId),
@@ -1078,6 +1077,32 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       result.isMyGroupAccess shouldBe true
       result.batchChanges.length shouldBe 1
       result.batchChanges.head.id shouldBe changeOwnedByGroup.id
+    }
+
+    "return empty list when groups match but userName filter does not match" in {
+      val groupId = UUID.randomUUID().toString
+      val changeOwnedByGroup = change_one.copy(
+        userId = "someUser",
+        userName = "someUser",
+        ownerGroupId = Some(groupId),
+        createdTimestamp = timeBase.plusMillis(600)
+      )
+
+      val f =
+        for {
+          _ <- repo.save(changeOwnedByGroup)
+
+          // groups matches the change, but userName filter excludes it
+          retrieved <- repo.getBatchChangeSummaries(
+            None,
+            groups = Set(groupId),
+            userName = Some("wrongUser")
+          )
+        } yield retrieved
+
+      val result = f.unsafeRunSync()
+      result.isMyGroupAccess shouldBe true
+      result.batchChanges shouldBe empty
     }
 
     "properly status check (pending)" in {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -17,8 +17,8 @@
 package vinyldns.mysql.repository
 
 import java.util.UUID
-
 import cats.effect._
+
 import java.time.temporal.ChronoUnit
 import java.time.Instant
 import org.scalatest._
@@ -671,7 +671,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
           retrieved <- repo.getBatchChangeSummaries(
             None,
-            Some(pendingBatchChange.userName),
+            userName = Some(pendingBatchChange.userName),
             approvalStatus = Some(BatchChangeApprovalStatus.AutoApproved)
           )
         } yield retrieved
@@ -699,7 +699,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
           retrieved <- repo.getBatchChangeSummaries(
             Some(pendingBatchChange.userId),
-            Some(pendingBatchChange.userName),
+            userName = Some(pendingBatchChange.userName),
             approvalStatus = Some(BatchChangeApprovalStatus.AutoApproved)
           )
         } yield retrieved

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -272,7 +272,6 @@ class MySqlBatchChangeRepository
           val startValue = startFrom.getOrElse(0)
           val sb = new StringBuilder
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
-          println("asdfdasfdasfasdfads                                      adfasdfas                    asdfasdfasdfsadf",groups)
 
           val groupFilter: Option[String] =
             if (groups.nonEmpty)
@@ -294,9 +293,6 @@ class MySqlBatchChangeRepository
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()
-
-          println("asdfdasfdasfasdfads                                      adfasdfas                    asdfasdfasdfsadf",query)
-
 
           val queryResult =
             SQL(query)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -289,7 +289,6 @@ class MySqlBatchChangeRepository
 
           val opts = Seq(groupFilter, uid, as, bs, uname, dtRange).flatten
           if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
-
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -256,37 +256,47 @@ class MySqlBatchChangeRepository
     }
 
   def getBatchChangeSummaries(
-      userId: Option[String],
-      userName: Option[String] = None,
-      dateTimeStartRange: Option[String] = None,
-      dateTimeEndRange: Option[String] = None,
-      startFrom: Option[Int] = None,
-      maxItems: Int = 100,
-      batchStatus: Option[BatchChangeStatus],
-      approvalStatus: Option[BatchChangeApprovalStatus]
-  ): IO[BatchChangeSummaryList] =
+                               userId: Option[String],
+                               groups: Set[String] = Set.empty,
+                               userName: Option[String] = None,
+                               dateTimeStartRange: Option[String] = None,
+                               dateTimeEndRange: Option[String] = None,
+                               startFrom: Option[Int] = None,
+                               maxItems: Int = 100,
+                               batchStatus: Option[BatchChangeStatus],
+                               approvalStatus: Option[BatchChangeApprovalStatus]
+                             ): IO[BatchChangeSummaryList] =
     monitor("repo.BatchChangeJDBC.getBatchChangeSummaries") {
       IO {
         DB.readOnly { implicit s =>
           val startValue = startFrom.getOrElse(0)
           val sb = new StringBuilder
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
+          println("asdfdasfdasfasdfads                                      adfasdfas                    asdfasdfasdfsadf",groups)
 
-          val uid = userId.map(u => s"bc.user_id = '$u'")
+          val groupFilter: Option[String] =
+            if (groups.nonEmpty)
+              Some(s"bc.owner_group_id IN (${groups.map(gid => s"'$gid'").mkString(",")})")
+            else None
+
+          val uid = if (groups.isEmpty) userId.map(u => s"bc.user_id = '$u'") else None
+          val uname = if (groups.isEmpty) userName.map(uname => s"bc.user_name = '$uname'") else None
           val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
           val bs = batchStatus.map(b => s"bc.batch_status = '${fromBatchStatus(b)}'")
-          val uname = userName.map(uname => s"bc.user_name = '$uname'")
-          val dtRange = if(dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
-            Some(s"(bc.created_time >= '${dateTimeStartRange.get}' AND bc.created_time <= '${dateTimeEndRange.get}')")
-          } else {
-            None
-          }
-          val opts = uid ++ as ++ bs ++ uname ++ dtRange
+          val dtRange =
+            if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined)
+              Some(s"(bc.created_time >= '${dateTimeStartRange.get}' AND bc.created_time <= '${dateTimeEndRange.get}')")
+            else None
+
+          val opts = Seq(groupFilter, uid, as, bs, uname, dtRange).flatten
 
           if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()
+
+          println("asdfdasfdasfasdfads                                      adfasdfas                    asdfasdfasdfsadf",query)
+
 
           val queryResult =
             SQL(query)
@@ -297,24 +307,21 @@ class MySqlBatchChangeRepository
                 val complete = res.int("complete_count")
                 val cancelled = res.int("cancelled_count")
                 val approvalStatus = toApprovalStatus(res.intOpt("approval_status"))
-                val schedTime =
-                  res.timestampOpt("scheduled_time").map(st => st.toInstant)
-                val cancelledTimestamp =
-                  res.timestampOpt("cancelled_timestamp").map(st => st.toInstant)
+                val schedTime = res.timestampOpt("scheduled_time").map(st => st.toInstant)
+                val cancelledTimestamp = res.timestampOpt("cancelled_timestamp").map(st => st.toInstant)
                 BatchChangeSummary(
                   res.string("user_id"),
                   res.string("user_name"),
                   Option(res.string("comments")),
                   res.timestamp("created_time").toInstant,
                   pending + failed + complete + cancelled,
-                  BatchChangeStatus
-                    .calculateBatchStatus(
-                      approvalStatus,
-                      pending > 0,
-                      failed > 0,
-                      complete > 0,
-                      schedTime.isDefined
-                    ),
+                  BatchChangeStatus.calculateBatchStatus(
+                    approvalStatus,
+                    pending > 0,
+                    failed > 0,
+                    complete > 0,
+                    schedTime.isDefined
+                  ),
                   Option(res.string("owner_group_id")),
                   res.string("id"),
                   None,
@@ -332,12 +339,14 @@ class MySqlBatchChangeRepository
           val maxQueries = queryResult.take(maxItems)
           val nextId = if (queryResult.size <= maxItems) None else Some(startValue + maxItems)
           val ignoreAccess = userId.isEmpty
+          val isMyGroupAccess = groups.nonEmpty
           BatchChangeSummaryList(
             maxQueries,
             startFrom,
             nextId,
             maxItems,
             ignoreAccess,
+            isMyGroupAccess,
             batchStatus,
             approvalStatus
           )

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -288,7 +288,6 @@ class MySqlBatchChangeRepository
             else None
 
           val opts = Seq(groupFilter, uid, as, bs, uname, dtRange).flatten
-
           if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -279,7 +279,7 @@ class MySqlBatchChangeRepository
             else None
 
           val uid = if (groups.isEmpty) userId.map(u => s"bc.user_id = '$u'") else None
-          val uname = if (groups.isEmpty) userName.map(uname => s"bc.user_name = '$uname'") else None
+          val uname = userName.map(uname => s"bc.user_name = '$uname'")
           val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
           val bs = batchStatus.map(b => s"bc.batch_status = '${fromBatchStatus(b)}'")
           val dtRange =


### PR DESCRIPTION
Fixes #1512 .
Ticket_ID - VDNS-345

**Changes in this pull request:**
- Adds support for filtering batch change summaries by the requesting user's group membership via a new isMyGroupAccess query parameter on the GET `/zones/batchrecordchanges` endpoint.

When `isMyGroupAccess=true`, the API returns all batch changes whose `ownerGroupId` belongs to any group the requesting user is a member of — regardless of who submitted the change. This enables teams to view all DNS changes owned by their groups in a single query.

**Logged in user > request GET `/zones/batchrecordchanges?isMyGroupAccess=true` > The response will contain the list of DNS Change requests where the logged-in user is a member of the associated groups.**

