### PR TITLE
Added count api for groups and zones

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipProtocol.scala
@@ -174,6 +174,15 @@ final case class ListMyGroupsResponse(
     ignoreAccess: Boolean
 )
 
+final case class GroupCount(
+    totalCount: Int = 0,
+    myGroupCount: Int = 0,
+    adminGroupCount: Int = 0,
+    memberOnlyGroupCount: Int = 0,
+    noRoleGroupCount: Int = 0,
+    soleAdminGroupCount: Int = 0
+)
+
 final case class GroupNotFoundError(msg: String) extends Throwable(msg)
 
 final case class GroupAlreadyExistsError(msg: String) extends Throwable(msg)

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.domain.membership
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import scalikejdbc.DB
 import vinyldns.api.Interfaces._
@@ -52,6 +52,9 @@ class MembershipService(
     recordSetRepo: RecordSetRepository,
     validDomains: ValidEmailConfig
 ) extends MembershipServiceAlgebra with TransactionProvider {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   import MembershipValidations._
 
@@ -390,35 +393,33 @@ class MembershipService(
 
   def countGroups(auth: AuthPrincipal): Result[GroupCount] = {
     val userId = auth.signedInUser.id
-    val allGroupsIO = groupRepo.getAllGroups()
-      .map(_.filter(_.status == GroupStatus.Active))
-    val myGroupsIO =
-      if (auth.isSystemAdmin) {
-        groupRepo.getAllGroups().map(_.filter(_.status == GroupStatus.Active))
-      } else {
-        groupRepo.getGroups(auth.memberGroupIds.toSet)
-          .map(_.filter(_.status == GroupStatus.Active))
-      }
 
-    val actualMemberGroupsIO =
-      if (auth.isSystemAdmin) {
-        groupRepo.getAllGroups().map(_.filter(_.status == GroupStatus.Active))
-      } else {
-        groupRepo.getGroups(auth.memberGroupIds.toSet)
-          .map(_.filter(_.status == GroupStatus.Active))
-      }
+    if (auth.isSystemAdmin) {
+      groupRepo.getAllGroups()
+        .map { groups =>
+          val activeGroups         = groups.filter(_.status == GroupStatus.Active)
+          val totalCount           = activeGroups.size
+          val adminGroupCount      = activeGroups.count(_.adminUserIds.contains(userId))
+          val memberOnlyGroupCount = activeGroups.count(g => g.memberIds.contains(userId) && !g.adminUserIds.contains(userId))
+          val noRoleGroupCount     = totalCount - adminGroupCount - memberOnlyGroupCount
+          val soleAdminGroupCount  = activeGroups.count(g => g.adminUserIds.contains(userId) && g.adminUserIds.size == 1)
+          GroupCount(totalCount, totalCount, adminGroupCount, memberOnlyGroupCount, noRoleGroupCount, soleAdminGroupCount)
+        }
+        .toResult
+    } else {
+      val allGroupsIO    = groupRepo.getAllGroups().map(_.filter(_.status == GroupStatus.Active))
+      val memberGroupsIO = groupRepo.getGroups(auth.memberGroupIds.toSet).map(_.filter(_.status == GroupStatus.Active))
 
-    (for {
-      allGroups    <- allGroupsIO
-      myGroups     <- myGroupsIO
-      actualGroups <- actualMemberGroupsIO
-      totalCount           = allGroups.size
-      myGroupCount         = myGroups.size
-      adminGroupCount      = actualGroups.count(_.adminUserIds.contains(userId))
-      memberOnlyGroupCount = actualGroups.count(g => g.memberIds.contains(userId) && !g.adminUserIds.contains(userId))
-      noRoleGroupCount     = totalCount - adminGroupCount - memberOnlyGroupCount
-      soleAdminGroupCount  = actualGroups.count(g => g.adminUserIds.contains(userId) && g.adminUserIds.size == 1)
-    } yield GroupCount(totalCount, myGroupCount, adminGroupCount, memberOnlyGroupCount, noRoleGroupCount, soleAdminGroupCount)).toResult
+      (allGroupsIO, memberGroupsIO).parMapN { (allGroups, memberGroups) =>
+        val totalCount           = allGroups.size
+        val myGroupCount         = memberGroups.size
+        val adminGroupCount      = memberGroups.count(_.adminUserIds.contains(userId))
+        val memberOnlyGroupCount = memberGroups.count(g => g.memberIds.contains(userId) && !g.adminUserIds.contains(userId))
+        val noRoleGroupCount     = totalCount - adminGroupCount - memberOnlyGroupCount
+        val soleAdminGroupCount  = memberGroups.count(g => g.adminUserIds.contains(userId) && g.adminUserIds.size == 1)
+        GroupCount(totalCount, myGroupCount, adminGroupCount, memberOnlyGroupCount, noRoleGroupCount, soleAdminGroupCount)
+      }.toResult
+    }
   }
 
   def getExistingUser(userId: String): Result[User] =

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipService.scala
@@ -201,17 +201,18 @@ class MembershipService(
       maxItems: Int,
       authPrincipal: AuthPrincipal,
       ignoreAccess: Boolean,
-      abridged: Boolean = false
+      abridged: Boolean = false,
+      roleFilter: Option[Int] = None
   ): Result[ListMyGroupsResponse] = {
     val groupsCall =
-      if (authPrincipal.isSystemAdmin || ignoreAccess) {
+      if (authPrincipal.isSystemAdmin || ignoreAccess || roleFilter.contains(2)) {
         groupRepo.getAllGroups()
       } else {
         groupRepo.getGroups(authPrincipal.memberGroupIds.toSet)
       }
 
     groupsCall.map { grp =>
-      pageListGroupsResponse(grp.toList, groupNameFilter, startFrom, maxItems, ignoreAccess, abridged, authPrincipal)
+      pageListGroupsResponse(grp.toList, groupNameFilter, startFrom, maxItems, ignoreAccess, abridged, authPrincipal, roleFilter)
     }
   }.toResult
 
@@ -222,9 +223,17 @@ class MembershipService(
       maxItems: Int,
       ignoreAccess: Boolean,
       abridged: Boolean = false,
-      authPrincipal: AuthPrincipal
+      authPrincipal: AuthPrincipal,
+      roleFilter: Option[Int] = None
     ): ListMyGroupsResponse = {
-    val allMyGroups = allGroups
+    val userId = authPrincipal.signedInUser.id
+    val roleFiltered = roleFilter match {
+      case Some(0) => allGroups.filter(g => g.adminUserIds.contains(userId))
+      case Some(1) => allGroups.filter(g => g.memberIds.contains(userId) && !g.adminUserIds.contains(userId))
+      case Some(2) => allGroups.filter(g => !g.memberIds.contains(userId))
+      case _       => allGroups
+    }
+    val allMyGroups = roleFiltered
       .filter(_.status == GroupStatus.Active)
       .sortBy(_.name.toLowerCase)
       .map(x => GroupInfo.fromGroup(x, abridged, Some(authPrincipal)))
@@ -378,6 +387,39 @@ class MembershipService(
     userRepo
       .getUsers(userIds, startFrom, pageSize)
       .toResult[ListUsersResults]
+
+  def countGroups(auth: AuthPrincipal): Result[GroupCount] = {
+    val userId = auth.signedInUser.id
+    val allGroupsIO = groupRepo.getAllGroups()
+      .map(_.filter(_.status == GroupStatus.Active))
+    val myGroupsIO =
+      if (auth.isSystemAdmin) {
+        groupRepo.getAllGroups().map(_.filter(_.status == GroupStatus.Active))
+      } else {
+        groupRepo.getGroups(auth.memberGroupIds.toSet)
+          .map(_.filter(_.status == GroupStatus.Active))
+      }
+
+    val actualMemberGroupsIO =
+      if (auth.isSystemAdmin) {
+        groupRepo.getAllGroups().map(_.filter(_.status == GroupStatus.Active))
+      } else {
+        groupRepo.getGroups(auth.memberGroupIds.toSet)
+          .map(_.filter(_.status == GroupStatus.Active))
+      }
+
+    (for {
+      allGroups    <- allGroupsIO
+      myGroups     <- myGroupsIO
+      actualGroups <- actualMemberGroupsIO
+      totalCount           = allGroups.size
+      myGroupCount         = myGroups.size
+      adminGroupCount      = actualGroups.count(_.adminUserIds.contains(userId))
+      memberOnlyGroupCount = actualGroups.count(g => g.memberIds.contains(userId) && !g.adminUserIds.contains(userId))
+      noRoleGroupCount     = totalCount - adminGroupCount - memberOnlyGroupCount
+      soleAdminGroupCount  = actualGroups.count(g => g.adminUserIds.contains(userId) && g.adminUserIds.size == 1)
+    } yield GroupCount(totalCount, myGroupCount, adminGroupCount, memberOnlyGroupCount, noRoleGroupCount, soleAdminGroupCount)).toResult
+  }
 
   def getExistingUser(userId: String): Result[User] =
     userRepo

--- a/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/membership/MembershipServiceAlgebra.scala
@@ -49,7 +49,8 @@ trait MembershipServiceAlgebra {
       maxItems: Int,
       authPrincipal: AuthPrincipal,
       ignoreAccess: Boolean,
-      abridged: Boolean = false
+      abridged: Boolean = false,
+      roleFilter: Option[Int] = None
   ): Result[ListMyGroupsResponse]
 
   def listMembers(
@@ -83,4 +84,6 @@ trait MembershipServiceAlgebra {
                userIdentifier: String,
                authPrincipal: AuthPrincipal
              ): Result[UserResponseInfo]
+
+  def countGroups(auth: AuthPrincipal): Result[GroupCount]
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneProtocol.scala
@@ -329,6 +329,28 @@ case class ListZonesResponse(
 
 case class RecordSetCount( count: Int = 0 )
 
+case class ZoneCount(
+  totalCount: Int = 0,
+  myZonesCount: Int = 0,
+  sharedCount: Int = 0,
+  privateCount: Int = 0,
+  activeCount: Int = 0,
+  syncingCount: Int = 0,
+  abandonedCount: Int = 0,
+  ptrCount: Int = 0,
+  sharedPtrCount: Int = 0,
+  privatePtrCount: Int = 0,
+  abandonedPtrCount: Int = 0,
+  abandonedSharedCount: Int = 0,
+  myActiveCount: Int = 0,
+  mySyncingCount: Int = 0,
+  mySharedCount: Int = 0,
+  myPrivateCount: Int = 0,
+  myPtrCount: Int = 0,
+  myAbandonedCount: Int = 0,
+  myAbandonedPtrCount: Int = 0,
+  myAbandonedSharedCount: Int = 0
+)
 // Errors
 case class InvalidRequest(msg: String) extends Throwable(msg)
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -175,7 +175,8 @@ class ZoneService(
       maxItems: Int = 100,
       searchByAdminGroup: Boolean = false,
       ignoreAccess: Boolean = false,
-      includeReverse: Boolean = true
+      includeReverse: Boolean = true,
+      accessFilter: Option[Int] = None
   ): Result[ListZonesResponse] = {
     if(!searchByAdminGroup || nameFilter.isEmpty){
       for {
@@ -185,7 +186,8 @@ class ZoneService(
           startFrom,
           maxItems,
           ignoreAccess,
-          includeReverse
+          includeReverse,
+          accessFilter
       )
       zones = listZonesResult.zones
       groupIds = zones.map(_.adminGroupId).toSet
@@ -209,7 +211,8 @@ class ZoneService(
           maxItems,
           groupIds,
           ignoreAccess,
-          includeReverse
+          includeReverse,
+          accessFilter
         )
         zones = listZonesResult.zones
         groups <- groupRepository.getGroups(groupIds)
@@ -231,7 +234,8 @@ class ZoneService(
                         nameFilter: Option[String] = None,
                         startFrom: Option[String] = None,
                         maxItems: Int = 100,
-                        ignoreAccess: Boolean = false
+                        ignoreAccess: Boolean = false,
+                        accessFilter: Option[Int] = None
                       ): Result[ListDeletedZoneChangesResponse] = {
     for {
       listZonesChangeResult <- zoneChangeRepository.listDeletedZones(
@@ -239,7 +243,8 @@ class ZoneService(
         nameFilter,
         startFrom,
         maxItems,
-        ignoreAccess
+        ignoreAccess,
+        accessFilter
       )
       zoneChanges = listZonesChangeResult.zoneDeleted
       groupIds = zoneChanges.map(_.zone.adminGroupId).toSet
@@ -480,5 +485,45 @@ class ZoneService(
         }
       }
     } yield ZoneACLInfo(ruleInfos.filter(_.displayName.isDefined))
+  }
+
+  def countZones(auth: AuthPrincipal): Result[ZoneCount] = {
+    val user = auth.signedInUser
+    val isPrivileged = user.isSuper || user.isSupport
+    (
+      zoneRepository.countAllGlobalZoneStats(),
+      zoneChangeRepository.countAllAbandonedStats(),
+      if (isPrivileged) IO.pure((0, 0, 0, 0)) else zoneRepository.countAllUserZoneStats(auth),
+      if (isPrivileged) IO.pure((0, 0, 0)) else zoneChangeRepository.countAllAbandonedStatsForUser(auth)
+    ).mapN { (globalZone, globalAbandoned, userZoneStats, userAbandonedStats) =>
+      val (total, shared, ptr, sharedPtr, privatePtr, syncing) = globalZone
+      val (abandoned, abandonedPtr, abandonedShared) = globalAbandoned
+      val (myTotal, myShared, myPtr, mySyncing) =
+        if (isPrivileged) (total, shared, ptr, syncing) else userZoneStats
+      val (myAbandoned, myAbandonedPtr, myAbandonedShared) =
+        if (isPrivileged) (abandoned, abandonedPtr, abandonedShared) else userAbandonedStats
+      ZoneCount(
+        totalCount             = total,
+        myZonesCount           = myTotal,
+        sharedCount            = shared,
+        privateCount           = total - shared,
+        activeCount            = total - syncing,
+        syncingCount           = syncing,
+        abandonedCount         = abandoned,
+        ptrCount               = ptr,
+        sharedPtrCount         = sharedPtr,
+        privatePtrCount        = privatePtr,
+        abandonedPtrCount      = abandonedPtr,
+        abandonedSharedCount   = abandonedShared,
+        myActiveCount          = myTotal - mySyncing,
+        mySyncingCount         = mySyncing,
+        mySharedCount          = myShared,
+        myPrivateCount         = myTotal - myShared,
+        myPtrCount             = myPtr,
+        myAbandonedCount       = myAbandoned,
+        myAbandonedPtrCount    = myAbandonedPtr,
+        myAbandonedSharedCount = myAbandonedShared
+      )
+    }.toResult
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -526,4 +526,5 @@ class ZoneService(
       )
     }.toResult
   }
+  
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -16,7 +16,7 @@
 
 package vinyldns.api.domain.zone
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import vinyldns.api.domain.access.AccessValidationsAlgebra
 import vinyldns.api.Interfaces
@@ -73,6 +73,9 @@ class ZoneService(
     crypto: CryptoAlgebra,
     membershipService:MembershipService
 ) extends ZoneServiceAlgebra {
+
+  private implicit val cs: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   import accessValidation._
   import zoneValidations._
@@ -495,7 +498,7 @@ class ZoneService(
       zoneChangeRepository.countAllAbandonedStats(),
       if (isPrivileged) IO.pure((0, 0, 0, 0)) else zoneRepository.countAllUserZoneStats(auth),
       if (isPrivileged) IO.pure((0, 0, 0)) else zoneChangeRepository.countAllAbandonedStatsForUser(auth)
-    ).mapN { (globalZone, globalAbandoned, userZoneStats, userAbandonedStats) =>
+    ).parMapN { (globalZone, globalAbandoned, userZoneStats, userAbandonedStats) =>
       val (total, shared, ptr, sharedPtr, privatePtr, syncing) = globalZone
       val (abandoned, abandonedPtr, abandonedShared) = globalAbandoned
       val (myTotal, myShared, myPtr, mySyncing) =

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneServiceAlgebra.scala
@@ -46,7 +46,8 @@ trait ZoneServiceAlgebra {
       maxItems: Int,
       searchByAdminGroup: Boolean,
       ignoreAccess: Boolean,
-      includeReverse: Boolean
+      includeReverse: Boolean,
+      accessFilter: Option[Int] = None
   ): Result[ListZonesResponse]
 
   def listDeletedZones(
@@ -54,7 +55,8 @@ trait ZoneServiceAlgebra {
                         nameFilter: Option[String],
                         startFrom: Option[String],
                         maxItems: Int,
-                        ignoreAccess: Boolean
+                        ignoreAccess: Boolean,
+                        accessFilter: Option[Int] = None
                       ): Result[ListDeletedZoneChangesResponse]
 
   def listZoneChanges(
@@ -83,4 +85,6 @@ trait ZoneServiceAlgebra {
                              startFrom: Int,
                              maxItems: Int
                            ): Result[ListFailedZoneChangesResponse]
+
+  def countZones(auth: AuthPrincipal): Result[ZoneCount]
 }

--- a/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala
@@ -52,7 +52,14 @@ class MembershipRoute(
     case EmailValidationError(msg) => complete(StatusCodes.BadRequest, msg)
   }
 
-  val membershipRoute: Route = path("groups" / Segment) { groupId =>
+  val membershipRoute: Route = path("groups" / "count") {
+    (get & monitor("Endpoint.countGroups")) {
+      authenticateAndExecute(membershipService.countGroups(_)) { result =>
+        complete(StatusCodes.OK, result)
+      }
+    }
+  } ~
+    path("groups" / Segment) { groupId =>
     (get & monitor("Endpoint.getGroup")) {
       authenticateAndExecute(membershipService.getGroup(groupId, _)) { group =>
         complete(StatusCodes.OK, GroupInfo(group))
@@ -86,13 +93,15 @@ class MembershipRoute(
             "groupNameFilter".?,
             "ignoreAccess".as[Boolean].?(false),
             "abridged".as[Boolean].?(false),
+            "roleFilter".as[Int].?
           ) {
             (
                 startFrom: Option[String],
                 maxItems: Int,
                 groupNameFilter: Option[String],
                 ignoreAccess: Boolean,
-                abridged: Boolean
+                abridged: Boolean,
+                roleFilter: Option[Int]
             ) =>
               {
                 handleRejections(invalidQueryHandler) {
@@ -105,7 +114,7 @@ class MembershipRoute(
                   ) {
                     authenticateAndExecute(
                       membershipService
-                        .listMyGroups(groupNameFilter, startFrom, maxItems, _, ignoreAccess, abridged)
+                        .listMyGroups(groupNameFilter, startFrom, maxItems, _, ignoreAccess, abridged, roleFilter)
                     ) { groups =>
                       complete(StatusCodes.OK, groups)
                     }

--- a/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/ZoneRouting.scala
@@ -83,7 +83,8 @@ class ZoneRoute(
           "maxItems".as[Int].?(DEFAULT_MAX_ITEMS),
           "searchByAdminGroup".as[Boolean].?(false),
           "ignoreAccess".as[Boolean].?(false),
-          "includeReverse".as[Boolean].?(true)
+          "includeReverse".as[Boolean].?(true),
+          "accessFilter".as[Int].?
         ) {
           (
               nameFilter: Option[String],
@@ -91,7 +92,8 @@ class ZoneRoute(
               maxItems: Int,
               searchByAdminGroup: Boolean,
               ignoreAccess: Boolean,
-              includeReverse: Boolean
+              includeReverse: Boolean,
+              accessFilter: Option[Int]
           ) =>
             {
               handleRejections(invalidQueryHandler) {
@@ -101,7 +103,7 @@ class ZoneRoute(
                 ) {
                   authenticateAndExecute(
                     zoneService
-                      .listZones(_, nameFilter, startFrom, maxItems, searchByAdminGroup, ignoreAccess, includeReverse)
+                      .listZones(_, nameFilter, startFrom, maxItems, searchByAdminGroup, ignoreAccess, includeReverse, accessFilter)
                   ) { result =>
                     complete(StatusCodes.OK, result)
                   }
@@ -117,13 +119,15 @@ class ZoneRoute(
           "nameFilter".?,
           "startFrom".as[String].?,
           "maxItems".as[Int].?(DEFAULT_MAX_ITEMS),
-          "ignoreAccess".as[Boolean].?(false)
+          "ignoreAccess".as[Boolean].?(false),
+          "accessFilter".as[Int].?
         ) {
           (
             nameFilter: Option[String],
             startFrom: Option[String],
             maxItems: Int,
-            ignoreAccess: Boolean
+            ignoreAccess: Boolean,
+            accessFilter: Option[Int]
           ) =>
           {
             handleRejections(invalidQueryHandler) {
@@ -133,7 +137,7 @@ class ZoneRoute(
               ) {
                 authenticateAndExecute(
                   zoneService
-                    .listDeletedZones(_, nameFilter, startFrom, maxItems, ignoreAccess)
+                    .listDeletedZones(_, nameFilter, startFrom, maxItems, ignoreAccess, accessFilter)
                 ) { result =>
                   complete(StatusCodes.OK, result)
                 }
@@ -147,6 +151,13 @@ class ZoneRoute(
       (get & monitor("Endpoint.getBackendIds")) {
         authenticateAndExecute(_ => zoneService.getBackendIds()) { ids =>
           complete(StatusCodes.OK, ids)
+        }
+      }
+    } ~
+    path("zones" / "count") {
+      (get & monitor("Endpoint.countZones")) {
+        authenticateAndExecute(zoneService.countZones(_)) { result =>
+          complete(StatusCodes.OK, result)
         }
       }
     } ~

--- a/modules/api/src/test/functional/tests/membership/list_my_groups_test.py
+++ b/modules/api/src/test/functional/tests/membership/list_my_groups_test.py
@@ -150,3 +150,47 @@ def test_list_my_groups_as_support_user_with_ignore_access_true(list_my_groups_c
     assert_that(len(results["groups"]), greater_than(50))
     assert_that(results["maxItems"], is_(100))
     assert_that(results["ignoreAccess"], is_(True))
+
+
+
+def test_list_my_groups_with_role_filter_admin(list_my_groups_context):
+    """
+    Test that groups can be filtered to only admin groups via roleFilter=1
+    """
+    results = list_my_groups_context.client.list_my_groups(role_filter=1, status=200)
+    assert_that(results, has_key("groups"))
+    for group in results["groups"]:
+        assert_that(group, has_key("memberCount"))
+
+
+def test_list_my_groups_with_role_filter_member(list_my_groups_context):
+    """
+    Test that groups can be filtered to member-only groups via roleFilter=2
+    """
+    results = list_my_groups_context.client.list_my_groups(role_filter=2, status=200)
+    assert_that(results, has_key("groups"))
+    assert_that(results, has_key("ignoreAccess"))
+
+
+def test_count_groups_success(list_my_groups_context):
+    """
+    Test that the group count endpoint returns all expected fields
+    """
+    result = list_my_groups_context.client.count_groups(status=200)
+
+    assert_that(result, has_key("totalCount"))
+    assert_that(result, has_key("myGroupCount"))
+    assert_that(result, has_key("adminGroupCount"))
+    assert_that(result, has_key("memberOnlyGroupCount"))
+    assert_that(result, has_key("noRoleGroupCount"))
+    assert_that(result, has_key("soleAdminGroupCount"))
+    assert_that(result["myGroupCount"], greater_than_or_equal_to(0))
+    assert_that(result["totalCount"], greater_than_or_equal_to(result["myGroupCount"]))
+
+
+def test_count_groups_no_authorization(list_my_groups_context):
+    """
+    Test that we cannot retrieve group counts without authorization
+    """
+    list_my_groups_context.client.count_groups(sign_request=False, status=401)
+

--- a/modules/api/src/test/functional/tests/zones/list_zones_test.py
+++ b/modules/api/src/test/functional/tests/zones/list_zones_test.py
@@ -227,9 +227,9 @@ def test_list_zones_ignore_access_success_with_name_filter(shared_zone_test_cont
 
 def test_list_zones_access_filter_shared_only(shared_zone_test_context):
     """
-    Test that only shared zones are returned when accessFilter=1
+    Test that only shared zones are returned when accessFilter=0
     """
-    result = shared_zone_test_context.ok_vinyldns_client.list_zones(ignore_access=True, access_filter=1, status=200)
+    result = shared_zone_test_context.ok_vinyldns_client.list_zones(ignore_access=True, access_filter=0, status=200)
     zones = result["zones"]
 
     assert_that(len(zones), greater_than_or_equal_to(1))
@@ -239,9 +239,9 @@ def test_list_zones_access_filter_shared_only(shared_zone_test_context):
 
 def test_list_zones_access_filter_private_only(shared_zone_test_context):
     """
-    Test that only private zones are returned when accessFilter=0
+    Test that only private zones are returned when accessFilter=1
     """
-    result = shared_zone_test_context.ok_vinyldns_client.list_zones(ignore_access=True, access_filter=0, status=200)
+    result = shared_zone_test_context.ok_vinyldns_client.list_zones(ignore_access=True, access_filter=1, status=200)
     zones = result["zones"]
 
     assert_that(len(zones), greater_than_or_equal_to(1))

--- a/modules/api/src/test/functional/tests/zones/list_zones_test.py
+++ b/modules/api/src/test/functional/tests/zones/list_zones_test.py
@@ -224,3 +224,71 @@ def test_list_zones_ignore_access_success_with_name_filter(shared_zone_test_cont
     assert_that(result["ignoreAccess"], is_(True))
     assert_that(retrieved, has_item(has_entry("name", shared_zone_test_context.shared_zone["name"])))
     assert_that(retrieved, has_item(has_entry("accessLevel", "Read")))
+
+def test_list_zones_access_filter_shared_only(shared_zone_test_context):
+    """
+    Test that only shared zones are returned when accessFilter=1
+    """
+    result = shared_zone_test_context.ok_vinyldns_client.list_zones(ignore_access=True, access_filter=1, status=200)
+    zones = result["zones"]
+
+    assert_that(len(zones), greater_than_or_equal_to(1))
+    for zone in zones:
+        assert_that(zone["shared"], is_(True))
+
+
+def test_list_zones_access_filter_private_only(shared_zone_test_context):
+    """
+    Test that only private zones are returned when accessFilter=0
+    """
+    result = shared_zone_test_context.ok_vinyldns_client.list_zones(ignore_access=True, access_filter=0, status=200)
+    zones = result["zones"]
+
+    assert_that(len(zones), greater_than_or_equal_to(1))
+    for zone in zones:
+        assert_that(zone["shared"], is_(False))
+
+
+def test_list_zones_response_has_no_total_count(shared_zone_test_context):
+    """
+    Test that the list zones response does not include totalCount (available via /zones/count instead)
+    """
+    result = shared_zone_test_context.list_zones_client.list_zones(status=200)
+    assert_that(result, is_not(has_key("totalCount")))
+
+
+def test_count_zones_success(shared_zone_test_context):
+    """
+    Test that the zone count endpoint returns all expected fields
+    """
+    result = shared_zone_test_context.ok_vinyldns_client.count_zones(status=200)
+
+    assert_that(result, has_key("totalCount"))
+    assert_that(result, has_key("myZonesCount"))
+    assert_that(result, has_key("sharedCount"))
+    assert_that(result, has_key("privateCount"))
+    assert_that(result, has_key("activeCount"))
+    assert_that(result, has_key("syncingCount"))
+    assert_that(result, has_key("abandonedCount"))
+    assert_that(result, has_key("ptrCount"))
+    assert_that(result, has_key("sharedPtrCount"))
+    assert_that(result, has_key("privatePtrCount"))
+    assert_that(result, has_key("abandonedPtrCount"))
+    assert_that(result, has_key("abandonedSharedCount"))
+    assert_that(result, has_key("myActiveCount"))
+    assert_that(result, has_key("mySyncingCount"))
+    assert_that(result, has_key("mySharedCount"))
+    assert_that(result, has_key("myPrivateCount"))
+    assert_that(result, has_key("myPtrCount"))
+    assert_that(result, has_key("myAbandonedCount"))
+    assert_that(result, has_key("myAbandonedPtrCount"))
+    assert_that(result, has_key("myAbandonedSharedCount"))
+    assert_that(result["totalCount"], greater_than_or_equal_to(result["myZonesCount"]))
+    assert_that(result["totalCount"], equal_to(result["sharedCount"] + result["privateCount"]))
+
+
+def test_count_zones_no_authorization(shared_zone_test_context):
+    """
+    Test that we cannot retrieve zone counts without authorization
+    """
+    shared_zone_test_context.ok_vinyldns_client.count_zones(sign_request=False, status=401)

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -224,13 +224,14 @@ class VinylDNSClient(object):
 
         return data
 
-    def list_my_groups(self, group_name_filter=None, start_from=None, max_items=100, ignore_access=False, **kwargs):
+    def list_my_groups(self, group_name_filter=None, start_from=None, max_items=100, ignore_access=False, role_filter=None, **kwargs):
         """
         Retrieves my groups
         :param start_from: the start key of the page
         :param max_items: the page limit
         :param group_name_filter: only returns groups whose names contain filter string
         :param ignore_access: determines if groups should be retrieved based on requester's membership
+        :param role_filter: integer filter for role (e.g. 1=admin, 0=member)
         :return: the content of the response
         """
         args = []
@@ -242,8 +243,20 @@ class VinylDNSClient(object):
             args.append("maxItems={0}".format(max_items))
         if ignore_access is not False:
             args.append("ignoreAccess={0}".format(ignore_access))
+        if role_filter is not None:
+            args.append("roleFilter={0}".format(role_filter))
 
         url = urljoin(self.index_url, "/groups") + "?" + "&".join(args)
+        response, data = self.make_request(url, "GET", self.headers, **kwargs)
+
+        return data
+    
+    def count_groups(self, **kwargs):
+        """
+        Returns group count statistics for the current user
+        :return: the content of the response
+        """
+        url = urljoin(self.index_url, "/groups/count")
         response, data = self.make_request(url, "GET", self.headers, **kwargs)
 
         return data
@@ -484,7 +497,7 @@ class VinylDNSClient(object):
         return data
 
     def list_zones(self, name_filter=None, start_from=None, max_items=None, search_by_admin_group=False,
-                   ignore_access=False, **kwargs):
+                   ignore_access=False, access_filter=None, **kwargs):
         """
         Gets a list of zones that currently exist
         :return: a list of zones
@@ -507,9 +520,21 @@ class VinylDNSClient(object):
         if ignore_access:
             query.append("ignoreAccess=" + str(ignore_access))
 
+        if access_filter is not None:
+            query.append("accessFilter=" + str(access_filter))
+
         if query:
             url = url + "?" + "&".join(query)
 
+        response, data = self.make_request(url, "GET", self.headers, **kwargs)
+        return data
+    
+    def count_zones(self, **kwargs):
+        """
+        Returns zone count statistics for the current user
+        :return: the content of the response
+        """
+        url = urljoin(self.index_url, "/zones/count")
         response, data = self.make_request(url, "GET", self.headers, **kwargs)
         return data
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/membership/MembershipServiceSpec.scala
@@ -1407,5 +1407,125 @@ class MembershipServiceSpec
         error shouldBe a[UserNotFoundError]
       }
     }
+
+    "listEmailDomains" should {
+      "return the valid email domains from config" in {
+        val result = underTest.listEmailDomains(okAuth).value.unsafeRunSync().toOption.get
+        result shouldBe List("test.com", "*dummy.com")
+      }
+
+      "return an empty list when no valid domains are configured" in {
+        val result = underTestNew.listEmailDomains(okAuth).value.unsafeRunSync().toOption.get
+        result shouldBe List()
+      }
+    }
+
+    "listMyGroups with roleFilter" should {
+      "return only admin groups when roleFilter is 0" in {
+        val userId = okUser.id
+        val adminGroup    = Group("admin-group",  "test@test.com", id = "adminGroupId",
+          memberIds = Set(userId), adminUserIds = Set(userId))
+        val memberOnlyGrp = Group("member-group", "test@test.com", id = "memberGroupId",
+          memberIds = Set(userId), adminUserIds = Set(dummyUser.id))
+        doReturn(IO.pure(Set(adminGroup, memberOnlyGrp)))
+          .when(mockGroupRepo)
+          .getGroups(any[Set[String]])
+
+        val result = underTest
+          .listMyGroups(None, None, 100, okAuth, ignoreAccess = false, roleFilter = Some(0))
+          .value.unsafeRunSync().toOption.get
+
+        result.groups.map(_.id) should contain only adminGroup.id
+        result.groups.map(_.id) should not contain memberOnlyGrp.id
+      }
+
+      "return only member-only groups when roleFilter is 1" in {
+        val userId = okUser.id
+        val adminGroup    = Group("admin-group",  "test@test.com", id = "adminGroupId",
+          memberIds = Set(userId), adminUserIds = Set(userId))
+        val memberOnlyGrp = Group("member-group", "test@test.com", id = "memberGroupId",
+          memberIds = Set(userId), adminUserIds = Set(dummyUser.id))
+        doReturn(IO.pure(Set(adminGroup, memberOnlyGrp)))
+          .when(mockGroupRepo)
+          .getGroups(any[Set[String]])
+
+        val result = underTest
+          .listMyGroups(None, None, 100, okAuth, ignoreAccess = false, roleFilter = Some(1))
+          .value.unsafeRunSync().toOption.get
+
+        result.groups.map(_.id) should contain only memberOnlyGrp.id
+        result.groups.map(_.id) should not contain adminGroup.id
+      }
+
+      "return only non-member groups and call getAllGroups when roleFilter is 2" in {
+        val userId = okUser.id
+        val memberGroup    = Group("member-group",     "test@test.com", id = "memberGroupId",
+          memberIds = Set(userId), adminUserIds = Set(userId))
+        val nonMemberGroup = Group("non-member-group", "test@test.com", id = "nonMemberGroupId",
+          memberIds = Set(dummyUser.id), adminUserIds = Set(dummyUser.id))
+        doReturn(IO.pure(Set(memberGroup, nonMemberGroup)))
+          .when(mockGroupRepo)
+          .getAllGroups()
+
+        val result = underTest
+          .listMyGroups(None, None, 100, okAuth, ignoreAccess = false, roleFilter = Some(2))
+          .value.unsafeRunSync().toOption.get
+
+        result.groups.map(_.id) should contain only nonMemberGroup.id
+        result.groups.map(_.id) should not contain memberGroup.id
+        verify(mockGroupRepo).getAllGroups()
+      }
+    }
+
+    "countGroups" should {
+      "return correct counts for a system admin" in {
+        val userId      = superUser.id
+        val adminGroup  = Group("g1", "test@test.com", id = "g1Id",
+          memberIds = Set(userId), adminUserIds = Set(userId))
+        val memberOnly  = Group("g2", "test@test.com", id = "g2Id",
+          memberIds = Set(userId), adminUserIds = Set("other"))
+        val noRoleGroup = Group("g3", "test@test.com", id = "g3Id",
+          memberIds = Set("other"), adminUserIds = Set("other"))
+        val deletedGrp  = Group("g4", "test@test.com", id = "g4Id",
+          status = GroupStatus.Deleted)
+        doReturn(IO.pure(Set(adminGroup, memberOnly, noRoleGroup, deletedGrp)))
+          .when(mockGroupRepo)
+          .getAllGroups()
+
+        val result = underTest.countGroups(superUserAuth).value.unsafeRunSync().toOption.get
+        result.totalCount           shouldBe 3
+        result.myGroupCount         shouldBe 3
+        result.adminGroupCount      shouldBe 1
+        result.memberOnlyGroupCount shouldBe 1
+        result.noRoleGroupCount     shouldBe 1
+        result.soleAdminGroupCount  shouldBe 1
+      }
+
+      "return correct counts for a regular (non-system-admin) user" in {
+        val userId      = okUser.id
+        val adminGroup  = Group("g1", "test@test.com", id = "g1Id",
+          memberIds = Set(userId), adminUserIds = Set(userId))
+        val memberOnly  = Group("g2", "test@test.com", id = "g2Id",
+          memberIds = Set(userId), adminUserIds = Set("other"))
+        val noRoleGroup = Group("g3", "test@test.com", id = "g3Id",
+          memberIds = Set("other"), adminUserIds = Set("other"))
+        val deletedGrp  = Group("g4", "test@test.com", id = "g4Id",
+          status = GroupStatus.Deleted)
+        doReturn(IO.pure(Set(adminGroup, memberOnly, noRoleGroup, deletedGrp)))
+          .when(mockGroupRepo)
+          .getAllGroups()
+        doReturn(IO.pure(Set(adminGroup, memberOnly)))
+          .when(mockGroupRepo)
+          .getGroups(any[Set[String]])
+
+        val result = underTest.countGroups(okAuth).value.unsafeRunSync().toOption.get
+        result.totalCount           shouldBe 3
+        result.myGroupCount         shouldBe 2
+        result.adminGroupCount      shouldBe 1
+        result.memberOnlyGroupCount shouldBe 1
+        result.noRoleGroupCount     shouldBe 1
+        result.soleAdminGroupCount  shouldBe 1
+      }
+    }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -28,9 +28,10 @@ import org.scalatest.{BeforeAndAfterEach, EitherValues}
 import vinyldns.api.config.ValidEmailConfig
 import vinyldns.api.domain.access.AccessValidations
 import vinyldns.api.domain.membership.{EmailValidationError, MembershipService}
-import vinyldns.core.domain.record.RecordSetRepository
+import vinyldns.core.domain.record.{RecordChangeRepository, RecordSetCacheRepository, RecordSetRepository}
 //import vinyldns.api.domain.membership.{EmailValidationError, MembershipService}
-import vinyldns.api.repository.TestDataLoader
+import vinyldns.api.repository.{ApiDataAccessor, TestDataLoader}
+import vinyldns.core.domain.batch.BatchChangeRepository
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.membership._
 import vinyldns.core.domain.zone._
@@ -64,6 +65,9 @@ class ZoneServiceSpec
   private val mockMembershipRepo = mock[MembershipRepository]
   private val mockGroupChangeRepo = mock[GroupChangeRepository]
   private val mockRecordSetRepo = mock[RecordSetRepository]
+  private val mockRecordChangeRepo = mock[RecordChangeRepository]
+  private val mockRecordSetCacheRepo = mock[RecordSetCacheRepository]
+  private val mockBatchChangeRepo = mock[BatchChangeRepository]
   private val mockValidEmailConfig = ValidEmailConfig(valid_domains = List("test.com", "*dummy.com"),2)
   private val mockValidEmailConfigNew = ValidEmailConfig(valid_domains = List(),2)
   private val mockMembershipService = new MembershipService(mockGroupRepo,
@@ -1421,6 +1425,121 @@ class ZoneServiceSpec
 
       result.changeType shouldBe ZoneChangeType.Update
       result.zone.acl.rules.size shouldBe 0
+    }
+  }
+
+  "create a ZoneService via apply companion object" in {
+    val dataAccessor = ApiDataAccessor(
+      mockUserRepo,
+      mockGroupRepo,
+      mockMembershipRepo,
+      mockGroupChangeRepo,
+      mockRecordSetRepo,
+      mockRecordChangeRepo,
+      mockRecordSetCacheRepo,
+      mockZoneChangeRepo,
+      mockZoneRepo,
+      mockBatchChangeRepo
+    )
+    val service = ZoneService(
+      dataAccessor,
+      TestConnectionValidator,
+      mockMessageQueue,
+      new ZoneValidations(1000),
+      new AccessValidations(),
+      mockBackendResolver,
+      NoOpCrypto.instance,
+      mockMembershipService
+    )
+    service shouldBe a[ZoneService]
+  }
+
+  "ListDeletedZones" should {
+    "return Unknown user name if user cannot be found" in {
+      doReturn(IO.pure(ListDeletedZonesChangeResults(List(abcDeletedZoneChange))))
+        .when(mockZoneChangeRepo)
+        .listDeletedZones(abcAuth, None, None, 100, false, None)
+      doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
+      doReturn(IO.pure(ListUsersResults(Seq.empty, None)))
+        .when(mockUserRepo)
+        .getUsers(any[Set[String]], any[Option[String]], any[Option[Int]])
+
+      val result: ListDeletedZoneChangesResponse =
+        underTest.listDeletedZones(abcAuth).value.unsafeRunSync().toOption.get
+      result.zonesDeletedInfo.head.userName shouldBe "Unknown user name"
+    }
+  }
+
+  "countZones" should {
+    "return correct counts for a privileged (super) user" in {
+      doReturn(IO.pure((10, 3, 2, 1, 1, 4))).when(mockZoneRepo).countAllGlobalZoneStats()
+      doReturn(IO.pure((5, 1, 2))).when(mockZoneChangeRepo).countAllAbandonedStats()
+
+      val result = underTest.countZones(superUserAuth).value.unsafeRunSync().toOption.get
+      result.totalCount             shouldBe 10
+      result.myZonesCount           shouldBe 10
+      result.sharedCount            shouldBe 3
+      result.privateCount           shouldBe 7
+      result.activeCount            shouldBe 6
+      result.syncingCount           shouldBe 4
+      result.abandonedCount         shouldBe 5
+      result.ptrCount               shouldBe 2
+      result.sharedPtrCount         shouldBe 1
+      result.privatePtrCount        shouldBe 1
+      result.abandonedPtrCount      shouldBe 1
+      result.abandonedSharedCount   shouldBe 2
+      result.myActiveCount          shouldBe 6
+      result.mySyncingCount         shouldBe 4
+      result.mySharedCount          shouldBe 3
+      result.myPrivateCount         shouldBe 7
+      result.myPtrCount             shouldBe 2
+      result.myAbandonedCount       shouldBe 5
+      result.myAbandonedPtrCount    shouldBe 1
+      result.myAbandonedSharedCount shouldBe 2
+    }
+
+    "return correct counts for a privileged (support) user" in {
+      doReturn(IO.pure((10, 3, 2, 1, 1, 4))).when(mockZoneRepo).countAllGlobalZoneStats()
+      doReturn(IO.pure((5, 1, 2))).when(mockZoneChangeRepo).countAllAbandonedStats()
+
+      val result = underTest.countZones(supportUserAuth).value.unsafeRunSync().toOption.get
+      result.totalCount   shouldBe 10
+      result.myZonesCount shouldBe 10
+      result.mySharedCount shouldBe 3
+      result.myPtrCount   shouldBe 2
+    }
+
+    "return correct counts for a regular (non-privileged) user" in {
+      doReturn(IO.pure((10, 3, 2, 1, 1, 4))).when(mockZoneRepo).countAllGlobalZoneStats()
+      doReturn(IO.pure((5, 1, 2))).when(mockZoneChangeRepo).countAllAbandonedStats()
+      doReturn(IO.pure((6, 1, 1, 2)))
+        .when(mockZoneRepo)
+        .countAllUserZoneStats(any[AuthPrincipal])
+      doReturn(IO.pure((3, 0, 1)))
+        .when(mockZoneChangeRepo)
+        .countAllAbandonedStatsForUser(any[AuthPrincipal])
+
+      val result = underTest.countZones(okAuth).value.unsafeRunSync().toOption.get
+      result.totalCount             shouldBe 10
+      result.myZonesCount           shouldBe 6
+      result.sharedCount            shouldBe 3
+      result.privateCount           shouldBe 7
+      result.activeCount            shouldBe 6
+      result.syncingCount           shouldBe 4
+      result.abandonedCount         shouldBe 5
+      result.ptrCount               shouldBe 2
+      result.sharedPtrCount         shouldBe 1
+      result.privatePtrCount        shouldBe 1
+      result.abandonedPtrCount      shouldBe 1
+      result.abandonedSharedCount   shouldBe 2
+      result.myActiveCount          shouldBe 4
+      result.mySyncingCount         shouldBe 2
+      result.mySharedCount          shouldBe 1
+      result.myPrivateCount         shouldBe 5
+      result.myPtrCount             shouldBe 1
+      result.myAbandonedCount       shouldBe 3
+      result.myAbandonedPtrCount    shouldBe 0
+      result.myAbandonedSharedCount shouldBe 1
     }
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -845,7 +845,7 @@ class ZoneServiceSpec
     "not fail with no zones returned" in {
       doReturn(IO.pure(ListZonesResults(List())))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false, true)
+        .listZones(abcAuth, None, None, 100, false, true, None)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
@@ -860,7 +860,7 @@ class ZoneServiceSpec
     "return the appropriate zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false, true)
+        .listZones(abcAuth, None, None, 100, false, true, None)
       doReturn(IO.pure(Set(abcGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -877,7 +877,7 @@ class ZoneServiceSpec
     "return all zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone, zoneIp4, zoneIp6), ignoreAccess = true, includeReverse = true)))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, true, true)
+        .listZones(abcAuth, None, None, 100, true, true, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -896,7 +896,7 @@ class ZoneServiceSpec
     "return all forward zones" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone), ignoreAccess = true, includeReverse = false)))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, true, false)
+        .listZones(abcAuth, None, None, 100, true, false, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -918,7 +918,7 @@ class ZoneServiceSpec
         .getGroupsByName(any[String])
       doReturn(IO.pure(ListZonesResults(List(abcZone, zoneIp4, zoneIp6), ignoreAccess = true, zonesFilter = Some("abcGroup"))))
         .when(mockZoneRepo)
-        .listZonesByAdminGroupIds(abcAuth, None, 100, Set(abcGroup.id), ignoreAccess = true, includeReverse = true)
+        .listZonesByAdminGroupIds(abcAuth, None, 100, Set(abcGroup.id), ignoreAccess = true, includeReverse = true, accessFilter = None)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       // When searchByAdminGroup is true, zones are filtered by admin group name given in nameFilter
@@ -939,7 +939,7 @@ class ZoneServiceSpec
         .getGroupsByName(any[String])
       doReturn(IO.pure(ListZonesResults(List(abcZone), ignoreAccess = true, zonesFilter = Some("abcGroup"), includeReverse = false)))
         .when(mockZoneRepo)
-        .listZonesByAdminGroupIds(abcAuth, None, 100, Set(abcGroup.id), ignoreAccess = true, includeReverse = false)
+        .listZonesByAdminGroupIds(abcAuth, None, 100, Set(abcGroup.id), ignoreAccess = true, includeReverse = false, accessFilter = None)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       // When searchByAdminGroup is true, zones are filtered by admin group name given in nameFilter.
@@ -961,7 +961,7 @@ class ZoneServiceSpec
         .getGroups(any[Set[String]])
       doReturn(IO.pure(ListZonesResults(List(abcZone), ignoreAccess = true, zonesFilter = Some("abcZone"))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, Some("abcZone"), None, 100, true, true)
+        .listZones(abcAuth, Some("abcZone"), None, 100, true, true, None)
 
       // When searchByAdminGroup is false, zone name given in nameFilter is returned
       val result: ListZonesResponse =
@@ -977,7 +977,7 @@ class ZoneServiceSpec
     "return Unknown group name if zone admin group cannot be found" in {
       doReturn(IO.pure(ListZonesResults(List(abcZone, xyzZone))))
         .when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 100, false, true)
+        .listZones(abcAuth, None, None, 100, false, true, None)
       doReturn(IO.pure(Set(okGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
 
       val result: ListZonesResponse = underTest.listZones(abcAuth).value.unsafeRunSync().toOption.get
@@ -1001,7 +1001,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, None, 2, false, true)
+        .listZones(abcAuth, None, None, 2, false, true, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1027,7 +1027,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, Some("foo"), None, 2, false, true)
+        .listZones(abcAuth, Some("foo"), None, 2, false, true, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1051,7 +1051,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, Some("zone4."), 2, false, true)
+        .listZones(abcAuth, None, Some("zone4."), 2, false, true, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1074,7 +1074,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneRepo)
-        .listZones(abcAuth, None, Some("zone4."), 2, false, true)
+        .listZones(abcAuth, None, Some("zone4."), 2, false, true, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1091,7 +1091,7 @@ class ZoneServiceSpec
 
       doReturn(IO.pure(ListDeletedZonesChangeResults(List())))
         .when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, None, 100, false)
+        .listDeletedZones(abcAuth, None, None, 100, false, None)
       doReturn(IO.pure(Set(abcGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
       doReturn(IO.pure(ListUsersResults(Seq(okUser), None)))
         .when(mockUserRepo)
@@ -1109,7 +1109,7 @@ class ZoneServiceSpec
     "return the appropriate zones" in {
       doReturn(IO.pure(ListDeletedZonesChangeResults(List(abcDeletedZoneChange))))
         .when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, None, 100, false)
+        .listDeletedZones(abcAuth, None, None, 100, false, None)
       doReturn(IO.pure(Set(abcGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1130,7 +1130,7 @@ class ZoneServiceSpec
     "return all zones" in {
       doReturn(IO.pure(ListDeletedZonesChangeResults(List(abcDeletedZoneChange, xyzDeletedZoneChange), ignoreAccess = true)))
         .when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, None, 100, true)
+        .listDeletedZones(abcAuth, None, None, 100, true, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1151,7 +1151,7 @@ class ZoneServiceSpec
     "return Unknown group name if zone admin group cannot be found" in {
       doReturn(IO.pure(ListDeletedZonesChangeResults(List(abcDeletedZoneChange, xyzDeletedZoneChange))))
         .when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, None, 100, false)
+        .listDeletedZones(abcAuth, None, None, 100, false, None)
       doReturn(IO.pure(Set(okGroup))).when(mockGroupRepo).getGroups(any[Set[String]])
       doReturn(IO.pure(ListUsersResults(Seq(okUser), None)))
         .when(mockUserRepo)
@@ -1178,7 +1178,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, None, 2, false)
+        .listDeletedZones(abcAuth, None, None, 2, false, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1207,7 +1207,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, Some("foo"), None, 2, false)
+        .listDeletedZones(abcAuth, Some("foo"), None, 2, false, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1234,7 +1234,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, Some("zone4."), 2, false)
+        .listDeletedZones(abcAuth, None, Some("zone4."), 2, false, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])
@@ -1260,7 +1260,7 @@ class ZoneServiceSpec
           )
         )
       ).when(mockZoneChangeRepo)
-        .listDeletedZones(abcAuth, None, Some("zone4."), 2, false)
+        .listDeletedZones(abcAuth, None, Some("zone4."), 2, false, None)
       doReturn(IO.pure(Set(abcGroup, xyzGroup)))
         .when(mockGroupRepo)
         .getGroups(any[Set[String]])

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -92,7 +92,8 @@ trait EmptyZoneRepo extends ZoneRepository {
      maxItems: Int = 100,
      adminGroupIds: Set[String],
      ignoreAccess: Boolean = false,
-     includeReverse: Boolean = true
+     includeReverse: Boolean = true,
+     accessFilter: Option[Int] = None
    ): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def listZones(
@@ -101,7 +102,8 @@ trait EmptyZoneRepo extends ZoneRepository {
                  startFrom: Option[String] = None,
                  maxItems: Int = 100,
                  ignoreAccess: Boolean = false,
-                 includeReverse: Boolean = true
+                 includeReverse: Boolean = true,
+                 accessFilter: Option[Int] = None
                ): IO[ListZonesResults] = IO.pure(ListZonesResults())
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]] = IO.pure(List())
@@ -111,7 +113,14 @@ trait EmptyZoneRepo extends ZoneRepository {
   def getZonesByFilters(zoneNames: Set[String]): IO[Set[Zone]] = IO.pure(Set())
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]] = IO.pure(None)
+
+  def countAllGlobalZoneStats(): IO[(Int, Int, Int, Int, Int, Int)] = IO.pure((0, 0, 0, 0, 0, 0))
+
+  def countAllUserZoneStats(authPrincipal: AuthPrincipal): IO[(Int, Int, Int, Int)] = IO.pure((0, 0, 0, 0))
+  
+  def countZones(): IO[Int] = IO.pure(0)
 }
+
 
 trait EmptyGroupRepo extends GroupRepository {
 
@@ -130,6 +139,8 @@ trait EmptyGroupRepo extends GroupRepository {
   def getGroupsByName(groupName: String): IO[Set[Group]] = IO.pure(Set())
 
   def getAllGroups(): IO[Set[Group]] = IO.pure(Set())
+
+  def countGroups(): IO[Int] = IO.pure(0)
 }
 
 trait EmptyUserRepo extends UserRepository {

--- a/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/MembershipRoutingSpec.scala
@@ -205,7 +205,7 @@ class MembershipRoutingSpec
         result(
           ListMyGroupsResponse(Seq(okGroupInfo, twoUserGroupInfo), None, None, None, 100, false)
         )
-      ).when(membershipService).listMyGroups(None, None, 100, okAuth, false, false)
+      ).when(membershipService).listMyGroups(None, None, 100, okAuth, false, false, None)
 
       Get("/groups") ~> Route.seal(membershipRoute) ~> check {
         status shouldBe StatusCodes.OK
@@ -236,7 +236,8 @@ class MembershipRoutingSpec
           maxItems = 100,
           okAuth,
           ignoreAccess = false,
-          abridged = true
+          abridged = true,
+          roleFilter = None
         )
       Get("/groups?startFrom=anyString&maxItems=100&groupNameFilter=ok&abridged=true") ~> Route.seal(
         membershipRoute
@@ -269,9 +270,46 @@ class MembershipRoutingSpec
     "return a 500 response when fails" in {
       doReturn(result(new IllegalArgumentException("fail")))
         .when(membershipService)
-        .listMyGroups(None, None, 100, okAuth, false, abridged = false)
+        .listMyGroups(None, None, 100, okAuth, false, abridged = false, roleFilter = None)
 
       Get("/groups") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.InternalServerError
+      }
+    }
+    "return a 200 response when roleFilter is provided" in {
+      doReturn(
+        result(
+          ListMyGroupsResponse(Seq(okGroupInfo), None, None, None, 100, ignoreAccess = false)
+        )
+      ).when(membershipService).listMyGroups(None, None, 100, okAuth, ignoreAccess = false, abridged = false, roleFilter = Some(1))
+
+      Get("/groups?roleFilter=1") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.OK
+        val result = responseAs[ListMyGroupsResponse]
+        result.groups shouldBe Seq(okGroupInfo)
+      }
+    }
+  }
+
+  "GET groups count" should {
+    "return 200 with all group count fields" in {
+      doReturn(result(GroupCount(totalCount = 10, myGroupCount = 5, adminGroupCount = 2, memberOnlyGroupCount = 3, noRoleGroupCount = 4, soleAdminGroupCount = 1))).when(membershipService).countGroups(okAuth)
+
+      Get("/groups/count") ~> Route.seal(membershipRoute) ~> check {
+        status shouldBe StatusCodes.OK
+        val result = responseAs[GroupCount]
+        result.totalCount shouldBe 10
+        result.myGroupCount shouldBe 5
+        result.adminGroupCount shouldBe 2
+        result.memberOnlyGroupCount shouldBe 3
+        result.noRoleGroupCount shouldBe 4
+        result.soleAdminGroupCount shouldBe 1
+      }
+    }
+    "return 500 when countGroups fails" in {
+      doReturn(result(new RuntimeException("db error"))).when(membershipService).countGroups(okAuth)
+
+      Get("/groups/count") ~> Route.seal(membershipRoute) ~> check {
         status shouldBe StatusCodes.InternalServerError
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/ZoneRoutingSpec.scala
@@ -295,11 +295,12 @@ class ZoneRoutingSpec
         maxItems: Int,
         searchByAdminGroup: Boolean = false,
         ignoreAccess: Boolean = false,
-        includeReverse: Boolean = true
+        includeReverse: Boolean = true,
+        accessFilter: Option[Int] = None
     ): Result[ListZonesResponse] = {
 
-      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess, includeReverse) match {
-        case (_, None, Some("zone3."), 3, false, true) =>
+      val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess, includeReverse, accessFilter) match {
+        case (_, None, Some("zone3."), 3, false, true, None) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -310,7 +311,7 @@ class ZoneRoutingSpec
               ignoreAccess = false
             )
           )
-        case (_, None, Some("zone4."), 4, false, true) =>
+        case (_, None, Some("zone4."), 4, false, true, None) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -322,7 +323,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, 3, false, true) =>
+        case (_, None, None, 3, false, true, None) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -334,7 +335,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, 6, true, true) =>
+        case (_, None, None, 6, true, true, None) =>
           Right(
             ListZonesResponse(
               zones = List(
@@ -354,7 +355,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, 6, true, false) =>
+        case (_, None, None, 6, true, false, None) =>
           Right(
             ListZonesResponse(
               zones = List(
@@ -373,7 +374,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, Some(filter), Some("zone4."), 4, false, true) =>
+        case (_, Some(filter), Some("zone4."), 4, false, true, None) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -385,7 +386,7 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, Some(filter), Some("zone4."), 4, true, false) =>
+        case (_, Some(filter), Some("zone4."), 4, true, false, None) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo4, zoneSummaryInfo5),
@@ -398,7 +399,31 @@ class ZoneRoutingSpec
             )
           )
 
-        case (_, None, None, _, _, true) =>
+        case (_, None, None, 100, true, true, Some(1)) =>
+          Right(
+            ListZonesResponse(
+              zones = List(zoneSummaryInfo1, zoneSummaryInfo2),
+              nameFilter = None,
+              startFrom = None,
+              nextId = None,
+              maxItems = 100,
+              ignoreAccess = true
+            )
+          )
+
+        case (_, None, None, 100, true, true, Some(0)) =>
+          Right(
+            ListZonesResponse(
+              zones = List(zoneSummaryInfo3, zoneSummaryInfo4, zoneSummaryInfo5),
+              nameFilter = None,
+              startFrom = None,
+              nextId = None,
+              maxItems = 100,
+              ignoreAccess = true
+            )
+          )
+
+        case (_, None, None, _, _, true, None) =>
           Right(
             ListZonesResponse(
               zones = List(zoneSummaryInfo1, zoneSummaryInfo2, zoneSummaryInfo3),
@@ -420,7 +445,8 @@ class ZoneRoutingSpec
                           nameFilter: Option[String],
                           startFrom: Option[String],
                           maxItems: Int,
-                          ignoreAccess: Boolean = false
+                          ignoreAccess: Boolean = false,
+                          accessFilter: Option[Int] = None
                         ): Result[ListDeletedZoneChangesResponse] = {
 
       val outcome = (authPrincipal, nameFilter, startFrom, maxItems, ignoreAccess) match {
@@ -579,6 +605,9 @@ class ZoneRoutingSpec
     }
 
     def getBackendIds(): Result[List[String]] = List("backend-1", "backend-2").toResult
+
+    def countZones(auth: AuthPrincipal): Result[ZoneCount] =
+      Right(ZoneCount(totalCount = 6, myZonesCount = 3, sharedCount = 1, privateCount = 5, activeCount = 6, syncingCount = 0, abandonedCount = 1, ptrCount = 2, sharedPtrCount = 1, privatePtrCount = 1, abandonedPtrCount = 0, abandonedSharedCount = 0, myActiveCount = 3, mySyncingCount = 0, mySharedCount = 1, myPrivateCount = 2, myPtrCount = 1, myAbandonedCount = 1, myAbandonedPtrCount = 0, myAbandonedSharedCount = 0)).toResult
   }
 
   val zoneService: ZoneServiceAlgebra = TestZoneService
@@ -1173,6 +1202,22 @@ class ZoneRoutingSpec
         resp.includeReverse shouldBe false
       }
     }
+    
+    "return only shared zones when accessFilter=1" in {
+      Get(s"/zones?ignoreAccess=true&accessFilter=1") ~> zoneRoute ~> check {
+        val resp = responseAs[ListZonesResponse]
+        (resp.zones.map(_.id) should contain).only(zone1.id, zone2.id)
+        resp.ignoreAccess shouldBe true
+      }
+    }
+
+    "return only private zones when accessFilter=0" in {
+      Get(s"/zones?ignoreAccess=true&accessFilter=0") ~> zoneRoute ~> check {
+        val resp = responseAs[ListZonesResponse]
+        (resp.zones.map(_.id) should contain).only(zone3.id, zone4.id, zone5.id)
+        resp.ignoreAccess shouldBe true
+      }
+    }
 
     "return an error if the max items is out of range" in {
       Get(s"/zones?maxItems=700") ~> zoneRoute ~> check {
@@ -1180,6 +1225,35 @@ class ZoneRoutingSpec
         responseEntity.toString should include(
           "maxItems was 700, maxItems must be between 0 and 100"
         )
+      }
+    }
+  }
+
+  "GET zones count" should {
+    "return 200 with all zone count fields" in {
+      Get("/zones/count") ~> zoneRoute ~> check {
+        status shouldBe OK
+        val result = responseAs[ZoneCount]
+        result.totalCount shouldBe 6
+        result.myZonesCount shouldBe 3
+        result.sharedCount shouldBe 1
+        result.privateCount shouldBe 5
+        result.activeCount shouldBe 6
+        result.syncingCount shouldBe 0
+        result.abandonedCount shouldBe 1
+        result.ptrCount shouldBe 2
+        result.sharedPtrCount shouldBe 1
+        result.privatePtrCount shouldBe 1
+        result.abandonedPtrCount shouldBe 0
+        result.abandonedSharedCount shouldBe 0
+        result.myActiveCount shouldBe 3
+        result.mySyncingCount shouldBe 0
+        result.mySharedCount shouldBe 1
+        result.myPrivateCount shouldBe 2
+        result.myPtrCount shouldBe 1
+        result.myAbandonedCount shouldBe 1
+        result.myAbandonedPtrCount shouldBe 0
+        result.myAbandonedSharedCount shouldBe 0
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/GroupRepository.scala
@@ -39,4 +39,6 @@ trait GroupRepository extends Repository {
 
   def getAllGroups(): IO[Set[Group]]
 
+  def countGroups(): IO[Int]
+
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneChangeRepository.scala
@@ -35,11 +35,20 @@ trait ZoneChangeRepository extends Repository {
                         zoneNameFilter: Option[String] = None,
                         startFrom: Option[String] = None,
                         maxItems: Int = 100,
-                        ignoreAccess: Boolean = false
+                        ignoreAccess: Boolean = false,
+                        accessFilter: Option[Int] = None
                       ): IO[ListDeletedZonesChangeResults]
 
   def listFailedZoneChanges(
                              maxItems: Int = 100,
                              startFrom: Int= 0
                            ): IO[ListFailedZoneChangesResults]
+
+  /* Returns (abandoned, abandonedPtr, abandonedShared) in 1 SQL round-trip. */
+  def countAllAbandonedStats(): IO[(Int, Int, Int)]
+
+  /** Returns (myAbandoned, myAbandonedPtr, myAbandonedShared) in 1 SQL round-trip.
+    * For super/support callers ZoneService substitutes the global abandoned stats instead.
+    */
+  def countAllAbandonedStatsForUser(authPrincipal: AuthPrincipal): IO[(Int, Int, Int)]
 }

--- a/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/zone/ZoneRepository.scala
@@ -43,7 +43,8 @@ trait ZoneRepository extends Repository {
        maxItems: Int = 100,
        adminGroupIds: Set[String],
        ignoreAccess: Boolean = false,
-       includeReverse: Boolean = true
+       includeReverse: Boolean = true,
+       accessFilter: Option[Int] = None
      ): IO[ListZonesResults]
 
   def listZones(
@@ -52,12 +53,25 @@ trait ZoneRepository extends Repository {
       startFrom: Option[String] = None,
       maxItems: Int = 100,
       ignoreAccess: Boolean = false,
-      includeReverse: Boolean = true
+      includeReverse: Boolean = true,
+      accessFilter: Option[Int] = None
   ): IO[ListZonesResults]
 
   def getZonesByAdminGroupId(adminGroupId: String): IO[List[Zone]]
 
   def getFirstOwnedZoneAclGroupId(groupId: String): IO[Option[String]]
+
+  def countZones(): IO[Int]
+
+  /* Returns (total, shared, ptr, sharedPtr, privatePtr, syncing) in 2 SQL round-trips.
+  */
+  def countAllGlobalZoneStats(): IO[(Int, Int, Int, Int, Int, Int)]
+
+  /** Returns (myTotal, myShared, myPtr, mySyncing) in 1 SQL round-trip.
+    * For super/support callers ZoneService will substitute the global stats instead.
+    */
+  def countAllUserZoneStats(authPrincipal: AuthPrincipal): IO[(Int, Int, Int, Int)]
+
 }
 
 object ZoneRepository {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
@@ -158,4 +158,10 @@ class MySqlGroupRepositoryIntegrationSpec
       result should contain theSameElementsAs Set()
     }
   }
+
+  "MySqlGroupRepository.countGroups" should {
+    "return the total number of groups" in {
+      repo.countGroups().unsafeRunSync() shouldBe groups.size
+    }
+  }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -422,11 +422,11 @@ class MySqlZoneChangeRepositoryIntegrationSpec
       val listDeletedZones = repo.listDeletedZones(okUserAuth).unsafeRunSync()
 
       val expectedPageOne = List(listDeletedZones.zoneDeleted(0))
-      val expectedPageOneNext = Some(listDeletedZones.zoneDeleted(1).zone.id)
+      val expectedPageOneNext = Some(listDeletedZones.zoneDeleted(1).zone.name)
       val expectedPageTwo = List(listDeletedZones.zoneDeleted(1))
-      val expectedPageTwoNext = Some(listDeletedZones.zoneDeleted(2).zone.id)
+      val expectedPageTwoNext = Some(listDeletedZones.zoneDeleted(2).zone.name)
       val expectedPageThree = List(listDeletedZones.zoneDeleted(2))
-      val expectedPageThreeNext = Some(listDeletedZones.zoneDeleted(3).zone.id)
+      val expectedPageThreeNext = Some(listDeletedZones.zoneDeleted(3).zone.name)
 
       // get first page
       val pageOne = repo.listDeletedZones(okUserAuth,startFrom = None, maxItems = 1 ).unsafeRunSync()

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -581,8 +581,6 @@ class MySqlZoneChangeRepositoryIntegrationSpec
     }
 
     "countAllAbandonedStats returns correct totals" in {
-      val okUserAuth = AuthPrincipal(signedInUser = okUser, memberGroupIds = groups.map(_.id))
-
       val abandonedZone    = testZone.head.copy(id = UUID.randomUUID().toString,
         name = "abandoned-forward.", status = ZoneStatus.Deleted)
       val abandonedPtr     = testZone.head.copy(id = UUID.randomUUID().toString,

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -525,5 +525,120 @@ class MySqlZoneChangeRepositoryIntegrationSpec
       // dummy user can not access the revoked zone
       repo.listDeletedZones(dummyAuth).unsafeRunSync().zoneDeleted shouldBe empty
     }
+
+    "listDeletedZones filters by shared zones when accessFilter is Some(0)" in {
+      val okUserAuth = AuthPrincipal(signedInUser = okUser, memberGroupIds = groups.map(_.id))
+
+      val sharedZone   = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "shared-deleted.", shared = true, status = ZoneStatus.Deleted)
+      val privateZone  = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "private-deleted.", shared = false, status = ZoneStatus.Deleted)
+
+      val sharedChange  = ZoneChange(sharedZone,  sharedZone.account,  ZoneChangeType.Create, ZoneChangeStatus.Synced)
+      val privateChange = ZoneChange(privateZone, privateZone.account, ZoneChangeType.Create, ZoneChangeStatus.Synced)
+
+      saveZoneChanges(Seq(sharedChange, privateChange)).unsafeRunSync()
+
+      val result = repo.listDeletedZones(okUserAuth, ignoreAccess = true, accessFilter = Some(0)).unsafeRunSync()
+      result.zoneDeleted should contain only sharedChange
+    }
+
+    "listDeletedZones filters by private zones when accessFilter is Some(1)" in {
+      val okUserAuth = AuthPrincipal(signedInUser = okUser, memberGroupIds = groups.map(_.id))
+
+      val sharedZone   = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "shared-deleted2.", shared = true, status = ZoneStatus.Deleted)
+      val privateZone  = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "private-deleted2.", shared = false, status = ZoneStatus.Deleted)
+
+      val sharedChange  = ZoneChange(sharedZone,  sharedZone.account,  ZoneChangeType.Create, ZoneChangeStatus.Synced)
+      val privateChange = ZoneChange(privateZone, privateZone.account, ZoneChangeType.Create, ZoneChangeStatus.Synced)
+
+      saveZoneChanges(Seq(sharedChange, privateChange)).unsafeRunSync()
+
+      val result = repo.listDeletedZones(okUserAuth, ignoreAccess = true, accessFilter = Some(1)).unsafeRunSync()
+      result.zoneDeleted should contain only privateChange
+    }
+
+    "listDeletedZones filters by zone name using wildcard (*)" in {
+      val okUserAuth = AuthPrincipal(signedInUser = okUser, memberGroupIds = groups.map(_.id))
+
+      val zone1 = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "wildcard-match-1.", status = ZoneStatus.Deleted)
+      val zone2 = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "wildcard-match-2.", status = ZoneStatus.Deleted)
+      val zone3 = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "no-match-zone.", status = ZoneStatus.Deleted)
+
+      val changes = Seq(zone1, zone2, zone3).map(z =>
+        ZoneChange(z, z.account, ZoneChangeType.Create, ZoneChangeStatus.Synced))
+
+      saveZoneChanges(changes).unsafeRunSync()
+
+      val result = repo.listDeletedZones(okUserAuth, zoneNameFilter = Some("wildcard*"), ignoreAccess = true).unsafeRunSync()
+      result.zoneDeleted.map(_.zone.name) should contain allOf("wildcard-match-1.", "wildcard-match-2.")
+      result.zoneDeleted.map(_.zone.name) should not contain "no-match-zone."
+    }
+
+    "countAllAbandonedStats returns correct totals" in {
+      val okUserAuth = AuthPrincipal(signedInUser = okUser, memberGroupIds = groups.map(_.id))
+
+      val abandonedZone    = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "abandoned-forward.", status = ZoneStatus.Deleted)
+      val abandonedPtr     = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "abandoned.in-addr.arpa.", status = ZoneStatus.Deleted)
+      val abandonedShared  = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "abandoned-shared.", shared = true, status = ZoneStatus.Deleted)
+      // an active zone — should NOT be counted as abandoned
+      val activeZone       = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "active-not-abandoned.", status = ZoneStatus.Active)
+
+      val abandonedChanges = Seq(abandonedZone, abandonedPtr, abandonedShared).map(z =>
+        ZoneChange(z, z.account, ZoneChangeType.Create, ZoneChangeStatus.Synced))
+
+      // save active zone into the zone table so it is excluded from abandoned counts
+      zoneRepo.save(activeZone).unsafeRunSync()
+      saveZoneChanges(abandonedChanges).unsafeRunSync()
+
+      val (abandoned, abandonedPtrCount, abandonedSharedCount) =
+        repo.countAllAbandonedStats().unsafeRunSync()
+
+      abandoned          shouldBe 3
+      abandonedPtrCount  shouldBe 1
+      abandonedSharedCount shouldBe 1
+    }
+
+    "countAllAbandonedStatsForUser returns correct per-user totals" in {
+      val userId  = okUser.id
+      val userAcl = ZoneACL(rules = Set(ACLRule(accessLevel = AccessLevel.Read, userId = Some(userId))))
+
+      val myAbandoned = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "user-abandoned.", acl = userAcl, status = ZoneStatus.Deleted)
+      val myAbandonedPtr = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "user-abandoned.in-addr.arpa.", acl = userAcl, status = ZoneStatus.Deleted)
+      val otherAbandoned = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "other-abandoned.", status = ZoneStatus.Deleted)
+
+      val myChanges = Seq(myAbandoned, myAbandonedPtr).map(z =>
+        ZoneChange(z, z.account, ZoneChangeType.Create, ZoneChangeStatus.Synced))
+      val otherChange = ZoneChange(otherAbandoned, otherAbandoned.account, ZoneChangeType.Create, ZoneChangeStatus.Synced)
+
+      // save the zones so zone_access entries exist for the user
+      zoneRepo.save(myAbandoned).unsafeRunSync()
+      zoneRepo.save(myAbandonedPtr).unsafeRunSync()
+      // now delete them so they appear as abandoned
+      zoneRepo.deleteTx(myAbandoned).unsafeRunSync()
+      zoneRepo.deleteTx(myAbandonedPtr).unsafeRunSync()
+
+      saveZoneChanges(myChanges ++ Seq(otherChange)).unsafeRunSync()
+
+      val auth = AuthPrincipal(signedInUser = okUser, memberGroupIds = Seq.empty)
+      val (myTotal, myAbandonedPtrCount, myAbandonedSharedCount) =
+        repo.countAllAbandonedStatsForUser(auth).unsafeRunSync()
+
+      myTotal              shouldBe 2
+      myAbandonedPtrCount  shouldBe 1
+      myAbandonedSharedCount shouldBe 0
+    }
   }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneChangeRepositoryIntegrationSpec.scala
@@ -587,14 +587,12 @@ class MySqlZoneChangeRepositoryIntegrationSpec
         name = "abandoned.in-addr.arpa.", status = ZoneStatus.Deleted)
       val abandonedShared  = testZone.head.copy(id = UUID.randomUUID().toString,
         name = "abandoned-shared.", shared = true, status = ZoneStatus.Deleted)
-      // an active zone — should NOT be counted as abandoned
       val activeZone       = testZone.head.copy(id = UUID.randomUUID().toString,
         name = "active-not-abandoned.", status = ZoneStatus.Active)
 
       val abandonedChanges = Seq(abandonedZone, abandonedPtr, abandonedShared).map(z =>
         ZoneChange(z, z.account, ZoneChangeType.Create, ZoneChangeStatus.Synced))
 
-      // save active zone into the zone table so it is excluded from abandoned counts
       zoneRepo.save(activeZone).unsafeRunSync()
       saveZoneChanges(abandonedChanges).unsafeRunSync()
 
@@ -610,23 +608,22 @@ class MySqlZoneChangeRepositoryIntegrationSpec
       val userId  = okUser.id
       val userAcl = ZoneACL(rules = Set(ACLRule(accessLevel = AccessLevel.Read, userId = Some(userId))))
 
-      val myAbandoned = testZone.head.copy(id = UUID.randomUUID().toString,
-        name = "user-abandoned.", acl = userAcl, status = ZoneStatus.Deleted)
+      val myAbandoned    = testZone.head.copy(id = UUID.randomUUID().toString,
+        name = "user-abandoned.", acl = userAcl)
       val myAbandonedPtr = testZone.head.copy(id = UUID.randomUUID().toString,
-        name = "user-abandoned.in-addr.arpa.", acl = userAcl, status = ZoneStatus.Deleted)
+        name = "user-abandoned.in-addr.arpa.", acl = userAcl)
       val otherAbandoned = testZone.head.copy(id = UUID.randomUUID().toString,
-        name = "other-abandoned.", status = ZoneStatus.Deleted)
+        name = "other-abandoned.")
 
-      val myChanges = Seq(myAbandoned, myAbandonedPtr).map(z =>
-        ZoneChange(z, z.account, ZoneChangeType.Create, ZoneChangeStatus.Synced))
-      val otherChange = ZoneChange(otherAbandoned, otherAbandoned.account, ZoneChangeType.Create, ZoneChangeStatus.Synced)
-
-      // save the zones so zone_access entries exist for the user
       zoneRepo.save(myAbandoned).unsafeRunSync()
       zoneRepo.save(myAbandonedPtr).unsafeRunSync()
-      // now delete them so they appear as abandoned
       zoneRepo.deleteTx(myAbandoned).unsafeRunSync()
       zoneRepo.deleteTx(myAbandonedPtr).unsafeRunSync()
+
+      val myChanges = Seq(myAbandoned, myAbandonedPtr).map { z =>
+        ZoneChange(z.copy(status = ZoneStatus.Deleted), z.account, ZoneChangeType.Create, ZoneChangeStatus.Synced)
+      }
+      val otherChange = ZoneChange(otherAbandoned.copy(status = ZoneStatus.Deleted), otherAbandoned.account, ZoneChangeType.Create, ZoneChangeStatus.Synced)
 
       saveZoneChanges(myChanges ++ Seq(otherChange)).unsafeRunSync()
 

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -1006,5 +1006,137 @@ class MySqlZoneRepositoryIntegrationSpec
       // Only get zone with recurrence schedule
       repo.getAllZonesWithSyncSchedule.unsafeRunSync() shouldBe Set(updatedOkZone)
     }
+
+    "countZones returns the total number of zones" in {
+      val zones = Seq(
+        testZone("count-test-1."),
+        testZone("count-test-2."),
+        testZone("count-test-3.")
+      )
+      saveZones(zones).unsafeRunSync()
+      repo.countZones().unsafeRunSync() shouldBe 3
+    }
+
+    "countAllGlobalZoneStats returns correct totals" in {
+      val privateZone  = testZone("private-global.")
+      val sharedZone   = testZone("shared-global.").copy(shared = true)
+      val ptrZone      = testZone("100.in-addr.arpa.")
+      val sharedPtrZone = testZone("200.in-addr.arpa.").copy(shared = true)
+      val privatePtrZone = testZone("300.in-addr.arpa.")
+      val syncingZone  = testZone("syncing-global.").copy(status = ZoneStatus.Syncing)
+
+      saveZones(Seq(privateZone, sharedZone, ptrZone, sharedPtrZone, privatePtrZone, syncingZone)).unsafeRunSync()
+
+      val (total, shared, ptr, sharedPtr, privatePtr, syncing) =
+        repo.countAllGlobalZoneStats().unsafeRunSync()
+
+      total      shouldBe 6
+      shared     shouldBe 1
+      ptr        shouldBe 3
+      sharedPtr  shouldBe 1
+      privatePtr shouldBe 2
+      syncing    shouldBe 1
+    }
+
+    "countAllUserZoneStats returns correct per-user totals" in {
+      val userId = okUser.id
+      val userAcl = ZoneACL(rules = Set(ACLRule(accessLevel = AccessLevel.Read, userId = Some(userId))))
+
+      val myPrivate  = testZone("user-private.").copy(acl = userAcl)
+      val myShared   = testZone("user-shared.").copy(acl = userAcl, shared = true)
+      val myPtr      = testZone("400.in-addr.arpa.").copy(acl = userAcl)
+      val mySyncing  = testZone("user-syncing.").copy(acl = userAcl, status = ZoneStatus.Syncing)
+      val otherZone  = testZone("other-zone.")
+
+      saveZones(Seq(myPrivate, myShared, myPtr, mySyncing, otherZone)).unsafeRunSync()
+
+      val auth = AuthPrincipal(signedInUser = okUser, memberGroupIds = Seq.empty)
+      val (myTotal, mySharedCount, myPtrCount, mySyncingCount) =
+        repo.countAllUserZoneStats(auth).unsafeRunSync()
+
+      myTotal       shouldBe 4
+      mySharedCount shouldBe 1
+      myPtrCount    shouldBe 1
+      mySyncingCount shouldBe 1
+    }
+
+    "listZones applies accessFilter Some(0) with no name filter and includeReverse (WHERE branch)" in {
+      val sharedZone  = testZone("access-shared-1.").copy(shared = true)
+      val privateZone = testZone("access-private-1.")
+
+      saveZones(Seq(sharedZone, privateZone)).unsafeRunSync()
+
+      val result = repo.listZones(superUserAuth, accessFilter = Some(0)).unsafeRunSync()
+      result.zones should contain only sharedZone
+    }
+
+    "listZones applies accessFilter Some(1) with no name filter and includeReverse (WHERE branch)" in {
+      val sharedZone  = testZone("access-shared-2.").copy(shared = true)
+      val privateZone = testZone("access-private-2.")
+
+      saveZones(Seq(sharedZone, privateZone)).unsafeRunSync()
+
+      val result = repo.listZones(superUserAuth, accessFilter = Some(1)).unsafeRunSync()
+      result.zones should contain only privateZone
+    }
+
+    "listZones applies accessFilter Some(0) with name filter present (AND branch)" in {
+      val sharedZone  = testZone("and-shared.").copy(shared = true)
+      val privateZone = testZone("and-private.")
+
+      saveZones(Seq(sharedZone, privateZone)).unsafeRunSync()
+
+      val result = repo.listZones(superUserAuth, zoneNameFilter = Some("and*"), accessFilter = Some(0)).unsafeRunSync()
+      result.zones should contain only sharedZone
+    }
+
+    "listZones applies accessFilter Some(1) with name filter present (AND branch)" in {
+      val sharedZone  = testZone("andp-shared.").copy(shared = true)
+      val privateZone = testZone("andp-private.")
+
+      saveZones(Seq(sharedZone, privateZone)).unsafeRunSync()
+
+      val result = repo.listZones(superUserAuth, zoneNameFilter = Some("andp*"), accessFilter = Some(1)).unsafeRunSync()
+      result.zones should contain only privateZone
+    }
+
+    "listZones applies accessFilter Some(0) with includeReverse false (AND branch)" in {
+      val sharedForward  = testZone("rev-shared.").copy(shared = true)
+      val privateForward = testZone("rev-private.")
+      val sharedReverse  = testZone("10.in-addr.arpa.").copy(shared = true)
+
+      saveZones(Seq(sharedForward, privateForward, sharedReverse)).unsafeRunSync()
+
+      val result = repo.listZones(superUserAuth, includeReverse = false, accessFilter = Some(0)).unsafeRunSync()
+      result.zones should contain only sharedForward
+    }
+
+    "listZonesByAdminGroupIds applies accessFilter Some(0) for shared zones" in {
+      val groupId     = "accessFilterGroup"
+      val sharedZone  = testZone("bygroup-shared.", adminGroupId = groupId).copy(shared = true)
+      val privateZone = testZone("bygroup-private.", adminGroupId = groupId)
+
+      saveZones(Seq(sharedZone, privateZone)).unsafeRunSync()
+
+      val result = repo
+        .listZonesByAdminGroupIds(superUserAuth, None, 100, Set(groupId), ignoreAccess = true, accessFilter = Some(0))
+        .unsafeRunSync()
+
+      result.zones should contain only sharedZone
+    }
+
+    "listZonesByAdminGroupIds applies accessFilter Some(1) for private zones" in {
+      val groupId     = "accessFilterGroup2"
+      val sharedZone  = testZone("bygroup2-shared.", adminGroupId = groupId).copy(shared = true)
+      val privateZone = testZone("bygroup2-private.", adminGroupId = groupId)
+
+      saveZones(Seq(sharedZone, privateZone)).unsafeRunSync()
+
+      val result = repo
+        .listZonesByAdminGroupIds(superUserAuth, None, 100, Set(groupId), ignoreAccess = true, accessFilter = Some(1))
+        .unsafeRunSync()
+
+      result.zones should contain only privateZone
+    }
   }
 }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlZoneRepositoryIntegrationSpec.scala
@@ -1031,7 +1031,7 @@ class MySqlZoneRepositoryIntegrationSpec
         repo.countAllGlobalZoneStats().unsafeRunSync()
 
       total      shouldBe 6
-      shared     shouldBe 1
+      shared     shouldBe 2
       ptr        shouldBe 3
       sharedPtr  shouldBe 1
       privatePtr shouldBe 2

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
@@ -62,6 +62,12 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
          |  FROM `groups`
        """.stripMargin
 
+  private final val COUNT_GROUPS =
+    sql"""
+         |SELECT COUNT(*)
+         |  FROM `groups`
+       """.stripMargin
+
   private val BASE_GET_GROUPS_BY_IDS =
     """
       |SELECT data
@@ -217,6 +223,16 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
             .list()
             .apply()
         }.toSet
+      }
+    }
+
+  def countGroups(): IO[Int] =
+    monitor("repo.Group.countGroups") {
+      IO {
+        logger.debug(s"Counting all groups")
+        DB.readOnly { implicit s =>
+          COUNT_GROUPS.map(rs => rs.int(1)).single().apply().getOrElse(0)
+        }
       }
     }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -49,18 +49,6 @@ class MySqlZoneChangeRepository
       |  FROM zone_change zc
        """.stripMargin
 
-  private final val BASE_ZONE_NAME_COUNT_SQL =
-    """
-      |SELECT COUNT(z.name)
-      |  FROM zone z
-       """.stripMargin
-
-  private final val BASE_ZONE_NAME_SEARCH_SQL =
-    """
-      |SELECT z.name
-      |  FROM zone z
-       """.stripMargin
-
   private final val LIST_ZONES_CHANGES =
     sql"""
       |SELECT zc.data
@@ -175,7 +163,8 @@ class MySqlZoneChangeRepository
                         zoneNameFilter: Option[String] = None,
                         startFrom: Option[String] = None,
                         maxItems: Int = 100,
-                        ignoreAccess: Boolean = false
+                        ignoreAccess: Boolean = false,
+                        accessFilter: Option[Int] = None
                       ): IO[ListDeletedZonesChangeResults] =
     monitor("repo.ZoneChange.listDeletedZoneInZoneChanges") {
       IO {
@@ -184,20 +173,11 @@ class MySqlZoneChangeRepository
             withAccessors(authPrincipal.signedInUser, authPrincipal.memberGroupIds, ignoreAccess)
           val sb = new StringBuilder
           sb.append(withAccessorCheck)
+          sb.append("\n  LEFT JOIN zone z ON zc.zone_name = z.name")
+          sb.append(" WHERE z.name IS NULL")
+          sb.append(" AND zc.zone_status = 'Deleted'")
 
-          val zoneResults: Int =
-             SQL(BASE_ZONE_NAME_COUNT_SQL)
-               .map(_.int(1))
-               .single()
-               .apply()
-               .getOrElse(0)
-
-           sb.append(s" WHERE ")
-
-          if (zoneResults != 0) sb.append(s" zc.zone_name NOT IN ($BASE_ZONE_NAME_SEARCH_SQL) AND ")
-
-          sb.append(s" zc.zone_status = 'Deleted' ")
-
+          val extraBindParams = scala.collection.mutable.ListBuffer[Any]()
           val filters = if (zoneNameFilter.isDefined && zoneNameFilter.get.contains("*"))
               zoneNameFilter.map(flt => s"zc.zone_name LIKE '${flt.replace('*', '%')}'")
           else zoneNameFilter.map(flt => s"zc.zone_name LIKE '${flt.concat("%")}'")
@@ -207,32 +187,37 @@ class MySqlZoneChangeRepository
 
           sb.append(filters.mkString)
 
-          val resultOrdering = s"""|    GROUP BY zc.zone_name
-                                   |    ORDER BY zc.created_timestamp DESC
-                                 """.stripMargin
+          accessFilter.foreach { af =>
+            sb.append(s" AND INSTR(zc.data, X'4801') ${if (af == 0) "> 0" else "= 0"}")
+          }
 
-          sb.append(resultOrdering)
+          startFrom.foreach { cursorName =>
+            sb.append(" AND zc.zone_name > ?")
+            extraBindParams += cursorName
+          }
+
+          sb.append(
+            s"""
+               |    GROUP BY zc.zone_name
+               |    ORDER BY zc.zone_name ASC
+               |    LIMIT ${maxItems + 1}
+             """.stripMargin)
 
           val query = sb.toString
+          val allBindParams = accessors ++ extraBindParams.toSeq
+
 
           val deletedZoneResults: List[ZoneChange] =
             SQL(query)
-              .bind(accessors: _*)
+              .bind(allBindParams: _*)
               .map(extractZoneChange(1))
                 .list()
                 .apply()
 
-          val deletedZonesWithStartFrom: List[ZoneChange] = startFrom match {
-            case Some(zoneId) => deletedZoneResults.dropWhile(_.zone.id != zoneId)
-            case None => deletedZoneResults
-          }
-
-          val deletedZonesWithMaxItems = deletedZonesWithStartFrom.take(maxItems + 1)
-
           val (newResults, nextId) =
-            if (deletedZonesWithMaxItems.size > maxItems)
-              (deletedZonesWithMaxItems.dropRight(1), deletedZonesWithMaxItems.lastOption.map(_.zone.id))
-            else (deletedZonesWithMaxItems, None)
+            if (deletedZoneResults.size > maxItems)
+              (deletedZoneResults.dropRight(1), deletedZoneResults.lastOption.map(_.zone.name))
+            else (deletedZoneResults, None)
 
           ListDeletedZonesChangeResults(
             zoneDeleted = newResults,
@@ -257,6 +242,56 @@ class MySqlZoneChangeRepository
           val nextId = if (failedZoneChanges.size < maxItems) 0 else startFrom + maxItems
 
           ListFailedZoneChangesResults(failedZoneChanges,nextId,startFrom,maxItems)
+        }
+      }
+    }
+
+  def countAllAbandonedStats(): IO[(Int, Int, Int)] =
+    monitor("repo.ZoneChange.countAllAbandonedStats") {
+      IO {
+        DB.readOnly { implicit s =>
+          SQL("""
+            |SELECT
+            |  COUNT(DISTINCT zc.zone_name),
+            |  COUNT(DISTINCT CASE WHEN zc.zone_name LIKE '%in-addr.arpa.' OR zc.zone_name LIKE '%ip6.arpa.' THEN zc.zone_name END),
+            |  COUNT(DISTINCT CASE WHEN INSTR(zc.data, X'4801') > 0 THEN zc.zone_name END)
+            |FROM zone_change zc
+            |LEFT JOIN zone z ON zc.zone_name = z.name
+            |WHERE zc.zone_status = 'Deleted'
+            |  AND z.name IS NULL
+          """.stripMargin)
+            .map(rs => (rs.int(1), rs.int(2), rs.int(3)))
+            .single()
+            .apply()
+            .getOrElse((0, 0, 0))
+        }
+      }
+    }
+
+  def countAllAbandonedStatsForUser(authPrincipal: AuthPrincipal): IO[(Int, Int, Int)] =
+    monitor("repo.ZoneChange.countAllAbandonedStatsForUser") {
+      IO {
+        DB.readOnly { implicit s =>
+          val user = authPrincipal.signedInUser
+          val accessors = buildZoneSearchAccessorList(user, authPrincipal.memberGroupIds)
+          val questionMarks = List.fill(accessors.size)("?").mkString(",")
+          SQL(
+            s"""
+              |SELECT
+              |  COUNT(DISTINCT zc.zone_name),
+              |  COUNT(DISTINCT CASE WHEN zc.zone_name LIKE '%in-addr.arpa.' OR zc.zone_name LIKE '%ip6.arpa.' THEN zc.zone_name END),
+              |  COUNT(DISTINCT CASE WHEN INSTR(zc.data, X'4801') > 0 THEN zc.zone_name END)
+              |FROM zone_change zc
+              |JOIN zone_access za ON zc.zone_id = za.zone_id AND za.accessor_id IN ($questionMarks)
+              |LEFT JOIN zone z ON zc.zone_name = z.name
+              |WHERE zc.zone_status = 'Deleted'
+              |  AND z.name IS NULL
+            """.stripMargin)
+            .bind(accessors: _*)
+            .map(rs => (rs.int(1), rs.int(2), rs.int(3)))
+            .single()
+            .apply()
+            .getOrElse((0, 0, 0))
         }
       }
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -192,7 +192,7 @@ class MySqlZoneChangeRepository
           }
 
           startFrom.foreach { cursorName =>
-            sb.append(" AND zc.zone_name > ?")
+            sb.append(" AND zc.zone_name >= ?")
             extraBindParams += cursorName
           }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -271,7 +271,8 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
        maxItems: Int = 100,
        adminGroupIds: Set[String],
        ignoreAccess: Boolean = false,
-       includeReverse: Boolean = true
+       includeReverse: Boolean = true,
+       accessFilter: Option[Int] = None
   ): IO[ListZonesResults] =
     monitor("repo.ZoneJDBC.listZonesByAdminGroupIds") {
       IO {
@@ -297,6 +298,12 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             sb.append(" AND ")
             sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
           }
+
+          accessFilter match {
+            case Some(0) => sb.append(" AND INSTR(z.data, X'4801') > 0")
+            case Some(1) => sb.append(" AND INSTR(z.data, X'4801') = 0")
+            case _       =>
+          }
           
           if(startFrom.isDefined){
             sb.append(" AND ")
@@ -304,6 +311,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           }
 
           sb.append(s" GROUP BY z.name ")
+          sb.append(s" ORDER BY z.name ASC ")
           sb.append(s" LIMIT ${maxItems + 1}")
 
           val query = sb.toString
@@ -348,7 +356,8 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
       startFrom: Option[String] = None,
       maxItems: Int = 100,
       ignoreAccess: Boolean = false,
-      includeReverse: Boolean = true
+      includeReverse: Boolean = true,
+      accessFilter: Option[Int] = None
   ): IO[ListZonesResults] =
     monitor("repo.ZoneJDBC.listZones") {
       IO {
@@ -391,7 +400,18 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             }
           }
 
+          accessFilter match {
+            case Some(0) =>
+              if (filters.nonEmpty || !includeReverse) sb.append(" AND INSTR(z.data, X'4801') > 0")
+              else sb.append(" WHERE INSTR(z.data, X'4801') > 0")
+            case Some(1) =>
+              if (filters.nonEmpty || !includeReverse) sb.append(" AND INSTR(z.data, X'4801') = 0")
+              else sb.append(" WHERE INSTR(z.data, X'4801') = 0")
+            case _ =>
+          }
+
           sb.append(s" GROUP BY z.name ")
+          sb.append(s" ORDER BY z.name ASC ")
           sb.append(s" LIMIT ${maxItems + 1}")
 
           val query = sb.toString
@@ -438,6 +458,68 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
             .map(_.string(1))
             .single
             .apply()
+        }
+      }
+    }
+
+  
+  def countZones(): IO[Int] =
+    monitor("repo.ZoneJDBC.countZones") {
+      IO {
+        DB.readOnly { implicit s =>
+          SQL("SELECT COUNT(*) FROM zone").map(rs => rs.int(1)).single().apply().getOrElse(0)
+        }
+      }
+    }
+
+  def countAllGlobalZoneStats(): IO[(Int, Int, Int, Int, Int, Int)] =
+    monitor("repo.ZoneJDBC.countAllGlobalZoneStats") {
+      IO {
+        DB.readOnly { implicit s =>
+          val (total, shared, ptr, sharedPtr, privatePtr) =
+            SQL("""
+              |SELECT
+              |  COUNT(*),
+              |  COALESCE(SUM(CASE WHEN INSTR(data, X'4801') > 0 THEN 1 ELSE 0 END), 0),
+              |  COALESCE(SUM(CASE WHEN name LIKE '%in-addr.arpa.' OR name LIKE '%ip6.arpa.' THEN 1 ELSE 0 END), 0),
+              |  COALESCE(SUM(CASE WHEN (name LIKE '%in-addr.arpa.' OR name LIKE '%ip6.arpa.') AND INSTR(data, X'4801') > 0 THEN 1 ELSE 0 END), 0),
+              |  COALESCE(SUM(CASE WHEN (name LIKE '%in-addr.arpa.' OR name LIKE '%ip6.arpa.') AND INSTR(data, X'4801') = 0 THEN 1 ELSE 0 END), 0)
+              |FROM zone
+            """.stripMargin)
+              .map(rs => (rs.int(1), rs.int(2), rs.int(3), rs.int(4), rs.int(5)))
+              .single()
+              .apply()
+              .getOrElse((0, 0, 0, 0, 0))
+          val syncing =
+            SQL("SELECT COUNT(DISTINCT zone_id) FROM zone_access WHERE zone_status = 'Syncing'")
+              .map(rs => rs.int(1)).single().apply().getOrElse(0)
+          (total, shared, ptr, sharedPtr, privatePtr, syncing)
+        }
+      }
+    }
+
+  def countAllUserZoneStats(authPrincipal: AuthPrincipal): IO[(Int, Int, Int, Int)] =
+    monitor("repo.ZoneJDBC.countAllUserZoneStats") {
+      IO {
+        DB.readOnly { implicit s =>
+          val user = authPrincipal.signedInUser
+          val accessors = buildZoneSearchAccessorList(user, authPrincipal.memberGroupIds)
+          val questionMarks = List.fill(accessors.size)("?").mkString(",")
+          SQL(
+            s"""
+              |SELECT
+              |  COUNT(DISTINCT z.id),
+              |  COUNT(DISTINCT CASE WHEN INSTR(z.data, X'4801') > 0 THEN z.id END),
+              |  COUNT(DISTINCT CASE WHEN z.name LIKE '%in-addr.arpa.' OR z.name LIKE '%ip6.arpa.' THEN z.id END),
+              |  COUNT(DISTINCT CASE WHEN za.zone_status = 'Syncing' THEN z.id END)
+              |FROM zone z
+              |JOIN zone_access za ON z.id = za.zone_id AND za.accessor_id IN ($questionMarks)
+            """.stripMargin)
+            .bind(accessors: _*)
+            .map(rs => (rs.int(1), rs.int(2), rs.int(3), rs.int(4)))
+            .single()
+            .apply()
+            .getOrElse((0, 0, 0, 0))
         }
       }
     }

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -293,9 +293,27 @@ class VinylDNS @Inject() (
     })
   }
 
+  def getZoneCount(): Action[AnyContent] = userAction.async { implicit request =>
+    val vinyldnsRequest =
+      VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"zones/count")
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+  }
+
   def getValidEmailDomains(): Action[AnyContent] = userAction.async { implicit request =>
     val vinyldnsRequest =
       VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"groups/valid/domains")
+    executeRequest(vinyldnsRequest, request.user).map(response => {
+      Status(response.status)(response.body)
+        .withHeaders(cacheHeaders: _*)
+    })
+  }
+
+  def getGroupCount(): Action[AnyContent] = userAction.async { implicit request =>
+    val vinyldnsRequest =
+      VinylDNSRequest("GET", s"$vinyldnsServiceBackend", s"groups/count")
     executeRequest(vinyldnsRequest, request.user).map(response => {
       Status(response.status)(response.body)
         .withHeaders(cacheHeaders: _*)

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -28,10 +28,11 @@ GET           /api/recordsets                    @controllers.VinylDNS.listRecor
 
 GET           /api/zones                         @controllers.VinylDNS.getZones
 GET           /api/zones/backendids              @controllers.VinylDNS.getBackendIds
+GET           /api/zones/count                   @controllers.VinylDNS.getZoneCount
+GET           /api/zones/deleted/changes         @controllers.VinylDNS.getDeletedZones
+GET           /api/zones/name/:name              @controllers.VinylDNS.getZoneByName(name: String)
 GET           /api/zones/:id                     @controllers.VinylDNS.getZone(id: String)
 GET           /api/zones/:id/details             @controllers.VinylDNS.getCommonZoneDetails(id: String)
-GET           /api/zones/name/:name              @controllers.VinylDNS.getZoneByName(name: String)
-GET           /api/zones/deleted/changes         @controllers.VinylDNS.getDeletedZones
 GET           /api/zones/:id/changes             @controllers.VinylDNS.getZoneChange(id: String)
 POST          /api/zones                         @controllers.VinylDNS.addZone
 PUT           /api/zones/:id                     @controllers.VinylDNS.updateZone(id: String)
@@ -48,6 +49,7 @@ GET           /api/zones/:zid/recordsetcount     @controllers.VinylDNS.getRecord
 GET           /api/recordsetchange/history       @controllers.VinylDNS.listRecordSetChangeHistory
 
 GET           /api/groups                        @controllers.VinylDNS.getGroups
+GET           /api/groups/count                  @controllers.VinylDNS.getGroupCount
 GET           /api/groups/:gid                   @controllers.VinylDNS.getGroup(gid: String)
 GET           /api/groups/valid/domains           @controllers.VinylDNS.getValidEmailDomains
 GET           /api/groups/:gid/groupchanges      @controllers.VinylDNS.listGroupChanges(gid: String)


### PR DESCRIPTION
Fixes #1514.
Jira Ticket: VDNS-347

This PR adds backend support for the new Portal UI Insights cards and enhanced filtering capabilities.

Changes in this pull request:
Count APIs
1. Added Group count API for Insights cards.
2. Added Zone count API for Insights cards.
3. Implemented service, repository, protocol and routing changes required for count retrieval.

List API Enhancements
1. Added new filter parameters to Groups list API.
2. Added new filter parameters to Zones list API.
3. Updated repository queries to support the additional filters.

Tests
1. Added/updated route, service, repository and functional tests.
2. Verified count API responses and filter behavior.
