### PR TITLE
Paginate zone sync database load

### DIFF
--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -63,6 +63,7 @@ vinyldns {
 
   zone-sync-page-size = 5000 # number of records per page when loading zones from the database during sync
 
+
   queue {
     class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
 

--- a/modules/api/src/main/resources/reference.conf
+++ b/modules/api/src/main/resources/reference.conf
@@ -61,6 +61,8 @@ vinyldns {
 
   max-zone-size = 60000 # number of records that can be in a zone
 
+  zone-sync-page-size = 5000 # number of records per page when loading zones from the database during sync
+
   queue {
     class-name = "vinyldns.sqs.queue.SqsMessageQueueProvider"
 

--- a/modules/api/src/main/scala/vinyldns/api/Boot.scala
+++ b/modules/api/src/main/scala/vinyldns/api/Boot.scala
@@ -127,7 +127,8 @@ object Boot extends App {
         repositories.batchChangeRepository,
         notifiers,
         backendResolver,
-        vinyldnsConfig.serverConfig.maxZoneSize
+        vinyldnsConfig.serverConfig.maxZoneSize,
+        vinyldnsConfig.serverConfig.zoneSyncPageSize
       ).start
     } yield {
       val batchAccessValidations = new AccessValidations(

--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -34,6 +34,7 @@ import vinyldns.core.domain.record.{
   RecordSetCacheRepository,
   RecordSetRepository
 }
+import vinyldns.api.domain.zone.VinylDNSZoneViewLoader
 import vinyldns.core.domain.zone._
 import vinyldns.core.queue.{CommandMessage, MessageCount, MessageQueue}
 
@@ -218,7 +219,8 @@ object CommandHandler {
            batchChangeRepo: BatchChangeRepository,
            notifiers: AllNotifiers,
            backendResolver: BackendResolver,
-           maxZoneSize: Int
+           maxZoneSize: Int,
+           zoneSyncPageSize: Int = 5000
   )(implicit timer: Timer[IO]): IO[Unit] = {
     // Handlers for each type of change request
     val zoneChangeHandler =
@@ -233,7 +235,8 @@ object CommandHandler {
         zoneChangeRepo,
         zoneRepo,
         backendResolver,
-        maxZoneSize
+        maxZoneSize,
+        vinyldnsLoader = (z, rs, rsc) => VinylDNSZoneViewLoader(z, rs, rsc, pageSize = zoneSyncPageSize)
       )
     val batchChangeHandler =
       BatchChangeHandler(batchChangeRepo, notifiers)

--- a/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
@@ -36,12 +36,13 @@ final case class ServerConfig(
                                useRecordSetCache: Boolean,
                                loadTestData: Boolean,
                                isZoneSyncScheduleAllowed: Boolean,
+                               zoneSyncPageSize: Int,
                              )
 object ServerConfig {
 
   import ZoneRecordValidations.toCaseIgnoredRegexList
 
-  implicit val configReader: ConfigReader[ServerConfig] = ConfigReader.forProduct13[
+  implicit val configReader: ConfigReader[ServerConfig] = ConfigReader.forProduct14[
     ServerConfig,
     Int,
     Int,
@@ -55,7 +56,8 @@ object ServerConfig {
     Boolean,
     Boolean,
     Boolean,
-    Boolean
+    Boolean,
+    Int
   ](
     "health-check-timeout",
     "default-ttl",
@@ -69,7 +71,8 @@ object ServerConfig {
     "processing-disabled",
     "use-recordset-cache",
     "load-test-data",
-    "is-zone-sync-schedule-allowed"
+    "is-zone-sync-schedule-allowed",
+    "zone-sync-page-size"
   ) {
     case (
       timeout,
@@ -84,7 +87,8 @@ object ServerConfig {
       processingDisabled,
       useRecordSetCache,
       loadTestData,
-      isZoneSyncScheduleAllowed) =>
+      isZoneSyncScheduleAllowed,
+      zoneSyncPageSize) =>
       ServerConfig(
         timeout,
         ttl,
@@ -98,7 +102,8 @@ object ServerConfig {
         processingDisabled,
         useRecordSetCache,
         loadTestData,
-        isZoneSyncScheduleAllowed
+        isZoneSyncScheduleAllowed,
+        zoneSyncPageSize
       )
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
+++ b/modules/api/src/main/scala/vinyldns/api/config/ServerConfig.scala
@@ -18,6 +18,7 @@ package vinyldns.api.config
 
 import com.typesafe.config.Config
 import pureconfig.ConfigReader
+import pureconfig.error.CannotConvert
 import vinyldns.api.domain.zone.ZoneRecordValidations
 
 import scala.util.matching.Regex
@@ -104,6 +105,16 @@ object ServerConfig {
         loadTestData,
         isZoneSyncScheduleAllowed,
         zoneSyncPageSize
+      )
+  }.emap { c =>
+    if (c.zoneSyncPageSize > 0) Right(c)
+    else
+      Left(
+        CannotConvert(
+          c.zoneSyncPageSize.toString,
+          "zone-sync-page-size",
+          "must be a positive integer"
+        )
       )
   }
 }

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneViewLoader.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import org.slf4j.LoggerFactory
 import vinyldns.api.backend.dns.DnsConversions
 import vinyldns.core.domain.backend.Backend
-import vinyldns.core.domain.record.{NameSort, RecordSetCacheRepository, RecordSetRepository, RecordTypeSort}
+import vinyldns.core.domain.record.{NameSort, RecordSet, RecordSetCacheRepository, RecordSetRepository, RecordTypeSort}
 import vinyldns.core.domain.zone.Zone
 import vinyldns.core.route.Monitored
 
@@ -55,28 +55,46 @@ object VinylDNSZoneViewLoader {
 case class VinylDNSZoneViewLoader(
     zone: Zone,
     recordSetRepository: RecordSetRepository,
-    recordSetCacheRepository: RecordSetCacheRepository
+    recordSetCacheRepository: RecordSetCacheRepository,
+    pageSize: Int = 5000
 ) extends ZoneViewLoader
     with Monitored {
   def load: () => IO[ZoneView] =
     () =>
       monitor("vinyldns.loadZoneView") {
-        recordSetRepository
-          .listRecordSets(
-            zoneId = Some(zone.id),
-            startFrom = None,
-            maxItems = None,
-            recordNameFilter = None,
-            recordTypeFilter = None,
-            recordOwnerGroupFilter = None,
-            nameSort = NameSort.ASC,
-            recordTypeSort = RecordTypeSort.ASC
+        loadAllPages(startFrom = None, accumulated = List.empty).map { allRecordSets =>
+          VinylDNSZoneViewLoader.logger.info(
+            s"vinyldns.loadZoneView zoneName=${zone.name}; rsCount=${allRecordSets.size}"
           )
-          .map { result =>
-            VinylDNSZoneViewLoader.logger.info(
-              s"vinyldns.loadZoneView zoneName=${zone.name}; rsCount=${result.recordSets.size}"
-            )
-            ZoneView(zone, result.recordSets)
-          }
+          ZoneView(zone, allRecordSets)
+        }
+      }
+
+  private def loadAllPages(
+      startFrom: Option[String],
+      accumulated: List[RecordSet],
+      pageNumber: Int = 1
+  ): IO[List[RecordSet]] =
+    recordSetRepository
+      .listRecordSets(
+        zoneId = Some(zone.id),
+        startFrom = startFrom,
+        maxItems = Some(pageSize),
+        recordNameFilter = None,
+        recordTypeFilter = None,
+        recordOwnerGroupFilter = None,
+        nameSort = NameSort.ASC,
+        recordTypeSort = RecordTypeSort.ASC
+      )
+      .flatMap { result =>
+        val newAccumulated = accumulated ++ result.recordSets
+        VinylDNSZoneViewLoader.logger.info(
+          s"vinyldns.loadZoneView.page zoneName=${zone.name}; page=$pageNumber; " +
+            s"pageRecords=${result.recordSets.size}; totalSoFar=${newAccumulated.size}"
+        )
+        result.nextId match {
+          case Some(next) => loadAllPages(Some(next), newAccumulated, pageNumber + 1)
+          case None => IO.pure(newAccumulated)
+        }
       }
 }

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -142,30 +142,27 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
               s"zone.sync.changes; zoneName='${zone.name}'; " +
                 s"changeCount=${changesWithUserIds.size}; zoneChange='${zoneChange.id}'"
             )
-            val syncBatchSize = 1000
-            val changeBatches = changesWithUserIds.grouped(syncBatchSize).toList
+            val changeSet = ChangeSet(changesWithUserIds).copy(status = ChangeSetStatus.Applied)
 
-            logger.info(
-              s"zone.sync.batching; zoneName='${zone.name}'; " +
-                s"totalChanges=${changesWithUserIds.size}; batches=${changeBatches.size}; " +
-                s"batchSize=$syncBatchSize; zoneChange='${zoneChange.id}'"
-            )
+            executeWithinTransaction { db: DB =>
+              // we want to make sure we write to both the change repo and record set repo
+              // at the same time as this can take a while
+              val saveRecordChanges = time(s"zone.sync.saveChanges; zoneName='${zone.name}'")(
+                recordChangeRepository.save(db, changeSet)
+              )
+              val saveRecordSets = time(s"zone.sync.saveRecordSets; zoneName='${zone.name}'")(
+                recordSetRepository.apply(db, changeSet)
+              )
+              val saveRecordSetDatas = time(s"zone.sync.saveRecordSetDatas; zoneName='${zone.name}'")(
+                recordSetCacheRepository.save(db,changeSet)
+              )
 
-            changeBatches.zipWithIndex.foldLeft(IO.unit) { case (prevIO, (batch, idx)) =>
-              prevIO.flatMap { _ =>
-                val batchChangeSet = ChangeSet(batch).copy(status = ChangeSetStatus.Applied)
-                time(s"zone.sync.writeBatch; zoneName='${zone.name}'; batch=${idx + 1}/${changeBatches.size}") {
-                  executeWithinTransaction { db: DB =>
-                    for {
-                      _ <- recordChangeRepository.save(db, batchChangeSet)
-                      _ <- recordSetRepository.apply(db, batchChangeSet)
-                      _ <- recordSetCacheRepository.save(db, batchChangeSet)
-                    } yield ()
-                  }
-                }
-              }
-            }.map { _ =>
-              zoneChange.copy(
+              // join together the results of saving both the record changes as well as the record sets
+              for {
+                _ <- saveRecordChanges
+                _ <- saveRecordSets
+                _ <- saveRecordSetDatas
+              } yield zoneChange.copy(
                 zone.copy(status = ZoneStatus.Active, latestSync = Some(Instant.now.truncatedTo(ChronoUnit.MILLIS))),
                 status = ZoneChangeStatus.Synced
               )

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -46,7 +46,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
              backendResolver: BackendResolver,
              maxZoneSize: Int,
              vinyldnsLoader: (Zone, RecordSetRepository, RecordSetCacheRepository) => VinylDNSZoneViewLoader =
-        VinylDNSZoneViewLoader.apply
+        (z, rs, rsc) => VinylDNSZoneViewLoader(z, rs, rsc)
   ): ZoneChange => IO[ZoneChange] =
     zoneChange =>
       for {
@@ -91,7 +91,7 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
                backendResolver: BackendResolver,
                maxZoneSize: Int,
                vinyldnsLoader: (Zone, RecordSetRepository, RecordSetCacheRepository) => VinylDNSZoneViewLoader =
-        VinylDNSZoneViewLoader.apply
+        (z, rs, rsc) => VinylDNSZoneViewLoader(z, rs, rsc)
   ): IO[ZoneChange] =
     monitor("zone.sync") {
       time(s"zone.sync; zoneName='${zoneChange.zone.name}'") {
@@ -142,27 +142,30 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
               s"zone.sync.changes; zoneName='${zone.name}'; " +
                 s"changeCount=${changesWithUserIds.size}; zoneChange='${zoneChange.id}'"
             )
-            val changeSet = ChangeSet(changesWithUserIds).copy(status = ChangeSetStatus.Applied)
+            val syncBatchSize = 1000
+            val changeBatches = changesWithUserIds.grouped(syncBatchSize).toList
 
-            executeWithinTransaction { db: DB =>
-              // we want to make sure we write to both the change repo and record set repo
-              // at the same time as this can take a while
-              val saveRecordChanges = time(s"zone.sync.saveChanges; zoneName='${zone.name}'")(
-                recordChangeRepository.save(db, changeSet)
-              )
-              val saveRecordSets = time(s"zone.sync.saveRecordSets; zoneName='${zone.name}'")(
-                recordSetRepository.apply(db, changeSet)
-              )
-              val saveRecordSetDatas = time(s"zone.sync.saveRecordSetDatas; zoneName='${zone.name}'")(
-                recordSetCacheRepository.save(db,changeSet)
-              )
+            logger.info(
+              s"zone.sync.batching; zoneName='${zone.name}'; " +
+                s"totalChanges=${changesWithUserIds.size}; batches=${changeBatches.size}; " +
+                s"batchSize=$syncBatchSize; zoneChange='${zoneChange.id}'"
+            )
 
-              // join together the results of saving both the record changes as well as the record sets
-              for {
-                _ <- saveRecordChanges
-                _ <- saveRecordSets
-                _ <- saveRecordSetDatas
-              } yield zoneChange.copy(
+            changeBatches.zipWithIndex.foldLeft(IO.unit) { case (prevIO, (batch, idx)) =>
+              prevIO.flatMap { _ =>
+                val batchChangeSet = ChangeSet(batch).copy(status = ChangeSetStatus.Applied)
+                time(s"zone.sync.writeBatch; zoneName='${zone.name}'; batch=${idx + 1}/${changeBatches.size}") {
+                  executeWithinTransaction { db: DB =>
+                    for {
+                      _ <- recordChangeRepository.save(db, batchChangeSet)
+                      _ <- recordSetRepository.apply(db, batchChangeSet)
+                      _ <- recordSetCacheRepository.save(db, batchChangeSet)
+                    } yield ()
+                  }
+                }
+              }
+            }.map { _ =>
+              zoneChange.copy(
                 zone.copy(status = ZoneStatus.Active, latestSync = Some(Instant.now.truncatedTo(ChronoUnit.MILLIS))),
                 status = ZoneChangeStatus.Synced
               )

--- a/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
+++ b/modules/api/src/test/scala/vinyldns/api/VinylDNSTestHelpers.scala
@@ -85,7 +85,7 @@ trait VinylDNSTestHelpers {
     LimitsConfig(100,100,1000,1500,100,100,100)
 
   val testServerConfig: ServerConfig =
-    ServerConfig(100, 100, 100, 100, true, approvedNameServers, "blue", "unset", "vinyldns.", false, true, true, true)
+    ServerConfig(100, 100, 100, 100, true, approvedNameServers, "blue", "unset", "vinyldns.", false, true, true, true, 5000)
 
   val batchChangeConfig: BatchChangeConfig =
     BatchChangeConfig(batchChangeLimit, sharedApprovedTypes, v6DiscoveryNibbleBoundaries)

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
@@ -91,10 +91,9 @@ class ZoneViewLoaderSpec extends AnyWordSpec with Matchers with MockitoSugar wit
   )
 
   "VinylDNSZoneViewLoader" should {
-    "load the DNS Zones" in {
+    "load all records in a single page" in {
       val mockRecordSetRepo = mock[RecordSetRepository]
       val mockRecordSetDataRepo = mock[RecordSetCacheRepository]
-
 
       doReturn(IO(ListRecordSetResults(records, None, None, None, None, None, None, NameSort.ASC, RecordTypeSort.NONE)))
         .when(mockRecordSetRepo)
@@ -116,6 +115,125 @@ class ZoneViewLoaderSpec extends AnyWordSpec with Matchers with MockitoSugar wit
       val actual = underTest.load().unsafeRunSync()
 
       actual shouldBe expected
+    }
+
+    "paginate through multiple pages and accumulate all records" in {
+      val mockRecordSetRepo = mock[RecordSetRepository]
+      val mockRecordSetDataRepo = mock[RecordSetCacheRepository]
+
+      val page1Records = records.take(2)
+      val page2Records = records.drop(2)
+
+      // First call (startFrom = None) returns page 1 with a nextId
+      doReturn(IO(ListRecordSetResults(page1Records, Some("nextCursor1"), None, Some(2), None, None, None, NameSort.ASC, RecordTypeSort.NONE)))
+        .when(mockRecordSetRepo)
+        .listRecordSets(
+          any[Option[String]],
+          org.mockito.Matchers.eq(None: Option[String]),
+          any[Option[Int]],
+          any[Option[String]],
+          any[Option[Set[RecordType]]],
+          any[Option[String]],
+          any[NameSort],
+          any[RecordTypeSort]
+        )
+
+      // Second call (startFrom = Some("nextCursor1")) returns page 2 with no nextId
+      doReturn(IO(ListRecordSetResults(page2Records, None, Some("nextCursor1"), Some(2), None, None, None, NameSort.ASC, RecordTypeSort.NONE)))
+        .when(mockRecordSetRepo)
+        .listRecordSets(
+          any[Option[String]],
+          org.mockito.Matchers.eq(Some("nextCursor1")),
+          any[Option[Int]],
+          any[Option[String]],
+          any[Option[Set[RecordType]]],
+          any[Option[String]],
+          any[NameSort],
+          any[RecordTypeSort]
+        )
+
+      val underTest = VinylDNSZoneViewLoader(testZone, mockRecordSetRepo, mockRecordSetDataRepo, pageSize = 2)
+
+      val expected = ZoneView(testZone, records)
+
+      val actual = underTest.load().unsafeRunSync()
+
+      actual shouldBe expected
+
+      verify(mockRecordSetRepo, times(2)).listRecordSets(
+        any[Option[String]],
+        any[Option[String]],
+        any[Option[Int]],
+        any[Option[String]],
+        any[Option[Set[RecordType]]],
+        any[Option[String]],
+        any[NameSort],
+        any[RecordTypeSort]
+      )
+    }
+
+    "return an empty ZoneView for an empty zone" in {
+      val mockRecordSetRepo = mock[RecordSetRepository]
+      val mockRecordSetDataRepo = mock[RecordSetCacheRepository]
+
+      doReturn(IO(ListRecordSetResults(List.empty, None, None, None, None, None, None, NameSort.ASC, RecordTypeSort.NONE)))
+        .when(mockRecordSetRepo)
+        .listRecordSets(
+          any[Option[String]],
+          any[Option[String]],
+          any[Option[Int]],
+          any[Option[String]],
+          any[Option[Set[RecordType]]],
+          any[Option[String]],
+          any[NameSort],
+          any[RecordTypeSort]
+        )
+
+      val underTest = VinylDNSZoneViewLoader(testZone, mockRecordSetRepo, mockRecordSetDataRepo)
+
+      val actual = underTest.load().unsafeRunSync()
+
+      actual.recordSetsMap shouldBe empty
+    }
+
+    "propagate errors that occur during pagination" in {
+      val mockRecordSetRepo = mock[RecordSetRepository]
+      val mockRecordSetDataRepo = mock[RecordSetCacheRepository]
+
+      val page1Records = records.take(2)
+
+      // First page succeeds
+      doReturn(IO(ListRecordSetResults(page1Records, Some("nextCursor1"), None, Some(2), None, None, None, NameSort.ASC, RecordTypeSort.NONE)))
+        .when(mockRecordSetRepo)
+        .listRecordSets(
+          any[Option[String]],
+          org.mockito.Matchers.eq(None: Option[String]),
+          any[Option[Int]],
+          any[Option[String]],
+          any[Option[Set[RecordType]]],
+          any[Option[String]],
+          any[NameSort],
+          any[RecordTypeSort]
+        )
+
+      // Second page fails
+      doReturn(IO.raiseError(new RuntimeException("database connection lost")))
+        .when(mockRecordSetRepo)
+        .listRecordSets(
+          any[Option[String]],
+          org.mockito.Matchers.eq(Some("nextCursor1")),
+          any[Option[Int]],
+          any[Option[String]],
+          any[Option[Set[RecordType]]],
+          any[Option[String]],
+          any[NameSort],
+          any[RecordTypeSort]
+        )
+
+      val underTest = VinylDNSZoneViewLoader(testZone, mockRecordSetRepo, mockRecordSetDataRepo, pageSize = 2)
+
+      val thrown = the[RuntimeException] thrownBy underTest.load().unsafeRunSync()
+      thrown.getMessage shouldBe "database connection lost"
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -64,7 +64,7 @@ class ZoneSyncHandlerSpec
                        backendResolver: BackendResolver,
                        maxZoneSize: Int,
                        vinyldnsLoader: (Zone, RecordSetRepository,RecordSetCacheRepository) => VinylDNSZoneViewLoader =
-     VinylDNSZoneViewLoader.apply
+     (z, rs, rsc) => VinylDNSZoneViewLoader(z, rs, rsc)
   ): IO[ZoneChange] =
     monitor("zone.sync") {
       time(s"zone.sync; zoneName='${zoneChange.zone.name}'") {


### PR DESCRIPTION
  ## Summary

  - Paginates the VinylDNS database load during zone sync to prevent JDBC                                                                                      
    socket timeouts on large zones (100k+ records).
    Uses the existing cursor-based pagination in `listRecordSets` with a                                                                                       
    configurable page size (default 5000).                                                                                                                     
  - Splits the single write transaction into batches of 1000 changes each,                                                                                     
    reducing lock hold time and deadlock risk during sync.                                                                                                     
  - Adds `zone-sync-page-size` config option and per-page/per-batch logging                                                                                    
    for operational visibility.  