### PR TITLE
Tighten zone authorization checks

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/record/RecordSetService.scala
@@ -27,6 +27,7 @@ import vinyldns.core.domain.zone.{Zone, ZoneCommandResult, ZoneRepository}
 import vinyldns.core.queue.MessageQueue
 import cats.data._
 import cats.effect.IO
+import cats.implicits._
 import org.slf4j.{Logger, LoggerFactory}
 import org.xbill.DNS.ReverseMap
 import vinyldns.api.config.{DottedHostsConfig, HighValueDomainConfig, ZoneAuthConfigs}
@@ -223,13 +224,14 @@ class RecordSetService(
     } yield change
 
   def deleteRecordSet(
-                       recordSetId: String,
-                       zoneId: String,
-                       auth: AuthPrincipal
-                     ): Result[ZoneCommandResult] =
+                        recordSetId: String,
+                        zoneId: String,
+                        auth: AuthPrincipal
+                      ): Result[ZoneCommandResult] =
     for {
-      zone <- getZone(zoneId)
       existing <- getRecordSet(recordSetId)
+      _ <- recordSetBelongsToZone(existing, zoneId).toResult
+      zone <- getZone(zoneId)
       _ <- isNotHighValueDomain(existing, zone, highValueDomainConfig).toResult
       _ <- canDeleteRecordSet(auth, existing.name, existing.typ, zone, existing.ownerGroupId).toResult
       _ <- notPending(existing).toResult
@@ -558,7 +560,8 @@ class RecordSetService(
           recordTypeFilter,
           recordOwnerGroupFilter,
           nameSort,
-          recordTypeSort
+          recordTypeSort,
+          Some(authPrincipal)
         )
         .toResult[ListRecordSetResults]
       rsOwnerGroupIds = recordSetResults.recordSets.flatMap(_.ownerGroupId).toSet
@@ -611,7 +614,8 @@ class RecordSetService(
           Some(formattedRecordNameFilter),
           recordTypeFilter,
           recordOwnerGroupFilter,
-          nameSort
+          nameSort,
+          Some(authPrincipal)
         ).toResult[ListRecordSetResults]
       } else {
         // Search the record table directly
@@ -623,7 +627,8 @@ class RecordSetService(
           recordTypeFilter,
           recordOwnerGroupFilter,
           nameSort,
-          recordTypeSort
+          recordTypeSort,
+          Some(authPrincipal)
         ).toResult[ListRecordSetResults]
       }
       rsOwnerGroupIds = recordSetResults.recordSets.flatMap(_.ownerGroupId).toSet
@@ -666,7 +671,8 @@ class RecordSetService(
           recordTypeFilter,
           recordOwnerGroupFilter,
           nameSort,
-          recordTypeSort
+          recordTypeSort,
+          None
         )
         .toResult[ListRecordSetResults]
       rsOwnerGroupIds = recordSetResults.recordSets.flatMap(_.ownerGroupId).toSet
@@ -742,16 +748,24 @@ class RecordSetService(
     } yield ListRecordSetHistoryResponse(zoneId, recordSetChangesResults, recordSetChangesInfo)
 
   def listFailedRecordSetChanges(
-                                  authPrincipal: AuthPrincipal,
-                                  zoneId: Option[String] = None,
-                                  startFrom: Int= 0,
-                                  maxItems: Int = 100
-                                ): Result[ListFailedRecordSetChangesResponse] =
+                                   authPrincipal: AuthPrincipal,
+                                   zoneId: Option[String] = None,
+                                   startFrom: Int= 0,
+                                   maxItems: Int = 100
+                                 ): Result[ListFailedRecordSetChangesResponse] =
     for {
+      _ <- zoneId match {
+        case Some(id) =>
+          for {
+            zone <- getZone(id)
+            _ <- canSeeZone(authPrincipal, zone).toResult
+          } yield ()
+        case None => ().toResult
+      }
       recordSetChangesFailedResults <- recordChangeRepository
         .listFailedRecordSetChanges(zoneId, maxItems, startFrom)
         .toResult[ListFailedRecordSetChangesResults]
-      _ <- zoneAccess(recordSetChangesFailedResults.items, authPrincipal).toResult
+      _ <- zoneAccess(recordSetChangesFailedResults.items, authPrincipal)
     } yield
       ListFailedRecordSetChangesResponse(
         recordSetChangesFailedResults.items,
@@ -762,10 +776,8 @@ class RecordSetService(
   def zoneAccess(
                   RecordSetCh: List[RecordSetChange],
                   auth: AuthPrincipal
-                ): List[Result[Unit]] =
-    RecordSetCh.map { zn =>
-      canSeeZone(auth, zn.zone).toResult
-    }
+                ): Result[Unit] =
+    RecordSetCh.traverse_(zn => canSeeZone(auth, zn.zone).toResult)
 
   def getZone(zoneId: String): Result[Zone] =
     zoneRepository
@@ -848,6 +860,11 @@ class RecordSetService(
     } yield group
     ownerGroup.value.toResult
   }
+
+  private def recordSetBelongsToZone(recordSet: RecordSet, zoneId: String): Either[Throwable, Unit] =
+    ensuring(
+      RecordSetNotFoundError(s"RecordSet with id ${recordSet.id} does not exist in zone $zoneId.")
+    )(recordSet.zoneId == zoneId)
 
   def recordSetDoesNotExist(
                              backendConnection: Zone => Backend,

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -162,6 +162,7 @@ class ZoneService(
   def getZoneByName(zoneName: String, auth: AuthPrincipal): Result[ZoneInfo] =
     for {
       zone <- getZoneByNameOrFail(ensureTrailingDot(zoneName))
+      _ <- canSeeZone(auth, zone).toResult
       aclInfo <- getZoneAclDisplay(zone.acl)
       groupName <- getGroupName(zone.adminGroupId)
       accessLevel = getZoneAccess(auth, zone)
@@ -315,7 +316,7 @@ class ZoneService(
       zoneChangesFailedResults <- zoneChangeRepository
         .listFailedZoneChanges(maxItems, startFrom)
         .toResult[ListFailedZoneChangesResults]
-      _ <- zoneAccess(zoneChangesFailedResults.items, authPrincipal).toResult
+      _ <- zoneAccess(zoneChangesFailedResults.items, authPrincipal)
     } yield
       ListFailedZoneChangesResponse(
         zoneChangesFailedResults.items,
@@ -325,12 +326,10 @@ class ZoneService(
       )
 
   def zoneAccess(
-                  zoneCh: List[ZoneChange],
-                  auth: AuthPrincipal
-                ): List[Result[Unit]] =
-    zoneCh.map { zn =>
-      canSeeZone(auth, zn.zone).toResult
-    }
+                   zoneCh: List[ZoneChange],
+                   auth: AuthPrincipal
+                 ): Result[Unit] =
+    zoneCh.traverse_(zn => canSeeZone(auth, zn.zone).toResult)
 
   def addACLRule(
       zoneId: String,

--- a/modules/api/src/test/functional/tests/zones/get_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/get_zone_test.py
@@ -168,17 +168,13 @@ def test_get_zone_by_name_shared_zone_succeeds(shared_zone_test_context):
     assert_that(result["accessLevel"], is_("Delete"))
 
 
-def test_get_zone_by_name_succeeds_without_access(shared_zone_test_context):
+def test_get_zone_by_name_fails_without_access(shared_zone_test_context):
     """
     Test get an existing zone by name without access
     """
     client = shared_zone_test_context.dummy_vinyldns_client
 
-    result = client.get_zone_by_name(shared_zone_test_context.system_test_zone["name"], status=200)["zone"]
-    assert_that(result["id"], is_(shared_zone_test_context.system_test_zone["id"]))
-    assert_that(result["name"], is_(shared_zone_test_context.system_test_zone["name"]))
-    assert_that(result["adminGroupName"], is_(shared_zone_test_context.ok_group["name"]))
-    assert_that(result["accessLevel"], is_("NoAccess"))
+    client.get_zone_by_name(shared_zone_test_context.system_test_zone["name"], status=403)
 
 
 def test_get_zone_by_name_returns_404_when_not_found(shared_zone_test_context):

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -1520,9 +1520,25 @@ class RecordSetServiceSpec
       doReturn(IO.pure(Some(aaaa)))
         .when(mockRecordRepo)
         .getRecordSet(aaaa.id)
+      doReturn(IO.pure(Some(aaaa.copy(zoneId = zoneNotAuthorized.id))))
+        .when(mockRecordRepo)
+        .getRecordSet(aaaa.id)
       val result =
         underTest.deleteRecordSet(aaaa.id, zoneNotAuthorized.id, okAuth).value.unsafeRunSync().swap.toOption.get
       result shouldBe a[NotAuthorizedError]
+    }
+    "fail if the requested zone does not match the record zone" in {
+      val record = aaaa.copy(status = RecordSetStatus.Active, zoneId = okZone.id)
+      doReturn(IO.pure(Some(record)))
+        .when(mockRecordRepo)
+        .getRecordSet(record.id)
+
+      val result =
+        underTest.deleteRecordSet(record.id, zoneNotAuthorized.id, okAuth).value.unsafeRunSync().swap.toOption.get
+
+      result shouldBe RecordSetNotFoundError(
+        s"RecordSet with id ${record.id} does not exist in zone ${zoneNotAuthorized.id}."
+      )
     }
     "fail if the record is a high value domain" in {
       val record =
@@ -1792,7 +1808,8 @@ class RecordSetServiceSpec
           recordTypeFilter = any[Option[Set[RecordType.RecordType]]],
           recordOwnerGroupFilter = any[Option[String]],
           nameSort = any[NameSort.NameSort],
-          recordTypeSort = any[RecordTypeSort.RecordTypeSort]
+          recordTypeSort = any[RecordTypeSort.RecordTypeSort],
+          authPrincipal = any[Option[AuthPrincipal]]
         )
 
       val result: ListGlobalRecordSetsResponse =
@@ -1867,7 +1884,8 @@ class RecordSetServiceSpec
           recordNameFilter = any[Option[String]],
           recordTypeFilter = any[Option[Set[RecordType.RecordType]]],
           recordOwnerGroupFilter = any[Option[String]],
-          nameSort = any[NameSort.NameSort]
+          nameSort = any[NameSort.NameSort],
+          authPrincipal = any[Option[AuthPrincipal]]
         )
 
       val result =
@@ -1912,6 +1930,60 @@ class RecordSetServiceSpec
 
       result shouldBe an[InvalidRequest]
     }
+
+    "exclude recordsets in zones the caller cannot access" in {
+      doReturn(IO.pure(Set(okGroup)))
+        .when(mockGroupRepo)
+        .getGroups(any[Set[String]])
+
+      doReturn(IO.pure(Set(sharedZone)))
+        .when(mockZoneRepo)
+        .getZones(Set(sharedZone.id))
+
+      doReturn(
+        IO.pure(
+          ListRecordSetResults(
+            List(sharedZoneRecord),
+            recordNameFilter = Some("aaaa*"),
+            nameSort = NameSort.ASC,
+            recordTypeSort = RecordTypeSort.NONE
+          )
+        )
+      ).when(mockRecordDataRepo)
+        .listRecordSetData(
+          zoneId = any[Option[String]],
+          startFrom = any[Option[String]],
+          maxItems = any[Option[Int]],
+          recordNameFilter = any[Option[String]],
+          recordTypeFilter = any[Option[Set[RecordType.RecordType]]],
+          recordOwnerGroupFilter = any[Option[String]],
+          nameSort = any[NameSort.NameSort],
+          authPrincipal = any[Option[AuthPrincipal]]
+        )
+
+      val result =
+        underTest
+          .searchRecordSets(
+            startFrom = None,
+            maxItems = None,
+            recordNameFilter = "aaaa*",
+            recordTypeFilter = None,
+            recordOwnerGroupFilter = None,
+            nameSort = NameSort.ASC,
+            authPrincipal = okAuth,
+            recordTypeSort = RecordTypeSort.ASC
+          )
+          .value.unsafeRunSync().toOption.get
+
+      result.recordSets shouldBe List(
+        RecordSetGlobalInfo(
+          sharedZoneRecord,
+          sharedZone.name,
+          sharedZone.shared,
+          Some(okGroup.name)
+        )
+      )
+    }
   }
 
 
@@ -1938,7 +2010,8 @@ class RecordSetServiceSpec
           recordTypeFilter = None,
           recordOwnerGroupFilter = None,
           nameSort = NameSort.ASC,
-          recordTypeSort = RecordTypeSort.ASC
+          recordTypeSort = RecordTypeSort.ASC,
+          authPrincipal = None
         )
 
       val result: ListRecordSetsByZoneResponse =
@@ -1983,7 +2056,8 @@ class RecordSetServiceSpec
           recordTypeFilter = None,
           recordOwnerGroupFilter = None,
           nameSort = NameSort.ASC,
-          recordTypeSort = RecordTypeSort.ASC
+          recordTypeSort = RecordTypeSort.ASC,
+          authPrincipal = None
         )
 
       val result: ListRecordSetsByZoneResponse =
@@ -2153,6 +2227,15 @@ class RecordSetServiceSpec
             maxItems = 3)
 
         result shouldBe changesWithName
+      }
+
+      "return NotAuthorizedError when the caller cannot access the requested zone" in {
+        val error =
+          underTest
+            .listFailedRecordSetChanges(authPrincipal = okAuth, Some(zoneNotAuthorized.id))
+            .value.unsafeRunSync().swap.toOption.get
+
+        error shouldBe a[NotAuthorizedError]
       }
     }
 
@@ -3213,4 +3296,3 @@ class RecordSetServiceSpec
     }
   }
 }
-

--- a/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/record/RecordSetServiceSpec.scala
@@ -2229,6 +2229,32 @@ class RecordSetServiceSpec
         result shouldBe changesWithName
       }
 
+      "retrieve the recordset changes when zoneId is not provided" in {
+        val completeRecordSetChanges: List[RecordSetChange] = List(
+          pendingCreateAAAA.copy(status = RecordSetChangeStatus.Failed),
+          pendingCreateCNAME.copy(status = RecordSetChangeStatus.Failed)
+        )
+
+        doReturn(IO.pure(ListFailedRecordSetChangesResults(completeRecordSetChanges)))
+          .when(mockRecordChangeRepo)
+          .listFailedRecordSetChanges(None, 100, 0)
+
+        val result: ListFailedRecordSetChangesResponse =
+          underTest
+            .listFailedRecordSetChanges(authPrincipal = okAuth)
+            .value
+            .unsafeRunSync()
+            .toOption
+            .get
+
+        result shouldBe ListFailedRecordSetChangesResponse(
+          completeRecordSetChanges,
+          nextId = 0,
+          startFrom = 0,
+          maxItems = 100
+        )
+      }
+
       "return NotAuthorizedError when the caller cannot access the requested zone" in {
         val error =
           underTest

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -799,6 +799,13 @@ class ZoneServiceSpec
       val result = underTest.getZoneByName("abc.zone.recordsets", abcAuth).value.unsafeRunSync()
       result.right.value shouldBe expectedZoneInfo
     }
+
+    "return NotAuthorizedError when the caller cannot access the zone by name" in {
+      doReturn(IO.pure(Some(zoneNotAuthorized))).when(mockZoneRepo).getZoneByName(zoneNotAuthorized.name)
+
+      val error = underTest.getZoneByName(zoneNotAuthorized.name, okAuth).value.unsafeRunSync().swap.toOption.get
+      error shouldBe a[NotAuthorizedError]
+    }
   }
 
   "Getting a zone details" should {
@@ -1363,6 +1370,17 @@ class ZoneServiceSpec
       result.startFrom shouldBe 1
       result.nextId shouldBe 0
       result.maxItems shouldBe 1
+    }
+
+    "return NotAuthorizedError when failed changes include an inaccessible zone" in {
+      doReturn(IO.pure(ListFailedZoneChangesResults(
+        List(zoneCreate.copy(zone = zoneNotAuthorized, status = ZoneChangeStatus.Failed))
+      )))
+        .when(mockZoneChangeRepo)
+        .listFailedZoneChanges(100,0)
+
+      val error = underTest.listFailedZoneChanges(okAuth).value.unsafeRunSync().swap.toOption.get
+      error shouldBe a[NotAuthorizedError]
     }
   }
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneViewLoaderSpec.scala
@@ -106,7 +106,8 @@ class ZoneViewLoaderSpec extends AnyWordSpec with Matchers with MockitoSugar wit
           any[Option[Set[RecordType]]],
           any[Option[String]],
           any[NameSort],
-          any[RecordTypeSort]
+          any[RecordTypeSort],
+          any[Option[vinyldns.core.domain.auth.AuthPrincipal]]
         )
 
       val underTest = VinylDNSZoneViewLoader(testZone, mockRecordSetRepo, mockRecordSetDataRepo)

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -323,6 +323,7 @@ class ZoneSyncHandlerSpec
         any[Option[String]],
         any[NameSort],
         any[RecordTypeSort],
+        any[Option[vinyldns.core.domain.auth.AuthPrincipal]],
       )
 
     doReturn(IO(testChangeSet)).when(recordSetRepo).apply(any[DB], any[ChangeSet])

--- a/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/EmptyRepositories.scala
@@ -37,15 +37,16 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
   def apply(db: DB, changeSet: ChangeSet): IO[ChangeSet] = IO.pure(changeSet)
 
   def listRecordSets(
-                      zoneId: Option[String],
-                      startFrom: Option[String],
-                      maxItems: Option[Int],
-                      recordNameFilter: Option[String],
-                      recordTypeFilter: Option[Set[RecordType]],
-                      recordOwnerGroupFilter: Option[String],
-                      nameSort: NameSort,
-                      recordTypeSort: RecordTypeSort
-                    ): IO[ListRecordSetResults] =
+                       zoneId: Option[String],
+                       startFrom: Option[String],
+                       maxItems: Option[Int],
+                       recordNameFilter: Option[String],
+                       recordTypeFilter: Option[Set[RecordType]],
+                       recordOwnerGroupFilter: Option[String],
+                       nameSort: NameSort,
+                       recordTypeSort: RecordTypeSort,
+                       authPrincipal: Option[AuthPrincipal] = None
+                     ): IO[ListRecordSetResults] =
     IO.pure(ListRecordSetResults(nameSort = nameSort,recordTypeSort=recordTypeSort))
 
 
@@ -67,14 +68,15 @@ trait EmptyRecordSetRepo extends RecordSetRepository {
 trait EmptyRecordSetCacheRepo extends RecordSetCacheRepository {
 
   def listRecordSetData(
-                         zoneId: Option[String],
-                         startFrom: Option[String],
-                         maxItems: Option[Int],
-                         recordNameFilter: Option[String],
-                         recordTypeFilter: Option[Set[RecordType]],
-                         recordOwnerGroupFilter: Option[String],
-                         nameSort: NameSort
-                       ): IO[ListRecordSetResults] =
+                          zoneId: Option[String],
+                          startFrom: Option[String],
+                          maxItems: Option[Int],
+                          recordNameFilter: Option[String],
+                          recordTypeFilter: Option[Set[RecordType]],
+                          recordOwnerGroupFilter: Option[String],
+                          nameSort: NameSort,
+                          authPrincipal: Option[AuthPrincipal] = None
+                        ): IO[ListRecordSetResults] =
     IO.pure(ListRecordSetResults(nameSort = nameSort, recordTypeSort = RecordTypeSort.NONE))
 }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetCacheRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetCacheRepository.scala
@@ -18,6 +18,7 @@ package vinyldns.core.domain.record
 
 import cats.effect._
 import scalikejdbc.DB
+import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.repository.Repository
@@ -31,12 +32,13 @@ trait RecordSetCacheRepository extends Repository {
   def listRecordSetData(
                          zoneId: Option[String],
                          startFrom: Option[String],
-                         maxItems: Option[Int],
-                         recordNameFilter: Option[String],
-                         recordTypeFilter: Option[Set[RecordType]],
-                         recordOwnerGroupFilter: Option[String],
-                         nameSort: NameSort
-                       ): IO[ListRecordSetResults]
+                          maxItems: Option[Int],
+                          recordNameFilter: Option[String],
+                          recordTypeFilter: Option[Set[RecordType]],
+                          recordOwnerGroupFilter: Option[String],
+                          nameSort: NameSort,
+                          authPrincipal: Option[AuthPrincipal] = None
+                        ): IO[ListRecordSetResults]
 
   /**
    * Saves the recordset data to the database

--- a/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/record/RecordSetRepository.scala
@@ -18,6 +18,7 @@ package vinyldns.core.domain.record
 
 import cats.effect._
 import scalikejdbc.DB
+import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record.RecordType.RecordType
 import vinyldns.core.domain.record.RecordTypeSort.RecordTypeSort
@@ -35,7 +36,8 @@ trait RecordSetRepository extends Repository {
       recordTypeFilter: Option[Set[RecordType]],
       recordOwnerGroupFilter: Option[String],
       nameSort: NameSort,
-      recordTypeSort: RecordTypeSort
+      recordTypeSort: RecordTypeSort,
+      authPrincipal: Option[AuthPrincipal] = None
   ): IO[ListRecordSetResults]
 
   def getRecordSets(zoneId: String, name: String, typ: RecordType): IO[List[RecordSet]]

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -524,8 +524,11 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
         id = UUID.randomUUID().toString
       )
 
+      val allAccessChange = makeTestAddChange(allAccessRecord, allAccessZone)
+      val noAccessChange = makeTestAddChange(noAccessRecord, noAccessZone)
+
       saveZones(Seq(allAccessZone, noAccessZone))
-      insert(List(makeTestAddChange(allAccessRecord, allAccessZone), makeTestAddChange(noAccessRecord, noAccessZone)))
+      insert(List(allAccessChange, noAccessChange))
 
       val found = recordSetCacheRepo
         .listRecordSetData(
@@ -540,7 +543,7 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
         )
         .unsafeRunSync()
 
-      found.recordSets should contain theSameElementsAs List(recordSetDataWithFQDN(allAccessRecord, allAccessZone))
+      found.recordSets should contain theSameElementsAs List(recordSetDataWithFQDN(allAccessChange.recordSet, allAccessZone))
     }
     "return no recordsets when no zoneId or recordNameFilter are given" in {
       val found =

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -22,9 +22,11 @@ import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc.DB
+import vinyldns.core.TestMembershipData.{okGroup, okUser}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType._
-import vinyldns.core.domain.zone.Zone
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.zone.{Zone, ZoneACL}
 import vinyldns.mysql.TestMySqlInstance
 import vinyldns.mysql.repository.MySqlRecordSetRepository.PagingKey
 import vinyldns.mysql.TransactionProvider
@@ -44,6 +46,8 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
 
   private val recordSetRepo = TestMySqlInstance.recordSetRepository.asInstanceOf[MySqlRecordSetRepository]
 
+  private val zoneRepo = TestMySqlInstance.zoneRepository
+
   override protected def beforeEach(): Unit = clear()
 
   override protected def afterAll(): Unit = clear()
@@ -52,6 +56,7 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
     DB.localTx { s =>
       s.executeUpdate("DELETE FROM recordset_data")
       s.executeUpdate("DELETE FROM recordset")
+      s.executeUpdate("DELETE FROM zone")
     }
 
   def generateInserts(zone: Zone, count: Int, word: String = "insert"): List[RecordSetChange] = {
@@ -90,6 +95,9 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
 
   def recordSetDataWithFQDN(recordSet: RecordSet, zone: Zone): RecordSet =
     recordSet.copy(fqdn = Some(s"""${recordSet.name}.${zone.name}"""))
+
+  def saveZones(zones: Seq[Zone]): Unit =
+    zones.foreach(zone => zoneRepo.save(zone).unsafeRunSync())
 
   "apply" should {
     "properly revert changes that fail processing" in {
@@ -447,6 +455,42 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       found.recordSets should contain theSameElementsAs existing
         .map(r => recordSetDataWithFQDN(r, okZone))
         .reverse
+    }
+    "omit recordsets from groups if the user has more than 30 groups when doing a global search" in {
+      val groups = (1 to 40).map { num =>
+        okGroup.copy(name = "%02d".format(num), id = UUID.randomUUID().toString)
+      }
+
+      val zones = groups.map { group =>
+        okZone.copy(
+          name = s"${group.name}.",
+          id = UUID.randomUUID().toString,
+          adminGroupId = group.id,
+          acl = ZoneACL()
+        )
+      }
+
+      val changes = zones.map { zone =>
+        makeTestAddChange(
+          aaaa.copy(
+            zoneId = zone.id,
+            name = s"${zone.name.dropRight(1)}-record",
+            id = UUID.randomUUID().toString
+          ),
+          zone
+        )
+      }
+
+      saveZones(zones)
+      insert(changes.toList)
+
+      val auth = AuthPrincipal(okUser, groups.map(_.id))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(None, None, None, Some("*"), None, None, NameSort.ASC, Some(auth))
+        .unsafeRunSync()
+
+      found.recordSets.map(_.zoneId) should contain theSameElementsAs zones.take(29).map(_.id)
     }
     "return no recordsets when no zoneId or recordNameFilter are given" in {
       val found =

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -26,7 +26,7 @@ import vinyldns.core.TestMembershipData.{okGroup, okUser}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.zone.{Zone, ZoneACL}
+import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone, ZoneACL}
 import vinyldns.mysql.TestMySqlInstance
 import vinyldns.mysql.repository.MySqlRecordSetRepository.PagingKey
 import vinyldns.mysql.TransactionProvider
@@ -491,6 +491,56 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
         .unsafeRunSync()
 
       found.recordSets.map(_.zoneId) should contain theSameElementsAs zones.take(29).map(_.id)
+    }
+    "return recordsets from zones shared with everyone when doing a global search" in {
+      val allAccessZone = okZone.copy(
+        name = "all-access-recordsets.",
+        id = UUID.randomUUID().toString,
+        acl = ZoneACL(
+          rules = Set(
+            ACLRule(
+              accessLevel = AccessLevel.Read,
+              userId = None,
+              groupId = None
+            )
+          )
+        )
+      )
+      val noAccessZone = abcZone.copy(
+        name = "no-access-recordsets.",
+        id = UUID.randomUUID().toString,
+        adminGroupId = okGroup.id,
+        acl = ZoneACL()
+      )
+
+      val allAccessRecord = aaaa.copy(
+        zoneId = allAccessZone.id,
+        name = "all-access-record",
+        id = UUID.randomUUID().toString
+      )
+      val noAccessRecord = aaaa.copy(
+        zoneId = noAccessZone.id,
+        name = "no-access-record",
+        id = UUID.randomUUID().toString
+      )
+
+      saveZones(Seq(allAccessZone, noAccessZone))
+      insert(List(makeTestAddChange(allAccessRecord, allAccessZone), makeTestAddChange(noAccessRecord, noAccessZone)))
+
+      val found = recordSetCacheRepo
+        .listRecordSetData(
+          None,
+          None,
+          None,
+          Some("*access-record*"),
+          None,
+          None,
+          NameSort.ASC,
+          Some(AuthPrincipal(okUser, Seq.empty))
+        )
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(recordSetDataWithFQDN(allAccessRecord, allAccessZone))
     }
     "return no recordsets when no zoneId or recordNameFilter are given" in {
       val found =

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -725,8 +725,11 @@ class MySqlRecordSetRepositoryIntegrationSpec
         id = UUID.randomUUID().toString
       )
 
+      val allAccessChange = makeTestAddChange(allAccessRecord, allAccessZone)
+      val noAccessChange = makeTestAddChange(noAccessRecord, noAccessZone)
+
       saveZones(Seq(allAccessZone, noAccessZone))
-      insert(List(makeTestAddChange(allAccessRecord, allAccessZone), makeTestAddChange(noAccessRecord, noAccessZone)))
+      insert(List(allAccessChange, noAccessChange))
 
       val found = repo
         .listRecordSets(
@@ -742,7 +745,7 @@ class MySqlRecordSetRepositoryIntegrationSpec
         )
         .unsafeRunSync()
 
-      found.recordSets should contain theSameElementsAs List(recordSetWithFQDN(allAccessRecord, allAccessZone))
+      found.recordSets should contain theSameElementsAs List(recordSetWithFQDN(allAccessChange.recordSet, allAccessZone))
     }
     "return no recordsets when no zoneId or recordNameFilter are given" in {
       val found =

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -22,9 +22,11 @@ import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import scalikejdbc.DB
+import vinyldns.core.TestMembershipData.{okGroup, okUser}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType._
-import vinyldns.core.domain.zone.Zone
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.zone.{Zone, ZoneACL}
 import vinyldns.mysql.TestMySqlInstance
 import vinyldns.mysql.repository.MySqlRecordSetRepository.PagingKey
 import vinyldns.mysql.TransactionProvider
@@ -41,6 +43,7 @@ class MySqlRecordSetRepositoryIntegrationSpec
   import vinyldns.core.TestRecordSetData._
   import vinyldns.core.TestZoneData._
   private val repo = TestMySqlInstance.recordSetRepository.asInstanceOf[MySqlRecordSetRepository]
+  private val zoneRepo = TestMySqlInstance.zoneRepository
 
   override protected def beforeEach(): Unit = clear()
 
@@ -49,6 +52,7 @@ class MySqlRecordSetRepositoryIntegrationSpec
   def clear(): Unit =
     DB.localTx { s =>
       s.executeUpdate("DELETE FROM recordset")
+      s.executeUpdate("DELETE FROM zone")
     }
 
   def generateInserts(zone: Zone, count: Int, word: String = "insert"): List[RecordSetChange] = {
@@ -83,6 +87,9 @@ class MySqlRecordSetRepositoryIntegrationSpec
 
   def recordSetWithFQDN(recordSet: RecordSet, zone: Zone): RecordSet =
     recordSet.copy(fqdn = Some(s"""${recordSet.name}.${zone.name}"""))
+
+  def saveZones(zones: Seq[Zone]): Unit =
+    zones.foreach(zone => zoneRepo.save(zone).unsafeRunSync())
 
   "apply" should {
     "properly revert changes that fail processing" in {
@@ -649,6 +656,42 @@ class MySqlRecordSetRepositoryIntegrationSpec
       found.recordSets should contain theSameElementsAs existing
         .map(r => recordSetWithFQDN(r, okZone))
         .reverse
+    }
+    "omit recordsets from groups if the user has more than 30 groups when doing a global search" in {
+      val groups = (1 to 40).map { num =>
+        okGroup.copy(name = "%02d".format(num), id = UUID.randomUUID().toString)
+      }
+
+      val zones = groups.map { group =>
+        okZone.copy(
+          name = s"${group.name}.",
+          id = UUID.randomUUID().toString,
+          adminGroupId = group.id,
+          acl = ZoneACL()
+        )
+      }
+
+      val changes = zones.map { zone =>
+        makeTestAddChange(
+          aaaa.copy(
+            zoneId = zone.id,
+            name = s"${zone.name.dropRight(1)}-record",
+            id = UUID.randomUUID().toString
+          ),
+          zone
+        )
+      }
+
+      saveZones(zones)
+      insert(changes.toList)
+
+      val auth = AuthPrincipal(okUser, groups.map(_.id))
+
+      val found = repo
+        .listRecordSets(None, None, None, Some("*"), None, None, NameSort.ASC, RecordTypeSort.ASC, Some(auth))
+        .unsafeRunSync()
+
+      found.recordSets.map(_.zoneId) should contain theSameElementsAs zones.take(29).map(_.id)
     }
     "return no recordsets when no zoneId or recordNameFilter are given" in {
       val found =

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetRepositoryIntegrationSpec.scala
@@ -26,7 +26,7 @@ import vinyldns.core.TestMembershipData.{okGroup, okUser}
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.zone.{Zone, ZoneACL}
+import vinyldns.core.domain.zone.{ACLRule, AccessLevel, Zone, ZoneACL}
 import vinyldns.mysql.TestMySqlInstance
 import vinyldns.mysql.repository.MySqlRecordSetRepository.PagingKey
 import vinyldns.mysql.TransactionProvider
@@ -692,6 +692,57 @@ class MySqlRecordSetRepositoryIntegrationSpec
         .unsafeRunSync()
 
       found.recordSets.map(_.zoneId) should contain theSameElementsAs zones.take(29).map(_.id)
+    }
+    "return recordsets from zones shared with everyone when doing a global search" in {
+      val allAccessZone = okZone.copy(
+        name = "all-access-recordsets.",
+        id = UUID.randomUUID().toString,
+        acl = ZoneACL(
+          rules = Set(
+            ACLRule(
+              accessLevel = AccessLevel.Read,
+              userId = None,
+              groupId = None
+            )
+          )
+        )
+      )
+      val noAccessZone = abcZone.copy(
+        name = "no-access-recordsets.",
+        id = UUID.randomUUID().toString,
+        adminGroupId = okGroup.id,
+        acl = ZoneACL()
+      )
+
+      val allAccessRecord = aaaa.copy(
+        zoneId = allAccessZone.id,
+        name = "all-access-record",
+        id = UUID.randomUUID().toString
+      )
+      val noAccessRecord = aaaa.copy(
+        zoneId = noAccessZone.id,
+        name = "no-access-record",
+        id = UUID.randomUUID().toString
+      )
+
+      saveZones(Seq(allAccessZone, noAccessZone))
+      insert(List(makeTestAddChange(allAccessRecord, allAccessZone), makeTestAddChange(noAccessRecord, noAccessZone)))
+
+      val found = repo
+        .listRecordSets(
+          None,
+          None,
+          None,
+          Some("*access-record*"),
+          None,
+          None,
+          NameSort.ASC,
+          RecordTypeSort.ASC,
+          Some(AuthPrincipal(okUser, Seq.empty))
+        )
+        .unsafeRunSync()
+
+      found.recordSets should contain theSameElementsAs List(recordSetWithFQDN(allAccessRecord, allAccessZone))
     }
     "return no recordsets when no zoneId or recordNameFilter are given" in {
       val found =

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlAccessors.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlAccessors.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.mysql.repository
+
+import org.slf4j.Logger
+import vinyldns.core.domain.membership.User
+
+private[repository] object MySqlAccessors {
+  private final val MAX_ACCESSORS = 30
+  private final val EVERYONE_ACCESSOR = "EVERYONE"
+
+  def buildZoneSearchAccessorList(user: User, groupIds: Seq[String], logger: Logger): Seq[String] = {
+    val allAccessors = user.id +: groupIds
+
+    if (allAccessors.length > MAX_ACCESSORS) {
+      logger.warn(
+        s"User ${user.userName} with id ${user.id} has more than $MAX_ACCESSORS user/group memberships; some accessible zones may not be returned"
+      )
+    }
+
+    allAccessors.take(MAX_ACCESSORS) :+ EVERYONE_ACCESSOR
+  }
+}

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -19,6 +19,8 @@ package vinyldns.mysql.repository
 import cats.implicits._
 import org.slf4j.LoggerFactory
 import scalikejdbc._
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record._
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
@@ -35,6 +37,8 @@ class MySqlRecordSetCacheRepository
   extends RecordSetCacheRepository
     with Monitored
     with ProtobufConversions {
+
+  private final val MAX_ACCESSORS = 30
 
   private val INSERT_RECORDSETDATA =
     sql"INSERT INTO recordset_data(recordset_id, zone_id, fqdn, reverse_fqdn, type, record_data, ip) VALUES ({recordset_id}, {zone_id}, {fqdn}, {reverse_fqdn}, {type}, {record_data}, INET6_ATON({ip}))"
@@ -276,18 +280,20 @@ class MySqlRecordSetCacheRepository
     * @return A list of {@link RecordSet} matching the criteria
     */
   def listRecordSetData(
-                         zoneId: Option[String],
-                         startFrom: Option[String],
-                         maxItems: Option[Int],
-                         recordNameFilter: Option[String],
-                         recordTypeFilter: Option[Set[RecordType]],
-                         recordOwnerGroupFilter: Option[String],
-                         nameSort: NameSort
-                       ): IO[ListRecordSetResults] =
+                          zoneId: Option[String],
+                          startFrom: Option[String],
+                          maxItems: Option[Int],
+                          recordNameFilter: Option[String],
+                          recordTypeFilter: Option[Set[RecordType]],
+                          recordOwnerGroupFilter: Option[String],
+                          nameSort: NameSort,
+                          authPrincipal: Option[AuthPrincipal]
+                        ): IO[ListRecordSetResults] =
     monitor("repo.RecordSet.listRecordSetData") {
       IO {
         val maxPlusOne = maxItems.map(_ + 1)
         val wildcardStart = raw"^\s*[*%](.+[^*%])\s*$$".r
+        val authFilter = authPrincipal.filter(auth => zoneId.isEmpty && !auth.isSystemAdmin).map(buildAccessFilter)
 
         // setup optional filters
         val zoneAndNameFilters = (zoneId, recordNameFilter) match {
@@ -337,7 +343,7 @@ class MySqlRecordSetCacheRepository
           recordOwnerGroupFilter.map(owner => sqls"recordset.owner_group_id = $owner ")
 
         val opts =
-          (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter).toList
+          (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter ++ authFilter).toList
 
         val qualifiers = if (nameSort == ASC) {
           sqls"ORDER BY recordset.fqdn ASC, recordset.type ASC "
@@ -404,6 +410,23 @@ class MySqlRecordSetCacheRepository
         }
       }
     }
+
+  private def buildAccessFilter(authPrincipal: AuthPrincipal): SQLSyntax = {
+    val accessors = buildZoneSearchAccessorList(authPrincipal.signedInUser, authPrincipal.memberGroupIds)
+    sqls"recordset.zone_id IN (SELECT za.zone_id FROM zone_access za WHERE za.accessor_id IN ($accessors))"
+  }
+
+  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
+    val allAccessors = user.id +: groupIds
+
+    if (allAccessors.length > MAX_ACCESSORS) {
+      logger.warn(
+        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
+      )
+    }
+
+    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
+  }
 
 
   private val IPV4_ARPA = ".in-addr.arpa."

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -20,7 +20,6 @@ import cats.implicits._
 import org.slf4j.LoggerFactory
 import scalikejdbc._
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record._
 import vinyldns.core.protobuf.ProtobufConversions
 import vinyldns.core.route.Monitored
@@ -37,8 +36,6 @@ class MySqlRecordSetCacheRepository
   extends RecordSetCacheRepository
     with Monitored
     with ProtobufConversions {
-
-  private final val MAX_ACCESSORS = 30
 
   private val INSERT_RECORDSETDATA =
     sql"INSERT INTO recordset_data(recordset_id, zone_id, fqdn, reverse_fqdn, type, record_data, ip) VALUES ({recordset_id}, {zone_id}, {fqdn}, {reverse_fqdn}, {type}, {record_data}, INET6_ATON({ip}))"
@@ -412,20 +409,9 @@ class MySqlRecordSetCacheRepository
     }
 
   private def buildAccessFilter(authPrincipal: AuthPrincipal): SQLSyntax = {
-    val accessors = buildZoneSearchAccessorList(authPrincipal.signedInUser, authPrincipal.memberGroupIds)
+    val accessors =
+      MySqlAccessors.buildZoneSearchAccessorList(authPrincipal.signedInUser, authPrincipal.memberGroupIds, logger)
     sqls"recordset.zone_id IN (SELECT za.zone_id FROM zone_access za WHERE za.accessor_id IN ($accessors))"
-  }
-
-  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
-    val allAccessors = user.id +: groupIds
-
-    if (allAccessors.length > MAX_ACCESSORS) {
-      logger.warn(
-        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
-      )
-    }
-
-    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
   }
 
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -21,7 +21,6 @@ import cats.implicits._
 import org.slf4j.LoggerFactory
 import scalikejdbc._
 import vinyldns.core.domain.auth.AuthPrincipal
-import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType.RecordType
@@ -34,8 +33,6 @@ import scala.util.Try
 
 class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
   import MySqlRecordSetRepository._
-
-  private final val MAX_ACCESSORS = 30
 
   private val FIND_BY_ZONEID_NAME_TYPE =
     sql"""
@@ -299,20 +296,9 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     }
 
   private def buildAccessFilter(authPrincipal: AuthPrincipal): SQLSyntax = {
-    val accessors = buildZoneSearchAccessorList(authPrincipal.signedInUser, authPrincipal.memberGroupIds)
+    val accessors =
+      MySqlAccessors.buildZoneSearchAccessorList(authPrincipal.signedInUser, authPrincipal.memberGroupIds, logger)
     sqls"zone_id IN (SELECT za.zone_id FROM zone_access za WHERE za.accessor_id IN ($accessors))"
-  }
-
-  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
-    val allAccessors = user.id +: groupIds
-
-    if (allAccessors.length > MAX_ACCESSORS) {
-      logger.warn(
-        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
-      )
-    }
-
-    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
   }
 
   def getRecordSets(zoneId: String, name: String, typ: RecordType): IO[List[RecordSet]] =

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetRepository.scala
@@ -20,6 +20,8 @@ import cats.effect._
 import cats.implicits._
 import org.slf4j.LoggerFactory
 import scalikejdbc._
+import vinyldns.core.domain.auth.AuthPrincipal
+import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record.NameSort.NameSort
 import vinyldns.core.domain.record._
 import vinyldns.core.domain.record.RecordType.RecordType
@@ -32,6 +34,8 @@ import scala.util.Try
 
 class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
   import MySqlRecordSetRepository._
+
+  private final val MAX_ACCESSORS = 30
 
   private val FIND_BY_ZONEID_NAME_TYPE =
     sql"""
@@ -171,19 +175,21 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
     }
 
   def listRecordSets(
-                      zoneId: Option[String],
-                      startFrom: Option[String],
-                      maxItems: Option[Int],
-                      recordNameFilter: Option[String],
-                      recordTypeFilter: Option[Set[RecordType]],
-                      recordOwnerGroupFilter: Option[String],
-                      nameSort: NameSort,
-                      recordTypeSort: RecordTypeSort,
-                    ): IO[ListRecordSetResults] =
+                       zoneId: Option[String],
+                       startFrom: Option[String],
+                       maxItems: Option[Int],
+                       recordNameFilter: Option[String],
+                       recordTypeFilter: Option[Set[RecordType]],
+                       recordOwnerGroupFilter: Option[String],
+                       nameSort: NameSort,
+                       recordTypeSort: RecordTypeSort,
+                      authPrincipal: Option[AuthPrincipal],
+                     ): IO[ListRecordSetResults] =
     monitor("repo.RecordSet.listRecordSets") {
       IO {
         DB.readOnly { implicit s =>
           val maxPlusOne = maxItems.map(_ + 1)
+          val authFilter = authPrincipal.filter(auth => zoneId.isEmpty && !auth.isSystemAdmin).map(buildAccessFilter)
 
           // setup optional filters
           val zoneAndNameFilters = (zoneId, recordNameFilter) match {
@@ -226,7 +232,7 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
             recordOwnerGroupFilter.map(owner => sqls"owner_group_id = $owner ")
 
           val opts =
-            (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter).toList
+            (zoneAndNameFilters ++ sortBy ++ typeFilter ++ ownerGroupFilter ++ authFilter).toList
 
           val nameSortQualifiers = nameSort match {
             case NameSort.ASC => sqls"ORDER BY fqdn ASC, type ASC "
@@ -291,6 +297,23 @@ class MySqlRecordSetRepository extends RecordSetRepository with Monitored {
         }
       }
     }
+
+  private def buildAccessFilter(authPrincipal: AuthPrincipal): SQLSyntax = {
+    val accessors = buildZoneSearchAccessorList(authPrincipal.signedInUser, authPrincipal.memberGroupIds)
+    sqls"zone_id IN (SELECT za.zone_id FROM zone_access za WHERE za.accessor_id IN ($accessors))"
+  }
+
+  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
+    val allAccessors = user.id +: groupIds
+
+    if (allAccessors.length > MAX_ACCESSORS) {
+      logger.warn(
+        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
+      )
+    }
+
+    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
+  }
 
   def getRecordSets(zoneId: String, name: String, typ: RecordType): IO[List[RecordSet]] =
     monitor("repo.RecordSet.getRecordSets") {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -35,8 +35,6 @@ class MySqlZoneChangeRepository
     with Monitored {
   private final val logger = LoggerFactory.getLogger(classOf[MySqlZoneChangeRepository])
 
-  private final val MAX_ACCESSORS = 30
-
   private final val PUT_ZONE_CHANGE =
     sql"""
       |REPLACE INTO zone_change (change_id, zone_id, data, created_timestamp, zone_name, zone_status)
@@ -146,7 +144,7 @@ class MySqlZoneChangeRepository
     } else {
       // User is not super or support,
       // let's join across to the zone access table so we return only zones a user has access to
-      val accessors = buildZoneSearchAccessorList(user, groupIds)
+      val accessors = MySqlAccessors.buildZoneSearchAccessorList(user, groupIds, logger)
       val questionMarks = List.fill(accessors.size)("?").mkString(",")
       val withAccessorCheck = BASE_ZONE_CHANGE_SEARCH_SQL +
         s"""
@@ -155,20 +153,6 @@ class MySqlZoneChangeRepository
         """.stripMargin
       (withAccessorCheck, accessors)
     }
-
-  /* Limit the accessors so that we don't have boundless parameterized queries */
-  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
-    val allAccessors = user.id +: groupIds
-
-    if (allAccessors.length > MAX_ACCESSORS) {
-      logger.warn(
-        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
-      )
-    }
-
-    // Take the top 30 accessors, but add "EVERYONE" to the list so that we include zones that have everyone access
-    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
-  }
 
   def listDeletedZones(
                         authPrincipal: AuthPrincipal,

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -35,7 +35,6 @@ import scala.concurrent.duration._
 class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with Monitored {
 
   private final val logger = LoggerFactory.getLogger(classOf[MySqlZoneRepository])
-  private final val MAX_ACCESSORS = 30
   private final val INITIAL_RETRY_DELAY = 1.millis
   final val MAX_RETRIES = 10
   private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
@@ -455,7 +454,7 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
     } else {
       // User is not super or support,
       // let's join across to the zone access table so we return only zones a user has access to
-      val accessors = buildZoneSearchAccessorList(user, groupIds)
+      val accessors = MySqlAccessors.buildZoneSearchAccessorList(user, groupIds, logger)
       val questionMarks = List.fill(accessors.size)("?").mkString(",")
       val withAccessorCheck = BASE_ZONE_SEARCH_SQL +
         s"""
@@ -464,20 +463,6 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
     """.stripMargin
       (withAccessorCheck, accessors)
     }
-
-  /* Limit the accessors so that we don't have boundless parameterized queries */
-  private def buildZoneSearchAccessorList(user: User, groupIds: Seq[String]): Seq[String] = {
-    val allAccessors = user.id +: groupIds
-
-    if (allAccessors.length > MAX_ACCESSORS) {
-      logger.warn(
-        s"User ${user.userName} with id ${user.id} is in more than $MAX_ACCESSORS groups, no all zones maybe returned!"
-      )
-    }
-
-    // Take the top 30 accessors, but add "EVERYONE" to the list so that we include zones that have everyone access
-    allAccessors.take(MAX_ACCESSORS) :+ "EVERYONE"
-  }
 
   private def putZone(zone: Zone)(implicit session: DBSession): Zone = {
     PUT_ZONE


### PR DESCRIPTION
## Summary
- enforce zone visibility when looking up a zone by name or listing failed zone/record changes
- prevent global record set searches from returning zones the caller cannot access
- validate that a deleted record set belongs to the requested zone
- share MySQL zone-accessor filtering logic across zone and recordset repositories

## API behavior changes
- `GET /zones/name/{zoneName}` now returns `403` when the caller cannot access the zone instead of returning zone details.
- `GET /zones/deleted` only lists deleted zones visible to the caller.
- `GET /zones/{zoneId}/failed` only lists failed zone changes for zones visible to the caller.
- `GET /recordsets` global searches now omit recordsets in zones the caller cannot access.
- `GET /recordsets/{recordSetId}/failed` only returns failed recordset changes for zones visible to the caller.
- `DELETE /zones/{zoneId}/recordsets/{recordSetId}` now verifies the recordset belongs to the requested zone before authorizing deletion.

## Testing
- sbt -Dsbt.log.noformat=true -Dsbt.supershell=false "project api" "testOnly vinyldns.api.domain.record.RecordSetServiceSpec vinyldns.api.domain.zone.ZoneServiceSpec"
- sbt -Dsbt.log.noformat=true -Dsbt.supershell=false "mysql/IntegrationTest/testOnly vinyldns.mysql.repository.MySqlRecordSetRepositoryIntegrationSpec vinyldns.mysql.repository.MySqlRecordSetCacheRepositoryIntegrationSpec" (compiled, test execution requires local MariaDB on localhost:19002)

VDNS-352