### PR TITLE
Sanitize portal autocomplete rendering

### DIFF
--- a/modules/portal/app/views/groups/groupDetail.scala.html
+++ b/modules/portal/app/views/groups/groupDetail.scala.html
@@ -168,7 +168,7 @@
                                             <td>{{change.created}}</td>
                                             <td>{{change.id}}</td>
                                             <td>{{change.changeType}}</td>
-                                            <td class="col-md-3 wrap-long-text" ng-bind-html="changeMessage(change.groupChangeMessage)"></td>
+                                            <td class="col-md-3 wrap-long-text preserve-line-breaks" ng-bind="changeMessage(change.groupChangeMessage)"></td>
                                             <td class="col-md-3 wrap-long-text">
                                                 <a ng-if="change.changeType =='Create'" ng-click="viewGroupInfo(change.newGroup)" class="force-cursor">View created group</a>
 

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -450,6 +450,10 @@ input[type="file"] {
     word-break: break-all;
 }
 
+.preserve-line-breaks {
+    white-space: pre-line;
+}
+
 .no-wrap {
     white-space: nowrap;
     word-break: keep-all;

--- a/modules/portal/public/lib/autocomplete/autocomplete.js
+++ b/modules/portal/public/lib/autocomplete/autocomplete.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function(window) {
+    function escapeRegExp(value) {
+        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function renderItem(ul, item, term) {
+        var label = String(item.label || "");
+        var $item = $("<li></li>").data("ui-autocomplete-item", item.value);
+        var $content = $("<div></div>");
+
+        if (!term) {
+            return $item.append($content.text(label)).appendTo(ul);
+        }
+
+        var matcher = new RegExp(escapeRegExp(String(term)), "gi");
+        var lastIndex = 0;
+
+        label.replace(matcher, function(match, offset) {
+            if (offset > lastIndex) {
+                $content.append(document.createTextNode(label.slice(lastIndex, offset)));
+            }
+
+            $("<b></b>").text(match).appendTo($content);
+            lastIndex = offset + match.length;
+            return match;
+        });
+
+        if (lastIndex === 0) {
+            $content.text(label);
+        } else if (lastIndex < label.length) {
+            $content.append(document.createTextNode(label.slice(lastIndex)));
+        }
+
+        return $item.append($content).appendTo(ul);
+    }
+
+    function applyRenderer(autocomplete) {
+        var instance = autocomplete.autocomplete("instance");
+        if (instance) {
+            instance._renderItem = function(ul, item) {
+                return renderItem(ul, item, this.term);
+            };
+        }
+    }
+
+    window.vinyldnsAutocomplete = {
+        applyRenderer: applyRenderer,
+        renderItem: renderItem
+    };
+})(window);

--- a/modules/portal/public/lib/controllers/controller.groups.js
+++ b/modules/portal/public/lib/controllers/controller.groups.js
@@ -31,6 +31,41 @@ angular.module('controller.groups', []).controller('GroupsController', function 
     $scope.validEmailDomains= [];
     $scope.maxGroupItemsDisplay = 3000;
 
+    function escapeRegExp(value) {
+        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function renderAutocompleteItem(ul, item, term) {
+        var label = String(item.label || "");
+        var $item = $("<li></li>").data("ui-autocomplete-item", item.value);
+        var $content = $("<div></div>");
+
+        if (!term) {
+            return $item.append($content.text(label)).appendTo(ul);
+        }
+
+        var matcher = new RegExp(escapeRegExp(String(term)), "gi");
+        var lastIndex = 0;
+
+        label.replace(matcher, function (match, offset) {
+            if (offset > lastIndex) {
+                $content.append(document.createTextNode(label.slice(lastIndex, offset)));
+            }
+
+            $("<b></b>").text(match).appendTo($content);
+            lastIndex = offset + match.length;
+            return match;
+        });
+
+        if (lastIndex === 0) {
+            $content.text(label);
+        } else if (lastIndex < label.length) {
+            $content.append(document.createTextNode(label.slice(lastIndex)));
+        }
+
+        return $item.append($content).appendTo(ul);
+    }
+
     // Paging status for group sets
     var groupsPaging = pagingService.getNewPagingParams(100);
     var allGroupsPaging = pagingService.getNewPagingParams(100);
@@ -74,7 +109,7 @@ angular.module('controller.groups', []).controller('GroupsController', function 
         return true;
     };
     // Autocomplete for group search
-    $("#group-search-text").autocomplete({
+    var groupSearch = $("#group-search-text").autocomplete({
       source: function( request, response ) {
         $.ajax({
           url: "/api/groups?maxItems=100&abridged=true",
@@ -102,14 +137,12 @@ angular.module('controller.groups', []).controller('GroupsController', function 
       }
     });
 
-    // Autocomplete text-highlight
-    $.ui.autocomplete.prototype._renderItem = function(ul, item) {
-            let txt = String(item.label).replace(new RegExp(this.term, "gi"),"<b>$&</b>");
-            return $("<li></li>")
-                  .data("ui-autocomplete-item", item.value)
-                  .append("<div>" + txt + "</div>")
-                  .appendTo(ul);
-    };
+    var groupSearchInstance = groupSearch.autocomplete("instance");
+    if (groupSearchInstance) {
+        groupSearchInstance._renderItem = function (ul, item) {
+            return renderAutocompleteItem(ul, item, this.term);
+        };
+    }
 
     $scope.createGroup = function (name, email, description) {
         //prevent user executing service call multiple times

--- a/modules/portal/public/lib/controllers/controller.groups.js
+++ b/modules/portal/public/lib/controllers/controller.groups.js
@@ -31,41 +31,6 @@ angular.module('controller.groups', []).controller('GroupsController', function 
     $scope.validEmailDomains= [];
     $scope.maxGroupItemsDisplay = 3000;
 
-    function escapeRegExp(value) {
-        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    }
-
-    function renderAutocompleteItem(ul, item, term) {
-        var label = String(item.label || "");
-        var $item = $("<li></li>").data("ui-autocomplete-item", item.value);
-        var $content = $("<div></div>");
-
-        if (!term) {
-            return $item.append($content.text(label)).appendTo(ul);
-        }
-
-        var matcher = new RegExp(escapeRegExp(String(term)), "gi");
-        var lastIndex = 0;
-
-        label.replace(matcher, function (match, offset) {
-            if (offset > lastIndex) {
-                $content.append(document.createTextNode(label.slice(lastIndex, offset)));
-            }
-
-            $("<b></b>").text(match).appendTo($content);
-            lastIndex = offset + match.length;
-            return match;
-        });
-
-        if (lastIndex === 0) {
-            $content.text(label);
-        } else if (lastIndex < label.length) {
-            $content.append(document.createTextNode(label.slice(lastIndex)));
-        }
-
-        return $item.append($content).appendTo(ul);
-    }
-
     // Paging status for group sets
     var groupsPaging = pagingService.getNewPagingParams(100);
     var allGroupsPaging = pagingService.getNewPagingParams(100);
@@ -137,12 +102,7 @@ angular.module('controller.groups', []).controller('GroupsController', function 
       }
     });
 
-    var groupSearchInstance = groupSearch.autocomplete("instance");
-    if (groupSearchInstance) {
-        groupSearchInstance._renderItem = function (ul, item) {
-            return renderAutocompleteItem(ul, item, this.term);
-        };
-    }
+    vinyldnsAutocomplete.applyRenderer(groupSearch);
 
     $scope.createGroup = function (name, email, description) {
         //prevent user executing service call multiple times

--- a/modules/portal/public/lib/controllers/controller.groups.spec.js
+++ b/modules/portal/public/lib/controllers/controller.groups.spec.js
@@ -24,6 +24,8 @@ describe('Controller: GroupsController', function () {
         module('controller.groups')
     });
     beforeEach(inject(function ($rootScope, $controller, $q, groupsService, profileService, utilityService, pagingService) {
+        this.rootScope = $rootScope;
+        this.controllerFactory = $controller;
         this.scope = $rootScope.$new();
         this.groupsService = groupsService;
         this.utilityService = utilityService;
@@ -227,5 +229,30 @@ describe('Controller: GroupsController', function () {
         expect(getGroupSets.calls.count()).toBe(3);
         expect(getGroupSets.calls.mostRecent().args).toEqual(
             [expectedMaxItems, expectedStartFrom, expectedIgnoreAccess, expectedQuery]);
+    });
+
+    it('renders group autocomplete labels as text while preserving highlights', function () {
+        document.body.innerHTML = '<input id="group-search-text" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('GroupsController', {'$scope': scope});
+
+        var instance = $('#group-search-text').autocomplete('instance');
+        var rendered = instance._renderItem($('<ul></ul>'), {
+            label: '<img src=x onerror=alert(1)>Team',
+            value: '<img src=x onerror=alert(1)>Team'
+        });
+
+        instance.term = 'Team';
+        rendered = instance._renderItem($('<ul></ul>'), {
+            label: '<img src=x onerror=alert(1)>Team',
+            value: '<img src=x onerror=alert(1)>Team'
+        });
+
+        expect(rendered.find('img').length).toBe(0);
+        expect(rendered.find('div').text()).toBe('<img src=x onerror=alert(1)>Team');
+        expect(rendered.find('b').text()).toBe('Team');
+
+        document.body.innerHTML = '';
     });
 });

--- a/modules/portal/public/lib/controllers/controller.membership.js
+++ b/modules/portal/public/lib/controllers/controller.membership.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-angular.module('controller.membership', []).controller('MembershipController', function ($scope, $log, $location, $sce, $timeout, pagingService,
+angular.module('controller.membership', []).controller('MembershipController', function ($scope, $log, $location, $timeout, pagingService,
                                                                                          groupsService, profileService, utilityService) {
 
     $scope.membership = { members: [], group: {} };
@@ -37,8 +37,7 @@ angular.module('controller.membership', []).controller('MembershipController', f
     };
 
     $scope.changeMessage = function (groupChangeMessage) {
-        message = groupChangeMessage.replaceAll('. ', '.<br>')
-        return $sce.trustAsHtml(message);
+        return (groupChangeMessage || '').split('. ').join('.\n');
     };
 
     // Initialize Bootstrap tooltips

--- a/modules/portal/public/lib/controllers/controller.membership.spec.js
+++ b/modules/portal/public/lib/controllers/controller.membership.spec.js
@@ -501,6 +501,12 @@ describe('Controller: MembershipController', function () {
         expect(this.scope.groupChanges).toEqual(response.data.changes);
     });
 
+    it('formats change messages as plain text with preserved line breaks', function () {
+        expect(this.scope.changeMessage('Sentence one. Sentence two.<script>alert(1)</script>')).toBe(
+            'Sentence one.\nSentence two.<script>alert(1)</script>'
+        );
+    });
+
     it('nextPage should call getGroupChanges with the correct parameters', function () {
 
         var response = {

--- a/modules/portal/public/lib/controllers/controller.recordsets.spec.js
+++ b/modules/portal/public/lib/controllers/controller.recordsets.spec.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('Controller: RecordSetsController', function () {
+    beforeEach(function () {
+        module('ngMock'),
+        module('service.records'),
+        module('service.groups'),
+        module('service.utility'),
+        module('service.paging'),
+        module('recordset')
+    });
+
+    beforeEach(inject(function ($rootScope, $controller, $q, recordsService, groupsService) {
+        this.rootScope = $rootScope;
+        this.controllerFactory = $controller;
+
+        recordsService.listRecordSetData = function() {
+            return $q.when({data: {recordSets: []}});
+        };
+
+        groupsService.getGroupsAbridged = function() {
+            return $q.when({data: {groups: []}});
+        };
+    }));
+
+    it('renders record autocomplete labels as text while preserving highlights', function () {
+        document.body.innerHTML = '<input id="record-search-text" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('RecordSetsController', {'$scope': scope});
+
+        var instance = $('#record-search-text').autocomplete('instance');
+        instance.term = 'Team';
+
+        var rendered = instance._renderItem($('<ul></ul>'), {
+            label: '<img src=x onerror=alert(1)>Team',
+            value: '<img src=x onerror=alert(1)>Team'
+        });
+
+        expect(rendered.find('img').length).toBe(0);
+        expect(rendered.find('div').text()).toBe('<img src=x onerror=alert(1)>Team');
+        expect(rendered.find('b').text()).toBe('Team');
+
+        document.body.innerHTML = '';
+    });
+});

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -40,50 +40,6 @@ angular.module('controller.zones', [])
 
     $scope.keyAlgorithms = ['HMAC-MD5', 'HMAC-SHA1', 'HMAC-SHA224', 'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512'];
 
-    function escapeRegExp(value) {
-        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    }
-
-    function renderAutocompleteItem(ul, item, term) {
-        var label = String(item.label || "");
-        var $item = $("<li></li>").data("ui-autocomplete-item", item.value);
-        var $content = $("<div></div>");
-
-        if (!term) {
-            return $item.append($content.text(label)).appendTo(ul);
-        }
-
-        var matcher = new RegExp(escapeRegExp(String(term)), "gi");
-        var lastIndex = 0;
-
-        label.replace(matcher, function (match, offset) {
-            if (offset > lastIndex) {
-                $content.append(document.createTextNode(label.slice(lastIndex, offset)));
-            }
-
-            $("<b></b>").text(match).appendTo($content);
-            lastIndex = offset + match.length;
-            return match;
-        });
-
-        if (lastIndex === 0) {
-            $content.text(label);
-        } else if (lastIndex < label.length) {
-            $content.append(document.createTextNode(label.slice(lastIndex)));
-        }
-
-        return $item.append($content).appendTo(ul);
-    }
-
-    function applyAutocompleteRenderer(autocomplete) {
-        var instance = autocomplete.autocomplete("instance");
-        if (instance) {
-            instance._renderItem = function (ul, item) {
-                return renderAutocompleteItem(ul, item, this.term);
-            };
-        }
-    }
-
     // Paging status for zone sets
     var zonesPaging = pagingService.getNewPagingParams(100);
     var allZonesPaging = pagingService.getNewPagingParams(100);
@@ -168,7 +124,7 @@ angular.module('controller.zones', [])
           }
         });
 
-        applyAutocompleteRenderer(zoneSearch);
+        vinyldnsAutocomplete.applyRenderer(zoneSearch);
     };
 
     // Should be the default autocomplete search result option
@@ -205,7 +161,7 @@ angular.module('controller.zones', [])
               }
             });
 
-            applyAutocompleteRenderer(zoneSearch);
+            vinyldnsAutocomplete.applyRenderer(zoneSearch);
         } else {
             $.zoneAutocompleteSearch();
         }

--- a/modules/portal/public/lib/controllers/controller.zones.js
+++ b/modules/portal/public/lib/controllers/controller.zones.js
@@ -40,6 +40,50 @@ angular.module('controller.zones', [])
 
     $scope.keyAlgorithms = ['HMAC-MD5', 'HMAC-SHA1', 'HMAC-SHA224', 'HMAC-SHA256', 'HMAC-SHA384', 'HMAC-SHA512'];
 
+    function escapeRegExp(value) {
+        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function renderAutocompleteItem(ul, item, term) {
+        var label = String(item.label || "");
+        var $item = $("<li></li>").data("ui-autocomplete-item", item.value);
+        var $content = $("<div></div>");
+
+        if (!term) {
+            return $item.append($content.text(label)).appendTo(ul);
+        }
+
+        var matcher = new RegExp(escapeRegExp(String(term)), "gi");
+        var lastIndex = 0;
+
+        label.replace(matcher, function (match, offset) {
+            if (offset > lastIndex) {
+                $content.append(document.createTextNode(label.slice(lastIndex, offset)));
+            }
+
+            $("<b></b>").text(match).appendTo($content);
+            lastIndex = offset + match.length;
+            return match;
+        });
+
+        if (lastIndex === 0) {
+            $content.text(label);
+        } else if (lastIndex < label.length) {
+            $content.append(document.createTextNode(label.slice(lastIndex)));
+        }
+
+        return $item.append($content).appendTo(ul);
+    }
+
+    function applyAutocompleteRenderer(autocomplete) {
+        var instance = autocomplete.autocomplete("instance");
+        if (instance) {
+            instance._renderItem = function (ul, item) {
+                return renderAutocompleteItem(ul, item, this.term);
+            };
+        }
+    }
+
     // Paging status for zone sets
     var zonesPaging = pagingService.getNewPagingParams(100);
     var allZonesPaging = pagingService.getNewPagingParams(100);
@@ -96,7 +140,7 @@ angular.module('controller.zones', [])
 
     $.zoneAutocompleteSearch = function() {
         // Autocomplete for zone search
-        $(".zone-search-text").autocomplete({
+        var zoneSearch = $(".zone-search-text").autocomplete({
           source: function( request, response ) {
             $.ajax({
               url: "/api/zones?maxItems=100",
@@ -123,6 +167,8 @@ angular.module('controller.zones', [])
             $(this).removeClass("ui-corner-top").addClass("ui-corner-all");
           }
         });
+
+        applyAutocompleteRenderer(zoneSearch);
     };
 
     // Should be the default autocomplete search result option
@@ -131,7 +177,7 @@ angular.module('controller.zones', [])
     $('.isGroupSearch').change(function() {
         if(this.checked) {
             // Autocomplete for search by admin group
-            $(".zone-search-text").autocomplete({
+            var zoneSearch = $(".zone-search-text").autocomplete({
               source: function( request, response ) {
                 $.ajax({
                   url: "/api/groups?maxItems=100&abridged=true",
@@ -158,19 +204,12 @@ angular.module('controller.zones', [])
                 $(this).removeClass("ui-corner-top").addClass("ui-corner-all");
               }
             });
+
+            applyAutocompleteRenderer(zoneSearch);
         } else {
             $.zoneAutocompleteSearch();
         }
     });
-
-    // Autocomplete text-highlight
-    $.ui.autocomplete.prototype._renderItem = function(ul, item) {
-            let txt = String(item.label).replace(new RegExp(this.term, "gi"),"<b>$&</b>");
-            return $("<li></li>")
-                  .data("ui-autocomplete-item", item.value)
-                  .append("<div>" + txt + "</div>")
-                  .appendTo(ul);
-    };
 
     /* Refreshes zone data set and then re-displays */
     $scope.refreshZones = function () {

--- a/modules/portal/public/lib/controllers/controller.zones.spec.js
+++ b/modules/portal/public/lib/controllers/controller.zones.spec.js
@@ -26,6 +26,8 @@ describe('Controller: ZonesController', function () {
         module('controller.zones')
     });
     beforeEach(inject(function ($rootScope, $controller, $q, groupsService, profileService, recordsService, zonesService, utilityService, pagingService) {
+        this.rootScope = $rootScope;
+        this.controllerFactory = $controller;
         this.scope = $rootScope.$new();
         this.groupsService = groupsService;
         this.zonesService = zonesService;
@@ -186,5 +188,28 @@ describe('Controller: ZonesController', function () {
         expect(getDeletedZoneSets.calls.mostRecent().args).toEqual(
             [expectedMaxItems, expectedStartFrom, expectedQuery, expectedIgnoreAccess]);
 
+    });
+
+    it('renders group search autocomplete labels as text while preserving highlights', function () {
+        document.body.innerHTML = '<input class="zone-search-text" /><input class="isGroupSearch" type="checkbox" />';
+
+        var scope = this.rootScope.$new();
+        this.controllerFactory('ZonesController', {'$scope': scope});
+
+        $('.isGroupSearch').prop('checked', true).trigger('change');
+
+        var instance = $('.zone-search-text').autocomplete('instance');
+        instance.term = 'Team';
+
+        var rendered = instance._renderItem($('<ul></ul>'), {
+            label: '<img src=x onerror=alert(1)>Team',
+            value: '<img src=x onerror=alert(1)>Team'
+        });
+
+        expect(rendered.find('img').length).toBe(0);
+        expect(rendered.find('div').text()).toBe('<img src=x onerror=alert(1)>Team');
+        expect(rendered.find('b').text()).toBe('Team');
+
+        document.body.innerHTML = '';
     });
 });

--- a/modules/portal/public/lib/recordset/recordsets.controller.js
+++ b/modules/portal/public/lib/recordset/recordsets.controller.js
@@ -105,7 +105,7 @@
                 $('[data-toggle="tooltip"]').tooltip();
             });
 
-            $( "#record-search-text" ).autocomplete({
+            var recordSearchAutocomplete = $( "#record-search-text" ).autocomplete({
               source: function( request, response ) {
                 $.ajax({
                   url: "/api/recordsets?maxItems=100",
@@ -131,12 +131,7 @@
               }
             });
 
-            $.ui.autocomplete.prototype._renderItem = function( ul, item ) {
-                    let recordSet = String(item.label).replace(new RegExp(this.term, "gi"),"<b>$&</b>");
-                    return $("<li></li>")
-                          .data("ui-autocomplete-item", item.value)
-                          .append("<div>" + recordSet + "</div>")
-                          .appendTo(ul); };
+            vinyldnsAutocomplete.applyRenderer(recordSearchAutocomplete);
 
             $scope.viewRecordHistory = function(recordFqdn, recordType, zoneId, recordId) {
                $scope.recordFqdn = recordFqdn;


### PR DESCRIPTION
## Summary
- Sanitize portal autocomplete result rendering for group and zone searches by treating labels as text and only highlighting matched substrings
- Render group change messages as plain text with preserved line breaks in the group detail view
- Add unit coverage for the sanitized autocomplete rendering and change message formatting

## Testing
- `cd modules/portal && npx grunt unit`
- Passed: 174 tests, 0 failures

VDNS-353
