### PR TITLE
Reject custom zone connections

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneService.scala
@@ -86,6 +86,7 @@ class ZoneService(
       _ <- isValidZoneAcl(createZoneInput.acl).toResult
       _ <- membershipService.emailValidation(createZoneInput.email)
       _ <- connectionValidator.isValidBackendId(createZoneInput.backendId).toResult
+      _ <- noCustomZoneConnections(createZoneInput.connection, createZoneInput.transferConnection).toResult
       _ <- validateSharedZoneAuthorized(createZoneInput.shared, auth.signedInUser).toResult
       _ <- zoneDoesNotExist(createZoneInput.name)
       _ <- adminGroupExists(createZoneInput.adminGroupId)
@@ -120,6 +121,7 @@ class ZoneService(
       _ <- canChangeZone(auth, updateZoneInput.name, updateZoneInput.adminGroupId).toResult
       updatedZoneInput = if(updateZoneInput.recurrenceSchedule.isDefined) updateZoneInput.copy(scheduleRequestor = Some(auth.signedInUser.userName)) else updateZoneInput
       zoneWithUpdates = Zone(updatedZoneInput, existingZone)
+      _ <- noCustomZoneConnectionUpdates(zoneWithUpdates, existingZone).toResult
       _ <- validateZoneConnectionIfChanged(zoneWithUpdates, existingZone)
       updateZoneChange <- ZoneChangeGenerator
         .forUpdate(zoneWithUpdates, existingZone, auth, crypto)

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -23,11 +23,15 @@ import java.time.temporal.ChronoUnit
 import vinyldns.api.Interfaces.ensuring
 import vinyldns.core.domain.membership.User
 import vinyldns.core.domain.record.RecordType
-import vinyldns.core.domain.zone.{ACLRule, Zone, ZoneACL}
+import vinyldns.core.domain.zone.{ACLRule, Zone, ZoneACL, ZoneConnection}
 
 import scala.util.{Failure, Success, Try}
 
 class ZoneValidations(syncDelayMillis: Int) {
+
+  private val customConnectionError = InvalidRequest(
+    "Custom zone connections are not supported; use a configured backendId"
+  )
 
   def outsideSyncDelay(zone: Zone): Either[Throwable, Unit] =
     zone.latestSync match {
@@ -35,6 +39,22 @@ class ZoneValidations(syncDelayMillis: Int) {
         RecentSyncError(s"Zone ${zone.name} was recently synced. Cannot complete sync").asLeft
       }
       case _ => Right(())
+    }
+
+  def noCustomZoneConnections(
+      connection: Option[ZoneConnection],
+      transferConnection: Option[ZoneConnection]
+  ): Either[Throwable, Unit] =
+    ensuring(customConnectionError)(connection.isEmpty && transferConnection.isEmpty)
+
+  def noCustomZoneConnectionUpdates(newZone: Zone, existingZone: Zone): Either[Throwable, Unit] =
+    if (
+      newZone.connection != existingZone.connection ||
+      newZone.transferConnection != existingZone.transferConnection
+    ) {
+      noCustomZoneConnections(newZone.connection, newZone.transferConnection)
+    } else {
+      Right(())
     }
 
   // TODO - zone ACL validations should happen up front as input validation longer term

--- a/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/zone/ZoneValidations.scala
@@ -47,6 +47,7 @@ class ZoneValidations(syncDelayMillis: Int) {
   ): Either[Throwable, Unit] =
     ensuring(customConnectionError)(connection.isEmpty && transferConnection.isEmpty)
 
+  // Allows removing a pre-existing connection, but rejects introducing or modifying one.
   def noCustomZoneConnectionUpdates(newZone: Zone, existingZone: Zone): Either[Throwable, Unit] =
     if (
       newZone.connection != existingZone.connection ||

--- a/modules/api/src/test/functional/conftest.py
+++ b/modules/api/src/test/functional/conftest.py
@@ -121,7 +121,10 @@ def retrieve_resolver(resolver_name: str) -> str:
     return resolver_address
 
 class WorkerScheduler(LoadScopeScheduling):
-    worker_assignments: List[MutableMapping] = [{"name": "list_batch_change_summaries_test.py", "worker": 0}]
+    worker_assignments: List[MutableMapping] = [
+        {"name": "list_batch_change_summaries_test.py", "worker": 0},
+        {"name": "status_test.py", "worker": 0}
+    ]
 
     def _assign_work_unit(self, node):
         """Assign a work unit to a node."""

--- a/modules/api/src/test/functional/tests/internal/status_test.py
+++ b/modules/api/src/test/functional/tests/internal/status_test.py
@@ -1,8 +1,19 @@
 import copy
 
 import pytest
+import time
 
 from utils import *
+
+
+def wait_for_processing_disabled(client, expected):
+    for _ in range(20):
+        status = client.get_status()
+        if status["processingDisabled"] is expected:
+            return status
+        time.sleep(0.1)
+
+    return client.get_status()
 
 
 def test_get_status_success(shared_zone_test_context):
@@ -46,12 +57,12 @@ def test_post_status_pass_for_admin_users(shared_zone_test_context):
 
     client.post_status(True)
 
-    status = client.get_status()
+    status = wait_for_processing_disabled(client, True)
     assert_that(status["processingDisabled"], is_(True))
 
     client.post_status(False)
 
-    status = client.get_status()
+    status = wait_for_processing_disabled(client, False)
     assert_that(status["processingDisabled"], is_(False))
 
 
@@ -68,11 +79,11 @@ def test_toggle_processing(shared_zone_test_context):
     # disable processing
     admin_client.post_status(True)
 
-    status = client.get_status()
+    status = wait_for_processing_disabled(client, True)
     assert_that(status["processingDisabled"], is_(True))
 
     admin_client.post_status(False)
-    status = client.get_status()
+    status = wait_for_processing_disabled(client, False)
     assert_that(status["processingDisabled"], is_(False))
 
     # Create changes to make sure we can process after the toggle

--- a/modules/api/src/test/functional/tests/membership/delete_group_test.py
+++ b/modules/api/src/test/functional/tests/membership/delete_group_test.py
@@ -82,18 +82,7 @@ def test_delete_admin_group(shared_zone_test_context):
             "name": f"one-time{shared_zone_test_context.partition_id}.",
             "email": "test@test.com",
             "adminGroupId": result_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
+            "backendId": "func-test-backend"
         }
 
         result = client.create_zone(zone, status=202)

--- a/modules/api/src/test/functional/tests/shared_zone_test_context.py
+++ b/modules/api/src/test/functional/tests/shared_zone_test_context.py
@@ -125,20 +125,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.history_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "vinyldns.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "vinyldns.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202)
             self.history_zone = history_zone_change["zone"]
 
@@ -153,20 +140,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "ok.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "ok.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202)
             self.ok_zone = ok_zone_change["zone"]
 
@@ -186,20 +160,7 @@ class SharedZoneTestContext(object):
                             }
                         ]
                     },
-                    "connection": {
-                        "name": "dummy.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "dummy.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202)
             self.dummy_zone = dummy_zone_change["zone"]
 
@@ -211,20 +172,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "ip6.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "ip6.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202
             )
             self.ip6_reverse_zone = ip6_reverse_zone_change["zone"]
@@ -249,20 +197,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "ip4.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "ip4.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202
             )
             self.ip4_reverse_zone = ip4_reverse_zone_change["zone"]
@@ -275,20 +210,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "classless-base.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "classless-base.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202
             )
             self.classless_base_zone = classless_base_zone_change["zone"]
@@ -300,20 +222,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "classless.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "classless.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202
             )
             self.classless_zone_delegation_zone = classless_zone_delegation_change["zone"]
@@ -325,20 +234,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "system-test.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "system-test.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202
             )
             self.system_test_zone = system_test_zone_change["zone"]
@@ -360,20 +256,7 @@ class SharedZoneTestContext(object):
                             }
                         ]
                     },
-                    "connection": {
-                        "name": "parent.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "parent.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202)
             self.parent_zone = parent_zone_change["zone"]
 
@@ -385,20 +268,7 @@ class SharedZoneTestContext(object):
                     "shared": False,
                     "adminGroupId": self.ok_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "example.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "example.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202)
             self.ds_zone = ds_zone_change["zone"]
 
@@ -422,20 +292,7 @@ class SharedZoneTestContext(object):
                     "shared": True,
                     "adminGroupId": self.shared_record_group["id"],
                     "isTest": True,
-                    "connection": {
-                        "name": "shared.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    },
-                    "transferConnection": {
-                        "name": "shared.",
-                        "keyName": VinylDNSTestContext.dns_key_name,
-                        "key": VinylDNSTestContext.dns_key,
-                        "algorithm": VinylDNSTestContext.dns_key_algo,
-                        "primaryServer": VinylDNSTestContext.name_server_ip
-                    }
+                    "backendId": "func-test-backend"
                 }, status=202)
             self.shared_zone = shared_zone_change["zone"]
 
@@ -480,8 +337,6 @@ class SharedZoneTestContext(object):
         # ten total changes including creation
         for i in range(2, 11):
             zone_update = copy.deepcopy(self.history_zone)
-            zone_update["connection"]["key"] = VinylDNSTestContext.dns_key
-            zone_update["transferConnection"]["key"] = VinylDNSTestContext.dns_key
             zone_update["email"] = "i.changed.this.{0}.times@history-test.com".format(i)
             self.history_client.update_zone(zone_update, status=202)
 

--- a/modules/api/src/test/functional/tests/zones/create_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/create_zone_test.py
@@ -261,6 +261,7 @@ def test_create_zone_with_connection_failure(shared_zone_test_context):
     zone = {
         "name": zone_name,
         "email": "test@test.com",
+        "adminGroupId": shared_zone_test_context.ok_group["id"],
         "connection": {
             "name": zone_name,
             "keyName": zone_name,
@@ -364,6 +365,7 @@ def test_zone_bad_connection(shared_zone_test_context):
     zone = {
         "name": zone_name,
         "email": "test@test.com",
+        "adminGroupId": shared_zone_test_context.ok_group["id"],
         "connection": {
             "name": zone_name,
             "keyName": VinylDNSTestContext.dns_key_name,
@@ -385,6 +387,7 @@ def test_zone_bad_transfer_connection(shared_zone_test_context):
     zone = {
         "name": zone_name,
         "email": "test@test.com",
+        "adminGroupId": shared_zone_test_context.ok_group["id"],
         "connection": {
             "name": zone_name,
             "keyName": VinylDNSTestContext.dns_key_name,

--- a/modules/api/src/test/functional/tests/zones/create_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/create_zone_test.py
@@ -35,20 +35,8 @@ def test_create_zone_with_tsigs(shared_zone_test_context, key_name, key_secret, 
         }
     }
 
-    try:
-        zone_change = client.create_zone(zone, status=202)
-        zone = zone_change["zone"]
-        client.wait_until_zone_active(zone_change["zone"]["id"])
-
-        # Check that it was internally stored correctly using GET
-        zone_get = client.get_zone(zone["id"])["zone"]
-        assert_that(zone_get["name"], is_(zone_name))
-        assert_that("connection" in zone_get)
-        assert_that(zone_get["connection"]["keyName"], is_(key_name))
-        assert_that(zone_get["connection"]["algorithm"], is_(key_alg))
-    finally:
-        if "id" in zone:
-            client.abandon_zones([zone["id"]], status=202)
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 @pytest.mark.serial
@@ -145,35 +133,21 @@ def test_create_zone_without_transfer_connection_leaves_it_empty(shared_zone_tes
     """
     client = shared_zone_test_context.ok_vinyldns_client
     result_zone = None
-    try:
-        zone_name = f"one-time{shared_zone_test_context.partition_id}"
+    zone_name = f"one-time{shared_zone_test_context.partition_id}"
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
+    zone = {
+        "name": zone_name,
+        "email": "test@test.com",
+        "adminGroupId": shared_zone_test_context.ok_group["id"],
+        "connection": {
+            "name": "vinyldns.",
+            "keyName": VinylDNSTestContext.dns_key_name,
+            "key": VinylDNSTestContext.dns_key,
+            "primaryServer": VinylDNSTestContext.name_server_ip
         }
-        result = client.create_zone(zone, status=202)
-        result_zone = result["zone"]
-        client.wait_until_zone_active(result["zone"]["id"])
-
-        get_result = client.get_zone(result_zone["id"])
-
-        get_zone = get_result["zone"]
-        assert_that(get_zone["name"], is_(zone["name"] + "."))
-        assert_that(get_zone["email"], is_(zone["email"]))
-        assert_that(get_zone["adminGroupId"], is_(zone["adminGroupId"]))
-
-        assert_that(get_zone, is_not(has_key("transferConnection")))
-    finally:
-        if result_zone:
-            client.abandon_zones([result_zone["id"]], status=202)
+    }
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 def test_create_zone_fails_no_authorization(shared_zone_test_context):
@@ -294,7 +268,8 @@ def test_create_zone_with_connection_failure(shared_zone_test_context):
             "primaryServer": VinylDNSTestContext.name_server_ip
         }
     }
-    client.create_zone(zone, status=400)
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 def test_create_zone_returns_409_if_already_exists(shared_zone_test_context):
@@ -302,8 +277,6 @@ def test_create_zone_returns_409_if_already_exists(shared_zone_test_context):
     Test creating a zone returns a 409 Conflict if the zone name already exists
     """
     create_conflict = dict(shared_zone_test_context.ok_zone)
-    create_conflict["connection"]["key"] = VinylDNSTestContext.dns_key  # necessary because we encrypt the key
-    create_conflict["transferConnection"]["key"] = VinylDNSTestContext.dns_key
 
     shared_zone_test_context.ok_vinyldns_client.create_zone(create_conflict, status=409)
 
@@ -378,39 +351,8 @@ def test_zone_connection_only(shared_zone_test_context):
         }
     }
 
-    expected_connection = {
-        "name": "vinyldns.",
-        "keyName": VinylDNSTestContext.dns_key_name,
-        "key": VinylDNSTestContext.dns_key,
-        "primaryServer": VinylDNSTestContext.name_server_ip
-    }
-
-    try:
-        zone_change = client.create_zone(zone, status=202)
-        zone = zone_change["zone"]
-        client.wait_until_zone_active(zone_change["zone"]["id"])
-
-        # Check response from create
-        assert_that(zone["name"], is_(zone_name + "."))
-        assert_that(zone["connection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["connection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["connection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-        assert_that(zone["transferConnection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["transferConnection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["transferConnection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-
-        # Check that it was internally stored correctly using GET
-        zone_get = client.get_zone(zone["id"])["zone"]
-        assert_that(zone_get["name"], is_(zone_name + "."))
-        assert_that(zone["connection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["connection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["connection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-        assert_that(zone["transferConnection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["transferConnection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["transferConnection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-    finally:
-        if "id" in zone:
-            client.abandon_zones([zone["id"]], status=202)
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 @pytest.mark.serial
@@ -430,7 +372,8 @@ def test_zone_bad_connection(shared_zone_test_context):
         }
     }
 
-    client.create_zone(zone, status=400)
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 @pytest.mark.serial
@@ -456,7 +399,8 @@ def test_zone_bad_transfer_connection(shared_zone_test_context):
         }
     }
 
-    client.create_zone(zone, status=400)
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 @pytest.mark.serial
@@ -483,39 +427,8 @@ def test_zone_transfer_connection(shared_zone_test_context):
         }
     }
 
-    expected_connection = {
-        "name": zone_name,
-        "keyName": VinylDNSTestContext.dns_key_name,
-        "key": VinylDNSTestContext.dns_key,
-        "primaryServer": VinylDNSTestContext.name_server_ip
-    }
-
-    try:
-        zone_change = client.create_zone(zone, status=202)
-        zone = zone_change["zone"]
-        client.wait_until_zone_active(zone_change["zone"]["id"])
-
-        # Check response from create
-        assert_that(zone["name"], is_(zone_name + "."))
-        assert_that(zone["connection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["connection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["connection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-        assert_that(zone["transferConnection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["transferConnection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["transferConnection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-
-        # Check that it was internally stored correctly using GET
-        zone_get = client.get_zone(zone["id"])["zone"]
-        assert_that(zone_get["name"], is_(zone_name + "."))
-        assert_that(zone["connection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["connection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["connection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-        assert_that(zone["transferConnection"]["name"], is_(expected_connection["name"]))
-        assert_that(zone["transferConnection"]["keyName"], is_(expected_connection["keyName"]))
-        assert_that(zone["transferConnection"]["primaryServer"], is_(expected_connection["primaryServer"]))
-    finally:
-        if "id" in zone:
-            client.abandon_zones([zone["id"]], status=202)
+    result = client.create_zone(zone, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 @pytest.mark.serial
@@ -527,18 +440,7 @@ def test_user_cannot_create_zone_with_nonmember_admin_group(shared_zone_test_con
         "name": f"one-time{shared_zone_test_context.partition_id}.",
         "email": "test@test.com",
         "adminGroupId": shared_zone_test_context.dummy_group["id"],
-        "connection": {
-            "name": "vinyldns.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
-        },
-        "transferConnection": {
-            "name": "vinyldns.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
-        }
+        "backendId": "func-test-backend"
     }
 
     shared_zone_test_context.ok_vinyldns_client.create_zone(zone, status=403)
@@ -557,19 +459,11 @@ def test_user_cannot_create_zone_with_failed_validations(shared_zone_test_contex
             "keyName": VinylDNSTestContext.dns_key_name,
             "key": VinylDNSTestContext.dns_key,
             "primaryServer": VinylDNSTestContext.name_server_ip
-        },
-        "transferConnection": {
-            "name": "vinyldns.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
         }
     }
 
     result = shared_zone_test_context.ok_vinyldns_client.create_zone(zone, status=400)
-    assert_that(result["errors"], contains_inanyorder(
-        contains_string("not-approved.thing.com. is not an approved name server")
-    ))
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 def test_normal_user_cannot_create_shared_zone(shared_zone_test_context):

--- a/modules/api/src/test/functional/tests/zones/delete_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/delete_zone_test.py
@@ -17,18 +17,7 @@ def test_delete_zone_success(shared_zone_test_context):
             "name": zone_name,
             "email": "test@test.com",
             "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
+            "backendId": "func-test-backend"
         }
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
@@ -58,18 +47,7 @@ def test_delete_zone_twice(shared_zone_test_context):
             "name": zone_name,
             "email": "test@test.com",
             "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
+            "backendId": "func-test-backend"
         }
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]

--- a/modules/api/src/test/functional/tests/zones/sync_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/sync_zone_test.py
@@ -23,18 +23,7 @@ def test_sync_zone_success(shared_zone_test_context):
         "email": "test@test.com",
         "adminGroupId": shared_zone_test_context.ok_group["id"],
         "isTest": True,
-        "connection": {
-            "name": "vinyldns.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
-        },
-        "transferConnection": {
-            "name": "vinyldns.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
-        }
+        "backendId": "func-test-backend"
     }
     try:
         zone_change = client.create_zone(zone, status=202)

--- a/modules/api/src/test/functional/tests/zones/update_zone_test.py
+++ b/modules/api/src/test/functional/tests/zones/update_zone_test.py
@@ -7,6 +7,15 @@ from vinyldns_context import VinylDNSTestContext
 from datetime import datetime, timezone, timedelta
 
 
+def new_backend_zone(shared_zone_test_context, zone_name, admin_group_id=None):
+    return {
+        "name": zone_name,
+        "email": "test@test.com",
+        "adminGroupId": admin_group_id or shared_zone_test_context.ok_group["id"],
+        "backendId": "func-test-backend"
+    }
+
+
 @pytest.mark.serial
 def test_update_zone_success(shared_zone_test_context):
     """
@@ -25,23 +34,7 @@ def test_update_zone_success(shared_zone_test_context):
             "recordTypes": ["A", "AAAA", "CNAME"]
         }
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -84,23 +77,7 @@ def test_update_zone_success_wildcard(shared_zone_test_context):
             "recordTypes": ["A", "AAAA", "CNAME"]
         }
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -143,23 +120,7 @@ def test_update_zone_success_number_of_dots(shared_zone_test_context):
             "recordTypes": ["A", "AAAA", "CNAME"]
         }
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -202,23 +163,7 @@ def test_update_invalid_email(shared_zone_test_context):
             "recordTypes": ["A", "AAAA", "CNAME"]
         }
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -247,23 +192,7 @@ def test_update_invalid_domain(shared_zone_test_context):
             "recordTypes": ["A", "AAAA", "CNAME"]
         }
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -293,23 +222,7 @@ def test_update_invalid_email_number_of_dots(shared_zone_test_context):
             "recordTypes": ["A", "AAAA", "CNAME"]
         }
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -331,23 +244,7 @@ def test_update_zone_sync_schedule_fails(shared_zone_test_context):
     try:
         zone_name = f"one-time{shared_zone_test_context.partition_id}"
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -372,23 +269,7 @@ def test_update_zone_sync_schedule_success(shared_zone_test_context):
     try:
         zone_name = f"one-time{shared_zone_test_context.partition_id}"
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result_zone["id"])
@@ -489,23 +370,7 @@ def test_update_missing_zone_data(shared_zone_test_context):
     try:
         zone_name = f"one-time{shared_zone_test_context.partition_id}."
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result["zone"]["id"])
@@ -539,23 +404,7 @@ def test_update_invalid_zone_data(shared_zone_test_context):
     try:
         zone_name = f"one-time{shared_zone_test_context.partition_id}."
 
-        zone = {
-            "name": zone_name,
-            "email": "test@test.com",
-            "adminGroupId": shared_zone_test_context.ok_group["id"],
-            "connection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            },
-            "transferConnection": {
-                "name": "vinyldns.",
-                "keyName": VinylDNSTestContext.dns_key_name,
-                "key": VinylDNSTestContext.dns_key,
-                "primaryServer": VinylDNSTestContext.name_server_ip
-            }
-        }
+        zone = new_backend_zone(shared_zone_test_context, zone_name)
         result = client.create_zone(zone, status=202)
         result_zone = result["zone"]
         client.wait_until_zone_active(result["zone"]["id"])
@@ -588,19 +437,8 @@ def test_update_zone_returns_404_if_zone_not_found(shared_zone_test_context):
         "name": f"one-time{shared_zone_test_context.partition_id}.",
         "email": "test@test.com",
         "id": "nothere",
-        "connection": {
-            "name": "old-shared.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
-        },
-        "transferConnection": {
-            "name": "old-shared.",
-            "keyName": VinylDNSTestContext.dns_key_name,
-            "key": VinylDNSTestContext.dns_key,
-            "primaryServer": VinylDNSTestContext.name_server_ip
-        },
-        "adminGroupId": shared_zone_test_context.ok_group["id"]
+        "adminGroupId": shared_zone_test_context.ok_group["id"],
+        "backendId": "func-test-backend"
     }
     client.update_zone(zone, status=404)
 
@@ -1045,8 +883,14 @@ def test_activate_reverse_v4_zone_with_bad_key_fails(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
 
     update = copy.deepcopy(shared_zone_test_context.ip4_reverse_zone)
-    update["connection"]["key"] = "f00sn+4G2ldMn0q1CV3vsg=="
-    client.update_zone(update, status=400)
+    update["connection"] = {
+        "name": "ip4.",
+        "keyName": VinylDNSTestContext.dns_key_name,
+        "key": "f00sn+4G2ldMn0q1CV3vsg==",
+        "primaryServer": VinylDNSTestContext.name_server_ip
+    }
+    result = client.update_zone(update, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 def test_activate_reverse_v6_zone_with_bad_key_fails(shared_zone_test_context):
@@ -1056,8 +900,14 @@ def test_activate_reverse_v6_zone_with_bad_key_fails(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
 
     update = copy.deepcopy(shared_zone_test_context.ip6_reverse_zone)
-    update["connection"]["key"] = "f00sn+4G2ldMn0q1CV3vsg=="
-    client.update_zone(update, status=400)
+    update["connection"] = {
+        "name": "ip6.",
+        "keyName": VinylDNSTestContext.dns_key_name,
+        "key": "f00sn+4G2ldMn0q1CV3vsg==",
+        "primaryServer": VinylDNSTestContext.name_server_ip
+    }
+    result = client.update_zone(update, status=400)
+    assert_that(result, contains_string("Custom zone connections are not supported"))
 
 
 def test_user_cannot_update_zone_to_nonexisting_admin_group(shared_zone_test_context):
@@ -1066,7 +916,6 @@ def test_user_cannot_update_zone_to_nonexisting_admin_group(shared_zone_test_con
     """
     zone_update = copy.deepcopy(shared_zone_test_context.ok_zone)
     zone_update["adminGroupId"] = "some-bad-id"
-    zone_update["connection"]["key"] = VinylDNSTestContext.dns_key
 
     shared_zone_test_context.ok_vinyldns_client.update_zone(zone_update, status=400)
 
@@ -1085,18 +934,7 @@ def test_user_can_update_zone_to_another_admin_group(shared_zone_test_context):
                 "name": f"one-time{shared_zone_test_context.partition_id}.",
                 "email": "test@test.com",
                 "adminGroupId": shared_zone_test_context.dummy_group["id"],
-                "connection": {
-                    "name": "vinyldns.",
-                    "keyName": VinylDNSTestContext.dns_key_name,
-                    "key": VinylDNSTestContext.dns_key,
-                    "primaryServer": VinylDNSTestContext.name_server_ip
-                },
-                "transferConnection": {
-                    "name": "vinyldns.",
-                    "keyName": VinylDNSTestContext.dns_key_name,
-                    "key": VinylDNSTestContext.dns_key,
-                    "primaryServer": VinylDNSTestContext.name_server_ip
-                }
+                "backendId": "func-test-backend"
             }, status=202
         )
         zone = result["zone"]
@@ -1213,13 +1051,8 @@ def test_update_connection_info_success(shared_zone_test_context):
     client = shared_zone_test_context.ok_vinyldns_client
     zone = shared_zone_test_context.system_test_zone
 
-    # validating current zone state
     to_update = client.get_zone(zone["id"])["zone"]
-    assert_that(to_update, has_key("connection"))
-    assert_that(to_update, has_key("transferConnection"))
-
-    to_update.pop("connection")
-    to_update.pop("transferConnection")
+    assert_that(to_update, has_key("backendId"))
     to_update["backendId"] = "func-test-backend"
     test_rs = None
     try:
@@ -1227,8 +1060,6 @@ def test_update_connection_info_success(shared_zone_test_context):
         client.wait_until_zone_change_status_synced(change)
         new_zone = change["zone"]
 
-        assert_that(new_zone, is_not(has_key("connection")))
-        assert_that(new_zone, is_not(has_key("transferConnection")))
         assert_that(new_zone["backendId"], is_("func-test-backend"))
 
         # test adding a recordset - validates the key
@@ -1253,8 +1084,6 @@ def test_update_connection_info_invalid_backendid(shared_zone_test_context):
     zone = shared_zone_test_context.ok_zone
 
     to_update = client.get_zone(zone["id"])["zone"]
-    to_update.pop("connection")
-    to_update.pop("transferConnection")
     to_update["backendId"] = "bad-backend-id"
 
     result = client.update_zone(to_update, status=400)

--- a/modules/api/src/test/functional/utils.py
+++ b/modules/api/src/test/functional/utils.py
@@ -76,7 +76,11 @@ def dns_server_port(zone):
     :param zone: a populated zone model
     :return: a tuple (host, port), port is an int
     """
-    name_server = zone["connection"]["primaryServer"]
+    if "connection" in zone:
+        name_server = zone["connection"]["primaryServer"]
+    else:
+        # Zones created with backendId do not expose connection details in API responses.
+        name_server = VinylDNSTestContext.name_server_ip
     name_server_port = 53
     if VinylDNSTestContext.resolver_ip is not None:
         name_server = VinylDNSTestContext.resolver_ip
@@ -95,8 +99,9 @@ def dns_do_command(zone, record_name, record_type, command, ttl=0, rdata=""):
     """
     # Get the algorithm name from the DNS library (vinylDNS uses "-" in the name and dnspython uses "_")
     algo_name = getattr(dns.tsig, VinylDNSTestContext.dns_key_algo.replace("-", "_"))
+    key_name = zone["connection"]["keyName"] if "connection" in zone else VinylDNSTestContext.dns_key_name
     keyring = dns.tsigkeyring.from_text({
-        zone["connection"]["keyName"]: (algo_name, VinylDNSTestContext.dns_key)
+        key_name: (algo_name, VinylDNSTestContext.dns_key)
     })
 
     (name_server, name_server_port) = dns_server_port(zone)

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneServiceSpec.scala
@@ -126,7 +126,6 @@ class ZoneServiceSpec
   private val createZoneAuthorized = CreateZoneInput(
     "ok.zone.recordsets.",
     "test@test.com",
-    connection = testConnection,
     adminGroupId = okGroup.id
   )
 
@@ -134,7 +133,6 @@ class ZoneServiceSpec
     okZone.id,
     "ok.zone.recordsets.",
     "test@test.com",
-    connection = testConnection,
     adminGroupId = okGroup.id
   )
 
@@ -161,7 +159,7 @@ class ZoneServiceSpec
       resultZone.email shouldBe okZone.email
       resultZone.name shouldBe okZone.name
       resultZone.status shouldBe ZoneStatus.Syncing
-      resultZone.connection shouldBe okZone.connection
+      resultZone.connection shouldBe createZoneAuthorized.connection
       resultZone.shared shouldBe false
     }
 
@@ -386,7 +384,7 @@ class ZoneServiceSpec
       resultZone.email shouldBe okZone.email
       resultZone.name shouldBe okZone.name
       resultZone.status shouldBe ZoneStatus.Syncing
-      resultZone.connection shouldBe okZone.connection
+      resultZone.connection shouldBe newZone.connection
       resultZone.shared shouldBe true
     }
 
@@ -404,7 +402,7 @@ class ZoneServiceSpec
       resultZone.email shouldBe okZone.email
       resultZone.name shouldBe okZone.name
       resultZone.status shouldBe ZoneStatus.Syncing
-      resultZone.connection shouldBe okZone.connection
+      resultZone.connection shouldBe newZone.connection
       resultZone.shared shouldBe true
     }
 
@@ -418,6 +416,20 @@ class ZoneServiceSpec
 
     "return an InvalidRequest if zone has a specified backend ID that is invalid" in {
       val newZone = createZoneAuthorized.copy(backendId = Some("badId"))
+
+      val error = underTest.connectToZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
+      error shouldBe an[InvalidRequest]
+    }
+
+    "return an InvalidRequest if a custom connection is supplied" in {
+      val newZone = createZoneAuthorized.copy(connection = testConnection)
+
+      val error = underTest.connectToZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
+      error shouldBe an[InvalidRequest]
+    }
+
+    "return an InvalidRequest if a custom transfer connection is supplied" in {
+      val newZone = createZoneAuthorized.copy(transferConnection = testConnection)
 
       val error = underTest.connectToZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]
@@ -505,7 +517,7 @@ class ZoneServiceSpec
         updateZoneAuthorized.copy(connection = Some(badConnection), adminGroupId = okGroup.id)
 
       val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
-      error shouldBe a[ConnectionFailed]
+      error shouldBe an[InvalidRequest]
     }
 
     "return an error if the user is not authorized for the zone" in {
@@ -611,6 +623,17 @@ class ZoneServiceSpec
     }
     "return an InvalidRequest if zone has a specified backend ID that is invalid" in {
       val newZone = updateZoneAuthorized.copy(backendId = Some("badId"))
+
+      val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
+      error shouldBe an[InvalidRequest]
+    }
+
+    "return an InvalidRequest if a custom transfer connection is added" in {
+      doReturn(IO.pure(Some(okZone.copy(connection = None, transferConnection = None))))
+        .when(mockZoneRepo)
+        .getZone(anyString)
+
+      val newZone = updateZoneAuthorized.copy(transferConnection = testConnection)
 
       val error = underTest.updateZone(newZone, okAuth).value.unsafeRunSync().swap.toOption.get
       error shouldBe an[InvalidRequest]

--- a/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneValidationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/zone/ZoneValidationsSpec.scala
@@ -54,6 +54,35 @@ class ZoneValidationsSpec
     }
   }
 
+  "noCustomZoneConnections" should {
+    "succeed when both connections are absent" in {
+      noCustomZoneConnections(None, None) should be(right)
+    }
+
+    "fail when a primary connection is supplied" in {
+      leftValue(noCustomZoneConnections(okZone.connection, None)) shouldBe a[InvalidRequest]
+    }
+
+    "fail when a transfer connection is supplied" in {
+      leftValue(noCustomZoneConnections(None, okZone.connection)) shouldBe a[InvalidRequest]
+    }
+  }
+
+  "noCustomZoneConnectionUpdates" should {
+    "succeed when existing custom connections are unchanged" in {
+      noCustomZoneConnectionUpdates(okZone, okZone) should be(right)
+    }
+
+    "fail when a custom connection is changed" in {
+      val replacement = okZone.connection.map(_.copy(primaryServer = "10.1.1.2"))
+      leftValue(noCustomZoneConnectionUpdates(okZone.copy(connection = replacement), okZone)) shouldBe a[InvalidRequest]
+    }
+
+    "succeed when custom connections are removed" in {
+      noCustomZoneConnectionUpdates(okZone.copy(connection = None), okZone) should be(right)
+    }
+  }
+
   "isValidAclRule" should {
     "fail if mask is an invalid regex" in {
       val invalidRegexMaskRuleInfo = baseAclRuleInfo.copy(recordMask = Some("x{5,-3}"))


### PR DESCRIPTION
## Summary
- reject custom zone connection and transfer connection inputs during zone creation
- reject updates that introduce or modify custom zone connections while allowing removals
- add zone service and validation coverage for the new invalid request behavior

## Testing
- `sbt -batch "api/testOnly vinyldns.api.domain.zone.ZoneValidationsSpec vinyldns.api.domain.zone.ZoneServiceSpec"`
- passed: 115 tests, 0 failures

VDNS-356