### PR TITLE
Add count API for DNS batch record changes

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -580,6 +580,27 @@ class BatchChangeService(
       summary.copy(reviewerName = userName)
     }
 
+  private case class BatchChangeFilterCriteria(
+      userId: Option[String],
+      submitterUserName: Option[String],
+      startDateTime: Option[String],
+      endDateTime: Option[String]
+  )
+
+  private def buildFilterCriteria(
+      auth: AuthPrincipal,
+      ignoreAccess: Boolean,
+      userName: Option[String],
+      dateTimeStartRange: Option[String],
+      dateTimeEndRange: Option[String]
+  ): BatchChangeFilterCriteria =
+    BatchChangeFilterCriteria(
+      userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId),
+      submitterUserName = userName.filter(_.nonEmpty),
+      startDateTime = dateTimeStartRange.filter(_.nonEmpty),
+      endDateTime = dateTimeEndRange.filter(_.nonEmpty)
+    )
+
   def listBatchChangeSummaries(
       auth: AuthPrincipal,
       userName: Option[String] = None,
@@ -591,13 +612,10 @@ class BatchChangeService(
       batchStatus: Option[BatchChangeStatus] = None,
       approvalStatus: Option[BatchChangeApprovalStatus] = None
   ): BatchResult[BatchChangeSummaryList] = {
-    val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
-    val submitterUserName = if(userName.isDefined && userName.get.isEmpty) None else userName
-    val startDateTime = if(dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None else dateTimeStartRange
-    val endDateTime = if(dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None else dateTimeEndRange
+    val criteria = buildFilterCriteria(auth, ignoreAccess, userName, dateTimeStartRange, dateTimeEndRange)
     for {
       listResults <- batchChangeRepo
-        .getBatchChangeSummaries(userId, submitterUserName, startDateTime, endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
+        .getBatchChangeSummaries(criteria.userId, criteria.submitterUserName, criteria.startDateTime, criteria.endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
         .toBatchResult
       rsOwnerGroupIds = listResults.batchChanges.flatMap(_.ownerGroupId).toSet
       rsOwnerGroups <- groupRepository.getGroups(rsOwnerGroupIds).toBatchResult
@@ -630,17 +648,9 @@ class BatchChangeService(
       ignoreAccess: Boolean = false,
       approvalStatus: Option[BatchChangeApprovalStatus] = None
   ): BatchResult[BatchChangeCount] = {
-    val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
-    val submitterUserName =
-      if (userName.isDefined && userName.get.isEmpty) None else userName
-    val startDateTime =
-      if (dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None
-      else dateTimeStartRange
-    val endDateTime =
-      if (dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None
-      else dateTimeEndRange
+    val criteria = buildFilterCriteria(auth, ignoreAccess, userName, dateTimeStartRange, dateTimeEndRange)
     batchChangeRepo
-      .getBatchChangeCount(userId, submitterUserName, startDateTime, endDateTime, approvalStatus)
+      .getBatchChangeCount(criteria.userId, criteria.submitterUserName, criteria.startDateTime, criteria.endDateTime, approvalStatus)
       .toBatchResult
   }
 

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -622,6 +622,28 @@ class BatchChangeService(
     } yield listWithGroupNames
   }
 
+  def getBatchChangeCount(
+      auth: AuthPrincipal,
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      ignoreAccess: Boolean = false,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): BatchResult[BatchChangeCount] = {
+    val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
+    val submitterUserName =
+      if (userName.isDefined && userName.get.isEmpty) None else userName
+    val startDateTime =
+      if (dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None
+      else dateTimeStartRange
+    val endDateTime =
+      if (dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None
+      else dateTimeEndRange
+    batchChangeRepo
+      .getBatchChangeCount(userId, submitterUserName, startDateTime, endDateTime, approvalStatus)
+      .toBatchResult
+  }
+
   def rejectBatchChange(
       batchChange: BatchChange,
       reviewComment: Option[String],

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -20,7 +20,7 @@ import vinyldns.api.domain.batch.BatchChangeInterfaces.BatchResult
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.domain.batch.BatchChangeStatus.BatchChangeStatus
-import vinyldns.core.domain.batch.{BatchChange, BatchChangeInfo, BatchChangeSummaryList}
+import vinyldns.core.domain.batch.{BatchChange, BatchChangeCount, BatchChangeInfo, BatchChangeSummaryList}
 
 // $COVERAGE-OFF$
 trait BatchChangeServiceAlgebra {
@@ -43,6 +43,15 @@ trait BatchChangeServiceAlgebra {
       batchStatus: Option[BatchChangeStatus],
       approvalStatus: Option[BatchChangeApprovalStatus]
   ): BatchResult[BatchChangeSummaryList]
+
+  def getBatchChangeCount(
+      auth: AuthPrincipal,
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      ignoreAccess: Boolean = false,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): BatchResult[BatchChangeCount]
 
   def rejectBatchChange(
       batchChangeId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -138,17 +138,24 @@ class BatchChangeRoute(
               {
                 val convertApprovalStatus =
                   approvalStatus.flatMap(BatchChangeApprovalStatus.find)
-                authenticateAndExecute(
-                  batchChangeService.getBatchChangeCount(
-                    _,
-                    userName,
-                    dateTimeRangeStart,
-                    dateTimeRangeEnd,
-                    ignoreAccess,
-                    convertApprovalStatus
-                  )
-                ) { result =>
-                  complete(StatusCodes.OK, result)
+                handleRejections(invalidQueryHandler) {
+                  validate(
+                    approvalStatus.forall(s => BatchChangeApprovalStatus.find(s).isDefined),
+                    s"approvalStatus '${approvalStatus.getOrElse("")}' is not a valid value."
+                  ) {
+                    authenticateAndExecute(
+                      batchChangeService.getBatchChangeCount(
+                        _,
+                        userName,
+                        dateTimeRangeStart,
+                        dateTimeRangeEnd,
+                        ignoreAccess,
+                        convertApprovalStatus
+                      )
+                    ) { result =>
+                      complete(StatusCodes.OK, result)
+                    }
+                  }
                 }
               }
           }

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -119,6 +119,41 @@ class BatchChangeRoute(
             }
         }
       } ~
+      path("zones" / "batchrecordchanges" / "count") {
+        (get & monitor("Endpoint.getBatchChangeCount")) {
+          parameters(
+            "userName".as[String].?,
+            "dateTimeRangeStart".as[String].?,
+            "dateTimeRangeEnd".as[String].?,
+            "ignoreAccess".as[Boolean].?(false),
+            "approvalStatus".as[String].?
+          ) {
+            (
+                userName: Option[String],
+                dateTimeRangeStart: Option[String],
+                dateTimeRangeEnd: Option[String],
+                ignoreAccess: Boolean,
+                approvalStatus: Option[String]
+            ) =>
+              {
+                val convertApprovalStatus =
+                  approvalStatus.flatMap(BatchChangeApprovalStatus.find)
+                authenticateAndExecute(
+                  batchChangeService.getBatchChangeCount(
+                    _,
+                    userName,
+                    dateTimeRangeStart,
+                    dateTimeRangeEnd,
+                    ignoreAccess,
+                    convertApprovalStatus
+                  )
+                ) { result =>
+                  complete(StatusCodes.OK, result)
+                }
+              }
+          }
+        }
+      } ~
       path("zones" / "batchrecordchanges" / Segment) { id =>
         (get & monitor("Endpoint.getBatchChange")) {
           authenticateAndExecute(batchChangeService.getBatchChange(id, _)) { chg =>

--- a/modules/api/src/test/functional/tests/batch/get_batch_change_count_test.py
+++ b/modules/api/src/test/functional/tests/batch/get_batch_change_count_test.py
@@ -205,14 +205,10 @@ def test_get_batch_change_count_filters_by_approval_status(shared_zone_test_cont
 
 def test_get_batch_change_count_unrecognized_approval_status_is_ignored(shared_zone_test_context):
     """
-    Test that an unrecognized approvalStatus query value is ignored and falls back to the
-    unfiltered count for the user
+    Test that an unrecognized approvalStatus query value is rejected with HTTP 400
     """
     client = shared_zone_test_context.ok_vinyldns_client
 
-    unfiltered = client.get_batch_change_count(status=200)
-    bad_filter = client.get_batch_change_count(approval_status="NotAStatus", status=200)
+    error = client.get_batch_change_count(approval_status="NotAStatus", status=400)
 
-    assert_count_is_consistent(unfiltered)
-    assert_count_is_consistent(bad_filter)
-    assert_that(bad_filter["total"], is_(greater_than_or_equal_to(unfiltered["total"])))
+    assert_that(error, contains_string("NotAStatus"))

--- a/modules/api/src/test/functional/tests/batch/get_batch_change_count_test.py
+++ b/modules/api/src/test/functional/tests/batch/get_batch_change_count_test.py
@@ -1,0 +1,218 @@
+import pytest
+
+from utils import *
+from vinyldns_context import VinylDNSTestContext
+from vinyldns_python import VinylDNSClient
+
+# Status buckets returned by the batch change count endpoint
+COUNT_STATUS_KEYS = [
+    "complete",
+    "failed",
+    "partialFailure",
+    "rejected",
+    "cancelled",
+    "pendingReview",
+    "scheduled",
+    "pendingProcessing",
+]
+
+
+def assert_count_is_consistent(count):
+    """
+    The count response should expose all status buckets plus a total, and the total
+    should always equal the sum of the individual status buckets.
+    """
+    assert_that(count, has_key("total"))
+    for key in COUNT_STATUS_KEYS:
+        assert_that(count, has_key(key))
+        assert_that(count[key], is_(greater_than_or_equal_to(0)))
+
+    assert_that(count["total"], is_(sum(count[key] for key in COUNT_STATUS_KEYS)))
+
+
+def test_get_batch_change_count_with_no_changes_is_zero():
+    """
+    Test that a user with no batch changes gets a count of zero for every status bucket
+    """
+    client = VinylDNSClient(VinylDNSTestContext.vinyldns_url, "listZeroSummariesAccessKey", "listZeroSummariesSecretKey")
+
+    count = client.get_batch_change_count(status=200)
+
+    assert_count_is_consistent(count)
+    assert_that(count["total"], is_(0))
+    for key in COUNT_STATUS_KEYS:
+        assert_that(count[key], is_(0))
+
+
+def test_get_batch_change_count_reflects_completed_changes(shared_zone_test_context):
+    """
+    Test that completing batch changes increments the complete and total counts
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+    ok_zone_name = shared_zone_test_context.ok_zone["name"]
+
+    before = client.get_batch_change_count(status=200)
+    assert_count_is_consistent(before)
+
+    to_delete = set()
+    try:
+        for i in range(2):
+            batch_change_input = {
+                "comments": f"count-test-complete-{i}",
+                "changes": [
+                    get_change_A_AAAA_json(generate_record_name(ok_zone_name), address="1.2.3.4")
+                ]
+            }
+            batch_change = client.create_batch_change(batch_change_input, status=202)
+            completed = client.wait_until_batch_change_completed(batch_change)
+            assert_that(completed["status"], is_("Complete"))
+            to_delete.update((change["zoneId"], change["recordSetId"]) for change in completed["changes"])
+
+        after = client.get_batch_change_count(status=200)
+
+        assert_count_is_consistent(after)
+        # Counts are cumulative (batch changes are never deleted), so the delta is at least
+        # the number of changes we just completed
+        assert_that(after["total"], is_(greater_than_or_equal_to(before["total"] + 2)))
+        assert_that(after["complete"], is_(greater_than_or_equal_to(before["complete"] + 2)))
+    finally:
+        for result_rs in to_delete:
+            delete_result = client.delete_recordset(result_rs[0], result_rs[1], status=(202, 404))
+            if not isinstance(delete_result, str):
+                client.wait_until_recordset_change_status(delete_result, "Complete")
+
+
+def test_get_batch_change_count_only_includes_callers_changes(shared_zone_test_context):
+    """
+    Test that a batch change created by one user is not counted for a different user
+    (access is scoped to the authenticated user when ignoreAccess is not set)
+    """
+    creator = shared_zone_test_context.ok_vinyldns_client
+    other = VinylDNSClient(VinylDNSTestContext.vinyldns_url, "listZeroSummariesAccessKey", "listZeroSummariesSecretKey")
+    ok_zone_name = shared_zone_test_context.ok_zone["name"]
+
+    # The zero-summaries user never owns any batch changes
+    assert_that(other.get_batch_change_count(status=200)["total"], is_(0))
+
+    to_delete = set()
+    try:
+        batch_change_input = {
+            "comments": "count-test-access-scoping",
+            "changes": [
+                get_change_A_AAAA_json(generate_record_name(ok_zone_name), address="1.2.3.4")
+            ]
+        }
+        batch_change = creator.create_batch_change(batch_change_input, status=202)
+        completed = creator.wait_until_batch_change_completed(batch_change)
+        to_delete.update((change["zoneId"], change["recordSetId"]) for change in completed["changes"])
+
+        # The other user's count is unaffected by the creator's batch change
+        other_count = other.get_batch_change_count(status=200)
+        assert_count_is_consistent(other_count)
+        assert_that(other_count["total"], is_(0))
+    finally:
+        for result_rs in to_delete:
+            delete_result = creator.delete_recordset(result_rs[0], result_rs[1], status=(202, 404))
+            if not isinstance(delete_result, str):
+                creator.wait_until_recordset_change_status(delete_result, "Complete")
+
+
+def test_get_batch_change_count_ignore_access_for_super_user(shared_zone_test_context):
+    """
+    Test that a super user requesting with ignoreAccess=true gets counts across all users,
+    which is always at least as large as the count scoped to their own changes
+    """
+    super_user = shared_zone_test_context.super_user_client
+    creator = shared_zone_test_context.ok_vinyldns_client
+    ok_zone_name = shared_zone_test_context.ok_zone["name"]
+
+    to_delete = set()
+    try:
+        batch_change_input = {
+            "comments": "count-test-ignore-access",
+            "changes": [
+                get_change_A_AAAA_json(generate_record_name(ok_zone_name), address="1.2.3.4")
+            ]
+        }
+        batch_change = creator.create_batch_change(batch_change_input, status=202)
+        completed = creator.wait_until_batch_change_completed(batch_change)
+        to_delete.update((change["zoneId"], change["recordSetId"]) for change in completed["changes"])
+
+        scoped_count = super_user.get_batch_change_count(status=200)
+        all_users_count = super_user.get_batch_change_count(ignore_access=True, status=200)
+
+        assert_count_is_consistent(scoped_count)
+        assert_count_is_consistent(all_users_count)
+
+        # ignoreAccess includes every user's batch changes, so it must include the change
+        # the ok user just created and be at least as large as the super user's own scope
+        assert_that(all_users_count["total"], is_(greater_than_or_equal_to(scoped_count["total"])))
+        assert_that(all_users_count["complete"], is_(greater_than_or_equal_to(1)))
+    finally:
+        for result_rs in to_delete:
+            delete_result = creator.delete_recordset(result_rs[0], result_rs[1], status=(202, 404))
+            if not isinstance(delete_result, str):
+                creator.wait_until_recordset_change_status(delete_result, "Complete")
+
+
+def test_get_batch_change_count_ignore_access_is_ignored_for_non_super_user(shared_zone_test_context):
+    """
+    Test that a non-privileged user requesting with ignoreAccess=true still only gets their
+    own counts (ignoreAccess only applies to system admins)
+    """
+    other = VinylDNSClient(VinylDNSTestContext.vinyldns_url, "listZeroSummariesAccessKey", "listZeroSummariesSecretKey")
+
+    count = other.get_batch_change_count(ignore_access=True, status=200)
+
+    assert_count_is_consistent(count)
+    assert_that(count["total"], is_(0))
+
+
+@pytest.mark.manual_batch_review
+def test_get_batch_change_count_filters_by_approval_status(shared_zone_test_context):
+    """
+    Test that filtering the count by approvalStatus returns only batch changes in that status
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    before = client.get_batch_change_count(approval_status="PendingReview", status=200)
+    assert_count_is_consistent(before)
+
+    pending_bc = None
+    try:
+        batch_change_input = {
+            "changes": [
+                get_change_A_AAAA_json("zone.discovery.failure.", address="4.3.2.1")
+            ],
+            "ownerGroupId": shared_zone_test_context.ok_group["id"]
+        }
+        pending_bc = client.create_batch_change(batch_change_input, status=202)
+        get_batch = client.get_batch_change(pending_bc["id"])
+        assert_that(get_batch["status"], is_("PendingReview"))
+
+        after = client.get_batch_change_count(approval_status="PendingReview", status=200)
+        assert_count_is_consistent(after)
+
+        # The filtered count should only ever reflect pending review batch changes
+        assert_that(after["pendingReview"], is_(greater_than_or_equal_to(before["pendingReview"] + 1)))
+        assert_that(after["total"], is_(after["pendingReview"] + after["scheduled"]))
+        assert_that(after["complete"], is_(0))
+    finally:
+        if pending_bc:
+            rejecter = shared_zone_test_context.support_user_client
+            rejecter.reject_batch_change(pending_bc["id"], status=200)
+
+
+def test_get_batch_change_count_unrecognized_approval_status_is_ignored(shared_zone_test_context):
+    """
+    Test that an unrecognized approvalStatus query value is ignored and falls back to the
+    unfiltered count for the user
+    """
+    client = shared_zone_test_context.ok_vinyldns_client
+
+    unfiltered = client.get_batch_change_count(status=200)
+    bad_filter = client.get_batch_change_count(approval_status="NotAStatus", status=200)
+
+    assert_count_is_consistent(unfiltered)
+    assert_count_is_consistent(bad_filter)
+    assert_that(bad_filter["total"], is_(greater_than_or_equal_to(unfiltered["total"])))

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -690,6 +690,31 @@ class VinylDNSClient(object):
         response, data = self.make_request(url, "GET", self.headers, **kwargs)
         return data
 
+    def get_batch_change_count(self, user_name=None, date_time_range_start=None, date_time_range_end=None,
+                               ignore_access=False, approval_status=None, **kwargs):
+        """
+        Gets the count of a user's batch changes grouped by status
+        :return: the content of the response
+        """
+        args = []
+        if user_name is not None:
+            args.append("userName={0}".format(user_name))
+        if date_time_range_start is not None:
+            args.append("dateTimeRangeStart={0}".format(date_time_range_start))
+        if date_time_range_end is not None:
+            args.append("dateTimeRangeEnd={0}".format(date_time_range_end))
+        if ignore_access:
+            args.append("ignoreAccess={0}".format(ignore_access))
+        if approval_status is not None:
+            args.append("approvalStatus={0}".format(approval_status))
+
+        url = urljoin(self.index_url, "/zones/batchrecordchanges/count")
+        if args:
+            url = url + "?" + "&".join(args)
+
+        response, data = self.make_request(url, "GET", self.headers, **kwargs)
+        return data
+
     def add_zone_acl_rule_with_wait(self, zone_id, acl_rule, sign_request=True, **kwargs):
         """
         Puts an acl rule on the zone and waits for success

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -2579,6 +2579,221 @@ class BatchChangeServiceSpec
     }
   }
 
+  "getBatchChangeCount" should {
+    def saveBatch(
+        ownerAuth: AuthPrincipal,
+        approvalStatus: BatchChangeApprovalStatus.BatchChangeApprovalStatus,
+        offsetMillis: Long = 0L,
+        userNameOverride: Option[String] = None
+    ): BatchChange = {
+      val bc = BatchChange(
+        ownerAuth.userId,
+        userNameOverride.getOrElse(ownerAuth.signedInUser.userName),
+        None,
+        Instant.ofEpochMilli(Instant.now.truncatedTo(ChronoUnit.MILLIS).toEpochMilli + offsetMillis),
+        List(),
+        approvalStatus = approvalStatus
+      )
+      batchChangeRepo.save(bc).unsafeRunSync()
+      bc
+    }
+
+    "return zero counts when the user has no batch changes" in {
+      val result = underTest.getBatchChangeCount(auth).value.unsafeRunSync().toOption.get
+
+      result.total shouldBe 0
+      result.complete shouldBe 0
+      result.failed shouldBe 0
+      result.partialFailure shouldBe 0
+      result.rejected shouldBe 0
+      result.cancelled shouldBe 0
+      result.pendingReview shouldBe 0
+      result.scheduled shouldBe 0
+      result.pendingProcessing shouldBe 0
+    }
+
+    "return counts grouped by status for the authenticated user's batch changes" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+      saveBatch(auth, BatchChangeApprovalStatus.ManuallyRejected, offsetMillis = 3)
+      saveBatch(auth, BatchChangeApprovalStatus.Cancelled, offsetMillis = 4)
+
+      val result = underTest.getBatchChangeCount(auth).value.unsafeRunSync().toOption.get
+
+      // AutoApproved with no changes derives to Complete
+      result.complete shouldBe 2
+      result.pendingReview shouldBe 1
+      result.rejected shouldBe 1
+      result.cancelled shouldBe 1
+      result.failed shouldBe 0
+      result.partialFailure shouldBe 0
+      result.scheduled shouldBe 0
+      result.pendingProcessing shouldBe 0
+      result.total shouldBe 5
+    }
+
+    "exclude other users' batch changes when ignoreAccess is false" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(notAuth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+      saveBatch(notAuth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+
+      val result = underTest.getBatchChangeCount(auth).value.unsafeRunSync().toOption.get
+
+      result.total shouldBe 1
+      result.complete shouldBe 1
+    }
+
+    "return counts for all users when ignoreAccess is true and the requester is a system admin" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(notAuth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+      saveBatch(notAuth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+
+      val result =
+        underTest
+          .getBatchChangeCount(superUserAuth, ignoreAccess = true)
+          .value
+          .unsafeRunSync()
+          .toOption
+          .get
+
+      result.total shouldBe 3
+      result.complete shouldBe 2
+      result.pendingReview shouldBe 1
+    }
+
+    "scope counts to the requester's own batches when ignoreAccess is true but requester is not a system admin" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(notAuth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+
+      val result =
+        underTest
+          .getBatchChangeCount(auth, ignoreAccess = true)
+          .value
+          .unsafeRunSync()
+          .toOption
+          .get
+
+      result.total shouldBe 1
+      result.complete shouldBe 1
+    }
+
+    "filter counts by approvalStatus when provided" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 1)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+
+      val result = underTest
+        .getBatchChangeCount(
+          auth,
+          approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 2
+      result.pendingReview shouldBe 2
+      result.complete shouldBe 0
+    }
+
+    "filter counts by userName when provided" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(
+        auth,
+        BatchChangeApprovalStatus.AutoApproved,
+        offsetMillis = 1,
+        userNameOverride = Some("anotherUser")
+      )
+
+      val result = underTest
+        .getBatchChangeCount(superUserAuth, userName = Some("anotherUser"), ignoreAccess = true)
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 1
+      result.complete shouldBe 1
+    }
+
+    "normalize an empty-string userName to no filter" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 1)
+
+      val result = underTest
+        .getBatchChangeCount(auth, userName = Some(""))
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 2
+    }
+
+    "normalize empty-string date range bounds to no filter" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+
+      val result = underTest
+        .getBatchChangeCount(
+          auth,
+          dateTimeStartRange = Some(""),
+          dateTimeEndRange = Some("")
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 2
+    }
+
+    "filter counts by an inclusive date range when provided" in {
+      val now = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+      // saved batch is in the future; range bounded to a past window should exclude it
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 60000L)
+
+      val past =
+        LocalDateTime.ofInstant(now.minusSeconds(120), ZoneId.of("UTC")).format(formatter)
+      val pastEnd =
+        LocalDateTime.ofInstant(now.minusSeconds(60), ZoneId.of("UTC")).format(formatter)
+
+      val excluded = underTest
+        .getBatchChangeCount(
+          auth,
+          dateTimeStartRange = Some(past),
+          dateTimeEndRange = Some(pastEnd)
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      excluded.total shouldBe 0
+
+      // open-ended range encompassing the saved batch should include it
+      val futureEnd =
+        LocalDateTime.ofInstant(now.plusSeconds(600), ZoneId.of("UTC")).format(formatter)
+
+      val included = underTest
+        .getBatchChangeCount(
+          auth,
+          dateTimeStartRange = Some(past),
+          dateTimeEndRange = Some(futureEnd)
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      included.total shouldBe 1
+      included.complete shouldBe 1
+    }
+  }
+
   "getOwnerGroup" should {
     "return None if owner group ID is None" in {
       underTest.getOwnerGroup(None).value.unsafeRunSync().toOption.get shouldBe None

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -180,4 +180,70 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     batches.clear()
     singleChangesMap.clear()
   }
+
+  def getBatchChangeCount(
+      userId: Option[String],
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): IO[BatchChangeCount] = {
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    val startInstant = dateTimeStartRange.map(dt =>
+      LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant
+    )
+    val endInstant = dateTimeEndRange.map(dt =>
+      LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant
+    )
+
+    val filtered = batches.values.toList
+      .filter(b => userId.forall(_ == b.userId))
+      .filter(b => userName.forall(_ == b.userName))
+      .filter(b => startInstant.forall(_.isBefore(b.createdTimestamp)))
+      .filter(b => endInstant.forall(_.isAfter(b.createdTimestamp)))
+      .filter(b => approvalStatus.forall(_ == b.approvalStatus))
+
+    val statuses: List[BatchChangeStatus] = filtered.map { sc =>
+      val changes = sc.changes.flatMap(singleChangesMap.get)
+      BatchChange(
+        sc.userId,
+        sc.userName,
+        sc.comments,
+        sc.createdTimestamp,
+        changes,
+        sc.ownerGroupId,
+        sc.approvalStatus,
+        sc.reviewerId,
+        sc.reviewComment,
+        sc.reviewTimestamp,
+        sc.id
+      ).status
+    }
+
+    def cnt(s: BatchChangeStatus): Int = statuses.count(_ == s)
+
+    val complete          = cnt(BatchChangeStatus.Complete)
+    val failed            = cnt(BatchChangeStatus.Failed)
+    val partialFailure    = cnt(BatchChangeStatus.PartialFailure)
+    val rejected          = cnt(BatchChangeStatus.Rejected)
+    val cancelled         = cnt(BatchChangeStatus.Cancelled)
+    val pendingReview     = cnt(BatchChangeStatus.PendingReview)
+    val scheduled         = cnt(BatchChangeStatus.Scheduled)
+    val pendingProcessing = cnt(BatchChangeStatus.PendingProcessing)
+
+    IO.pure(
+      BatchChangeCount(
+        total = complete + failed + partialFailure + rejected +
+          cancelled + pendingReview + scheduled + pendingProcessing,
+        complete = complete,
+        failed = failed,
+        partialFailure = partialFailure,
+        rejected = rejected,
+        cancelled = cancelled,
+        pendingReview = pendingReview,
+        scheduled = scheduled,
+        pendingProcessing = pendingProcessing
+      )
+    )
+  }
 }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -941,18 +941,11 @@ class BatchChangeRoutingSpec()
       }
     }
 
-    "ignore an unrecognized approvalStatus value (falls through to no filter)" in {
+    "return 400 for an unrecognized approvalStatus value" in {
       Get("/zones/batchrecordchanges/count?approvalStatus=NotAStatus") ~>
         batchChangeRoute ~> check {
-        status shouldBe OK
-
-        val resp = responseAs[BatchChangeCount]
-
-        // Same as the no-filter case for okAuth
-        resp.total shouldBe 4
-        resp.complete shouldBe 2
-        resp.pendingReview shouldBe 1
-        resp.pendingProcessing shouldBe 1
+        status shouldBe BadRequest
+        responseAs[String] should include("NotAStatus")
       }
     }
 

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -488,6 +488,63 @@ class BatchChangeRoutingSpec()
         case ("batchId", _) => EitherT(IO.pure(BatchChangeNotPendingReview("batchId").asLeft))
         case (_, _) => EitherT(IO.pure(BatchChangeNotFound("notFoundId").asLeft))
       }
+
+    def getBatchChangeCount(
+        auth: AuthPrincipal,
+        userName: Option[String] = None,
+        dateTimeStartRange: Option[String] = None,
+        dateTimeEndRange: Option[String] = None,
+        ignoreAccess: Boolean = false,
+        approvalStatus: Option[BatchChangeApprovalStatus] = None
+    ): EitherT[IO, BatchChangeErrorResponse, BatchChangeCount] =
+      (auth.userId, ignoreAccess, approvalStatus, userName, dateTimeStartRange, dateTimeEndRange) match {
+        case (okAuth.userId, false, None, None, None, None) =>
+          EitherT.rightT(
+            BatchChangeCount(
+              total = 4,
+              complete = 2,
+              failed = 0,
+              partialFailure = 0,
+              rejected = 0,
+              cancelled = 0,
+              pendingReview = 1,
+              scheduled = 0,
+              pendingProcessing = 1
+            )
+          )
+        case (okAuth.userId, false, Some(BatchChangeApprovalStatus.PendingReview), None, None, None) =>
+          EitherT.rightT(
+            BatchChangeCount(total = 1, pendingReview = 1)
+          )
+        case (
+            okAuth.userId,
+            false,
+            None,
+            Some(uname),
+            Some("2023-11-14 00:00:00"),
+            Some("2023-11-15 00:00:00")
+            ) if uname == okAuth.signedInUser.userName =>
+          EitherT.rightT(BatchChangeCount(total = 1, complete = 1))
+        case (superUserAuth.userId, true, None, None, None, None) =>
+          EitherT.rightT(
+            BatchChangeCount(
+              total = 7,
+              complete = 3,
+              failed = 1,
+              partialFailure = 1,
+              rejected = 1,
+              cancelled = 0,
+              pendingReview = 1,
+              scheduled = 0,
+              pendingProcessing = 0
+            )
+          )
+        case (superUserAuth.userId, true, Some(BatchChangeApprovalStatus.PendingReview), None, None, None) =>
+          EitherT.rightT(BatchChangeCount(total = 2, pendingReview = 2))
+        case (superUserAuth.userId, false, _, _, _, _) =>
+          EitherT.rightT(BatchChangeCount())
+        case _ => EitherT.rightT(BatchChangeCount())
+      }
   }
 
   "POST batch change" should {
@@ -793,6 +850,121 @@ class BatchChangeRoutingSpec()
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
         resp.approvalStatus.toString shouldBe Some(BatchChangeApprovalStatus.PendingReview).toString
+      }
+    }
+  }
+
+  "GET batch change count" should {
+    "return the count grouped by status for the authenticated user" in {
+      Get("/zones/batchrecordchanges/count") ~> batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 4
+        resp.complete shouldBe 2
+        resp.failed shouldBe 0
+        resp.partialFailure shouldBe 0
+        resp.rejected shouldBe 0
+        resp.cancelled shouldBe 0
+        resp.pendingReview shouldBe 1
+        resp.scheduled shouldBe 0
+        resp.pendingProcessing shouldBe 1
+      }
+    }
+
+    "filter the count by approvalStatus query param" in {
+      Get("/zones/batchrecordchanges/count?approvalStatus=PendingReview") ~>
+        batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 1
+        resp.pendingReview shouldBe 1
+        resp.complete shouldBe 0
+      }
+    }
+
+    "filter the count by userName and date range query params" in {
+      val url =
+        s"/zones/batchrecordchanges/count?userName=${okAuth.signedInUser.userName}" +
+          "&dateTimeRangeStart=2023-11-14%2000:00:00" +
+          "&dateTimeRangeEnd=2023-11-15%2000:00:00"
+
+      Get(url) ~> batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 1
+        resp.complete shouldBe 1
+      }
+    }
+
+    "return the count across all users when ignoreAccess is true and requester is a super user" in {
+      Get("/zones/batchrecordchanges/count?ignoreAccess=true") ~>
+        superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 7
+        resp.complete shouldBe 3
+        resp.failed shouldBe 1
+        resp.partialFailure shouldBe 1
+        resp.rejected shouldBe 1
+        resp.pendingReview shouldBe 1
+      }
+    }
+
+    "filter by approvalStatus when ignoreAccess is true and requester is a super user" in {
+      Get("/zones/batchrecordchanges/count?ignoreAccess=true&approvalStatus=PendingReview") ~>
+        superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 2
+        resp.pendingReview shouldBe 2
+      }
+    }
+
+    "default ignoreAccess to false when omitted" in {
+      // super user with no ignoreAccess param should not get the cross-user totals
+      Get("/zones/batchrecordchanges/count") ~> superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 0
+      }
+    }
+
+    "ignore an unrecognized approvalStatus value (falls through to no filter)" in {
+      Get("/zones/batchrecordchanges/count?approvalStatus=NotAStatus") ~>
+        batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        // Same as the no-filter case for okAuth
+        resp.total shouldBe 4
+        resp.complete shouldBe 2
+        resp.pendingReview shouldBe 1
+        resp.pendingProcessing shouldBe 1
+      }
+    }
+
+    "return zero counts for an unrelated authenticated user" in {
+      Get("/zones/batchrecordchanges/count") ~> notAuthRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 0
+        resp.complete shouldBe 0
+        resp.pendingReview shouldBe 0
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -39,6 +39,14 @@ trait BatchChangeRepository extends Repository {
       approvalStatus: Option[BatchChangeApprovalStatus] = None
   ): IO[BatchChangeSummaryList]
 
+  def getBatchChangeCount(
+      userId: Option[String],
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): IO[BatchChangeCount]
+
   // updateSingleChanges updates status, recordSetId, recordChangeId and systemMessage (in data).
   def updateSingleChanges(singleChanges: List[SingleChange]): IO[Option[BatchChange]]
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -97,3 +97,15 @@ case class BatchChangeSummaryList(
     dateTimeStartRange: Option[String] = None,
     dateTimeEndRange: Option[String] = None,
 )
+
+case class BatchChangeCount(
+    total: Int = 0,
+    complete: Int = 0,
+    failed: Int = 0,
+    partialFailure: Int = 0,
+    rejected: Int = 0,
+    cancelled: Int = 0,
+    pendingReview: Int = 0,
+    scheduled: Int = 0,
+    pendingProcessing: Int = 0
+)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -1178,6 +1178,46 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       excluded.total shouldBe 0
     }
 
+    "count batch changes with a start-only date bound" in {
+      val old = randomBatchChangeWithList(
+        randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+      ).copy(createdTimestamp = Instant.parse("2000-06-01T00:00:00Z"))
+      val recent = randomBatchChangeWithList(
+        randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+      ).copy(createdTimestamp = Instant.now.truncatedTo(ChronoUnit.MILLIS))
+
+      val f =
+        for {
+          _ <- repo.save(old)
+          _ <- repo.save(recent)
+          result <- repo.getBatchChangeCount(None, dateTimeStartRange = Some("2020-01-01 00:00:00"))
+        } yield result
+
+      val count = f.unsafeRunSync()
+      count.total shouldBe 1
+      count.complete shouldBe 1
+    }
+
+    "count batch changes with an end-only date bound" in {
+      val old = randomBatchChangeWithList(
+        randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+      ).copy(createdTimestamp = Instant.parse("2000-06-01T00:00:00Z"))
+      val recent = randomBatchChangeWithList(
+        randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+      ).copy(createdTimestamp = Instant.now.truncatedTo(ChronoUnit.MILLIS))
+
+      val f =
+        for {
+          _ <- repo.save(old)
+          _ <- repo.save(recent)
+          result <- repo.getBatchChangeCount(None, dateTimeEndRange = Some("2010-12-31 23:59:59"))
+        } yield result
+
+      val count = f.unsafeRunSync()
+      count.total shouldBe 1
+      count.complete shouldBe 1
+    }
+
     "return zero counts when the user has no matching batch changes" in {
       val f =
         for {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -1034,5 +1034,158 @@ class MySqlBatchChangeRepositoryIntegrationSpec
 
       saved.unsafeRunSync().get.status shouldBe BatchChangeStatus.Cancelled
     }
+
+    "return zero counts when there are no batch changes" in {
+      val count = repo.getBatchChangeCount(None).unsafeRunSync()
+
+      count.total shouldBe 0
+      count.complete shouldBe 0
+      count.failed shouldBe 0
+      count.partialFailure shouldBe 0
+      count.rejected shouldBe 0
+      count.cancelled shouldBe 0
+      count.pendingReview shouldBe 0
+      count.scheduled shouldBe 0
+      count.pendingProcessing shouldBe 0
+    }
+
+    "count batch changes grouped by status across all users when no userId is given" in {
+      // change_two and change_six share an id (both copied from completeBatchChange),
+      // so build fresh Complete batch changes with unique ids instead
+      def completeChange: BatchChange =
+        randomBatchChangeWithList(
+          randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+        )
+      val cancelledBatchChange =
+        randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.Cancelled)
+      val f =
+        for {
+          _ <- repo.save(change_one) // PendingReview
+          _ <- repo.save(completeChange) // Complete
+          _ <- repo.save(completeChange) // Complete
+          _ <- repo.save(change_three) // Failed
+          _ <- repo.save(change_four) // PartialFailure
+          _ <- repo.save(change_five) // Rejected
+          _ <- repo.save(otherUserBatchChange) // PendingProcessing
+          _ <- repo.save(cancelledBatchChange) // Cancelled
+          retrieved <- repo.getBatchChangeCount(None)
+        } yield retrieved
+
+      val count = f.unsafeRunSync()
+
+      count.total shouldBe 8
+      count.complete shouldBe 2
+      count.failed shouldBe 1
+      count.partialFailure shouldBe 1
+      count.rejected shouldBe 1
+      count.cancelled shouldBe 1
+      count.pendingReview shouldBe 1
+      count.pendingProcessing shouldBe 1
+      count.scheduled shouldBe 0
+    }
+
+    "scope the count to a single user when a userId is given" in {
+      def completeChange: BatchChange =
+        randomBatchChangeWithList(
+          randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+        )
+      val f =
+        for {
+          _ <- repo.save(change_one) // PendingReview (okAuth)
+          _ <- repo.save(completeChange) // Complete (okAuth)
+          _ <- repo.save(completeChange) // Complete (okAuth)
+          _ <- repo.save(change_three) // Failed (okAuth)
+          _ <- repo.save(change_four) // PartialFailure (okAuth)
+          _ <- repo.save(change_five) // Rejected (okAuth)
+          _ <- repo.save(otherUserBatchChange) // PendingProcessing (Other)
+          retrieved <- repo.getBatchChangeCount(Some(pendingBatchChange.userId))
+        } yield retrieved
+
+      val count = f.unsafeRunSync()
+
+      // otherUserBatchChange belongs to "Other" so it is excluded
+      count.total shouldBe 6
+      count.complete shouldBe 2
+      count.failed shouldBe 1
+      count.partialFailure shouldBe 1
+      count.rejected shouldBe 1
+      count.pendingReview shouldBe 1
+      count.pendingProcessing shouldBe 0
+    }
+
+    "count batch changes filtered by user name" in {
+      val f =
+        for {
+          _ <- repo.save(change_one)
+          _ <- repo.save(change_two)
+          _ <- repo.save(otherUserBatchChange)
+          retrieved <- repo.getBatchChangeCount(None, userName = Some(pendingBatchChange.userName))
+        } yield retrieved
+
+      val count = f.unsafeRunSync()
+
+      count.total shouldBe 2
+      count.complete shouldBe 1
+      count.pendingReview shouldBe 1
+    }
+
+    "count batch changes filtered by approval status" in {
+      val f =
+        for {
+          _ <- repo.save(change_one) // PendingReview approval
+          _ <- repo.save(change_two) // AutoApproved
+          _ <- repo.save(change_five) // ManuallyRejected
+          retrieved <- repo.getBatchChangeCount(
+            None,
+            approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
+          )
+        } yield retrieved
+
+      val count = f.unsafeRunSync()
+
+      count.total shouldBe 1
+      count.pendingReview shouldBe 1
+      count.complete shouldBe 0
+    }
+
+    "count batch changes filtered by an inclusive date range" in {
+      val now = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+      val savedChange = randomBatchChangeWithList(
+        randomBatchChange().changes.map(_.complete("recordChangeId", "recordSetId"))
+      ).copy(createdTimestamp = now)
+
+      // Use fixed, very wide/narrow windows so the assertion exercises the range filter
+      // logic without being sensitive to the JVM/DB timezone used to persist created_time.
+      val f =
+        for {
+          _ <- repo.save(savedChange)
+          included <- repo.getBatchChangeCount(
+            None,
+            dateTimeStartRange = Some("2000-01-01 00:00:00"),
+            dateTimeEndRange = Some("2999-12-31 23:59:59")
+          )
+          excluded <- repo.getBatchChangeCount(
+            None,
+            dateTimeStartRange = Some("2000-01-01 00:00:00"),
+            dateTimeEndRange = Some("2000-12-31 23:59:59")
+          )
+        } yield (included, excluded)
+
+      val (included, excluded) = f.unsafeRunSync()
+
+      included.total shouldBe 1
+      included.complete shouldBe 1
+      excluded.total shouldBe 0
+    }
+
+    "return zero counts when the user has no matching batch changes" in {
+      val f =
+        for {
+          _ <- repo.save(change_one)
+          retrieved <- repo.getBatchChangeCount(Some("doesnotexist"))
+        } yield retrieved
+
+      f.unsafeRunSync().total shouldBe 0
+    }
   }
 }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -255,6 +255,63 @@ class MySqlBatchChangeRepository
       }
     }
 
+  def getBatchChangeCount(
+      userId: Option[String],
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): IO[BatchChangeCount] =
+    monitor("repo.BatchChangeJDBC.getBatchChangeCount") {
+      IO {
+        DB.readOnly { implicit s =>
+          val uid   = userId.map(u => s"user_id = '$u'")
+          val uname = userName.map(n => s"user_name = '$n'")
+          val as    = approvalStatus.map(a => s"approval_status = '${fromApprovalStatus(a)}'")
+          val dtRange = if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined)
+            Some(s"(created_time >= '${dateTimeStartRange.get}' AND created_time <= '${dateTimeEndRange.get}')")
+          else None
+
+          val extraConds = uid ++ uname ++ as ++ dtRange
+          val extraWhere = if (extraConds.nonEmpty) " AND " + extraConds.mkString(" AND ") else ""
+
+          def countSql(status: String) =
+            s"SELECT '$status' AS batch_status, COUNT(*) AS cnt FROM batch_change WHERE batch_status = '$status'$extraWhere"
+
+          val statuses = List("Complete", "Failed", "PartialFailure", "Rejected",
+                              "Cancelled", "PendingReview", "Scheduled", "PendingProcessing")
+          val unionQuery = statuses.map(countSql).mkString("\nUNION ALL\n")
+
+          val counts = SQL(unionQuery)
+            .map { res => res.string("batch_status") -> res.int("cnt") }
+            .list()
+            .apply()
+            .toMap
+
+          val complete          = counts.getOrElse("Complete", 0)
+          val failed            = counts.getOrElse("Failed", 0)
+          val partialFailure    = counts.getOrElse("PartialFailure", 0)
+          val rejected          = counts.getOrElse("Rejected", 0)
+          val cancelled         = counts.getOrElse("Cancelled", 0)
+          val pendingReview     = counts.getOrElse("PendingReview", 0)
+          val scheduled         = counts.getOrElse("Scheduled", 0)
+          val pendingProcessing = counts.getOrElse("PendingProcessing", 0)
+          BatchChangeCount(
+            total             = complete + failed + partialFailure + rejected +
+                                cancelled + pendingReview + scheduled + pendingProcessing,
+            complete          = complete,
+            failed            = failed,
+            partialFailure    = partialFailure,
+            rejected          = rejected,
+            cancelled         = cancelled,
+            pendingReview     = pendingReview,
+            scheduled         = scheduled,
+            pendingProcessing = pendingProcessing
+          )
+        }
+      }
+    }
+
   def getBatchChangeSummaries(
       userId: Option[String],
       userName: Option[String] = None,

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -255,6 +255,25 @@ class MySqlBatchChangeRepository
       }
     }
 
+  private def buildWhereConditions(
+      userId: Option[String],
+      userName: Option[String],
+      dateTimeStartRange: Option[String],
+      dateTimeEndRange: Option[String],
+      approvalStatus: Option[BatchChangeApprovalStatus],
+      tablePrefix: String = ""
+  ): (List[String], List[(Symbol, Any)]) = {
+    val p = if (tablePrefix.nonEmpty) s"$tablePrefix." else ""
+    val items = List(
+      userId.map(u => (s"${p}user_id = {userId}", 'userId -> (u: Any))),
+      userName.map(n => (s"${p}user_name = {userName}", 'userName -> (n: Any))),
+      approvalStatus.map(a => (s"${p}approval_status = {approvalStatus}", 'approvalStatus -> (fromApprovalStatus(a): Any))),
+      dateTimeStartRange.map(s => (s"${p}created_time >= {dateTimeStartRange}", 'dateTimeStartRange -> (s: Any))),
+      dateTimeEndRange.map(e => (s"${p}created_time <= {dateTimeEndRange}", 'dateTimeEndRange -> (e: Any)))
+    ).flatten
+    (items.map(_._1), items.map(_._2))
+  }
+
   def getBatchChangeCount(
       userId: Option[String],
       userName: Option[String] = None,
@@ -265,24 +284,13 @@ class MySqlBatchChangeRepository
     monitor("repo.BatchChangeJDBC.getBatchChangeCount") {
       IO {
         DB.readOnly { implicit s =>
-          val uid   = userId.map(u => s"user_id = '$u'")
-          val uname = userName.map(n => s"user_name = '$n'")
-          val as    = approvalStatus.map(a => s"approval_status = '${fromApprovalStatus(a)}'")
-          val dtRange = if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined)
-            Some(s"(created_time >= '${dateTimeStartRange.get}' AND created_time <= '${dateTimeEndRange.get}')")
-          else None
+          val (condStrings, condParams) = buildWhereConditions(userId, userName, dateTimeStartRange, dateTimeEndRange, approvalStatus)
+          val whereClause = if (condStrings.nonEmpty) " WHERE " + condStrings.mkString(" AND ") else ""
 
-          val extraConds = uid ++ uname ++ as ++ dtRange
-          val extraWhere = if (extraConds.nonEmpty) " AND " + extraConds.mkString(" AND ") else ""
+          val countQuery = s"SELECT batch_status, COUNT(*) AS cnt FROM batch_change$whereClause GROUP BY batch_status"
 
-          def countSql(status: String) =
-            s"SELECT '$status' AS batch_status, COUNT(*) AS cnt FROM batch_change WHERE batch_status = '$status'$extraWhere"
-
-          val statuses = List("Complete", "Failed", "PartialFailure", "Rejected",
-                              "Cancelled", "PendingReview", "Scheduled", "PendingProcessing")
-          val unionQuery = statuses.map(countSql).mkString("\nUNION ALL\n")
-
-          val counts = SQL(unionQuery)
+          val counts = SQL(countQuery)
+            .bindByName(condParams: _*)
             .map { res => res.string("batch_status") -> res.int("cnt") }
             .list()
             .apply()
@@ -329,25 +337,20 @@ class MySqlBatchChangeRepository
           val sb = new StringBuilder
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
 
-          val uid = userId.map(u => s"bc.user_id = '$u'")
-          val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
-          val bs = batchStatus.map(b => s"bc.batch_status = '${fromBatchStatus(b)}'")
-          val uname = userName.map(uname => s"bc.user_name = '$uname'")
-          val dtRange = if(dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
-            Some(s"(bc.created_time >= '${dateTimeStartRange.get}' AND bc.created_time <= '${dateTimeEndRange.get}')")
-          } else {
-            None
-          }
-          val opts = uid ++ as ++ bs ++ uname ++ dtRange
+          val (baseConds, baseParams) = buildWhereConditions(userId, userName, dateTimeStartRange, dateTimeEndRange, approvalStatus, tablePrefix = "bc")
+          val bsCond  = batchStatus.map(_ => s"bc.batch_status = {batchStatus}")
+          val bsParam = batchStatus.map(b => 'batchStatus -> (fromBatchStatus(b): Any))
+          val allConds  = baseConds ++ bsCond.toList
+          val allParams = baseParams ++ bsParam.toList
 
-          if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
+          if (allConds.nonEmpty) sb.append("WHERE ").append(allConds.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()
 
           val queryResult =
             SQL(query)
-              .bindByName('startFrom -> startValue, 'maxItems -> (maxItems + 1))
+              .bindByName((allParams ++ List('startFrom -> (startValue: Any), 'maxItems -> ((maxItems + 1): Any))): _*)
               .map { res =>
                 val pending = res.int("pending_count")
                 val failed = res.int("fail_count")


### PR DESCRIPTION
Fixes [vinyldns#1521](https://github.com/vinyldns/vinyldns/issues/1521)
Ticket-id: VDNS-358

Adds a new API endpoint to retrieve the total count of DNS batch record changes with support for flexible filtering.

Endpoint

GET /zones/batchrecordchanges/count

Query Parameters

ignoreAccess — when set, super users can query counts across all users
userName — filter count by a specific submitter
startDateTime / endDateTime — filter by submission time range
approvalStatus — filter by approval status

Changes

Added BatchChangeCount response model
Extended BatchChangeRepository interface with getBatchChangeCount
Implemented the query in the MySQL repository with dynamic filter support
Added service-level authorization logic (user-scoped vs admin access)
Registered the route in BatchChangeRouting
Added unit tests covering normal user, super user, and filtered query scenarios