### PR TITLE
Generate API credentials with SecureRandom

### DIFF
--- a/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/membership/User.scala
@@ -16,7 +16,8 @@
 
 package vinyldns.core.domain.membership
 
-import java.util.UUID
+import java.security.SecureRandom
+import java.util.{Random, UUID}
 
 import org.apache.commons.lang3.RandomStringUtils
 import java.time.Instant
@@ -73,5 +74,15 @@ final case class User(
 }
 
 object User {
-  def generateKey: String = RandomStringUtils.randomAlphanumeric(20)
+
+  private[membership] val CredentialKeyLength: Int = 20
+
+  // Cryptographically strong source for access/secret keys; randomAlphanumeric uses a
+  // predictable JVM-default PRNG and is unsuitable for credentials.
+  private[membership] val secureRandom: SecureRandom = new SecureRandom()
+
+  def generateKey: String = generateKey(secureRandom)
+
+  private[membership] def generateKey(random: Random): String =
+    RandomStringUtils.random(CredentialKeyLength, 0, 0, true, true, null, random)
 }

--- a/modules/core/src/test/scala/vinyldns/core/domain/membership/UserSpec.scala
+++ b/modules/core/src/test/scala/vinyldns/core/domain/membership/UserSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.core.domain.membership
+
+import java.security.SecureRandom
+import java.util.Random
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import vinyldns.core.domain.Encrypted
+
+class UserSpec extends AnyWordSpec with Matchers {
+
+  "User.generateKey" should {
+    "generate 20-character alphanumeric keys" in {
+      val keys = List.fill(1000)(User.generateKey)
+      keys.foreach { key =>
+        key.length shouldBe User.CredentialKeyLength
+        key should fullyMatch regex "[A-Za-z0-9]+"
+      }
+    }
+
+    "generate unique keys" in {
+      val keys = List.fill(10000)(User.generateKey)
+      keys.distinct.size shouldBe keys.size
+    }
+
+    // Regression guard for SRC-021: credentials must come from a cryptographically
+    // strong source, never a JVM-default pseudo-random generator.
+    "draw from a SecureRandom by default" in {
+      User.secureRandom shouldBe a[SecureRandom]
+    }
+
+    "derive its output solely from the supplied random source" in {
+      // Same seed must reproduce the same key, proving the key is fully determined by the
+      // supplied source; this fails if the implementation falls back to a hidden/shared PRNG.
+      User.generateKey(new Random(42L)) shouldBe User.generateKey(new Random(42L))
+      User.generateKey(new Random(1L)) should not be User.generateKey(new Random(2L))
+    }
+  }
+
+  "User.regenerateCredentials" should {
+    "replace both the access key and the secret key" in {
+      val original = User(userName = "test", accessKey = "old-access", secretKey = Encrypted("old-secret"))
+      val regenerated = original.regenerateCredentials()
+
+      regenerated.accessKey should not be original.accessKey
+      regenerated.secretKey.value should not be original.secretKey.value
+      regenerated.accessKey.length shouldBe User.CredentialKeyLength
+      regenerated.secretKey.value.length shouldBe User.CredentialKeyLength
+    }
+  }
+}


### PR DESCRIPTION
  ## Summary

  API access/secret keys were generated via `RandomStringUtils.randomAlphanumeric(20)`,
  backed by a predictable JVM-default PRNG (SRC-021). `User.generateKey` now draws from
  a `SecureRandom`; the alphanumeric set and 20-char length are unchanged, so format
  stays compatible while entropy becomes cryptographically strong. Both keys flow
  through `generateKey`, so one fix covers both.

  ## Tests

  New `UserSpec`: keys are 20-char alphanumeric and unique; default source is a
  `SecureRandom` (guards against PRNG fallback); `generateKey` derives output solely
  from the supplied source; `regenerateCredentials()` rotates both keys.

  ## Note

  Existing keys should be rotated operationally (self-service via `regenerateCredentials()`);
  this PR does not force a mass invalidation.
