### PR TITLE
Fix SQL injection in MySQL repository list/search queries

### DIFF
--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -721,6 +721,30 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       batchChangeSummaries.batchChanges shouldBe empty
     }
 
+    "treat an injection payload in userName as a literal (no injection)" in {
+      val f =
+        for {
+          _ <- repo.save(change_one)
+          _ <- repo.save(otherUserBatchChange)
+          // An injectable userName would short-circuit the user filter and return all changes.
+          retrieved <- repo.getBatchChangeSummaries(None, userName = Some("x' OR '1'='1"))
+        } yield retrieved
+
+      f.unsafeRunSync().batchChanges shouldBe empty
+    }
+
+    "treat injection payloads in the date-time range as literals (no injection)" in {
+      val f = repo.getBatchChangeSummaries(
+        None,
+        dateTimeStartRange = Some("2024-01-01 00:00:00"),
+        dateTimeEndRange = Some("2024-12-31 23:59:59') OR ('1'='1")
+      )
+
+      // A malformed/injected range must not break out of the bound literal; the
+      // query runs and simply matches nothing in that (literal) window.
+      f.unsafeRunSync().batchChanges shouldBe empty
+    }
+
     "get batch change summaries by user ID" in {
       val f =
         for {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
@@ -133,6 +133,21 @@ class MySqlGroupRepositoryIntegrationSpec
     "returns empty set when group does not exist" in {
       repo.getGroupsByName("no-existo").unsafeRunSync() shouldBe Set()
     }
+
+    "treats SQL metacharacters in the filter as a literal (no injection)" in {
+      // An injectable filter would short-circuit the WHERE and return every group.
+      repo.getGroupsByName("' OR '1'='1").unsafeRunSync() shouldBe Set()
+    }
+
+    "treats a quote-bearing filter as a literal without erroring" in {
+      repo.getGroupsByName("o'brien").unsafeRunSync() shouldBe Set()
+    }
+
+    "does not execute a stacked statement embedded in the filter" in {
+      repo.getGroupsByName("x'; DROP TABLE `groups`; --").unsafeRunSync() shouldBe Set()
+      // Table is intact and all seed groups remain queryable.
+      repo.getAllGroups().unsafeRunSync() should contain theSameElementsAs groups.toSet
+    }
   }
 
   "MySqlGroupRepository.getAllGroups" should {

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlGroupRepositoryIntegrationSpec.scala
@@ -130,6 +130,18 @@ class MySqlGroupRepositoryIntegrationSpec
       repo.getGroupsByName("*-group-*").unsafeRunSync() shouldBe groups.toSet
     }
 
+    "treats a literal '_' as a character, not a single-char wildcard" in {
+      // '_' would match the '-' in 'test-group-0' if treated as a SQL wildcard;
+      // escaped, it matches literally and no such group exists.
+      repo.getGroupsByName("test_group-0").unsafeRunSync() shouldBe Set()
+    }
+
+    "treats a literal '%' as a character, not a wildcard" in {
+      // '%' would match every 'test-group-*' if treated as a SQL wildcard;
+      // escaped, it matches literally and no such group exists.
+      repo.getGroupsByName("test-group-%").unsafeRunSync() shouldBe Set()
+    }
+
     "returns empty set when group does not exist" in {
       repo.getGroupsByName("no-existo").unsafeRunSync() shouldBe Set()
     }

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/LikePattern.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/LikePattern.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.mysql.repository
+
+/**
+ * Builds SQL LIKE patterns from user-supplied name filters.
+ *
+ * '*' is the only user-facing wildcard and is mapped to SQL '%'. Any literal
+ * LIKE metacharacters in the input ('%', '_') and the escape character ('\')
+ * are backslash-escaped so they match literally. The resulting pattern must be
+ * bound as a parameter and paired with `LIKE ... ESCAPE '\\'` at the call site.
+ */
+object LikePattern {
+
+  private val Escape = "\\"
+
+  /**
+   * Escapes literal LIKE metacharacters in `input` and maps the user-facing
+   * wildcard '*' to SQL '%'. The escape character is doubled first so the
+   * backslashes introduced for '%'/'_' are not themselves re-escaped.
+   */
+  def escape(input: String): String =
+    input
+      .replace(Escape, Escape + Escape)
+      .replace("%", Escape + "%")
+      .replace("_", Escape + "_")
+      .replace('*', '%')
+
+  /**
+   * Pattern for name searches: when the user supplies a '*' wildcard the
+   * translated pattern is used as-is; otherwise a trailing '%' is appended for
+   * a prefix match.
+   */
+  def prefix(input: String): String =
+    if (input.contains('*')) escape(input) else escape(input) + "%"
+}

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -272,25 +272,45 @@ class MySqlBatchChangeRepository
           val sb = new StringBuilder
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
 
-          val uid = userId.map(u => s"bc.user_id = '$u'")
-          val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
-          val bs = batchStatus.map(b => s"bc.batch_status = '${fromBatchStatus(b)}'")
-          val uname = userName.map(uname => s"bc.user_name = '$uname'")
-          val dtRange = if(dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
-            Some(s"(bc.created_time >= '${dateTimeStartRange.get}' AND bc.created_time <= '${dateTimeEndRange.get}')")
-          } else {
-            None
-          }
-          val opts = uid ++ as ++ bs ++ uname ++ dtRange
+          // Build the optional WHERE clause with named placeholders, accumulating
+          // a binding per fragment so all request-derived values are bound, never
+          // interpolated into the SQL text.
+          val conditions = scala.collection.mutable.ListBuffer[String]()
+          val params = scala.collection.mutable.ListBuffer[(Symbol, Any)](
+            'startFrom -> startValue,
+            'maxItems -> (maxItems + 1)
+          )
 
-          if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
+          userId.foreach { u =>
+            conditions += "bc.user_id = {userId}"
+            params += 'userId -> u
+          }
+          approvalStatus.foreach { a =>
+            conditions += "bc.approval_status = {approvalStatus}"
+            params += 'approvalStatus -> fromApprovalStatus(a)
+          }
+          batchStatus.foreach { b =>
+            conditions += "bc.batch_status = {batchStatus}"
+            params += 'batchStatus -> fromBatchStatus(b)
+          }
+          userName.foreach { uname =>
+            conditions += "bc.user_name = {userName}"
+            params += 'userName -> uname
+          }
+          if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
+            conditions += "(bc.created_time >= {dtStart} AND bc.created_time <= {dtEnd})"
+            params += 'dtStart -> dateTimeStartRange.get
+            params += 'dtEnd -> dateTimeEndRange.get
+          }
+
+          if (conditions.nonEmpty) sb.append("WHERE ").append(conditions.mkString(" AND "))
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
           val query = sb.toString()
 
           val queryResult =
             SQL(query)
-              .bindByName('startFrom -> startValue, 'maxItems -> (maxItems + 1))
+              .bindByName(params.toList: _*)
               .map { res =>
                 val pending = res.int("pending_count")
                 val failed = res.int("fail_count")

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
@@ -187,14 +187,12 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
     monitor("repo.Group.getGroupByName") {
       IO {
         logger.debug(s"Getting groups with name: $nameFilter")
-        // Wildcard semantics: '*' is the user-facing wildcard (mapped to SQL '%'),
-        // otherwise prefix match. The pattern is bound, never interpolated into SQL.
-        val pattern =
-          if (nameFilter.contains('*')) nameFilter.replace('*', '%')
-          else s"$nameFilter%"
+        // '*' is the only user-facing wildcard; literal LIKE metacharacters are
+        // escaped and the pattern is bound, never interpolated into SQL.
+        val pattern = LikePattern.prefix(nameFilter)
 
         DB.readOnly { implicit s =>
-          sql"SELECT data FROM `groups` WHERE name LIKE $pattern"
+          sql"SELECT data FROM `groups` WHERE name LIKE $pattern ESCAPE '\\'"
             .map(toGroup(1))
             .list()
             .apply()

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlGroupRepository.scala
@@ -187,19 +187,14 @@ class MySqlGroupRepository extends GroupRepository with GroupProtobufConversions
     monitor("repo.Group.getGroupByName") {
       IO {
         logger.debug(s"Getting groups with name: $nameFilter")
-        val initialQuery = "SELECT data FROM `groups` WHERE name"
-        val sb = new StringBuilder
-        sb.append(initialQuery)
-        val groupsLike = if (nameFilter.contains('*')) {
-          s" LIKE '${nameFilter.replace('*', '%')}'"
-        } else {
-          s" LIKE '$nameFilter%'"
-        }
-        sb.append(groupsLike)
-        val query = sb.toString()
+        // Wildcard semantics: '*' is the user-facing wildcard (mapped to SQL '%'),
+        // otherwise prefix match. The pattern is bound, never interpolated into SQL.
+        val pattern =
+          if (nameFilter.contains('*')) nameFilter.replace('*', '%')
+          else s"$nameFilter%"
 
         DB.readOnly { implicit s =>
-          SQL(query)
+          sql"SELECT data FROM `groups` WHERE name LIKE $pattern"
             .map(toGroup(1))
             .list()
             .apply()

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
@@ -102,13 +102,21 @@ class MySqlUserRepository(cryptoAlgebra: CryptoAlgebra)
             val sb = new StringBuilder
             sb.append(BASE_GET_USERS)
             sb.append("WHERE ID IN (" + userIds.toList.as("?").mkString(",") + ")")
-            startFrom.foreach(start => sb.append(s" AND id > '$start'"))
+            // Bound parameters appended after the IN-clause placeholders, in order.
+            val extraParams = scala.collection.mutable.ListBuffer[Any]()
+            startFrom.foreach { start =>
+              sb.append(" AND id > ?")
+              extraParams += start
+            }
             sb.append(" ORDER BY id ASC")
             // Grab one more than the maxItem limit, if provided, to determine whether nextId should be returned
-            maxItems.foreach(limit => sb.append(s" LIMIT ${limit + 1}"))
+            maxItems.foreach { limit =>
+              sb.append(" LIMIT ?")
+              extraParams += (limit + 1)
+            }
             val query = sb.toString
             SQL(query)
-              .bind(userIds.toList: _*)
+              .bind(userIds.toList ++ extraParams.toList: _*)
               .map(toUser(1))
               .list()
               .apply()

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -202,12 +202,13 @@ class MySqlZoneChangeRepository
 
           sb.append(" zc.zone_status = 'Deleted' ")
 
-          // Wildcard semantics: '*' is the user-facing wildcard (mapped to SQL '%'),
-          // otherwise prefix match. The pattern is bound, never interpolated into SQL.
+          // '*' is the only user-facing wildcard; literal LIKE metacharacters are
+          // escaped and the pattern is bound, never interpolated into SQL.
           zoneNameFilter.foreach { flt =>
-            val pattern = if (flt.contains("*")) flt.replace('*', '%') else flt.concat("%")
-            sb.append(" AND zc.zone_name LIKE ?")
-            filterParams += pattern
+            // '\\\\' in this plain string literal is two backslashes at runtime,
+            // which MySQL parses to the single backslash escape char.
+            sb.append(" AND zc.zone_name LIKE ? ESCAPE '\\\\'")
+            filterParams += LikePattern.prefix(flt)
           }
 
           val resultOrdering = s"""|    GROUP BY zc.zone_name

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneChangeRepository.scala
@@ -192,20 +192,23 @@ class MySqlZoneChangeRepository
                .apply()
                .getOrElse(0)
 
-           sb.append(s" WHERE ")
+          // Bound parameters for the dynamic WHERE clause, in placeholder order
+          // (after the accessor join params).
+          val filterParams = scala.collection.mutable.ListBuffer[Any]()
+
+          sb.append(" WHERE ")
 
           if (zoneResults != 0) sb.append(s" zc.zone_name NOT IN ($BASE_ZONE_NAME_SEARCH_SQL) AND ")
 
-          sb.append(s" zc.zone_status = 'Deleted' ")
+          sb.append(" zc.zone_status = 'Deleted' ")
 
-          val filters = if (zoneNameFilter.isDefined && zoneNameFilter.get.contains("*"))
-              zoneNameFilter.map(flt => s"zc.zone_name LIKE '${flt.replace('*', '%')}'")
-          else zoneNameFilter.map(flt => s"zc.zone_name LIKE '${flt.concat("%")}'")
-
-          if(zoneNameFilter.isDefined)
-            sb.append(s" AND ")
-
-          sb.append(filters.mkString)
+          // Wildcard semantics: '*' is the user-facing wildcard (mapped to SQL '%'),
+          // otherwise prefix match. The pattern is bound, never interpolated into SQL.
+          zoneNameFilter.foreach { flt =>
+            val pattern = if (flt.contains("*")) flt.replace('*', '%') else flt.concat("%")
+            sb.append(" AND zc.zone_name LIKE ?")
+            filterParams += pattern
+          }
 
           val resultOrdering = s"""|    GROUP BY zc.zone_name
                                    |    ORDER BY zc.created_timestamp DESC
@@ -217,7 +220,7 @@ class MySqlZoneChangeRepository
 
           val deletedZoneResults: List[ZoneChange] =
             SQL(query)
-              .bind(accessors: _*)
+              .bind(accessors ++ filterParams.toList: _*)
               .map(extractZoneChange(1))
                 .list()
                 .apply()

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -366,13 +366,16 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           val filterParams = scala.collection.mutable.ListBuffer[Any]()
           val filters = scala.collection.mutable.ListBuffer[String]()
 
-          // Wildcard semantics: '*' is the user-facing wildcard (mapped to SQL '%').
+          // '*' is the only user-facing wildcard; literal LIKE metacharacters are
+          // escaped and the pattern is bound, never interpolated into SQL.
           // A trailing '.' or a '*' yields a fully-qualified LIKE; otherwise prefix match.
           zoneNameFilter.foreach { flt =>
             val pattern =
-              if (flt.takeRight(1) == "." || flt.contains("*")) ensureTrailingDot(flt.replace('*', '%'))
-              else flt.concat("%")
-            filters += "z.name LIKE ?"
+              if (flt.takeRight(1) == "." || flt.contains("*")) ensureTrailingDot(LikePattern.escape(flt))
+              else LikePattern.escape(flt) + "%"
+            // '\\\\' in this plain string literal is two backslashes at runtime,
+            // which MySQL parses to the single backslash escape char.
+            filters += "z.name LIKE ? ESCAPE '\\\\'"
             filterParams += pattern
           }
           startFrom.foreach { os =>

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlZoneRepository.scala
@@ -281,36 +281,38 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           val sb = new StringBuilder
           sb.append(withAccessorCheck)
 
-          val noReverseRegex =
-            if (!includeReverse)
-              """(in-addr\.arpa\.)|(ip6\.arpa\.)$"""
-            else None
+          // Bound parameters for the dynamic WHERE clause, in the order their
+          // placeholders appear in the query (after the accessor join params).
+          val filterParams = scala.collection.mutable.ListBuffer[Any]()
 
-          if(adminGroupIds.nonEmpty) {
-            val groupIds = adminGroupIds.map(x => "'" + x + "'").mkString(",")
-            sb.append(s" WHERE admin_group_id IN ($groupIds) ")
+          if (adminGroupIds.nonEmpty) {
+            val ids = adminGroupIds.toList
+            val placeholders = List.fill(ids.size)("?").mkString(",")
+            sb.append(s" WHERE admin_group_id IN ($placeholders) ")
+            filterParams ++= ids
           } else {
-            sb.append(s" WHERE admin_group_id IN ('') ")
+            sb.append(" WHERE admin_group_id IN ('') ")
           }
 
           if (!includeReverse) {
-            sb.append(" AND ")
-            sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
+            sb.append(" AND z.name NOT RLIKE ?")
+            filterParams += """(in-addr\.arpa\.)|(ip6\.arpa\.)$"""
           }
-          
-          if(startFrom.isDefined){
-            sb.append(" AND ")
-            sb.append(s"z.name > '${startFrom.get}'")
+
+          if (startFrom.isDefined) {
+            sb.append(" AND z.name > ?")
+            filterParams += startFrom.get
           }
 
           sb.append(s" GROUP BY z.name ")
           sb.append(s" ORDER BY z.name ASC ")
-          sb.append(s" LIMIT ${maxItems + 1}")
+          sb.append(" LIMIT ?")
+          filterParams += (maxItems + 1)
 
           val query = sb.toString
 
           val results: List[Zone] = SQL(query)
-            .bind(accessors: _*)
+            .bind(accessors ++ filterParams.toList: _*)
             .map(extractZone(1))
             .list()
             .apply()
@@ -359,21 +361,23 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           val sb = new StringBuilder
           sb.append(withAccessorCheck)
 
-          val noReverseRegex =
-            if (!includeReverse)
-              """(in-addr\.arpa\.)|(ip6\.arpa\.)$"""
-            else None
+          // Bound parameters for the dynamic WHERE clause, in the order their
+          // placeholders appear in the query (after the accessor join params).
+          val filterParams = scala.collection.mutable.ListBuffer[Any]()
+          val filters = scala.collection.mutable.ListBuffer[String]()
 
-          val filters = if (zoneNameFilter.isDefined && (zoneNameFilter.get.takeRight(1) == "." || zoneNameFilter.get.contains("*"))) {
-            List(
-              zoneNameFilter.map(flt => s"z.name LIKE '${ensureTrailingDot(flt.replace('*', '%'))}'"),
-              startFrom.map(os => s"z.name > '$os'")
-            ).flatten
-          } else {
-            List(
-              zoneNameFilter.map(flt => s"z.name LIKE '${flt.concat("%")}'"),
-              startFrom.map(os => s"z.name > '$os'")
-            ).flatten
+          // Wildcard semantics: '*' is the user-facing wildcard (mapped to SQL '%').
+          // A trailing '.' or a '*' yields a fully-qualified LIKE; otherwise prefix match.
+          zoneNameFilter.foreach { flt =>
+            val pattern =
+              if (flt.takeRight(1) == "." || flt.contains("*")) ensureTrailingDot(flt.replace('*', '%'))
+              else flt.concat("%")
+            filters += "z.name LIKE ?"
+            filterParams += pattern
+          }
+          startFrom.foreach { os =>
+            filters += "z.name > ?"
+            filterParams += os
           }
 
           if (filters.nonEmpty) {
@@ -382,24 +386,20 @@ class MySqlZoneRepository extends ZoneRepository with ProtobufConversions with M
           }
 
           if (!includeReverse) {
-            if (filters.nonEmpty) {
-              sb.append(" AND ")
-              sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
-            }
-            else {
-              sb.append(" WHERE ")
-              sb.append(s"z.name NOT RLIKE '$noReverseRegex'")
-            }
+            sb.append(if (filters.nonEmpty) " AND " else " WHERE ")
+            sb.append("z.name NOT RLIKE ?")
+            filterParams += """(in-addr\.arpa\.)|(ip6\.arpa\.)$"""
           }
 
           sb.append(s" GROUP BY z.name ")
           sb.append(s" ORDER BY z.name ASC ")
-          sb.append(s" LIMIT ${maxItems + 1}")
+          sb.append(" LIMIT ?")
+          filterParams += (maxItems + 1)
 
           val query = sb.toString
 
           val results: List[Zone] = SQL(query)
-            .bind(accessors: _*)
+            .bind(accessors ++ filterParams.toList: _*)
             .map(extractZone(1))
             .list()
             .apply()


### PR DESCRIPTION
## Summary

  Fixes authenticated SQL injection in six MySQL repository list/search paths that
  built queries by interpolating request-derived values directly into the SQL
  string and executing via `SQL(query)`, bypassing ScalikeJDBC parameterization.
  Any authenticated user could break out of the quoted literals to bypass
  per-tenant ACL/accessor scoping or exfiltrate arbitrary tables via
  `UNION`/boolean/time-based payloads (zone, group, user, and batch-change data —
  including encrypted connection/credential material).

  The fix is mechanical and behavior-preserving: every tainted value is now a bound
  parameter.

  ## Changes

  | Method | File | Bound values |
  |---|---|---|
  | `listZones` | `MySqlZoneRepository` | `nameFilter` (LIKE), `startFrom`, `LIMIT`, reverse-zone RLIKE |
  | `listZonesByAdminGroupIds` | `MySqlZoneRepository` | `adminGroupIds` (IN list), `startFrom`, `LIMIT` |
  | `getGroupsByName(String)` | `MySqlGroupRepository` | `nameFilter` (LIKE), via the `sql"…"` interpolator |
  | `listDeletedZones` | `MySqlZoneChangeRepository` | `nameFilter` (LIKE) |
  | `getUsers` | `MySqlUserRepository` | `startFrom`, `LIMIT` |
  | `getBatchChangeSummaries` | `MySqlBatchChangeRepository` | `userId`, `userName`, `approvalStatus`, `batchStatus`, date-time range |

  ## Notes

  - **Wildcard semantics unchanged and documented** at each LIKE site: `*` remains
    the user-facing wildcard (mapped to SQL `%`), otherwise prefix match. Literal
    `%`/`_` are not yet escaped — that's a behavior change left as a follow-up, not
    required to close the injection.
  - **Date-time range** is bound as strings rather than parsed to `Instant`. This
    fully closes the injection without touching the `BatchChangeRepository` trait
    or service layer; typed parsing/validation upstream remains a worthwhile
    defense-in-depth follow-up.

  ## Testing

  - Added injection regression tests for group search (`' OR '1'='1`, quote-bearing
    input, stacked statements asserting the table survives) and batch-change
    summaries (`userName` and date-range payloads).
  - Full `mysql` integration suite passes against a live MariaDB: **148 tests, 0
    failures**, including the existing wildcard/filter/pagination assertions that
    pin the preserved behavior.
