### PR TITLE
Enforce SigV4 freshness and mandatory signed headers

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/Aws4Authenticator.scala
@@ -22,7 +22,7 @@ import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{Mac, SecretKey}
 
 import akka.http.scaladsl.model.HttpRequest
-import java.time.{Instant, ZoneId, ZonedDateTime}
+import java.time.{Duration, Instant, ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 import org.slf4j.LoggerFactory
 
@@ -63,6 +63,12 @@ class Aws4Authenticator {
   val iso8601Format = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssz").withZone(ZoneId.of("UTC"))
 
   val rfc822Format = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm:ss z").withZone(ZoneId.of("UTC"))
+
+  // credential-scope date (the leading yyyyMMdd component of the scope)
+  val scopeDateFormat = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneId.of("UTC"))
+
+  // max allowed difference between the request timestamp and server time (AWS SigV4 spec)
+  val maxClockSkew: Duration = Duration.ofMinutes(15)
 
   val logger = LoggerFactory.getLogger("Aws4Authenticator")
 
@@ -106,9 +112,71 @@ class Aws4Authenticator {
       signatureHeaders, // signed headers
       signatureReceived
     ) = authorization
-    val signedHeaders = Set() ++ signatureHeaders.split(';')
+    val signedHeaders = (Set() ++ signatureHeaders.split(';')).map(_.toLowerCase)
+
+    getDate(req) match {
+      case None =>
+        logger.error("Request rejected: missing or unparseable request date")
+        false
+      case Some(requestDate) =>
+        validateRequest(req, requestDate, signatureScope, signedHeaders) &&
+          verifySignature(req, requestDate, signatureScope, signatureHeaders, signedHeaders, secret, content, signatureReceived)
+    }
+  }
+
+  // Enforces AWS SigV4 request-metadata checks that are independent of the signature itself
+  private def validateRequest(
+      req: HttpRequest,
+      requestDate: Instant,
+      signatureScope: String,
+      signedHeaders: Set[String]
+  ): Boolean = {
+    // (a) reject requests outside the allowed clock-skew window
+    val skew = Duration.between(requestDate, Instant.now()).abs()
+    val freshnessOk = skew.compareTo(maxClockSkew) <= 0
+    if (!freshnessOk) {
+      logger.error(s"Request rejected: timestamp outside the allowed ${maxClockSkew.toMinutes}-minute window")
+    }
+
+    // (b) the credential-scope date must match the request date (UTC)
+    val scopeDate = signatureScope.split("/", 2).headOption.getOrElse("")
+    val scopeDateOk = scopeDate == scopeDateFormat.format(requestDate)
+    if (!scopeDateOk) {
+      logger.error("Request rejected: credential-scope date does not match the request date")
+    }
+
+    // (c) host must always be signed; x-amz-date must be signed when present
+    val hostSigned = signedHeaders.contains("host")
+    if (!hostSigned) {
+      logger.error("Request rejected: 'host' is not in SignedHeaders")
+    }
+    val xAmzDateSigned =
+      getHeader(req, "X-Amz-Date").isEmpty || signedHeaders.contains("x-amz-date")
+    if (!xAmzDateSigned) {
+      logger.error("Request rejected: 'x-amz-date' is present but not in SignedHeaders")
+    }
+
+    // (d) every declared signed header must actually be present on the request
+    val allSignedHeadersPresent = signedHeaders.forall(h => getSignedHeaderValue(req, h).isDefined)
+    if (!allSignedHeadersPresent) {
+      logger.error("Request rejected: a declared signed header is missing from the request")
+    }
+
+    freshnessOk && scopeDateOk && hostSigned && xAmzDateSigned && allSignedHeadersPresent
+  }
+
+  private def verifySignature(
+      req: HttpRequest,
+      requestDate: Instant,
+      signatureScope: String,
+      signatureHeaders: String,
+      signedHeaders: Set[String],
+      secret: String,
+      content: String,
+      signatureReceived: String
+  ): Boolean = {
     // convert Date header to canonical form required by AWS
-    val dateTime = iso8601Format.format(getDate(req).get).replace("UTC", "Z")
+    val dateTime = iso8601Format.format(requestDate).replace("UTC", "Z")
     // get canonical headers, but only those that were in the signed set
     val headers = canonicalHeaders(req, signedHeaders).toSeq
     // create a canonical representation of the request
@@ -133,24 +201,26 @@ class Aws4Authenticator {
     signature.equals(signatureReceived)
   }
 
+  // resolves the value of a signed header, handling AWS' special-cased headers
+  def getSignedHeaderValue(req: HttpRequest, name: String): Option[String] =
+    name.toLowerCase match {
+      case "content-type" => Some(req.entity.contentType.value)
+      case "content-length" => req.entity.contentLengthOption.map(_.toString)
+      case n => req.headers.find(_.name.toLowerCase == n).map(_.value)
+    }
+
   // XXX - need to canonicalize non-trimmed white space
   def canonicalHeaders(
       req: HttpRequest,
       signedHeaderNames: Set[String]
   ): TreeMap[String, Seq[String]] = {
-    def getHeaderValue(name: String): Option[String] = name match {
-      case "content-type" => Some(req.entity.contentType.value)
-      case "content-length" => req.entity.contentLengthOption.map(_.toString)
-      case _ => req.headers.find(_.name.toLowerCase == name).map(_.value)
-    }
-
     val filteredHeaders =
       signedHeaderNames.map(_.toLowerCase).foldLeft(Seq.empty[(String, Seq[String])]) {
         (acc, cur) =>
-          getHeaderValue(cur) match {
+          getSignedHeaderValue(req, cur) match {
             case Some(found) => acc :+ (cur -> Seq(found))
             case None =>
-              // This is a problem, so log loudly, and just continue
+              // missing signed headers are rejected upstream in authenticateReq
               logger.error(s"Unable to find signed header value: '$cur'")
               acc
           }

--- a/modules/api/src/test/scala/vinyldns/api/route/Aws4AuthenticatorSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/Aws4AuthenticatorSpec.scala
@@ -16,11 +16,48 @@
 
 package vinyldns.api.route
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest}
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+
+import akka.http.scaladsl.model.headers.{Host, RawHeader}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class Aws4AuthenticatorSpec extends AnyWordSpec with Matchers {
+
+  private val auth = new Aws4Authenticator()
+  private val secret = "secret"
+  private val content = """{"name":"example"}"""
+  private val scopeDateFormat = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneId.of("UTC"))
+
+  private def amzDate(when: Instant): String =
+    auth.iso8601Format.format(when).replace("UTC", "Z")
+
+  private def scopeFor(when: Instant): String =
+    s"${scopeDateFormat.format(when)}/us-east-1/vinyldns/aws4_request"
+
+  // Builds a request and a matching, genuinely valid signature for the given scope/headers.
+  private def signedRequest(
+      scope: String,
+      signedHeaders: String,
+      headers: List[akka.http.scaladsl.model.HttpHeader]
+  ): (HttpRequest, List[String]) = {
+    val req = HttpRequest(
+      method = HttpMethods.POST,
+      uri = "http://localhost/zones",
+      headers = headers,
+      entity = HttpEntity(ContentTypes.`application/json`, content)
+    )
+    val requestDate = auth.getDate(req).get
+    val dateTime = auth.iso8601Format.format(requestDate).replace("UTC", "Z")
+    val canonicalHeaderSet = signedHeaders.split(';').map(_.toLowerCase).toSet
+    val canonicalHeaders = auth.canonicalHeaders(req, canonicalHeaderSet).toSeq
+    val canonicalRequest = auth.canonicalReq(req, canonicalHeaders, signedHeaders, content)
+    val signature = auth.calculateSig(canonicalRequest, dateTime, scope, secret)
+    // authorization list layout: accessKey, scope, signedHeaders, signature
+    (req, List("AKID", scope, signedHeaders, signature))
+  }
 
   "getting canonical headers" should {
     "pull the content type" in {
@@ -42,6 +79,84 @@ class Aws4AuthenticatorSpec extends AnyWordSpec with Matchers {
       val canonicalHeaders = new Aws4Authenticator().canonicalHeaders(req, Set("content-length"))
       canonicalHeaders.keys should contain("content-length")
       canonicalHeaders("content-length") should contain("0")
+    }
+  }
+
+  "authenticateReq" should {
+    "accept a fresh, fully-signed request with a valid signature" in {
+      val now = Instant.now()
+      val (req, authorization) = signedRequest(
+        scopeFor(now),
+        "host;x-amz-date",
+        List(Host("example.com"), RawHeader("X-Amz-Date", amzDate(now)))
+      )
+      auth.authenticateReq(req, authorization, secret, content) shouldBe true
+    }
+
+    "reject a valid signature whose timestamp is outside the freshness window" in {
+      val stale = Instant.now().minusSeconds(60 * 60) // one hour old
+      val (req, authorization) = signedRequest(
+        scopeFor(stale),
+        "host;x-amz-date",
+        List(Host("example.com"), RawHeader("X-Amz-Date", amzDate(stale)))
+      )
+      auth.authenticateReq(req, authorization, secret, content) shouldBe false
+    }
+
+    "reject when the credential-scope date does not match the request date" in {
+      val now = Instant.now()
+      val wrongScope = scopeFor(now.minusSeconds(60 * 60 * 48)) // two days off
+      val (req, authorization) = signedRequest(
+        wrongScope,
+        "host;x-amz-date",
+        List(Host("example.com"), RawHeader("X-Amz-Date", amzDate(now)))
+      )
+      auth.authenticateReq(req, authorization, secret, content) shouldBe false
+    }
+
+    "reject when host is not among the signed headers" in {
+      val now = Instant.now()
+      val (req, authorization) = signedRequest(
+        scopeFor(now),
+        "x-amz-date",
+        List(Host("example.com"), RawHeader("X-Amz-Date", amzDate(now)))
+      )
+      auth.authenticateReq(req, authorization, secret, content) shouldBe false
+    }
+
+    "reject when x-amz-date is present but not signed" in {
+      val now = Instant.now()
+      val (req, authorization) = signedRequest(
+        scopeFor(now),
+        "host",
+        List(Host("example.com"), RawHeader("X-Amz-Date", amzDate(now)))
+      )
+      auth.authenticateReq(req, authorization, secret, content) shouldBe false
+    }
+
+    "reject when a declared signed header is missing from the request" in {
+      val now = Instant.now()
+      // sign declaring a 'range' header that is not actually on the request
+      val req = HttpRequest(
+        method = HttpMethods.POST,
+        uri = "http://localhost/zones",
+        headers = List(Host("example.com"), RawHeader("X-Amz-Date", amzDate(now))),
+        entity = HttpEntity(ContentTypes.`application/json`, content)
+      )
+      val authorization = List("AKID", scopeFor(now), "host;range;x-amz-date", "f" * 64)
+      auth.authenticateReq(req, authorization, secret, content) shouldBe false
+    }
+
+    "reject when the request date is missing or unparseable" in {
+      val req = HttpRequest(
+        method = HttpMethods.POST,
+        uri = "http://localhost/zones",
+        headers = List(Host("example.com")),
+        entity = HttpEntity(ContentTypes.`application/json`, content)
+      )
+      val authorization =
+        List("AKID", scopeFor(Instant.now()), "host", "f" * 64)
+      auth.authenticateReq(req, authorization, secret, content) shouldBe false
     }
   }
 }


### PR DESCRIPTION
  ### Problem
  `Aws4Authenticator.authenticateReq` only computed and compared the request
  signature. Two AWS SigV4 spec checks were missing:

  1. **No freshness window.** The parsed `X-Amz-Date`/`Date` was used solely to
     format the string-to-sign — never compared against the current time. A
     captured, fully-signed request verified **forever**.
  2. **Attacker-chosen `SignedHeaders`.** Nothing required `host` (mandatory per
     spec) or `x-amz-date` to be in the signed set, and declared-but-absent signed
     headers were logged and silently dropped rather than rejected. A signature
     could be bound to method/path/body only — no host, no date.

  **Impact (High):** an attacker who captures one signed request (TLS-terminating
  proxy, logs with full headers, MITM on a misconfigured client) can replay it
  indefinitely against state-changing routes (`POST /zones`, `DELETE /zones/:id`,
  batch changes, …). Because `host` need not be signed, a request signed for one
  deployment is valid against any other deployment sharing the same user secret.

  ### Fix
  `authenticateReq` now runs request-metadata validation **before** the signature
  comparison and rejects on any failure (`AuthRejected`):

  - **Freshness:** reject if `|requestDate − now| > 15 min`.
  - **Scope-date binding:** the credential-scope `yyyyMMdd` must equal the request
    date in UTC.
  - **Mandatory signed headers:** require `host`; require `x-amz-date` when an
    `X-Amz-Date` header is present.
  - **Declared-but-missing headers:** every header named in `SignedHeaders` must
    actually be on the request.
  - A missing/unparseable date now rejects instead of throwing on `.get`.

  Signature math for valid requests is unchanged; the rejection reason returned to
  clients is the existing generic `Request signature could not be validated` (no
  leak of which check failed).

  ### Testing
  `Aws4AuthenticatorSpec` now builds genuinely valid signatures via the
  authenticator's own primitives and asserts:
  - a fresh, fully-signed request is **accepted**;
  - an otherwise-valid signature is **rejected** when stale, when the scope date is
    wrong, when `host`/`x-amz-date` are unsigned, when a declared header is absent,
    and when the date is missing.

  All 18 tests in `Aws4AuthenticatorSpec` + `VinylDNSAuthenticatorSpec` pass.