### PR TITLE
Batch recordset_data writes during zone sync

### DIFF
--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepositoryIntegrationSpec.scala
@@ -71,9 +71,7 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
     val pendingChanges = generateInserts(zone, count, word)
     val bigPendingChangeSet = ChangeSet(pendingChanges)
     executeWithinTransaction { db: DB =>
-      recordSetCacheRepo.save(db, bigPendingChangeSet)
-      recordSetRepo.apply(db, bigPendingChangeSet)
-
+      recordSetCacheRepo.save(db, bigPendingChangeSet).flatMap(_ => recordSetRepo.apply(db, bigPendingChangeSet))
     }.unsafeRunSync()
     pendingChanges
   }
@@ -81,9 +79,7 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
   def insert(changes: List[RecordSetChange]): Unit = {
     val bigPendingChangeSet = ChangeSet(changes)
     executeWithinTransaction { db: DB =>
-      recordSetCacheRepo.save(db, bigPendingChangeSet)
-      recordSetRepo.apply(db, bigPendingChangeSet)
-
+      recordSetCacheRepo.save(db, bigPendingChangeSet).flatMap(_ => recordSetRepo.apply(db, bigPendingChangeSet))
     }.unsafeRunSync()
     ()
   }
@@ -102,10 +98,10 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
           .copy(status = RecordSetChangeStatus.Failed)
       val deleteChange = makePendingTestDeleteChange(existing(1))
         .copy(status = RecordSetChangeStatus.Failed)
+      val revertChangeSet = ChangeSet(Seq(addChange, updateChange, deleteChange))
       executeWithinTransaction { db: DB =>
-        recordSetCacheRepo.save(db, ChangeSet(Seq(addChange, updateChange, deleteChange)))
-        recordSetRepo.apply(db, ChangeSet(Seq(addChange, updateChange, deleteChange)))
-      }
+        recordSetCacheRepo.save(db, revertChangeSet).flatMap(_ => recordSetRepo.apply(db, revertChangeSet))
+      }.unsafeRunSync()
       recordSetCacheRepo.getRecordSetData(rsOk.id).unsafeRunSync() shouldBe None
       recordSetCacheRepo.getRecordSetData(existing.head.id).unsafeRunSync() shouldBe Some(
         recordSetDataWithFQDN(existing.head, okZone)
@@ -164,18 +160,18 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
         recordSet = recordForFailed.copy(status = RecordSetStatus.Pending),
         status = RecordSetChangeStatus.Pending
       )
+      val existingPendingChangeSet = ChangeSet(existingPending)
       executeWithinTransaction { db: DB =>
-        recordSetCacheRepo.save(db, ChangeSet(existingPending))
-        recordSetRepo.apply(db, ChangeSet(existingPending))
+        recordSetCacheRepo.save(db, existingPendingChangeSet).flatMap(_ => recordSetRepo.apply(db, existingPendingChangeSet))
       }.attempt.unsafeRunSync()
       recordSetCacheRepo.getRecordSetData(failedChange.recordSet.id).unsafeRunSync() shouldBe
         Some(
           existingPending.recordSet
             .copy(fqdn = Some(s"""${failedChange.recordSet.name}.${okZone.name}"""))
         )
+      val createsChangeSet = ChangeSet(Seq(successfulChange, pendingChange, failedChange))
       executeWithinTransaction { db: DB =>
-        recordSetCacheRepo.save(db, ChangeSet(Seq(successfulChange, pendingChange, failedChange)))
-        recordSetRepo.apply(db, ChangeSet(Seq(successfulChange, pendingChange, failedChange)))
+        recordSetCacheRepo.save(db, createsChangeSet).flatMap(_ => recordSetRepo.apply(db, createsChangeSet))
       }.attempt.unsafeRunSync()
 
       // success and pending changes have records saved
@@ -199,10 +195,12 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       val pendingChanges = generateInserts(okZone, 1000)
       val bigPendingChangeSet = ChangeSet(pendingChanges)
       val saveRecSets = executeWithinTransaction { db: DB =>
-        recordSetCacheRepo.save(db, bigPendingChangeSet)
-        recordSetCacheRepo.save(db, bigPendingChangeSet)
-        recordSetRepo.apply(db, bigPendingChangeSet)
-        recordSetRepo.apply(db, bigPendingChangeSet)
+        for {
+          _ <- recordSetCacheRepo.save(db, bigPendingChangeSet)
+          _ <- recordSetCacheRepo.save(db, bigPendingChangeSet)
+          _ <- recordSetRepo.apply(db, bigPendingChangeSet)
+          r <- recordSetRepo.apply(db, bigPendingChangeSet)
+        } yield r
       }
       saveRecSets.attempt.unsafeRunSync() shouldBe right
     }
@@ -211,13 +209,37 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
 
       val bigPendingChangeSet = ChangeSet(pendingChanges)
       executeWithinTransaction { db: DB =>
-        recordSetCacheRepo.save(db, bigPendingChangeSet)
-        recordSetRepo.apply(db, bigPendingChangeSet)
-
+        recordSetCacheRepo.save(db, bigPendingChangeSet).flatMap(_ => recordSetRepo.apply(db, bigPendingChangeSet))
       }.attempt.unsafeRunSync()
       // let's make sure we have all 1000 records
       val recordCount = recordSetCacheRepo.getRecordSetDataCount(okZone.id).unsafeRunSync()
       recordCount shouldBe 20
+    }
+    "batch inserts across multiple groups" in {
+      // exceed the 1000-row batch group size to exercise grouped batching
+      val pendingChanges = generateInserts(okZone, 2500)
+      val bigPendingChangeSet = ChangeSet(pendingChanges)
+      executeWithinTransaction { db: DB =>
+        recordSetCacheRepo.save(db, bigPendingChangeSet).flatMap(_ => recordSetRepo.apply(db, bigPendingChangeSet))
+      }.attempt.unsafeRunSync() shouldBe right
+      recordSetCacheRepo.getRecordSetDataCount(okZone.id).unsafeRunSync() shouldBe 2500
+    }
+    "batch insert record types that have no IP (null ip column)" in {
+      // CNAME/NS/TXT parse to a null ip; exercise null binding through batchByName
+      val changes = List(
+        cname.copy(zoneId = okZone.id, name = "cname-null-ip"),
+        ns.copy(zoneId = okZone.id, name = "ns-null-ip"),
+        txt.copy(zoneId = okZone.id, name = "txt-null-ip")
+      ).map(makeTestAddChange(_, okZone))
+      insert(changes)
+      // cname(1) + ns(2 NSData) + txt(1) = 4 recordset_data rows, all with a null ip
+      recordSetCacheRepo.getRecordSetDataCount(okZone.id).unsafeRunSync() shouldBe 4
+      val names = recordSetCacheRepo
+        .listRecordSetData(Some(okZone.id), None, None, None, None, None, NameSort.ASC)
+        .unsafeRunSync()
+        .recordSets
+        .map(_.name)
+      names should contain allElementsOf changes.map(_.recordSet.name)
     }
     "work for deletes, updates, and inserts" in {
       // create some record sets to be updated
@@ -240,9 +262,7 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
       // exercise the entire change set
       val cs = ChangeSet(deletes ++ updates ++ inserts)
       executeWithinTransaction { db: DB =>
-        recordSetCacheRepo.save(db, cs)
-        recordSetRepo.apply(db, cs)
-
+        recordSetCacheRepo.save(db, cs).flatMap(_ => recordSetRepo.apply(db, cs))
       }.attempt.unsafeRunSync()
       // make sure the deletes are gone
       recordSetCacheRepo.getRecordSetData(deletes(0).recordSet.id).unsafeRunSync() shouldBe None
@@ -259,6 +279,49 @@ class MySqlRecordSetCacheRepositoryIntegrationSpec
         Some(inserts(0).recordSet.name)
       recordSetCacheRepo.getRecordSetData(inserts(1).recordSet.id).unsafeRunSync().map(_.name) shouldBe
         Some(inserts(1).recordSet.name)
+    }
+    "apply a mixed create/update/delete changeset atomically with correct row counts" in {
+      // seed 6 single-data records (1 recordset_data row each)
+      val existing = insert(okZone, 6).map(_.recordSet).sortBy(_.name)
+
+      // delete the first two
+      val deletes = existing
+        .take(2)
+        .map(makePendingTestDeleteChange(_, okZone).copy(status = RecordSetChangeStatus.Complete))
+
+      // update the next two (rename, same id)
+      val updates = existing
+        .slice(2, 4)
+        .map(rs => makeCompleteTestUpdateChange(rs, rs.copy(name = "renamed-" + rs.name), okZone))
+
+      // leave existing(4) and existing(5) untouched, and create two brand new records
+      val creates = generateInserts(okZone, 2, "brand-new")
+
+      val cs = ChangeSet(deletes ++ updates ++ creates)
+      executeWithinTransaction { db: DB =>
+        recordSetCacheRepo.save(db, cs).flatMap(_ => recordSetRepo.apply(db, cs))
+      }.attempt.unsafeRunSync() shouldBe right
+
+      // deletes are gone
+      deletes.foreach { d =>
+        recordSetCacheRepo.getRecordSetData(d.recordSet.id).unsafeRunSync() shouldBe None
+      }
+      // updates reflect the new name (delete-then-insert leaves exactly one row each)
+      updates.foreach { u =>
+        recordSetCacheRepo.getRecordSetData(u.recordSet.id).unsafeRunSync().map(_.name) shouldBe
+          Some(u.recordSet.name)
+      }
+      // untouched seed records survive unchanged
+      existing.slice(4, 6).foreach { rs =>
+        recordSetCacheRepo.getRecordSetData(rs.id).unsafeRunSync().map(_.name) shouldBe Some(rs.name)
+      }
+      // creates are present
+      creates.map(_.recordSet).foreach { rs =>
+        recordSetCacheRepo.getRecordSetData(rs.id).unsafeRunSync().map(_.name) shouldBe Some(rs.name)
+      }
+      // 6 seeded - 2 deleted + 2 created = 6; count == 6 proves updates neither dropped
+      // rows nor left duplicates (would be 4 or 8 respectively)
+      recordSetCacheRepo.getRecordSetDataCount(okZone.id).unsafeRunSync() shouldBe 6
     }
   }
   "list record sets" should {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlRecordSetCacheRepository.scala
@@ -64,68 +64,57 @@ class MySqlRecordSetCacheRepository
 
   def save(db: DB, changeSet: ChangeSet): IO[ChangeSet] = {
     val byStatus = changeSet.changes.groupBy(_.status)
+
+    // Failed creates get their (possibly pending) data removed; failed updates/deletes
+    // are reverted to their previous record data.
     val failedChanges = byStatus.getOrElse(RecordSetChangeStatus.Failed, Seq())
     val (failedCreates, failedUpdatesOrDeletes) =
       failedChanges.partition(_.changeType == RecordSetChangeType.Create)
 
-    val reversionDeletes = failedCreates.map(d => Seq[Any](d.recordSet.id))
-    failedUpdatesOrDeletes.flatMap { change =>
-      change.updates.map { oldRs =>
-        Seq[Any](
-          updateRecordDataList(
-            db,
-            oldRs.id,
-            oldRs.records,
-            oldRs.typ,
-            oldRs.zoneId,
-            toFQDN(change.zone.name, oldRs.name)
-          )
-        )
-      }
-    }
-    // address successful and pending changes
+    // Successful and pending changes
     val completeChanges = byStatus.getOrElse(RecordSetChangeStatus.Complete, Seq())
     val completeChangesByType = completeChanges.groupBy(_.changeType)
     val completeCreates = completeChangesByType.getOrElse(RecordSetChangeType.Create, Seq())
     val completeUpdates = completeChangesByType.getOrElse(RecordSetChangeType.Update, Seq())
     val completeDeletes = completeChangesByType.getOrElse(RecordSetChangeType.Delete, Seq())
-
     val pendingChanges = byStatus.getOrElse(RecordSetChangeStatus.Pending, Seq())
 
-    // all pending changes are saved as if they are creates
-    (completeCreates ++ pendingChanges).map { i =>
-      Seq[Any](
-        insertRecordDataList(
-          db,
-          i.recordSet.id,
-          i.recordSet.records,
-          i.recordSet.typ,
-          i.recordSet.zoneId,
-          toFQDN(i.zone.name, i.recordSet.name)
-        ))
-    }
-    completeUpdates.map { u =>
-      Seq[Any](
-        updateRecordDataList(
-          db,
-          u.recordSet.id,
-          u.recordSet.records,
-          u.recordSet.typ,
-          u.recordSet.zoneId,
-          toFQDN(u.zone.name, u.recordSet.name),
-        )
-      )
-    }
+    // Record ids whose data must be removed: explicit deletes, failed-create reversions, and
+    // the existing rows for anything being (re)written so updates are delete-then-insert.
+    val deleteParams: Seq[Seq[Any]] =
+      (completeDeletes.map(_.recordSet.id) ++
+        failedCreates.map(_.recordSet.id) ++
+        completeUpdates.map(_.recordSet.id) ++
+        failedUpdatesOrDeletes.flatMap(_.updates.map(_.id))).map(id => Seq[Any](id))
 
-    val deletes: Seq[Seq[Any]] = completeDeletes.map(d => Seq[Any](d.recordSet.id))
+    // Rows to insert: creates/pending and updated records use the new record set; failed
+    // update/delete reversions restore the previous record set.
+    val insertParams: Seq[Seq[(Symbol, Any)]] =
+      (completeCreates ++ pendingChanges).flatMap { c =>
+        recordDataRows(c.recordSet.id, c.recordSet.zoneId, toFQDN(c.zone.name, c.recordSet.name),
+          c.recordSet.typ, c.recordSet.records)
+      } ++ completeUpdates.flatMap { u =>
+        recordDataRows(u.recordSet.id, u.recordSet.zoneId, toFQDN(u.zone.name, u.recordSet.name),
+          u.recordSet.typ, u.recordSet.records)
+      } ++ failedUpdatesOrDeletes.flatMap { change =>
+        change.updates.toList.flatMap { oldRs =>
+          recordDataRows(oldRs.id, oldRs.zoneId, toFQDN(change.zone.name, oldRs.name),
+            oldRs.typ, oldRs.records)
+        }
+      }
+
     IO {
       db.withinTx { implicit session =>
-        (deletes ++ reversionDeletes).grouped(1000).foreach { group =>
+        // batch groups kept at 1000 to limit lock contention, matching MySqlRecordSetRepository.
+        // batchByName lets rewriteBatchedStatements collapse the inserts into multi-row statements.
+        deleteParams.grouped(1000).foreach { group =>
           DELETE_RECORDSETDATA.batch(group: _*).apply()
+        }
+        insertParams.grouped(1000).foreach { group =>
+          INSERT_RECORDSETDATA.batchByName(group: _*).apply()
         }
       }
     }.as(changeSet)
-
   }
 
   def deleteRecordSetDataInZone(db: DB, zone_id: String, zoneName: String): IO[Unit] =
@@ -146,83 +135,58 @@ class MySqlRecordSetCacheRepository
       }
     }
 
-  def insertRecordDataList(db: DB,
-                           recordID: String,
-                           recordData: List[RecordData],
-                           recordType: RecordType,
-                           zoneId: String,
-                           fqdn: String): Unit = storeRecordDataList(db, recordID, recordData, recordType, zoneId, fqdn)
-
   def updateRecordDataList(db: DB,
                            recordID: String,
                            recordData: List[RecordData],
                            recordType: RecordType,
                            zoneId: String,
-                           fqdn: String): Unit = {
+                           fqdn: String): Unit =
     db.withinTx { implicit session =>
       DELETE_RECORDSETDATA
         .bind(recordID)
         .update()
         .apply()
-      storeRecordDataList(db, recordID, recordData, recordType, zoneId, fqdn)
+      recordDataRows(recordID, zoneId, fqdn, recordType, recordData).grouped(1000).foreach { group =>
+        INSERT_RECORDSETDATA.batchByName(group: _*).apply()
+      }
     }
-  }
-
-  private def storeRecordDataList(db: DB,
-                                  recordId: String,
-                                  recordData: List[RecordData],
-                                  recordType: RecordType,
-                                  zoneId: String,
-                                  fqdn: String): Unit = {
-    recordData.foreach(record => saveRecordSetData(db, recordId, zoneId, fqdn, recordType, record))
-  }
 
   /**
-   * Inserts data into the RecordSet Data table
-   *
-   * @param db         The database connection
-   * @param recordId   The record identifier
-   * @param zoneId     The zone identifier
-   * @param fqdn       The fully qualified domain name
-   * @param recordType The record type
-   * @param recordData The record data
+   * Builds the batchByName parameter rows for a record set's data (one row per record data).
    */
-  private def saveRecordSetData(db: DB,
-                                recordId: String,
-                                zoneId: String,
-                                fqdn: String,
-                                recordType: RecordType,
-                                recordData: RecordData,
-                               ): Unit = {
-    // We want to get the protobuf string format of the record data. This provides
-    // slightly more information when doing RData searches.
-    // Example:
-    //  An SOA record may contain the following
-    //    mname:"auth.vinyldns.io."  rname:"admin.vinyldns.io."  serial:14  refresh:7200  retry:3600  expire:1209600  minimum:900
-    // This allows us to potentially search for SOA records with "refresh:7200"
-    val recordDataString = raw"""([a-z]+): ("|\d)""".r.replaceAllIn(recordDataToPB(recordData).toString.trim, "$1:$2")
+  private def recordDataRows(recordId: String,
+                             zoneId: String,
+                             fqdn: String,
+                             recordType: RecordType,
+                             recordData: List[RecordData]): Seq[Seq[(Symbol, Any)]] =
+    recordData.map { rd =>
+      // We want the protobuf string format of the record data. This provides slightly more
+      // information when doing RData searches. Example:
+      //  An SOA record may contain the following
+      //    mname:"auth.vinyldns.io."  rname:"admin.vinyldns.io."  serial:14  refresh:7200  ...
+      // This allows us to potentially search for SOA records with "refresh:7200"
+      val recordDataString =
+        raw"""([a-z]+): ("|\d)""".r.replaceAllIn(recordDataToPB(rd).toString.trim, "$1:$2")
 
-    // Extract the IP address from the forward or reverse record
-    val parsedIp = recordType match {
-      case RecordType.PTR => parseIP(fqdn)
-      case RecordType.A | RecordType.AAAA => parseIP(recordDataString)
-      case _ => None
+      // Extract the IP address from the forward or reverse record
+      val parsedIp = recordType match {
+        case RecordType.PTR => parseIP(fqdn)
+        case RecordType.A | RecordType.AAAA => parseIP(recordDataString)
+        case _ => None
+      }
+
+      Seq[(Symbol, Any)](
+        'recordset_id -> recordId,
+        'zone_id -> zoneId,
+        'fqdn -> fqdn,
+        'reverse_fqdn -> fqdn.reverse,
+        'type -> recordType.toString,
+        'record_data -> recordDataString,
+        // bind the Option (not orNull): scalikejdbc's batch binding maps None to SQL NULL,
+        // whereas a raw null is silently dropped from the batch.
+        'ip -> parsedIp
+      )
     }
-
-    db.withinTx { implicit session =>
-      INSERT_RECORDSETDATA
-        .bindByName(
-          'recordset_id -> recordId,
-          'zone_id -> zoneId,
-          'fqdn -> fqdn,
-          'reverse_fqdn -> fqdn.reverse,
-          'type -> recordType.toString,
-          'record_data -> recordDataString,
-          'ip -> parsedIp.orNull
-        )
-        .update()
-        .apply()
-    }}
 
   /**
     * Retrieves recordset data for records with the given {@code recordId} in the recordset


### PR DESCRIPTION
  ## Summary

  Speeds up the recordset-cache write during zone sync by batching it.
  `MySqlRecordSetCacheRepository.save` previously inserted `recordset_data`
  one row at a time, each in its own transaction, so `rewriteBatchedStatements`
  never kicked in. On a 300k-record zone this phase (`zone.sync.saveRecordSetDatas`)
  was ~267s of a ~448s sync — the single largest cost.

  `save` now collects all deletes and inserts and runs them as grouped batch
  statements (`batch`/`batchByName`, groups of 1000) within one transaction,
  the same pattern `MySqlRecordSetRepository` already uses. Expected to bring
  the cache write down toward the record-set repo's ballpark (tens of seconds).

  ## Changes

  - **Batch the cache write.** Single-row, per-transaction inserts → grouped
    `batch`/`batchByName` inside one `withinTx`.
  - **Correctness fix.** Inserts/updates previously executed eagerly as side
    effects *outside* the caller's transaction. They now run inside the
    returned `IO`, so cache writes are part of the sync transaction.
    (`ZoneSyncHandler` already sequences the save, so production is correct;
    the integration tests were relying on the old side-effect behavior and
    are updated to sequence the IOs.)
  - **Null `ip` binding.** Bind `ip` as an `Option` instead of `orNull`; a raw
    null is silently dropped by `batchByName`, which would have prevented all
    non-IP record types (CNAME/NS/TXT/SOA/MX/…) from being written.

  ## Testing

  - Full mysql integration suite: 278/278; mysql unit: 24/24; api
    `ZoneSyncHandlerSpec`: 18/18.
  - New integration tests: >1000-row batch boundary, null-`ip` record types,
    and a mixed create/update/delete changeset asserting exact row counts
    (proves updates remain delete-then-insert with no dropped/duplicate rows).

  ## Notes

  - No schema or config changes.
  - Complements #1515 (which chunks the sync write transaction but does not
    change this per-row insert path); best landed on top of it so the cache
    write participates in #1515's batch transaction.