### PR TITLE
Fix "Group with ID null was not found" popups on shared zones

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala
@@ -267,10 +267,15 @@ trait DnsJsonProtocol extends JsonValidation {
 
 
   case object ownershipTransferSerializer extends ValidationSerializer[OwnershipTransfer] {
+    // Treat blank and the literal string "null" as an absent group id so bad
+    // client payloads never persist requestedOwnerGroupId as the string "null".
+    private def sanitizeRequestedOwnerGroupId(id: Option[String]): Option[String] =
+      id.map(_.trim).filter(v => v.nonEmpty && !v.equalsIgnoreCase("null"))
+
     override def fromJson(js: JValue): ValidatedNel[String, OwnershipTransfer] =
       (
         (js \ "ownershipTransferStatus").required[OwnershipTransferStatus]("Missing ownershipTransfer.ownershipTransferStatus"),
-        (js \ "requestedOwnerGroupId").optional[String],
+        (js \ "requestedOwnerGroupId").optional[String].map(sanitizeRequestedOwnerGroupId),
         ).mapN(OwnershipTransfer.apply)
 
     override def toJson(rsa: OwnershipTransfer): JValue =

--- a/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/VinylDNSJsonProtocolSpec.scala
@@ -880,6 +880,38 @@ class VinylDNSJsonProtocolSpec
       anonymize(actual).recordSetGroupChange.get.requestedOwnerGroupId shouldBe Some("updated-admin-group-id")
       anonymize(actual).ownerGroupId shouldBe Some("updated-ok-group-id")
     }
+
+    "treat the string \"null\" requestedOwnerGroupId as absent" in {
+      val recordSetJValue: JValue =
+        ("zoneId" -> "1") ~~
+          ("name" -> "TestRecordName") ~~
+          ("type" -> "CNAME") ~~
+          ("ttl" -> 1000) ~~
+          ("status" -> "Pending") ~~
+          ("records" -> List("cname" -> "cname.data ")) ~~
+          ("ownerGroupId" -> "updated-ok-group-id") ~~
+          ("recordSetGroupChange" -> Some(("ownershipTransferStatus" -> "AutoApproved") ~~
+            ("requestedOwnerGroupId" -> "null")))
+
+      val actual = recordSetJValue.extract[RecordSet]
+      actual.recordSetGroupChange.get.requestedOwnerGroupId shouldBe None
+    }
+
+    "treat a blank requestedOwnerGroupId as absent" in {
+      val recordSetJValue: JValue =
+        ("zoneId" -> "1") ~~
+          ("name" -> "TestRecordName") ~~
+          ("type" -> "CNAME") ~~
+          ("ttl" -> 1000) ~~
+          ("status" -> "Pending") ~~
+          ("records" -> List("cname" -> "cname.data ")) ~~
+          ("ownerGroupId" -> "updated-ok-group-id") ~~
+          ("recordSetGroupChange" -> Some(("ownershipTransferStatus" -> "AutoApproved") ~~
+            ("requestedOwnerGroupId" -> "  ")))
+
+      val actual = recordSetJValue.extract[RecordSet]
+      actual.recordSetGroupChange.get.requestedOwnerGroupId shouldBe None
+    }
   }
 }
 

--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -121,7 +121,7 @@ angular.module('controller.records', [])
       */
 
     function isNotRequestedGroupMemberResponse(record, profileId) {
-        if (record.recordSetGroupChange && record.recordSetGroupChange.requestedOwnerGroupId) {
+        if (record.recordSetGroupChange && isValidGroupId(record.recordSetGroupChange.requestedOwnerGroupId)) {
             return groupsService
                 .getGroupMemberList(record.recordSetGroupChange.requestedOwnerGroupId)
                 .then(response => {
@@ -142,6 +142,9 @@ angular.module('controller.records', [])
     }
 
     $scope.recordSetGroupOwnershipStatus = function recordSetGroupOwnershipStatus(groupId, profileId, record) {
+        if (!isValidGroupId(groupId)) {
+            return Promise.resolve();
+        }
         function success(response) {
            var ownershipTransferStatus;
            const status = record.recordSetGroupChange && record.recordSetGroupChange.ownershipTransferStatus 
@@ -182,8 +185,13 @@ angular.module('controller.records', [])
             });
     };
 
+    // Treats missing, null, and the string "null" as an absent group id
+    function isValidGroupId(groupId) {
+        return groupId != undefined && groupId != null && groupId != "null";
+    }
+
     function getGroup(groupId) {
-        if (groupId != undefined && groupId != "null"){
+        if (isValidGroupId(groupId)){
             $log.debug('groupsService::getGroup-success');
             function success(response) {
                  $scope.recordSetRequestedOwnershipName = response.data.name;
@@ -697,7 +705,7 @@ angular.module('controller.records', [])
                     newRecords.push(recordsService.toDisplayRecord(record, $scope.zoneInfo.name));
                 });
                 angular.forEach(newRecords, function(record) {
-                    if(record.ownerGroupId != undefined) {
+                    if(isValidGroupId(record.ownerGroupId)) {
                         $scope.recordSetGroupOwnershipStatus(record.ownerGroupId, $scope.profile.id, record);
                     }else {record.isCurrentRecordSetOwner= null;}
                 });

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -433,4 +433,44 @@ describe('Controller: RecordsController', function () {
         expect(listRecordSetsByZone.calls.mostRecent().args).toEqual(
             [expectedZoneId, expectedMaxItems, expectedStartFrom, expectedQuery, expectedRecordTypeFilter, expectedNameSort, expectedRecordTypeSort]);
     });
+
+    it('recordSetGroupOwnershipStatus does not fetch members when the group id is the string "null"', function () {
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
+        var getGroupMemberList = spyOn(this.groupsService, 'getGroupMemberList')
+            .and.returnValue(this.q.when({data: {members: []}}));
+
+        this.scope.profile = {id: "some-user"};
+        this.scope.recordSetGroupOwnershipStatus("null", this.scope.profile.id, {});
+        this.scope.$digest();
+
+        expect(getGroupMemberList.calls.count()).toBe(0);
+    });
+
+    it('recordSetGroupOwnershipStatus does not fetch members when the requested owner group id is the string "null"', function () {
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
+        var getGroupMemberList = spyOn(this.groupsService, 'getGroupMemberList')
+            .and.returnValue(this.q.when({data: {members: []}}));
+
+        this.scope.profile = {id: "some-user", isSuper: true};
+        var record = {recordSetGroupChange: {ownershipTransferStatus: "AutoApproved", requestedOwnerGroupId: "null"}};
+        this.scope.recordSetGroupOwnershipStatus("valid-owner-group", this.scope.profile.id, record);
+        this.scope.$digest();
+
+        // Only the owner group lookup runs; the "null" requested owner group is skipped
+        expect(getGroupMemberList.calls.count()).toBe(1);
+        expect(getGroupMemberList.calls.mostRecent().args).toEqual(["valid-owner-group"]);
+    });
+
+    it('recordSetGroupOwnershipStatus fetches members for a valid group id', function () {
+        this.$httpBackend.when('GET', '/api/users/currentuser').respond({});
+        var getGroupMemberList = spyOn(this.groupsService, 'getGroupMemberList')
+            .and.returnValue(this.q.when({data: {members: []}}));
+
+        this.scope.profile = {id: "some-user"};
+        this.scope.recordSetGroupOwnershipStatus("valid-group", this.scope.profile.id, {});
+        this.scope.$digest();
+
+        expect(getGroupMemberList.calls.count()).toBe(1);
+        expect(getGroupMemberList.calls.mostRecent().args).toEqual(["valid-group"]);
+    });
 });


### PR DESCRIPTION
VDNS-368

 ## Problem

  When viewing certain shared zones, the portal fires a cascade of error popups:

  > HTTP 404 (Not Found): Group with ID null was not found

  One popup per affected record. In the reported zone, 9 CNAME records were
  affected — all with valid `ownerGroupId` values but
  `recordSetGroupChange.requestedOwnerGroupId` persisted as the literal string
  `"null"` inside the protobuf blob.

  ## Root cause

  Two parts:

  1. **Weak portal guards.** The ownership-status code path only guarded with
     truthiness / `!= undefined`, which does not catch the string `"null"` (it is
     truthy and `!= undefined`). On zone load, for each owned record Angular built
     `GET /api/groups/null/members`; the API echoed the segment back as
     `Group with ID null was not found` and it rendered as a popup. A sibling
     `getGroup` helper was already hardened for exactly this case, but the guard
     was never applied to the ownership-status path.
  2. **Bad data on the write path.** Affected records had `requestedOwnerGroupId`
     stored as the string `"null"` rather than an absent/`None` value.

  ## Changes

  ### Portal — stops the popups
  `modules/portal/public/lib/controllers/controller.records.js`
  - Added `isValidGroupId(groupId)` helper that treats `undefined`, `null`, and
    the string `"null"` as absent.
  - Applied it to all three ownership-status call sites:
    `isNotRequestedGroupMemberResponse`, `recordSetGroupOwnershipStatus` (early
    return before the member lookup), and the `updateRecordDisplay` per-record loop.
  - Refactored `getGroup` to use the shared helper.

  ### API — prevents recurrence
  `modules/api/src/main/scala/vinyldns/api/route/DnsJsonProtocol.scala`
  - Sanitized `requestedOwnerGroupId` at the parse boundary in
    `ownershipTransferSerializer.fromJson`, so blank and `"null"` values map to
    `None` before they can be written to the protobuf blob — regardless of which
    client sends them.

  ### Tests
  - Portal (`controller.records.spec.js`): no member lookup for a `"null"` group id;
    a `"null"` requested owner group is skipped while a valid owner group is still
    checked; valid ids still fetch.
  - API (`VinylDNSJsonProtocolSpec.scala`): `"null"` and blank `requestedOwnerGroupId`
    both parse to `None`.

  ## Acceptance criteria
  - [x] Viewing a shared zone with affected records produces no "Group with ID null" popups.
  - [x] Newly created/updated records never persist `requestedOwnerGroupId` as the string `"null"`.
  - [x] The get-group-members call is not issued when the group id is absent, `null`, or `"null"`.