### PR TITLE
Record owner group update fix

### DIFF
--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -198,6 +198,15 @@ angular.module('controller.records', [])
         else {$scope.recordSetRequestedOwnershipName = "None";}
     };
 
+    function normalizeOwnershipStatus(record) {
+        if (!record.recordSetGroupChange && record.ownerGroupId) {
+            record.recordSetGroupChange = {
+                requestedOwnerGroupId: angular.copy(record.ownerGroupId),
+                ownershipTransferStatus: "AutoApproved"
+            };
+        }
+    }
+
     $scope.deleteRecord = function(record) {
         $scope.currentRecord = angular.copy(record);
         $scope.recordModal = {
@@ -236,11 +245,7 @@ angular.module('controller.records', [])
 
     $scope.editRecord = function(record) {
         $scope.currentRecord = angular.copy(record);
-        if ($scope.currentRecord.recordSetGroupChange == undefined){
-            $scope.currentRecord.recordSetGroupChange = {}
-            $scope.currentRecord.recordSetGroupChange.requestedOwnerGroupId = angular.copy(record.ownerGroupId);
-            $scope.currentRecord.recordSetGroupChange.ownershipTransferStatus = angular.copy("AutoApproved");
-        }
+        normalizeOwnershipStatus($scope.currentRecord);
         getGroup($scope.currentRecord.recordSetGroupChange.requestedOwnerGroupId);
         $scope.recordModal = {
             previous: angular.copy(record),
@@ -393,6 +398,7 @@ angular.module('controller.records', [])
     $scope.submitUpdateRecord = function () {
         var record = angular.copy($scope.currentRecord);
         record['onlyFour'] = true;
+        delete record.recordSetGroupChange;
         if ($scope.addRecordForm.$valid) {
             updateRecordSet(record);
             $scope.addRecordForm.$setPristine();
@@ -697,6 +703,7 @@ angular.module('controller.records', [])
                     newRecords.push(recordsService.toDisplayRecord(record, $scope.zoneInfo.name));
                 });
                 angular.forEach(newRecords, function(record) {
+                    normalizeOwnershipStatus(record);
                     if(record.ownerGroupId != undefined) {
                         $scope.recordSetGroupOwnershipStatus(record.ownerGroupId, $scope.profile.id, record);
                     }else {record.isCurrentRecordSetOwner= null;}

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -97,6 +97,66 @@ describe('Controller: RecordsController', function () {
         expect(this.scope.currentRecord.sshfpItems).toEqual([{algorithm: '', type: '', fingerprint: ''}]);
     });
 
+    describe('submitUpdateRecord', function () {
+        function mockSuccessfulUpdateRecordSet(recordsService, sentRecordRef) {
+            spyOn(recordsService, 'updateRecordSet').and.callFake(function (zoneId, recordId, payload) {
+                sentRecordRef.value = payload;
+                return {
+                    then: function (fn) {
+                        fn({ data: { recordSet: {} }, status: 200, statusText: 'OK' });
+                        return this;
+                    },
+                    catch: function () {}
+                };
+            });
+        }
+
+        beforeEach(function () {
+            this.scope.currentRecord = {
+                id: 'record-id-1',
+                zoneId: 'zone-id-1',
+                name: 'test-record',
+                type: 'A',
+                ttl: 300,
+                aRecordData: ['1.2.3.4'],
+                status: 'Active'
+            };
+            this.scope.addRecordForm = {$valid: true, $setPristine: function () {}};
+        });
+
+        it('removes recordSetGroupChange before sending update to backend', function () {
+            this.scope.currentRecord.recordSetGroupChange = {
+                ownershipTransferStatus: 'PendingReview',
+                requestedOwnerGroupId: 'group-id-1'
+            };
+
+            var sentRecord = { value: undefined };
+            mockSuccessfulUpdateRecordSet(this.recordsService, sentRecord);
+
+            this.scope.submitUpdateRecord();
+
+            expect(sentRecord.value.recordSetGroupChange).toBeUndefined();
+            expect(sentRecord.value.name).toBe('test-record');
+            expect(sentRecord.value.ttl).toBe(300);
+        });
+
+        it('does not send ownership transfer payload when owner group is changed via update modal', function () {
+            this.scope.currentRecord.ownerGroupId = 'group-id-2';
+            this.scope.currentRecord.recordSetGroupChange = {
+                ownershipTransferStatus: 'ManuallyApproved',
+                requestedOwnerGroupId: 'group-id-2'
+            };
+
+            var sentRecord = { value: undefined };
+            mockSuccessfulUpdateRecordSet(this.recordsService, sentRecord);
+
+            this.scope.submitUpdateRecord();
+
+            expect(sentRecord.value.recordSetGroupChange).toBeUndefined();
+            expect(sentRecord.value.ownerGroupId).toBe('group-id-2');
+        });
+    });
+
     it('refreshZone updates zoneInfo and isZoneAdmin when user is in admin group', function() {
         mockZone = {
             name: "dummy.",


### PR DESCRIPTION
VDNS-425

Fixes #1533.


Changes in this pull request:
- Fixed the shared-zone update flow for records created via CLI or API where changing the Record Owner Group could fail with:
`Unable to AutoApprove the Ownership transfer status for the record: None`
- Updated the standard record update path so it does not send ownership-transfer metadata during a normal record edit.
- Preserved ownership display behavior for records that have an `ownerGroupId` but are missing `recordSetGroupChange`, so CLI/API-created records still render correctly in the portal.

Added and refined controller tests for:
- ensuring standard record updates do not send `recordSetGroupChange`.
- ensuring owner-group updates through the regular update modal do not send ownership-transfer payloads unintentionally.
