### PR TITLE
Portal record details modal fix

### DIFF
--- a/modules/portal/public/lib/controllers/controller.records.js
+++ b/modules/portal/public/lib/controllers/controller.records.js
@@ -357,7 +357,11 @@ angular.module('controller.records', [])
             sharedZone: $scope.zoneInfo.shared,
             sharedDisplayEnabled: $scope.sharedDisplayEnabled
         };
-        getGroup($scope.currentRecord.recordSetGroupChange.requestedOwnerGroupId)
+        var ownerGroupId = $scope.currentRecord.recordSetGroupChange &&
+            $scope.currentRecord.recordSetGroupChange.requestedOwnerGroupId;
+        if (ownerGroupId) {
+            getGroup(ownerGroupId);
+        }
         $log.debug('RecordsController::viewRecordInfo', record);
         $("#record_modal").modal("show");
     };

--- a/modules/portal/public/lib/controllers/controller.records.spec.js
+++ b/modules/portal/public/lib/controllers/controller.records.spec.js
@@ -97,6 +97,52 @@ describe('Controller: RecordsController', function () {
         expect(this.scope.currentRecord.sshfpItems).toEqual([{algorithm: '', type: '', fingerprint: ''}]);
     });
 
+    describe('viewRecordInfo', function () {
+        beforeEach(function () {
+            this.testRecord = {
+                id: 'record-id-1',
+                zoneId: 'zone-id-1',
+                name: 'test-record',
+                type: 'A',
+                ttl: 300,
+                records: [{address: '1.2.3.4'}],
+                status: 'Active'
+            };
+
+            spyOn(this.recordsService, 'toDisplayRecord').and.callFake(function (record) {
+                return angular.copy(record);
+            });
+
+            spyOn(this.groupsService, 'getGroup').and.returnValue(this.q.when({ data: { name: 'group-name' } }));
+        });
+
+        it('opens record info when recordSetGroupChange is missing', function () {
+            expect(function () {
+                this.scope.viewRecordInfo(this.testRecord);
+            }.bind(this)).not.toThrow();
+
+            expect(this.scope.recordModal.action).toBe(this.scope.recordModalState.VIEW_DETAILS);
+            expect(this.scope.currentRecord.name).toBe('test-record');
+            expect(this.recordsService.toDisplayRecord.calls.count()).toBe(1);
+            expect(this.groupsService.getGroup).not.toHaveBeenCalled();
+        });
+
+        it('opens record info and keeps requested owner group when recordSetGroupChange exists', function () {
+            var recordWithGroupChange = angular.copy(this.testRecord);
+            recordWithGroupChange.recordSetGroupChange = {
+                requestedOwnerGroupId: 'group-id-1',
+                ownershipTransferStatus: 'PendingReview'
+            };
+
+            this.scope.viewRecordInfo(recordWithGroupChange);
+
+            expect(this.scope.recordModal.action).toBe(this.scope.recordModalState.VIEW_DETAILS);
+            expect(this.scope.currentRecord.recordSetGroupChange.requestedOwnerGroupId).toBe('group-id-1');
+            expect(this.recordsService.toDisplayRecord.calls.count()).toBe(1);
+            expect(this.groupsService.getGroup).toHaveBeenCalledWith('group-id-1');
+        });
+    });
+
     it('refreshZone updates zoneInfo and isZoneAdmin when user is in admin group', function() {
         mockZone = {
             name: "dummy.",


### PR DESCRIPTION
VDNS-409

Fixes #1530.

Changes in this pull request:
- Added null-safe handling for record changes that do not include `recordSetGroupChange`.
- Updated the record details flow so viewing created, updated or deleted record changes no longer assumes ownership-transfer metadata is present.
- Ensured the Recent Record Changes table can open the details modal for record-set changes made through direct zone record-set APIs and the VinylDNS CLI in addition to batch changes.
- Added controller coverage for record changes without `recordSetGroupChange`.

