### PR TITLE
RecordSet Details and Record Update Fixes

### DIFF
--- a/modules/frontend/src/components/records/RecordForm.tsx
+++ b/modules/frontend/src/components/records/RecordForm.tsx
@@ -196,6 +196,40 @@ export function RecordForm({ zoneId, zoneName, initialData, onSubmit, onCancel, 
             )}
           </div>
         )}
+
+        {/* Ownership Transfer fields — read-only, shown in edit mode when present */}
+        {mode === 'edit' && isSharedZone && initialData?.recordSetGroupChange?.requestedOwnerGroupId &&
+          initialData.recordSetGroupChange.requestedOwnerGroupId !== 'null' && (
+          <div className="col-md-4">
+            <label className="form-label fw-semibold small">
+              <i className="bi bi-arrow-left-right me-1 text-primary" />Ownership Transfer Group
+            </label>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              readOnly
+              value={
+                allGroups.find(g => g.id === initialData.recordSetGroupChange!.requestedOwnerGroupId)?.name
+                ?? initialData.ownerGroupName
+                ?? initialData.recordSetGroupChange.requestedOwnerGroupId
+              }
+            />
+          </div>
+        )}
+
+        {mode === 'edit' && isSharedZone && initialData?.recordSetGroupChange?.ownershipTransferStatus && (
+          <div className="col-md-4">
+            <label className="form-label fw-semibold small">
+              <i className="bi bi-info-circle me-1 text-primary" />Ownership Transfer Status
+            </label>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              readOnly
+              value={initialData.recordSetGroupChange.ownershipTransferStatus}
+            />
+          </div>
+        )}
       </div>
 
       {/* ── Record data rows ── */}

--- a/modules/frontend/src/components/records/RecordHistoryModal.tsx
+++ b/modules/frontend/src/components/records/RecordHistoryModal.tsx
@@ -827,9 +827,7 @@ export function RecordHistoryModal({
               {/* ── View recordset actions (Angular parity) ── */}
               {(() => {
                 const cType = String(selectedInfo.changeType ?? "");
-                // old record set: API returns it directly as `updates`, not `updates.recordSet`
-                const oldRs =
-                  selectedInfo.updates?.recordSet ?? selectedInfo.updates;
+                const oldRs = selectedInfo.updates as any;
                 const newRs = selectedInfo.recordSet;
 
                 // Inline record detail renderer

--- a/modules/frontend/src/components/records/RecordsTable.tsx
+++ b/modules/frontend/src/components/records/RecordsTable.tsx
@@ -151,7 +151,7 @@ const OWNERSHIP_STATUS_META: Record<string, { cls: string; icon: string; label: 
 };
 
 function OwnershipStatusBadge({ status }: { status?: string }) {
-  if (!status || status === 'None' || status === 'AutoApproved') {
+  if (!status || status === 'None') {
     return <span className="vds-ownership-badge vds-ownership-badge--none">—</span>;
   }
   const meta = OWNERSHIP_STATUS_META[status];
@@ -394,7 +394,10 @@ export function RecordsTable({
                     <td><OwnerGroupCell record={rec} /></td>
                     <td>
                       <OwnershipStatusBadge
-                        status={rec.recordSetGroupChange?.ownershipTransferStatus}
+                        status={
+                          rec.recordSetGroupChange?.ownershipTransferStatus ??
+                          (rec.ownerGroupId ? 'AutoApproved' : undefined)
+                        }
                       />
                     </td>
                   </>

--- a/modules/frontend/src/hooks/useRecords.ts
+++ b/modules/frontend/src/hooks/useRecords.ts
@@ -197,6 +197,19 @@ export function useRecords() {
   };
 }
 
+function normalizeOwnershipStatus(record: RecordSet): RecordSet {
+  if (!record.recordSetGroupChange && record.ownerGroupId) {
+    return {
+      ...record,
+      recordSetGroupChange: {
+        requestedOwnerGroupId: record.ownerGroupId,
+        ownershipTransferStatus: 'AutoApproved',
+      },
+    };
+  }
+  return record;
+}
+
 /** Hook for records within a single zone */
 export function useZoneRecords(zoneId: string) {
   const [nameFilter, setNameFilter] = useState('');
@@ -271,7 +284,7 @@ export function useZoneRecords(zoneId: string) {
   }, [prevPageUpdate, getPrevStartFrom]);
 
   return {
-    records: data?.recordSets ?? [],
+    records: (data?.recordSets ?? []).map(normalizeOwnershipStatus),
     isLoading,
     search,
     refetch,

--- a/modules/frontend/src/pages/GroupsPage.tsx
+++ b/modules/frontend/src/pages/GroupsPage.tsx
@@ -278,14 +278,23 @@ export function GroupsPage() {
     );
   };
 
-  const handleUpdate = (data: {
+  const handleUpdate = async (data: {
     name: string;
     email: string;
     description?: string;
   }) => {
     if (!editGroup) return;
+    let members = editGroup.members;
+    let admins = editGroup.admins;
+    try {
+      const res = await groupsService.getGroup(editGroup.id);
+      members = res.data.members;
+      admins = res.data.admins;
+    } catch {
+      // fall back to whatever the abridged list returned
+    }
     updateGroup(
-      { id: editGroup.id, group: { ...editGroup, ...data } },
+      { id: editGroup.id, group: { ...editGroup, ...data, members, admins } },
       {
         onSuccess: () => setEditGroup(null),
       },

--- a/modules/frontend/src/pages/ZoneDetailPage.tsx
+++ b/modules/frontend/src/pages/ZoneDetailPage.tsx
@@ -35,7 +35,7 @@ import { useZoneRecords } from '../hooks/useRecords';
 import { usePaging } from '../hooks/usePaging';
 import { formatDateTime } from '../utils/dateUtils';
 import type { Zone, AclRule } from '../types/zone';
-import type { RecordSet } from '../types/record';
+import type { RecordSet, RecordSetGroupChange } from '../types/record';
 
 type DetailTab = 'records' | 'recordChanges' | 'zoneChanges' | 'zone';
 
@@ -592,12 +592,36 @@ export function ZoneDetailPage() {
 
   // ── Handlers ───────────────────────────────────────────────────────────────
   const handleCreateRecord = (data: Partial<RecordSet>) => {
-    createRecord(data, { onSuccess: () => setShowRecordForm(false) });
+    const payload: Partial<RecordSet> = data.ownerGroupId
+      ? {
+          ...data,
+          recordSetGroupChange: data.recordSetGroupChange ?? {
+            ownershipTransferStatus: 'AutoApproved',
+          },
+        }
+      : data;
+    createRecord(payload, { onSuccess: () => setShowRecordForm(false) });
   };
 
   const handleUpdateRecord = (data: Partial<RecordSet>) => {
     if (!editRecord) return;
-    updateRecord({ recordSetId: editRecord.id, record: data }, { onSuccess: () => setEditRecord(null) });
+    const recordSetGroupChange: RecordSetGroupChange | undefined =
+      editRecord.recordSetGroupChange ??
+      (editRecord.ownerGroupId
+        ? { requestedOwnerGroupId: editRecord.ownerGroupId, ownershipTransferStatus: 'AutoApproved' }
+        : undefined);
+    updateRecord(
+      {
+        recordSetId: editRecord.id,
+        record: {
+          id: editRecord.id,
+          zoneId: editRecord.zoneId,
+          ...data,
+          ...(recordSetGroupChange && { recordSetGroupChange }),
+        },
+      },
+      { onSuccess: () => setEditRecord(null) },
+    );
   };
 
   const handleDeleteConfirm = () => {
@@ -878,35 +902,39 @@ export function ZoneDetailPage() {
                               <td className="vds-table-secondary vds-table-nowrap small">{c.userName ?? c.userId}</td>
                               <td className="vds-table-secondary vds-table-nowrap small">{formatDateTime(c.created)}</td>
                               <td className="small">
-                                {c.changeType === 'Create' && (
-                                  <button
-                                    className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
-                                    onClick={() => setViewingRecordSet({ label: 'Created Record Set', rs: c.recordSet })}>
-                                    <i className="bi bi-eye" />View created recordset
-                                  </button>
-                                )}
-                                {c.changeType === 'Update' && (
+                                {/* systemMessage always shown (e.g. "Change applied via zone sync") */}
+                                {c.systemMessage && <div className="vds-table-secondary mb-1">{c.systemMessage}</div>}
+                                {c.status !== 'Failed' && (
                                   <div className="d-flex flex-column gap-1">
-                                    <button
-                                      className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
-                                      onClick={() => setViewingRecordSet({ label: 'New Record Set', rs: c.recordSet })}>
-                                      <i className="bi bi-eye" />View new recordset
-                                    </button>
-                                    {c.updates?.recordSet && (
+                                    {c.changeType === 'Create' && (
                                       <button
                                         className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
-                                        onClick={() => setViewingRecordSet({ label: 'Old Record Set', rs: c.updates!.recordSet! })}>
-                                        <i className="bi bi-clock-history" />View old recordset
+                                        onClick={() => setViewingRecordSet({ label: 'Created Record Set', rs: c.recordSet })}>
+                                        <i className="bi bi-eye" />View created recordset
+                                      </button>
+                                    )}
+                                    {c.changeType === 'Update' && (<>
+                                      <button
+                                        className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
+                                        onClick={() => setViewingRecordSet({ label: 'New Record Set', rs: c.recordSet })}>
+                                        <i className="bi bi-eye" />View new recordset
+                                      </button>
+                                      {c.updates && (
+                                        <button
+                                          className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
+                                          onClick={() => setViewingRecordSet({ label: 'Old Record Set', rs: c.updates! })}>
+                                          <i className="bi bi-clock-history" />View old recordset
+                                        </button>
+                                      )}
+                                    </>)}
+                                    {c.changeType === 'Delete' && (
+                                      <button
+                                        className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
+                                        onClick={() => setViewingRecordSet({ label: 'Deleted Record Set', rs: c.recordSet })}>
+                                        <i className="bi bi-clock-history" />View deleted recordset
                                       </button>
                                     )}
                                   </div>
-                                )}
-                                {c.changeType === 'Delete' && (
-                                  <button
-                                    className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
-                                    onClick={() => setViewingRecordSet({ label: 'Deleted Record Set', rs: c.recordSet })}>
-                                    <i className="bi bi-clock-history" />View deleted recordset
-                                  </button>
                                 )}
                               </td>
                             </tr>
@@ -1425,9 +1453,9 @@ export function ZoneDetailPage() {
                                 onClick={() => setViewingRecordSet({ label: 'New Record Set', rs: c.recordSet })}>
                                 <i className="bi bi-eye" />View new recordset
                               </button>
-                              {c.updates?.recordSet && (
+                              {c.updates && (
                                 <button className="btn btn-sm vds-btn-flat px-2 py-0 d-flex align-items-center gap-1 vds-history-btn"
-                                  onClick={() => setViewingRecordSet({ label: 'Old Record Set', rs: c.updates!.recordSet! })}>
+                                  onClick={() => setViewingRecordSet({ label: 'Old Record Set', rs: c.updates! })}>
                                   <i className="bi bi-clock-history" />View old recordset
                                 </button>
                               )}
@@ -2717,6 +2745,43 @@ export function ZoneDetailPage() {
                 </div>
                 {/* Record data */}
                 <div className="px-4 py-3">
+                  {(viewingRecordSet.rs.ownerGroupId ||
+                    (viewingRecordSet.rs.recordSetGroupChange?.requestedOwnerGroupId &&
+                      viewingRecordSet.rs.recordSetGroupChange.requestedOwnerGroupId !== 'null') ||
+                    (viewingRecordSet.rs.recordSetGroupChange?.ownershipTransferStatus)) && (
+                    <div className="mb-3 pb-3" style={{ borderBottom: '1px solid #e3eaf4' }}>
+                      <div className="fw-semibold mb-2" style={{ fontSize: '0.85rem', color: '#3a5c8c' }}>
+                        <i className="bi bi-people-fill me-1" />Ownership
+                      </div>
+                      <div className="d-flex flex-wrap gap-3">
+                        {viewingRecordSet.rs.ownerGroupId && (
+                          <div>
+                            <div className="text-muted" style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Record Owner Group</div>
+                            <div className="fw-semibold small">
+                              {viewingRecordSet.rs.ownerGroupName ?? viewingRecordSet.rs.ownerGroupId}
+                            </div>
+                          </div>
+                        )}
+                        {viewingRecordSet.rs.recordSetGroupChange?.requestedOwnerGroupId &&
+                          viewingRecordSet.rs.recordSetGroupChange.requestedOwnerGroupId !== 'null' && (
+                          <div>
+                            <div className="text-muted" style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Ownership Transfer Group</div>
+                            <div className="fw-semibold small">
+                              {viewingRecordSet.rs.recordSetGroupChange.requestedOwnerGroupId}
+                            </div>
+                          </div>
+                        )}
+                        {viewingRecordSet.rs.recordSetGroupChange?.ownershipTransferStatus && (
+                          <div>
+                            <div className="text-muted" style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>Ownership Transfer Status</div>
+                            <div className="fw-semibold small">
+                              {viewingRecordSet.rs.recordSetGroupChange.ownershipTransferStatus}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
                   <div className="fw-semibold mb-2" style={{ fontSize: '0.85rem', color: '#3a5c8c' }}>
                     <i className="bi bi-list-ul me-1" />Record Data ({viewingRecordSet.rs.records.length})
                   </div>

--- a/modules/frontend/src/types/record.ts
+++ b/modules/frontend/src/types/record.ts
@@ -111,7 +111,7 @@ export interface RecordSetChange {
   userId: string;
   id: string;
   zoneId: string;
-  updates?: { recordSet?: RecordSet };
+  updates?: RecordSet;
   userName?: string;
 }
 


### PR DESCRIPTION
VDNS-459

Fixes #1555.

Changes in this pull request:
- Updated the Additional Info section to display both the previous and updated RecordSet details for Update changes.
- Enhanced the View Record Set modal to display Record Owner Group, Ownership Transfer Group, and Ownership Transfer Status for Create, Update and Delete changes whenever available.
- Fixed the record update flow by including the record ID and zone ID in the PUT request.
- Fixed an issue where super users were unable to edit groups due to the error: "Group must have at least one member and one admin."
