### PR TITLE
Keep LocalStack integration tests AWS-compatible

### DIFF
--- a/modules/api/src/it/scala/vinyldns/api/notifier/sns/SnsNotifierIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/notifier/sns/SnsNotifierIntegrationSpec.scala
@@ -21,6 +21,7 @@ import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.model.{GetQueueAttributesRequest, QueueAttributeName}
 import com.typesafe.config.{Config, ConfigFactory}
 import java.time.Instant
 import org.json4s.DefaultFormats
@@ -104,11 +105,27 @@ class SnsNotifierIntegrationSpec
         queueUrl <- IO {
           sqs.createQueue("batchChanges").getQueueUrl
         }
+        queueArn <- IO {
+          val queueArnAttribute = QueueAttributeName.QueueArn.toString
+          sqs
+            .getQueueAttributes(
+              new GetQueueAttributesRequest(queueUrl).withAttributeNames(queueArnAttribute)
+            )
+            .getAttributes
+            .get(queueArnAttribute)
+        }
         topic <- IO {
           sns.createTopic("batchChanges").getTopicArn
         }
+        subscription <- IO {
+          sns.subscribe(topic, "sqs", queueArn)
+        }
         _ <- IO {
-          sns.subscribe(topic, "sqs", queueUrl)
+          sns.setSubscriptionAttributes(
+            subscription.getSubscriptionArn,
+            "RawMessageDelivery",
+            "true"
+          )
         }
         notifier <- new SnsNotifierProvider()
           .load(NotifierConfig("", snsConfig), userRepository, groupRepository)
@@ -128,9 +145,11 @@ class SnsNotifierIntegrationSpec
       messages.size should be(1)
 
       val notification = parse(messages.get(0).getBody)
-      (notification \ "Message").extract[String] should be(
-        """{"userId":"ok","userName":"ok","createdTimestamp":"2019-07-22T19:38:23Z",""" +
-          """"status":"Complete","approvalStatus":"AutoApproved","id":"a615e2bb-8b35-4a39-8947-1edd0e653afa"}"""
+      notification should be(
+        parse(
+          """{"userId":"ok","userName":"ok","createdTimestamp":"2019-07-22T19:38:23Z",""" +
+            """"status":"Complete","approvalStatus":"AutoApproved","id":"a615e2bb-8b35-4a39-8947-1edd0e653afa"}"""
+        )
       )
     }
 

--- a/modules/api/src/it/scala/vinyldns/api/route53/Route53ApiIntegrationSpec.scala
+++ b/modules/api/src/it/scala/vinyldns/api/route53/Route53ApiIntegrationSpec.scala
@@ -124,10 +124,9 @@ class Route53ApiIntegrationSpec
       val results = recordSetRepository
         .listRecordSets(Some(testZone.id), None, None, None, None, None, NameSort.ASC, RecordTypeSort.ASC)
         .unsafeRunSync()
-      results.recordSets.map(_.typ).distinct should contain theSameElementsAs List(
-        rsOk.typ,
-        RecordType.NS
-      )
+      val recordTypes = results.recordSets.map(_.typ).distinct
+      recordTypes should contain(rsOk.typ)
+      recordTypes should contain(RecordType.NS)
       results.recordSets.map(_.name) should contain(rsOk.name)
 
       // Ensure that the NS record matches the zone name


### PR DESCRIPTION
## Context

[vinyldns/docker#3](https://github.com/vinyldns/docker/pull/3) upgrades the integration image from LocalStack 0.12 to 4.12. The newer emulator exposed assumptions in two integration tests that do not match the AWS APIs they exercise.

## Changes

- Look up the SQS queue ARN and use it as the SNS subscription endpoint. AWS requires an ARN for an SQS subscription; the queue URL is still used for SQS operations.
- Enable raw delivery for this test subscription so the test validates the notifier payload directly, independent of the SNS delivery envelope.
- Require the Route53 sync result to include the created record and an NS record without rejecting additional provider-managed records such as SOA.

These are integration-test-only changes, for compatibility with the updated LocalStack; production behavior is unchanged.

## Validation

Ran the affected suites against both the LocalStack 4.12 image from docker#3 and the older LocalStack fixture:

```text
api/IntegrationTest/testOnly vinyldns.api.route53.Route53ApiIntegrationSpec vinyldns.api.notifier.sns.SnsNotifierIntegrationSpec
```

Both runs passed all 3 tests.

VDNS-262