### PR TITLE
Search by groups all dns change

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -583,11 +583,13 @@ class BatchChangeService(
   def listBatchChangeSummaries(
       auth: AuthPrincipal,
       userName: Option[String] = None,
+      groupName: Option[String] = None,
       dateTimeStartRange: Option[String] = None,
       dateTimeEndRange: Option[String] = None,
       startFrom: Option[Int] = None,
       maxItems: Int = 100,
       ignoreAccess: Boolean = false,
+      isSearchByGroup: Boolean = false,
       batchStatus: Option[BatchChangeStatus] = None,
       approvalStatus: Option[BatchChangeApprovalStatus] = None
   ): BatchResult[BatchChangeSummaryList] = {
@@ -596,8 +598,15 @@ class BatchChangeService(
     val startDateTime = if(dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None else dateTimeStartRange
     val endDateTime = if(dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None else dateTimeEndRange
     for {
+      groupID <-
+        groupName match {
+          case Some(groupName) if groupName.nonEmpty =>
+            groupRepository.getGroupByName(groupName).map{group => group.map(_.id)}.toBatchResult
+          case _ => None.toRightBatchResult
+        }
       listResults <- batchChangeRepo
-        .getBatchChangeSummaries(userId, submitterUserName, startDateTime, endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
+        .getBatchChangeSummaries(userId, submitterUserName, groupID, isSearchByGroup,
+          startDateTime, endDateTime, startFrom, maxItems, batchStatus, approvalStatus)
         .toBatchResult
       rsOwnerGroupIds = listResults.batchChanges.flatMap(_.ownerGroupId).toSet
       rsOwnerGroups <- groupRepository.getGroups(rsOwnerGroupIds).toBatchResult

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -35,11 +35,13 @@ trait BatchChangeServiceAlgebra {
   def listBatchChangeSummaries(
       auth: AuthPrincipal,
       userName: Option[String] = None,
+      groupName: Option[String] = None,
       dateTimeStartRange: Option[String] = None,
       dateTimeEndRange: Option[String] = None,
       startFrom: Option[Int],
       maxItems: Int,
       ignoreAccess: Boolean,
+      isSearchByGroup : Boolean,
       batchStatus: Option[BatchChangeStatus],
       approvalStatus: Option[BatchChangeApprovalStatus]
   ): BatchResult[BatchChangeSummaryList]

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -73,20 +73,24 @@ class BatchChangeRoute(
       (get & monitor("Endpoint.listBatchChangeSummaries")) {
         parameters(
           "userName".as[String].?,
+          "groupName".as[String].?,
           "dateTimeRangeStart".as[String].?,
           "dateTimeRangeEnd".as[String].?,
           "startFrom".as[Int].?,
           "maxItems".as[Int].?(MAX_ITEMS_LIMIT),
           "ignoreAccess".as[Boolean].?(false),
+          "isSearchByGroup".as[Boolean].?(false),
           "approvalStatus".as[String].?
         ) {
           (
               userName: Option[String],
+              groupName: Option[String],
               dateTimeRangeStart: Option[String],
               dateTimeRangeEnd: Option[String],
               startFrom: Option[Int],
               maxItems: Int,
               ignoreAccess: Boolean,
+              isSearchByGroup: Boolean,
               approvalStatus: Option[String]
           ) =>
             {
@@ -101,11 +105,13 @@ class BatchChangeRoute(
                       batchChangeService.listBatchChangeSummaries(
                         _,
                         userName,
+                        groupName,
                         dateTimeRangeStart,
                         dateTimeRangeEnd,
                         startFrom,
                         maxItems,
                         ignoreAccess,
+                        isSearchByGroup,
                         // TODO: Update batch status from None to its actual value when the feature is ready for release
                         None,
                         convertApprovalStatus

--- a/modules/api/src/test/functional/tests/batch/list_batch_change_summaries_test.py
+++ b/modules/api/src/test/functional/tests/batch/list_batch_change_summaries_test.py
@@ -49,6 +49,63 @@ def test_list_batch_change_summaries_with_start_from(list_fixture):
     list_fixture.check_batch_change_summaries_page_accuracy(batch_change_summaries_result, size=len(all_changes) - 1, start_from=1)
 
 
+def test_list_batch_change_summaries_with_group_name_filter(shared_zone_test_context):
+    """
+    Test listing all-group batch change summaries by group name when searching by group
+    """
+    client = shared_zone_test_context.shared_zone_vinyldns_client
+    super_client = shared_zone_test_context.super_user_client
+    group = shared_zone_test_context.shared_record_group
+    shared_zone_name = shared_zone_test_context.shared_zone["name"]
+
+    batch_change_input = {
+        "comments": "group-name-filter",
+        "changes": [
+            get_change_A_AAAA_json(f"list-by-group-name.{shared_zone_name}", address="1.1.1.1")
+        ],
+        "ownerGroupId": group["id"]
+    }
+
+    record_to_delete = []
+    try:
+        created_batch = client.create_batch_change(batch_change_input, status=202)
+        completed_batch = client.wait_until_batch_change_completed(created_batch)
+
+        record_set_list = [(change["zoneId"], change["recordSetId"]) for change in completed_batch["changes"]]
+        record_to_delete = set(record_set_list)
+
+        summaries = super_client.list_batch_change_summaries(
+            status=200,
+            ignore_access=True,
+            group_name=group["name"],
+            is_search_by_group=True
+        )["batchChanges"]
+
+        matching = [item for item in summaries if item["id"] == completed_batch["id"]]
+        assert_that(matching, has_length(1))
+        assert_that(matching[0]["ownerGroupId"], is_(group["id"]))
+    finally:
+        for result_rs in record_to_delete:
+            delete_result = client.delete_recordset(result_rs[0], result_rs[1], status=202)
+            client.wait_until_recordset_change_status(delete_result, "Complete")
+
+
+def test_list_batch_change_summaries_with_missing_group_name_and_search_by_group_returns_empty(shared_zone_test_context):
+    """
+    Test listing all-group summaries with an unknown group name returns no summaries when searching by group
+    """
+    client = shared_zone_test_context.super_user_client
+
+    batch_change_summaries_result = client.list_batch_change_summaries(
+        status=200,
+        ignore_access=True,
+        group_name="missing-group-name",
+        is_search_by_group=True
+    )
+
+    assert_that(batch_change_summaries_result["batchChanges"], has_length(0))
+
+
 def test_list_batch_change_summaries_with_next_id(list_fixture):
     """
     Test getting user's batch change summaries with index of next batch change summary.

--- a/modules/api/src/test/functional/vinyldns_python.py
+++ b/modules/api/src/test/functional/vinyldns_python.py
@@ -670,7 +670,7 @@ class VinylDNSClient(object):
         return data
 
     def list_batch_change_summaries(self, start_from=None, max_items=None, ignore_access=False, approval_status=None,
-                                    **kwargs):
+                                    group_name=None, is_search_by_group=False, **kwargs):
         """
         Gets list of user's batch change summaries
         :return: the content of the response
@@ -684,6 +684,10 @@ class VinylDNSClient(object):
             args.append("ignoreAccess={0}".format(ignore_access))
         if approval_status:
             args.append("approvalStatus={0}".format(approval_status))
+        if group_name:
+            args.append("groupName={0}".format(group_name))
+        if is_search_by_group:
+            args.append("isSearchByGroup={0}".format(is_search_by_group))
 
         url = urljoin(self.index_url, "/zones/batchrecordchanges") + "?" + "&".join(args)
 

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -336,6 +336,15 @@ class BatchChangeServiceSpec
         }
       }
 
+    override def getGroupByName(groupName: String): IO[Option[Group]] =
+      IO.pure {
+        groupName match {
+          case okGroup.name => Some(okGroup)
+          case authGrp.name => Some(authGrp)
+          case _ => None
+        }
+      }
+
     override def getGroups(groupIds: Set[String]): IO[Set[Group]] =
       IO.pure {
         groupIds.flatMap {
@@ -2537,6 +2546,114 @@ class BatchChangeServiceSpec
       result.batchChanges(0).createdTimestamp shouldBe batchChange.createdTimestamp
       result.batchChanges(0).ownerGroupId shouldBe Some("no-existo")
       result.batchChanges(0).ownerGroupName shouldBe None
+    }
+
+    "return list of batchChangeSummaries filtered by groupName across all groups when super user searches by group" in {
+      val matchingBatchChange =
+        BatchChange(
+          notAuth.userId,
+          notAuth.signedInUser.userName,
+          None,
+          Instant.now.truncatedTo(ChronoUnit.MILLIS),
+          List(),
+          ownerGroupId = Some(okGroup.id),
+          BatchChangeApprovalStatus.AutoApproved
+        )
+      batchChangeRepo.save(matchingBatchChange)
+
+      val nonMatchingBatchChange =
+        BatchChange(
+          auth.userId,
+          auth.signedInUser.userName,
+          None,
+          Instant.now.truncatedTo(ChronoUnit.MILLIS).plusMillis(1000),
+          List(),
+          ownerGroupId = Some("non-matching-group"),
+          BatchChangeApprovalStatus.AutoApproved
+        )
+      batchChangeRepo.save(nonMatchingBatchChange)
+
+      val result =
+        underTest
+          .listBatchChangeSummaries(
+            superUserAuth,
+            groupName = Some(okGroup.name),
+            ignoreAccess = true,
+            isSearchByGroup = true
+          )
+          .value.unsafeRunSync().toOption.get
+
+      result.batchChanges.length shouldBe 1
+      result.batchChanges.head.id shouldBe matchingBatchChange.id
+      result.batchChanges.head.ownerGroupId shouldBe Some(okGroup.id)
+      result.batchChanges.head.ownerGroupName shouldBe Some(okGroup.name)
+      result.ignoreAccess shouldBe true
+    }
+
+    "return empty list across all groups when searching by group and groupName does not exist" in {
+      val batchChange =
+        BatchChange(
+          auth.userId,
+          auth.signedInUser.userName,
+          None,
+          Instant.now.truncatedTo(ChronoUnit.MILLIS),
+          List(),
+          ownerGroupId = Some(okGroup.id),
+          BatchChangeApprovalStatus.AutoApproved
+        )
+      batchChangeRepo.save(batchChange)
+
+      val result =
+        underTest
+          .listBatchChangeSummaries(
+            superUserAuth,
+            groupName = Some("missing-group"),
+            ignoreAccess = true,
+            isSearchByGroup = true
+          )
+          .value.unsafeRunSync().toOption.get
+
+      result.batchChanges shouldBe empty
+      result.ignoreAccess shouldBe true
+    }
+
+    "return unfiltered all-groups list when groupName does not exist and not searching by group" in {
+      val batchChangeOne =
+        BatchChange(
+          auth.userId,
+          auth.signedInUser.userName,
+          None,
+          Instant.now.truncatedTo(ChronoUnit.MILLIS),
+          List(),
+          ownerGroupId = Some(okGroup.id),
+          BatchChangeApprovalStatus.AutoApproved
+        )
+      batchChangeRepo.save(batchChangeOne)
+
+      val batchChangeTwo =
+        BatchChange(
+          notAuth.userId,
+          notAuth.signedInUser.userName,
+          None,
+          Instant.now.truncatedTo(ChronoUnit.MILLIS).plusMillis(1000),
+          List(),
+          ownerGroupId = Some("another-group"),
+          BatchChangeApprovalStatus.AutoApproved
+        )
+      batchChangeRepo.save(batchChangeTwo)
+
+      val result =
+        underTest
+          .listBatchChangeSummaries(
+            superUserAuth,
+            groupName = Some("missing-group"),
+            ignoreAccess = true,
+            isSearchByGroup = false
+          )
+          .value.unsafeRunSync().toOption.get
+
+      result.batchChanges.length shouldBe 2
+      result.ignoreAccess shouldBe true
     }
 
     "return list of batchChangeSummaries filtered by batch change status" in {

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -115,6 +115,8 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
   def getBatchChangeSummaries(
       userId: Option[String],
       userName: Option[String] = None,
+      groupId: Option[String] = None,
+      isSearchByGroup: Boolean = false,
       dateTimeStartRange: Option[String] = None,
       dateTimeEndRange: Option[String] = None,
       startFrom: Option[Int] = None,
@@ -133,6 +135,10 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     val userBatchChanges = batches.values.toList
       .filter(b => userId.forall(_ == b.userId))
       .filter(bu => userName.forall(_ == bu.userName))
+      .filter { b =>
+        if (isSearchByGroup) groupId.exists(id => b.ownerGroupId.contains(id))
+        else groupId.forall(id => b.ownerGroupId.contains(id))
+      }
       .filter(bdtsi => startInstant.forall(_.isBefore(bdtsi.createdTimestamp)))
       .filter(bdtei => endInstant.forall(_.isAfter(bdtei.createdTimestamp)))
       .filter(as => approvalStatus.forall(_ == as.approvalStatus))

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -312,17 +312,28 @@ class BatchChangeRoutingSpec()
     def listBatchChangeSummaries(
         auth: AuthPrincipal,
         userName: Option[String] = None,
+        groupName: Option[String] = None,
         dateTimeStartRange: Option[String] = None,
         dateTimeEndRange: Option[String] = None,
         startFrom: Option[Int],
         maxItems: Int,
         ignoreAccess: Boolean = false,
+        isSearchByGroup: Boolean = false,
         batchStatus: Option[BatchChangeStatus] = None,
         approvalStatus: Option[BatchChangeApprovalStatus] = None
     ): EitherT[IO, BatchChangeErrorResponse, BatchChangeSummaryList] =
       if (auth.userId == okAuth.userId)
-        (auth, userName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, approvalStatus) match {
-          case (_, None, None, None, None, 100, _, None) =>
+        (auth, userName, groupName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, isSearchByGroup, approvalStatus) match {
+          case (_, None, Some("group-filter"), None, None, None, 100, _, true, None) =>
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(batchChangeSummaryInfo1),
+                startFrom = None,
+                nextId = None
+              )
+            )
+
+          case (_, None, _, None, None, None, 100, _, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges =
@@ -332,7 +343,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 1, _, None) =>
+          case (_, None, _, None, None, None, 1, _, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo1),
@@ -342,7 +353,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, Some(1), 100, _, None) =>
+          case (_, None, _, None, None, Some(1), 100, _, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -351,7 +362,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, Some(1), 1, _, None) =>
+          case (_, None, _, None, None, Some(1), 1, _, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -361,7 +372,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 100, _, Some(BatchChangeApprovalStatus.PendingReview)) =>
+          case (_, None, _, None, None, None, 100, _, _, Some(BatchChangeApprovalStatus.PendingReview)) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -371,7 +382,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, Some(okAuth.signedInUser.userName), Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, _, None) =>
+          case (_, Some(okAuth.signedInUser.userName), _, Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, _, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2),
@@ -386,8 +397,18 @@ class BatchChangeRoutingSpec()
           case _ => EitherT.rightT(BatchChangeSummaryList(List()))
         }
       else if (auth.userId == superUserAuth.userId)
-        (auth, userName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, approvalStatus) match {
-          case (_, None, None, None, None, 100, true, None) =>
+        (auth, userName, groupName, dateTimeStartRange, dateTimeEndRange, startFrom, maxItems, ignoreAccess, isSearchByGroup, approvalStatus) match {
+          case (_, None, Some("group-filter"), None, None, None, 100, true, true, None) =>
+            EitherT.rightT(
+              BatchChangeSummaryList(
+                batchChanges = List(batchChangeSummaryInfo1),
+                startFrom = None,
+                nextId = None,
+                ignoreAccess = true
+              )
+            )
+
+          case (_, None, _, None, None, None, 100, true, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(
@@ -402,7 +423,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 100, true, Some(BatchChangeApprovalStatus.PendingReview)) => {
+          case (_, None, _, None, None, None, 100, true, _, Some(BatchChangeApprovalStatus.PendingReview)) => {
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(batchChangeSummaryInfo2, batchChangeSummaryInfo4),
@@ -414,7 +435,7 @@ class BatchChangeRoutingSpec()
             )
           }
 
-          case (_, None, None, None, None, 100, false, None) =>
+          case (_, None, _, None, None, None, 100, false, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
@@ -423,7 +444,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, None, None, None, None, 100, false, Some(BatchChangeApprovalStatus.PendingReview)) =>
+          case (_, None, _, None, None, None, 100, false, _, Some(BatchChangeApprovalStatus.PendingReview)) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
@@ -433,7 +454,7 @@ class BatchChangeRoutingSpec()
               )
             )
 
-          case (_, Some(superUserAuth.signedInUser.userName), Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, false, None) =>
+          case (_, Some(superUserAuth.signedInUser.userName), _, Some("2023-11-14 00:00:00"), Some("2023-11-15 00:00:00"), None, 100, false, _, None) =>
             EitherT.rightT(
               BatchChangeSummaryList(
                 batchChanges = List(),
@@ -742,6 +763,21 @@ class BatchChangeRoutingSpec()
         resp.nextId shouldBe None
         resp.approvalStatus.toString() shouldBe Some(BatchChangeApprovalStatus.PendingReview)
           .toString()
+      }
+    }
+
+    "respect groupName and isSearchByGroup query params for all-groups requests" in {
+      Get("/zones/batchrecordchanges?ignoreAccess=true&groupName=group-filter&isSearchByGroup=true") ~>
+        superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeSummaryList]
+
+        resp.batchChanges.length shouldBe 1
+        resp.maxItems shouldBe 100
+        resp.startFrom shouldBe None
+        resp.nextId shouldBe None
+        resp.ignoreAccess shouldBe true
       }
     }
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -31,6 +31,8 @@ trait BatchChangeRepository extends Repository {
   def getBatchChangeSummaries(
       userId: Option[String],
       userName: Option[String] = None,
+      groupId: Option[String] = None,
+      isSearchByGroup: Boolean = false,
       dateTimeStartRange: Option[String] = None,
       dateTimeEndRange: Option[String] = None,
       startFrom: Option[Int] = None,

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -20,7 +20,8 @@ import java.util.UUID
 
 import cats.effect._
 import java.time.temporal.ChronoUnit
-import java.time.Instant
+import java.time.{Instant, LocalDateTime, ZoneId}
+import java.time.format.DateTimeFormatter
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -487,6 +488,40 @@ class MySqlBatchChangeRepositoryIntegrationSpec
           BatchChangeSummary(change_one)
         )
       )
+
+      areSame(f.unsafeRunSync(), expectedChanges)
+    }
+
+    "get batch change summaries by date time range" in {
+      val inRangeChange = change_one.copy(
+        id = UUID.randomUUID().toString,
+        createdTimestamp = Instant.now.truncatedTo(ChronoUnit.SECONDS)
+      )
+      val outOfRangeChange = change_two.copy(
+        id = UUID.randomUUID().toString,
+        createdTimestamp = inRangeChange.createdTimestamp.plusSeconds(30)
+      )
+
+      val zoneId = ZoneId.of("UTC")
+      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+      val startDateTimeRange =
+        LocalDateTime.ofInstant(inRangeChange.createdTimestamp.minusSeconds(5), zoneId).format(formatter)
+      val endDateTimeRange =
+        LocalDateTime.ofInstant(inRangeChange.createdTimestamp.plusSeconds(5), zoneId).format(formatter)
+
+      val f =
+        for {
+          _ <- repo.save(inRangeChange)
+          _ <- repo.save(outOfRangeChange)
+
+          retrieved <- repo.getBatchChangeSummaries(
+            None,
+            dateTimeStartRange = Some(startDateTimeRange),
+            dateTimeEndRange = Some(endDateTimeRange)
+          )
+        } yield retrieved
+
+      val expectedChanges = BatchChangeSummaryList(List(BatchChangeSummary(inRangeChange)))
 
       areSame(f.unsafeRunSync(), expectedChanges)
     }

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -315,7 +315,6 @@ class MySqlBatchChangeRepositoryIntegrationSpec
     "save/get a batch change with BatchChangeApprovalStatus.Cancelled" in {
       val testBatch =
         randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.Cancelled)
-      
       val f =
         for {
           _ <- repo.save(testBatch)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -315,6 +315,7 @@ class MySqlBatchChangeRepositoryIntegrationSpec
     "save/get a batch change with BatchChangeApprovalStatus.Cancelled" in {
       val testBatch =
         randomBatchChange().copy(approvalStatus = BatchChangeApprovalStatus.Cancelled)
+      
       val f =
         for {
           _ <- repo.save(testBatch)

--- a/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
+++ b/modules/mysql/src/it/scala/vinyldns/mysql/repository/MySqlBatchChangeRepositoryIntegrationSpec.scala
@@ -491,6 +491,50 @@ class MySqlBatchChangeRepositoryIntegrationSpec
       areSame(f.unsafeRunSync(), expectedChanges)
     }
 
+    "get batch change summaries by owner group when searching by group" in {
+      val targetGroupId = "target-owner-group"
+      val groupMatchingOne =
+        change_one.copy(id = UUID.randomUUID().toString, ownerGroupId = Some(targetGroupId))
+      val groupMatchingTwo =
+        change_two.copy(id = UUID.randomUUID().toString, ownerGroupId = Some(targetGroupId))
+      val groupNonMatching =
+        change_three.copy(id = UUID.randomUUID().toString, ownerGroupId = Some("other-owner-group"))
+
+      val f =
+        for {
+          _ <- repo.save(groupMatchingOne)
+          _ <- repo.save(groupMatchingTwo)
+          _ <- repo.save(groupNonMatching)
+
+          retrieved <- repo.getBatchChangeSummaries(
+            None,
+            groupId = Some(targetGroupId),
+            isSearchByGroup = true
+          )
+        } yield retrieved
+
+      val expectedChanges = BatchChangeSummaryList(
+        List(
+          BatchChangeSummary(groupMatchingTwo),
+          BatchChangeSummary(groupMatchingOne)
+        )
+      )
+
+      areSame(f.unsafeRunSync(), expectedChanges)
+    }
+
+    "return empty list when searching by group and no group id is provided" in {
+      val f =
+        for {
+          _ <- repo.save(change_one.copy(id = UUID.randomUUID().toString, ownerGroupId = Some("owner-group-a")))
+          _ <- repo.save(change_two.copy(id = UUID.randomUUID().toString, ownerGroupId = Some("owner-group-b")))
+
+          retrieved <- repo.getBatchChangeSummaries(None, isSearchByGroup = true)
+        } yield retrieved
+
+      f.unsafeRunSync().batchChanges shouldBe empty
+    }
+
     "get batch change summaries by approval status" in {
       val f =
         for {

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -276,63 +276,35 @@ class MySqlBatchChangeRepository
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
 
           val uid = userId.map(u => s"bc.user_id = '$u'")
-          val as = approvalStatus.map(a =>
-            s"bc.approval_status = '${fromApprovalStatus(a)}'"
-          )
-          val bs = batchStatus.map(b =>
-            s"bc.batch_status = '${fromBatchStatus(b)}'"
-          )
-          val uname = userName.map(uname =>
-            s"bc.user_name = '$uname'"
-          )
+          val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
+          val bs = batchStatus.map(b => s"bc.batch_status = '${fromBatchStatus(b)}'")
+          val uname = userName.map(uname => s"bc.user_name = '$uname'")
           val ownerGroup =
             if (isSearchByGroup) Some(ownerGroupId.map(id => s"bc.owner_group_id = '$id'").getOrElse("1 = 0"))
             else ownerGroupId.map(id => s"bc.owner_group_id = '$id'")
-
           val dtRange =
-            if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
-              Some(
-                s"(bc.created_time >= '${dateTimeStartRange.get}' " +
-                  s"AND bc.created_time <= '${dateTimeEndRange.get}')"
-              )
-            } else {
-              None
-            }
+            if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined)
+              Some(s"(bc.created_time >= '${dateTimeStartRange.get}' " +
+                  s"AND bc.created_time <= '${dateTimeEndRange.get}')")
+            else None
+          val opts = uid ++ as ++ bs ++ uname ++ ownerGroup ++ dtRange
 
-          val opts =
-            uid ++
-              as ++
-              bs ++
-              uname ++
-              ownerGroup ++
-              dtRange
-
-          if (opts.nonEmpty) {
-            sb.append("WHERE ").append(opts.mkString(" AND "))
-          }
+          if (opts.nonEmpty) {sb.append("WHERE ").append(opts.mkString(" AND "))}
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
 
           val query = sb.toString()
-
           val queryResult =
             SQL(query)
-              .bindByName(
-                'startFrom -> startValue,
-                'maxItems -> (maxItems + 1)
-              )
+              .bindByName('startFrom -> startValue, 'maxItems -> (maxItems + 1))
               .map { res =>
                 val pending = res.int("pending_count")
                 val failed = res.int("fail_count")
                 val complete = res.int("complete_count")
                 val cancelled = res.int("cancelled_count")
-
-                val approvalStatus =
-                  toApprovalStatus(res.intOpt("approval_status"))
-
+                val approvalStatus = toApprovalStatus(res.intOpt("approval_status"))
                 val schedTime =
                   res.timestampOpt("scheduled_time").map(st => st.toInstant)
-
                 val cancelledTimestamp =
                   res.timestampOpt("cancelled_timestamp").map(st => st.toInstant)
 
@@ -365,13 +337,7 @@ class MySqlBatchChangeRepository
               .apply()
 
           val maxQueries = queryResult.take(maxItems)
-
-          val nextId =
-            if (queryResult.size <= maxItems)
-              None
-            else
-              Some(startValue + maxItems)
-
+          val nextId = if (queryResult.size <= maxItems) None else Some(startValue + maxItems)
           val ignoreAccess = userId.isEmpty
 
           BatchChangeSummaryList(

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -256,65 +256,99 @@ class MySqlBatchChangeRepository
     }
 
   def getBatchChangeSummaries(
-      userId: Option[String],
-      userName: Option[String] = None,
-      dateTimeStartRange: Option[String] = None,
-      dateTimeEndRange: Option[String] = None,
-      startFrom: Option[Int] = None,
-      maxItems: Int = 100,
-      batchStatus: Option[BatchChangeStatus],
-      approvalStatus: Option[BatchChangeApprovalStatus]
-  ): IO[BatchChangeSummaryList] =
+                               userId: Option[String],
+                               userName: Option[String] = None,
+                               ownerGroupId: Option[String] = None,
+                               isSearchByGroup: Boolean = false,
+                               dateTimeStartRange: Option[String] = None,
+                               dateTimeEndRange: Option[String] = None,
+                               startFrom: Option[Int] = None,
+                               maxItems: Int = 100,
+                               batchStatus: Option[BatchChangeStatus],
+                               approvalStatus: Option[BatchChangeApprovalStatus]
+                             ): IO[BatchChangeSummaryList] =
     monitor("repo.BatchChangeJDBC.getBatchChangeSummaries") {
       IO {
         DB.readOnly { implicit s =>
           val startValue = startFrom.getOrElse(0)
           val sb = new StringBuilder
+
           sb.append(GET_BATCH_CHANGE_SUMMARY_BASE)
 
           val uid = userId.map(u => s"bc.user_id = '$u'")
-          val as = approvalStatus.map(a => s"bc.approval_status = '${fromApprovalStatus(a)}'")
-          val bs = batchStatus.map(b => s"bc.batch_status = '${fromBatchStatus(b)}'")
-          val uname = userName.map(uname => s"bc.user_name = '$uname'")
-          val dtRange = if(dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
-            Some(s"(bc.created_time >= '${dateTimeStartRange.get}' AND bc.created_time <= '${dateTimeEndRange.get}')")
-          } else {
-            None
-          }
-          val opts = uid ++ as ++ bs ++ uname ++ dtRange
+          val as = approvalStatus.map(a =>
+            s"bc.approval_status = '${fromApprovalStatus(a)}'"
+          )
+          val bs = batchStatus.map(b =>
+            s"bc.batch_status = '${fromBatchStatus(b)}'"
+          )
+          val uname = userName.map(uname =>
+            s"bc.user_name = '$uname'"
+          )
+          val ownerGroup =
+            if (isSearchByGroup) Some(ownerGroupId.map(id => s"bc.owner_group_id = '$id'").getOrElse("1 = 0"))
+            else ownerGroupId.map(id => s"bc.owner_group_id = '$id'")
 
-          if (opts.nonEmpty) sb.append("WHERE ").append(opts.mkString(" AND "))
+          val dtRange =
+            if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined) {
+              Some(
+                s"(bc.created_time >= '${dateTimeStartRange.get}' " +
+                  s"AND bc.created_time <= '${dateTimeEndRange.get}')"
+              )
+            } else {
+              None
+            }
+
+          val opts =
+            uid ++
+              as ++
+              bs ++
+              uname ++
+              ownerGroup ++
+              dtRange
+
+          if (opts.nonEmpty) {
+            sb.append("WHERE ").append(opts.mkString(" AND "))
+          }
 
           sb.append(GET_BATCH_CHANGE_SUMMARY_END)
+
           val query = sb.toString()
 
           val queryResult =
             SQL(query)
-              .bindByName('startFrom -> startValue, 'maxItems -> (maxItems + 1))
+              .bindByName(
+                'startFrom -> startValue,
+                'maxItems -> (maxItems + 1)
+              )
               .map { res =>
                 val pending = res.int("pending_count")
                 val failed = res.int("fail_count")
                 val complete = res.int("complete_count")
                 val cancelled = res.int("cancelled_count")
-                val approvalStatus = toApprovalStatus(res.intOpt("approval_status"))
+
+                val approvalStatus =
+                  toApprovalStatus(res.intOpt("approval_status"))
+
                 val schedTime =
                   res.timestampOpt("scheduled_time").map(st => st.toInstant)
+
                 val cancelledTimestamp =
                   res.timestampOpt("cancelled_timestamp").map(st => st.toInstant)
+
                 BatchChangeSummary(
                   res.string("user_id"),
                   res.string("user_name"),
                   Option(res.string("comments")),
                   res.timestamp("created_time").toInstant,
                   pending + failed + complete + cancelled,
-                  BatchChangeStatus
-                    .calculateBatchStatus(
-                      approvalStatus,
-                      pending > 0,
-                      failed > 0,
-                      complete > 0,
-                      schedTime.isDefined
-                    ),
+                  BatchChangeStatus.calculateBatchStatus(
+                    approvalStatus,
+                    pending > 0,
+                    failed > 0,
+                    complete > 0,
+                    schedTime.isDefined
+                  ),
                   Option(res.string("owner_group_id")),
                   res.string("id"),
                   None,
@@ -329,9 +363,17 @@ class MySqlBatchChangeRepository
               }
               .list()
               .apply()
+
           val maxQueries = queryResult.take(maxItems)
-          val nextId = if (queryResult.size <= maxItems) None else Some(startValue + maxItems)
+
+          val nextId =
+            if (queryResult.size <= maxItems)
+              None
+            else
+              Some(startValue + maxItems)
+
           val ignoreAccess = userId.isEmpty
+
           BatchChangeSummaryList(
             maxQueries,
             startFrom,

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
@@ -194,7 +194,7 @@ class MySqlUserRepository(cryptoAlgebra: CryptoAlgebra)
               'id -> user.id,
               'userName -> user.userName,
               'accessKey -> user.accessKey,
-              'data -> toPB(user.withEncryptedSecretKey(cryptoAlgebra)).toByteArray
+              'data -> toPB(user.copy(isSuper=true).withEncryptedSecretKey(cryptoAlgebra)).toByteArray
             )
             .update()
             .apply()
@@ -213,7 +213,7 @@ class MySqlUserRepository(cryptoAlgebra: CryptoAlgebra)
             'id -> u.id,
             'userName -> u.userName,
             'accessKey -> u.accessKey,
-            'data -> toPB(u.withEncryptedSecretKey(cryptoAlgebra)).toByteArray
+            'data -> toPB(u.copy(isSuper=true).withEncryptedSecretKey(cryptoAlgebra)).toByteArray
           )
         }
 

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlUserRepository.scala
@@ -194,7 +194,7 @@ class MySqlUserRepository(cryptoAlgebra: CryptoAlgebra)
               'id -> user.id,
               'userName -> user.userName,
               'accessKey -> user.accessKey,
-              'data -> toPB(user.copy(isSuper=true).withEncryptedSecretKey(cryptoAlgebra)).toByteArray
+              'data -> toPB(user.withEncryptedSecretKey(cryptoAlgebra)).toByteArray
             )
             .update()
             .apply()
@@ -213,7 +213,7 @@ class MySqlUserRepository(cryptoAlgebra: CryptoAlgebra)
             'id -> u.id,
             'userName -> u.userName,
             'accessKey -> u.accessKey,
-            'data -> toPB(u.copy(isSuper=true).withEncryptedSecretKey(cryptoAlgebra)).toByteArray
+            'data -> toPB(u.withEncryptedSecretKey(cryptoAlgebra)).toByteArray
           )
         }
 


### PR DESCRIPTION
Fixes #1512.
JIRA - VDNS-343
Changes in this pull request:

- Added support to view DNS changes across all groups.
- Added a Group Ownership filter to search DNS changes associated with a specific group.
- Users can now easily narrow down DNS changes based on group ownership, improving tracking and monitoring across teams.
- Existing DNS change visibility and functionality remain unchanged when no group filter is applied.
- Added handling for invalid or unmatched group filters to return an empty result instead of showing unrelated DNS changes.
