### PR TITLE
Display Zone Sync Failures to End Users

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -137,7 +137,6 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
                     s"dotted host records: [$dottedGroupString]"
                 )
               }
-
             logger.info(
               s"zone.sync.changes; zoneName='${zone.name}'; " +
                 s"changeCount=${changesWithUserIds.size}; zoneChange='${zoneChange.id}'"

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneSyncHandler.scala
@@ -173,14 +173,21 @@ object ZoneSyncHandler extends DnsConversions with Monitored with TransactionPro
         case Left(e: Throwable) =>
           val errorMessage = new StringWriter
           e.printStackTrace(new PrintWriter(errorMessage))
+
           logger.error(
-            s"Encountered error syncing ; zoneName='${zoneChange.zone.name}'; zoneChange='${zoneChange.id}'. Error: ${errorMessage.toString.replaceAll("\n",";").replaceAll("\t"," ")}"
+            s"Encountered error syncing ; zoneName='${zoneChange.zone.name}'; zoneChange='${zoneChange.id}'. Error: ${errorMessage.toString.replaceAll("\n", ";").replaceAll("\t", " ")}"
           )
+
+          val systemMessage =
+            Option(e.getMessage).filter(_.nonEmpty).getOrElse("Zone synchronization failed")
+
           // We want to just move back to an active status, do not update latest sync
           zoneChange.copy(
             zone = zoneChange.zone.copy(status = ZoneStatus.Active),
-            status = ZoneChangeStatus.Failed
+            status = ZoneChangeStatus.Failed,
+            systemMessage = Some(systemMessage)
           )
+
         case Right(ok) => ok
       }
     }

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneSyncHandlerSpec.scala
@@ -149,11 +149,15 @@ class ZoneSyncHandlerSpec
             s"Encountered error syncing ; zoneName='${zoneChange.zone.name}'; zoneChange='${zoneChange.id}'",
             e
           )
+
+          val systemMessage =
+            Option(e.getMessage).filter(_.nonEmpty).getOrElse("Zone synchronization failed")
+
           // We want to just move back to an active status, do not update latest sync
           zoneChange.copy(
             zone = zoneChange.zone.copy(status = ZoneStatus.Active),
             status = ZoneChangeStatus.Failed,
-            systemMessage = Some("Changes Rolled back. " + e.getMessage)
+            systemMessage = Some(systemMessage)
           )
         case Right(ok) => ok
       }
@@ -433,6 +437,7 @@ class ZoneSyncHandlerSpec
       result.status shouldBe ZoneChangeStatus.Failed
       result.zone.status shouldBe ZoneStatus.Active
       result.zone.latestSync should not be defined
+      result.systemMessage shouldBe Some("Dns Failed")
     }
   }
 
@@ -661,6 +666,7 @@ class ZoneSyncHandlerSpec
       result.status shouldBe ZoneChangeStatus.Failed
       result.zone.status shouldBe ZoneStatus.Active
       result.zone.latestSync shouldBe testZoneChange.zone.latestSync
+      result.systemMessage shouldBe Some("Dns Failed")
     }
 
     "verify transaction by not saving changes to database when exception occurs while saving to RecordSetRepo" in {
@@ -675,12 +681,25 @@ class ZoneSyncHandlerSpec
 
       // Does not save changes to both recordChangeRepo and recordSetRepo as it rollbacks changes made when exception occurred in RecordSetRepo
       // Transaction saves either both record changes and record sets or saves none to database
-      result.systemMessage.get shouldBe "Changes Rolled back. Save Recordset Repo Failed!"
+      result.systemMessage.get shouldBe "Save Recordset Repo Failed!"
 
       // ZoneChangeStatus Fails as exception occurred
       result.status shouldBe ZoneChangeStatus.Failed
       result.zone.status shouldBe ZoneStatus.Active
       result.zone.latestSync should not be defined
+    }
+
+    "uses default message when sync exception has no message" in {
+      doReturn(mockBackend).when(mockBackendResolver).resolve(any[Zone])
+      doReturn(() => IO.raiseError(new RuntimeException()))
+        .when(mockVinylDNSLoader)
+        .load
+
+      val result = runSync.unsafeRunSync()
+
+      result.status shouldBe ZoneChangeStatus.Failed
+      result.zone.status shouldBe ZoneStatus.Active
+      result.systemMessage shouldBe Some("Zone synchronization failed")
     }
 
     "verify transaction by not saving changes to database when exception occurs while saving to RecordChangeRepo" in {
@@ -695,7 +714,7 @@ class ZoneSyncHandlerSpec
 
       // Does not save changes to both recordChangeRepo and recordSetRepo as it rollbacks changes made when exception occurred in RecordChangeRepo
       // Transaction saves either both record changes and record sets or saves none to database
-      result.systemMessage.get shouldBe "Changes Rolled back. Save Record change Repo Failed!"
+      result.systemMessage.get shouldBe "Save Record change Repo Failed!"
 
       // ZoneChangeStatus Fails as exception occurred
       result.status shouldBe ZoneChangeStatus.Failed

--- a/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
+++ b/modules/core/src/main/scala/vinyldns/core/protobuf/ProtobufConversions.scala
@@ -452,7 +452,7 @@ trait ProtobufConversions {
       .setUserId(zoneChange.userId)
       .setZone(toPB(zoneChange.zone))
 
-    zoneChange.systemMessage.map(builder.setSystemMessage)
+    zoneChange.systemMessage.foreach(builder.setSystemMessage)
 
     builder.build()
   }

--- a/modules/portal/app/views/zones/zoneTabs/zoneChangeHistory.scala.html
+++ b/modules/portal/app/views/zones/zoneTabs/zoneChangeHistory.scala.html
@@ -33,8 +33,10 @@
                     <th>Created</th>
                     <th>Updated</th>
                     <th>Change type</th>
+                    <th>Status</th>
                     <th>Admin group</th>
                     <th>ACL</th>
+                    <th>Error</th>
                 </tr>
             </thead>
             <tbody>
@@ -45,6 +47,11 @@
                     <td>{{ zoneChange.zone.created }}</td>
                     <td>{{ zoneChange.zone.updated }}</td>
                     <td>{{ zoneChange.changeType == "AutomatedSync" ? "Automated Sync" : zoneChange.changeType }}</td>
+                    <td>
+                        <span ng-if="zoneChange.status">
+                            {{ zoneChange.status }}
+                        </span>
+                    </td>
                     <td ng-switch="zoneChange.zone.adminGroupName || '_undefined_'">
                         <p ng-switch-when="_undefined_">Group has been deleted now.</p>
                         <a ng-switch-default ng-bind="zoneChange.zone.adminGroupName" href="/groups/{{zoneChange.zone.adminGroupId}}"></a>
@@ -54,6 +61,15 @@
                         <button class="btn btn-info btn-sm"
                                  ng-if="zoneChange.zone.acl.rules.length != 0"
                                  ng-click="refreshAclRule($index)">ACL Rules
+                        </button>
+                    </td>
+                    <td>
+                        <button
+                            type="button"
+                            class="btn btn-danger btn-sm"
+                            ng-if="zoneChange.status === 'Failed' && zoneChange.systemMessage"
+                            ng-click="showZoneChangeError(zoneChange)">
+                            View Error
                         </button>
                     </td>
                 </tr>
@@ -131,6 +147,33 @@
     </modal>
 </form>
 <!-- THE ACL RULE MODAL FORM ENDS -->
+
+<!-- ZONE CHANGE ERROR MODAL STARTS -->
+<form name="zoneChangeErrorForm" role="form" class="form-horizontal" novalidate>
+    <modal
+        modal-id="zoneChangeErrorModal"
+        modal-title="Zone Change Error">
+
+        <modal-body>
+            <div class="alert alert-danger">
+                <strong>Error:</strong>
+                <span ng-bind="selectedZoneChangeError"></span>
+            </div>
+        </modal-body>
+
+        <modal-footer>
+            <button
+                type="button"
+                class="btn btn-default"
+                data-dismiss="modal"
+                ng-click="closeZoneChangeError()">
+                Close
+            </button>
+        </modal-footer>
+
+    </modal>
+</form>
+<!-- ZONE CHANGE ERROR MODAL ENDS -->
 
 
 

--- a/modules/portal/public/lib/controllers/controller.manageZones.js
+++ b/modules/portal/public/lib/controllers/controller.manageZones.js
@@ -406,6 +406,15 @@ angular.module('controller.manageZones', ['angular-cron-jobs'])
                });
     };
 
+    $scope.showZoneChangeError = function(zoneChange) {
+        $scope.selectedZoneChangeError = zoneChange.systemMessage;
+        $("#zoneChangeErrorModal").modal("show");
+    };
+
+    $scope.closeZoneChangeError = function() {
+        $scope.selectedZoneChangeError = undefined;
+    };
+
     $scope.refreshAclRule = function (index) {
         $scope.allAclRules = [];
         $scope.aclRulesModal = {


### PR DESCRIPTION
Fixes #1537.
VDNS-435

Summary
Updated zone synchronization error handling to ensure failures are clearly communicated to end users instead of requiring them to check application logs.

Changes Made
- Added error handling in ZoneSyncHandler to capture synchronization exceptions.
- Updated failed zone sync changes to:
   - Set the zone status back to Active.
   - Set the zone change status to Failed.
   - Store the actual exception message in systemMessage.
- Added a fallback message "Zone synchronization failed" when the exception does not contain a meaningful error message.
- Updated test cases to verify that synchronization failure messages are correctly returned and stored.
- Verified zone update failure handling and ensured errors are surfaced to users through the existing user-facing error/pop-up flow.
- Users can now identify zone synchronization failures directly from Zones → Zone Change History.

