### PR TITLE
Add Sorting Functionality to DNS Change Request Details Table

### DIFF
--- a/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
+++ b/modules/portal/app/views/dnsChanges/dnsChangeDetail.scala.html
@@ -116,19 +116,65 @@
                         <table class="table">
                             <thead>
                             <tr>
-                                <th>Change Type</th>
-                                <th>Input Name</th>
-                                <th>Recordset Name</th>
-                                <th>Zone Name</th>
-                                <th>Record Type</th>
+                                <th ng-click="sortBy('changeType')" class="sortable-header">
+                                    <span>Change </span><span class="sort-with-icon">Type <i class="fa"
+                                    ng-class="{
+                                        'fa-sort': sortColumn != 'changeType',
+                                        'fa-sort-asc': sortColumn == 'changeType' && !reverseSort,
+                                        'fa-sort-desc': sortColumn == 'changeType' && reverseSort
+                                    }"></i></span>
+                                </th>
+                                <th ng-click="sortBy('inputName')" class="sortable-header">
+                                    <span>Input </span><span class="sort-with-icon">Name <i class="fa"
+                                    ng-class="{
+                                        'fa-sort': sortColumn != 'inputName',
+                                        'fa-sort-asc': sortColumn == 'inputName' && !reverseSort,
+                                        'fa-sort-desc': sortColumn == 'inputName' && reverseSort
+                                    }"></i></span>
+                                </th>
+
+                                <th ng-click="sortBy('recordName')" class="sortable-header">
+                                    <span>Recordset </span><span class="sort-with-icon">Name <i class="fa"
+                                    ng-class="{
+                                        'fa-sort': sortColumn != 'recordName',
+                                        'fa-sort-asc': sortColumn == 'recordName' && !reverseSort,
+                                        'fa-sort-desc': sortColumn == 'recordName' && reverseSort
+                                    }"></i></span>
+                                </th>
+
+                                <th ng-click="sortBy('zoneName')" class="sortable-header">
+                                    Zone Name
+                                    <i class="fa"
+                                    ng-class="{
+                                        'fa-sort': sortColumn != 'zoneName',
+                                        'fa-sort-asc': sortColumn == 'zoneName' && !reverseSort,
+                                        'fa-sort-desc': sortColumn == 'zoneName' && reverseSort
+                                    }"></i>
+                                </th>
+
+                                <th ng-click="sortBy('type')" class="sortable-header">
+                                    <span>Record </span><span class="sort-with-icon">Type <i class="fa"
+                                    ng-class="{
+                                        'fa-sort': sortColumn != 'type',
+                                        'fa-sort-asc': sortColumn == 'type' && !reverseSort,
+                                        'fa-sort-desc': sortColumn == 'type' && reverseSort
+                                    }"></i></span>
+                                </th>
                                 <th class="col-md-2">Record Data</th>
                                 <th>TTL</th>
-                                <th>Status</th>
+                                <th ng-click="sortBy('status')" class="sortable-header">
+                                    <span class="sort-with-icon">Status <i class="fa"
+                                    ng-class="{
+                                        'fa-sort': sortColumn != 'status',
+                                        'fa-sort-asc': sortColumn == 'status' && !reverseSort,
+                                        'fa-sort-desc': sortColumn == 'status' && reverseSort
+                                    }"></i></span>
+                                </th>
                                 <th class="col-md-2">Additional Info</th>
                             </tr>
                             </thead>
                             <tbody>
-                            <tr ng-repeat="change in batch.changes|filter:query" ng-class="{changeError: change.outstandingErrors}">
+                            <tr ng-repeat="change in batch.changes|filter:query|orderBy:sortColumn:reverseSort" ng-class="{changeError: change.outstandingErrors}">
                                 <td ng-bind="change.changeType"></td>
                                 <td class="wrap-long-text">{{change.inputName}}</td>
                                 <td class="wrap-long-text">{{change.recordName}}</td>

--- a/modules/portal/public/css/vinyldns.css
+++ b/modules/portal/public/css/vinyldns.css
@@ -654,3 +654,16 @@ input[type="file"] {
     background-color: #f0f0f0;
     border-radius: 4px;
 }
+
+.sortable-header {
+    cursor: pointer;
+}
+
+.sortable-header .fa {
+    margin-left: 4px;
+    font-size: 11px;
+}
+
+.sort-with-icon {
+    white-space: nowrap;
+}

--- a/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
+++ b/modules/portal/public/lib/dns-change/dns-change-detail.controller.js
@@ -25,6 +25,8 @@
             $scope.reviewComment;
             $scope.reviewConfirmationMsg;
             $scope.reviewType;
+            $scope.sortColumn = null;
+            $scope.reverseSort = false;
 
             // Initialize Bootstrap tooltips
             $(document).ready(function() {
@@ -37,6 +39,15 @@
                 // Trigger success alert using utilityService
                 var alert = utilityService.success('Successfully copied Batch ID to clipboard');
                 $scope.alerts.push(alert);
+            };
+
+            $scope.sortBy = function(column) {
+                if ($scope.sortColumn === column) {
+                    $scope.reverseSort = !$scope.reverseSort;
+                } else {
+                    $scope.sortColumn = column;
+                    $scope.reverseSort = false;
+                }
             };
 
             $scope.getBatchChange = function(batchChangeId) {

--- a/modules/portal/public/lib/dns-change/dns-change.spec.js
+++ b/modules/portal/public/lib/dns-change/dns-change.spec.js
@@ -80,6 +80,49 @@ describe('BatchChange', function(){
             }));
         });
 
+        describe('$scope.sortBy', function() {
+            it('should sort by the selected column in ascending order', function() {
+                this.scope.sortBy('inputName');
+
+                expect(this.scope.sortColumn).toBe('inputName');
+                expect(this.scope.reverseSort).toBe(false);
+            });
+
+            it('should reverse the sort order when the same column is selected again', function() {
+                this.scope.sortBy('inputName');
+                this.scope.sortBy('inputName');
+
+                expect(this.scope.sortColumn).toBe('inputName');
+                expect(this.scope.reverseSort).toBe(true);
+            });
+
+            it('should reset to ascending order when a different column is selected', function() {
+                this.scope.sortBy('inputName');
+                this.scope.sortBy('zoneName');
+
+                expect(this.scope.sortColumn).toBe('zoneName');
+                expect(this.scope.reverseSort).toBe(false);
+            });
+
+            it('should support sorting by all sortable columns', function() {
+                var sortableColumns = [
+                    'changeType',
+                    'inputName',
+                    'recordName',
+                    'zoneName',
+                    'type',
+                    'status'
+                ];
+
+                sortableColumns.forEach(function(column) {
+                    this.scope.sortBy(column);
+
+                    expect(this.scope.sortColumn).toBe(column);
+                    expect(this.scope.reverseSort).toBe(false);
+                }, this);
+            });
+        });
+
         describe('$scope.confirmApprove', function() {
             it('should resolve the promise', inject(function(dnsChangeService) {
 

--- a/modules/portal/public/lib/dns-change/dns-change.spec.js
+++ b/modules/portal/public/lib/dns-change/dns-change.spec.js
@@ -113,7 +113,6 @@ describe('BatchChange', function(){
                     'type',
                     'status'
                 ];
-
                 sortableColumns.forEach(function(column) {
                     this.scope.sortBy(column);
 


### PR DESCRIPTION
Fixes #1541.
VDNS-441

Sorting was not available in the completed DNS change request details page, making it difficult to locate and review specific changes when a request contains multiple records.

### Changes Made

* Added sorting functionality to the DNS Change Details table.
* Added sorting for the following columns:

  * Change Type
  * Input Name
  * Recordset Name
  * Zone Name
  * Record Type
  * Status
* Clicking a column sorts the records in ascending order, and clicking the same column again reverses the order to descending.
* Selecting a different column switches the sorting to that column and resets it to ascending order.
* Added unit tests to verify the sorting behavior including column selection and ascending/descending order changes.


