### PR TITLE
Add cache-control headers for credential responses

### DIFF
--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -331,7 +331,7 @@ class VinylDNS @Inject() (
           vinyldnsServiceBackend
         )
     ).as("text/csv")
-      .withHeaders( cacheHeaders: _* )
+      .withHeaders(cacheHeaders: _*)
       .withHeaders(
         "Content-Disposition" -> "attachment; filename=\"credentials.csv\""
       )

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -331,9 +331,7 @@ class VinylDNS @Inject() (
           vinyldnsServiceBackend
         )
     ).as("text/csv")
-     .withHeaders(
-        cacheHeaders: _*
-      )
+      .withHeaders( cacheHeaders: _* )
       .withHeaders(
         "Content-Disposition" -> "attachment; filename=\"credentials.csv\""
       )

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -331,7 +331,9 @@ class VinylDNS @Inject() (
           vinyldnsServiceBackend
         )
     ).as("text/csv")
-      .withHeaders(cacheHeaders: _*)
+      .withHeaders(
+        cacheHeaders: _*
+      )
       .withHeaders(
         "Content-Disposition" -> "attachment; filename=\"credentials.csv\""
       )

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -331,6 +331,12 @@ class VinylDNS @Inject() (
           vinyldnsServiceBackend
         )
     ).as("text/csv")
+     .withHeaders(
+        cacheHeaders: _*
+      )
+      .withHeaders(
+        "Content-Disposition" -> "attachment; filename=\"credentials.csv\""
+      )
   }
 
   def serveCredsFile(fileName: String): Action[AnyContent] = frontendAction.async {

--- a/modules/portal/test/controllers/VinylDNSSpec.scala
+++ b/modules/portal/test/controllers/VinylDNSSpec.scala
@@ -1426,6 +1426,14 @@ class VinylDNSSpec extends Specification with Mockito with TestApplicationData w
         content must contain(frodoUser.userName)
         content must contain(frodoUser.accessKey)
         content must contain(frodoUser.secretKey.value)
+        header("Content-Disposition", result) must beSome(
+          """attachment; filename="credentials.csv""""
+        )
+        header("Cache-Control", result) must beSome(
+          "no-cache, no-store, must-revalidate"
+        )
+        header("Pragma", result) must beSome("no-cache")
+        header("Expires", result) must beSome("0")
         there.was(one(crypto).decrypt(frodoUser.secretKey.value))
       }
       "redirect to login if user is not logged in" in new WithApplication(app) {


### PR DESCRIPTION
Fixes #.
VDNS-379

Changes in this pull request:
- Updated the credential-serving flow to prevent sensitive credential responses from being cached by browsers or intermediate proxies.
- Appropriate cache-control behavior has been added so that credential data is not unintentionally stored or reused from cache.

