### PR TITLE
Added escaping in LdapAuthenticator so the search filter now safely escapes LDAP metacharacters before interpolation.

### DIFF
--- a/modules/portal/app/controllers/LdapAuthenticator.scala
+++ b/modules/portal/app/controllers/LdapAuthenticator.scala
@@ -107,6 +107,16 @@ object LdapAuthenticator {
       createContext: ContextCreator
   ) {
 
+    private def escapeLdapFilterValue(value: String): String =
+      value.flatMap {
+        case '*' => "\\2a"
+        case '(' => "\\28"
+        case ')' => "\\29"
+        case '\\' => "\\5c"
+        case '\u0000' => "\\00"
+        case character => character.toString
+      }
+
     private val SEARCH_BASE = settings.ldapSearchBase
       .map(searchDomain ⇒ searchDomain.organization → searchDomain.domainName)
       .toMap
@@ -126,7 +136,7 @@ object LdapAuthenticator {
 
         val result = dirContext.search(
           SEARCH_BASE(organization),
-          s"(${settings.ldapUserNameAttribute}=$lookupUserName)",
+          s"(${settings.ldapUserNameAttribute}=${escapeLdapFilterValue(lookupUserName)})",
           searchControls
         )
 

--- a/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/LdapAuthenticatorSpec.scala
@@ -457,6 +457,19 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
         }
       }
 
+        "escape LDAP filter characters in the username when authenticating" in {
+          val mocks = createMocks
+          val username = "*)(mail=foo*"
+          val response = mocks.byDomainAuthenticator.authenticate(testDomain1, username, "bar")
+
+          response must beRight
+
+          val usernameFilterCapture = new ArgumentCapture[String]
+          there.was(one(mocks.context).search(anyString, usernameFilterCapture, any[SearchControls]))
+
+          usernameFilterCapture.value mustEqual "(sAMAccountName=\\2a\\29\\28mail=foo\\2a)"
+        }
+
       "and result.hasMore is false" in {
         val mocks = createMocks
         mocks.searchResults.hasMore.returns(false)
@@ -530,6 +543,22 @@ class LdapAuthenticatorSpec extends Specification with Mockito {
           there.was(one(mocks.attributes).get("sn"))
         }
       }
+
+      "escape LDAP filter characters in the username when looking up a user" in {
+        val mocks = createMocks
+        val serviceAccount = ServiceAccount("second", "serviceuser", "servicepass")
+        val username = "*)(mail=foo*"
+
+        val response = mocks.byDomainAuthenticator.lookup(testDomain1, username, serviceAccount)
+
+        response must beRight
+
+        val usernameFilterCapture = new ArgumentCapture[String]
+        there.was(one(mocks.context).search(anyString, usernameFilterCapture, any[SearchControls]))
+
+        usernameFilterCapture.value mustEqual "(sAMAccountName=\\2a\\29\\28mail=foo\\2a)"
+      }
+
       "return a Failure if the user does not exist" in {
         val mocks = createMocks
         val serviceAccount = ServiceAccount("first", "foo", "bar")


### PR DESCRIPTION
JIRA ID: VDNS-378

Changes in this pull request:

- Added LDAP filter escaping before filter interpolation in LdapAuthenticator.
- Applied the escaping to both authentication and lookup paths.
- Added regression test coverage for both paths to ensure LDAP special characters are handled safely.
- Prevents malformed LDAP filters and reduces the risk of LDAP filter injection.