### PR TITLE
Add OIDC state validation

### DIFF
--- a/modules/portal/app/actions/LegacySecuritySupport.scala
+++ b/modules/portal/app/actions/LegacySecuritySupport.scala
@@ -30,7 +30,6 @@ class LegacySecuritySupport @Inject() (
 ) extends AbstractController(components)
     with SecuritySupport {
   private val logger = LoggerFactory.getLogger(classOf[LegacySecuritySupport])
-
   def frontendAction: FrontendActionBuilder =
     new LegacyFrontendAction(
       userAccountAccessor.get,
@@ -48,7 +47,16 @@ class LegacySecuritySupport @Inject() (
           case Some(_) => Redirect(request.getQueryString("target").getOrElse("/index"))
           case None =>
             logger.info(s"No ${VinylDNS.ID_TOKEN} in session; Initializing oidc login")
-            Redirect(oidcAuthenticator.getCodeCall(request.uri).toString, 302)
+            val state = oidcAuthenticator.generateState()
+            val nonce = oidcAuthenticator.generateNonce()
+
+            Redirect(
+              oidcAuthenticator.getCodeCall(request.uri, state, nonce).toString,
+              302
+            ).withSession(
+              "oidc_state" -> state,
+              "oidc_nonce" -> nonce
+            )
         }
       } else {
         request.session.get("username") match {

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -145,8 +145,8 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
   }
 
   def getCodeFromAuthResponse(
-      request: RequestHeader,
-      expectedState: String
+    request: RequestHeader,
+    expectedState: String
   ): Either[ErrorResponse, AuthorizationCode] =
     Try(AuthenticationResponseParser.parse(new URI(request.uri))).toEither
       .leftMap { err =>
@@ -156,16 +156,22 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       }
       .flatMap {
         case s: AuthenticationSuccessResponse =>
-          val code = Option(s.getAuthorizationCode)
-          val state = Option(s.getState)
+          val state = request.getQueryString("state")
 
           if (!state.contains(expectedState)) {
             Left(ErrorResponse(400, "Invalid OIDC state"))
           } else {
-            code match {
-              case Some(c) => Right(c)
+            Option(s.getAuthorizationCode) match {
+              case Some(code) =>
+                Right(code)
+
               case None =>
-                Left(ErrorResponse(500, "No code value in getCodeFromAuthResponse"))
+                Left(
+                  ErrorResponse(
+                    500,
+                    "No code value in getCodeFromAuthResponse"
+                  )
+                )
             }
           }
 
@@ -173,8 +179,13 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
           val errorMessage =
             s"Sign in error: ${err.getErrorObject.getDescription}"
 
-          Left(ErrorResponse(err.toHTTPResponse.getStatusCode, errorMessage))
-      }
+          Left(
+            ErrorResponse(
+              err.toHTTPResponse.getStatusCode,
+              errorMessage
+            )
+          )
+    }
 
   def isNotExpired(claimsSet: JWTClaimsSet): Boolean = {
     val now = new Date()

--- a/modules/portal/app/controllers/OidcAuthenticator.scala
+++ b/modules/portal/app/controllers/OidcAuthenticator.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import java.net.{URI, URL}
-import java.util.{Date, UUID}
+import java.util.{Base64, Date, UUID}
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Query
@@ -41,7 +41,7 @@ import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.mvc.RequestHeader
 import pureconfig.generic.auto._
-
+import java.security.SecureRandom
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 import scala.collection.JavaConverters._
@@ -80,6 +80,20 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
   import OidcAuthenticator._
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[OidcAuthenticator])
+  private val secureRandom = new SecureRandom()
+
+  private def generateRandomValue(): String = {
+    val bytes = new Array[Byte](32)
+    secureRandom.nextBytes(bytes)
+    Base64.getUrlEncoder.withoutPadding().encodeToString(bytes)
+  }
+
+  def generateState(): String =
+    generateRandomValue()
+
+  def generateNonce(): String =
+    generateRandomValue()
+
   val oidcEnabled: Boolean = configuration.getOptional[Boolean]("oidc.enabled").getOrElse(false)
   lazy val oidcInfo: OidcConfig =
     ConfigSource.fromConfig(configuration.underlying).at("oidc").loadOrThrow[OidcConfig]
@@ -106,39 +120,59 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     processor
   }
 
-  def getCodeCall(requestURI: String = ""): Uri = {
-    val nonce = new Nonce()
+  def getCodeCall(
+      requestURI: String = "",
+      state: String,
+      nonce: String
+  ): Uri = {
     val loginId = UUID.randomUUID().toString
-    val redirectUri = s"${oidcInfo.redirectUri}/callback/${loginId}:${java.util.Base64.getEncoder.encodeToString(requestURI.getBytes)}"
+
+    val redirectUri =
+      s"${oidcInfo.redirectUri}/callback/${loginId}:${java.util.Base64.getEncoder.encodeToString(requestURI.getBytes)}"
 
     val query = Query(
       "client_id" -> oidcInfo.clientId,
       "response_type" -> "code",
       "redirect_uri" -> redirectUri,
       "scope" -> oidcInfo.scope,
-      "nonce" -> nonce.toString
+      "state" -> state,
+      "nonce" -> nonce
     )
 
     logger.info(s"Generated LoginId $loginId")
+
     Uri(s"${oidcInfo.authorizationEndpoint}").withQuery(query)
   }
 
-  def getCodeFromAuthResponse(request: RequestHeader): Either[ErrorResponse, AuthorizationCode] =
+  def getCodeFromAuthResponse(
+      request: RequestHeader,
+      expectedState: String
+  ): Either[ErrorResponse, AuthorizationCode] =
     Try(AuthenticationResponseParser.parse(new URI(request.uri))).toEither
       .leftMap { err =>
-        val errorMessage = s"Unexpected parse error in getCodeFromAuthResponse: ${err.getMessage}"
+        val errorMessage =
+          s"Unexpected parse error in getCodeFromAuthResponse: ${err.getMessage}"
         ErrorResponse(500, errorMessage)
       }
       .flatMap {
         case s: AuthenticationSuccessResponse =>
           val code = Option(s.getAuthorizationCode)
-          code match {
-            case Some(c) => Right(c)
-            case None =>
-              Left(ErrorResponse(500, "No code value in getCodeFromAuthResponse"))
+          val state = Option(s.getState)
+
+          if (!state.contains(expectedState)) {
+            Left(ErrorResponse(400, "Invalid OIDC state"))
+          } else {
+            code match {
+              case Some(c) => Right(c)
+              case None =>
+                Left(ErrorResponse(500, "No code value in getCodeFromAuthResponse"))
+            }
           }
+
         case err: AuthorizationErrorResponse =>
-          val errorMessage = s"Sign in error: ${err.getErrorObject.getDescription}"
+          val errorMessage =
+            s"Sign in error: ${err.getErrorObject.getDescription}"
+
           Left(ErrorResponse(err.toHTTPResponse.getStatusCode, errorMessage))
       }
 
@@ -165,20 +199,26 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
   def getStringFieldOption(claimsSet: JWTClaimsSet, field: String): Option[String] =
     Try(Option(claimsSet.getStringClaim(field))).toOption.flatten
 
-  def isValidIdToken(claimsSet: JWTClaimsSet): Boolean = {
+  def isValidIdToken(
+    claimsSet: JWTClaimsSet,
+    expectedNonce: Option[String] = None
+  ): Boolean = {
     val tid = getStringFieldOption(claimsSet, "tid")
     val aid = Try(List(claimsSet.getStringListClaim("aud").asScala).flatten).getOrElse(List())
 
-    // forall will return true if tenant id is not configured
-    // if it is configured match to the tenant id returned
+    val tokenNonce = getStringFieldOption(claimsSet, "nonce")
+    val isValidNonce = expectedNonce.forall(tokenNonce.contains)
+
     val isValidTenantId = oidcInfo.tenantId.forall(tid.contains)
     val isValidAppId = aid.contains(oidcInfo.clientId)
 
-    if (isValidAppId && isValidTenantId) {
+    if (isValidAppId && isValidTenantId && isValidNonce) {
       isNotExpired(claimsSet)
     } else {
       val user = getStringFieldOption(claimsSet, oidcInfo.jwtUsernameField)
-      logger.error(s"Token issue for user $user; tenantId = $tid, appId = $aid")
+      logger.error(
+        s"Token issue for user $user; tenantId = $tid, appId = $aid, nonceValid = $isValidNonce"
+      )
       false
     }
   }
@@ -193,7 +233,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
         None
     }
 
-    val isValid = claimsSet.exists(isValidIdToken)
+    val isValid = claimsSet.exists(claims => isValidIdToken(claims, None))
     val username = claimsSet.flatMap(getStringFieldOption(_, oidcInfo.jwtUsernameField))
     if (isValid) {
       // only return username if the token is valid
@@ -218,7 +258,10 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       lastname = getStringFieldOption(claimsSet, oidcInfo.jwtLastnameField)
     } yield OidcUserDetails(username, email, firstname, lastname)
 
-  def handleCallbackResponse(response: HTTPResponse): Either[ErrorResponse, JWTClaimsSet] = {
+  def handleCallbackResponse(
+      response: HTTPResponse,
+      expectedNonce: Option[String] = None
+  ): Either[ErrorResponse, JWTClaimsSet] = {
     def matchTokenResponse(token: TokenResponse) = token match {
       case success: OIDCTokenResponse => Right(success)
       case err: TokenErrorResponse =>
@@ -231,7 +274,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       val idToken = oidcTokenResposne.getOIDCTokens.getIDToken
 
       oidcTry(jwtProcessor.process(idToken, sc)).flatMap { claims =>
-        if (isValidIdToken(claims)) {
+        if (isValidIdToken(claims, expectedNonce)) {
           Right(claims)
         } else {
           Left(ErrorResponse(500, "Invalid ID token response received from from OIDC provider"))
@@ -246,7 +289,7 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
     } yield claims
   }
 
-  def oidcCallback(code: AuthorizationCode, loginId: String)(
+  def oidcCallback(code: AuthorizationCode, loginId: String, expectedNonce: Option[String])(
       implicit executionContext: ExecutionContext
   ): EitherT[IO, ErrorResponse, JWTClaimsSet] =
     EitherT {
@@ -256,7 +299,9 @@ class OidcAuthenticator @Inject() (wsClient: WSClient, configuration: Configurat
       val request = new TokenRequest(tokenEndpoint, clientAuth, codeGrant)
 
       logger.info(s"Sending token_id request for loginId [$loginId]")
-      IO(request.toHTTPRequest.send()).map(handleCallbackResponse)
+      IO(request.toHTTPRequest.send()).map(
+        response => handleCallbackResponse(response, expectedNonce)
+      )
     }
 
   private def oidcTry[A](t: => A): Either[ErrorResponse, A] =

--- a/modules/portal/app/controllers/VinylDNS.scala
+++ b/modules/portal/app/controllers/VinylDNS.scala
@@ -145,12 +145,45 @@ class VinylDNS @Inject() (
 
   def setOidcSession(loginId: String): Action[AnyContent] = Action.async { implicit request =>
     logger.info(s"Setting session for LoginId [$loginId]")
+    val expectedNonce = request.session.get("oidc_nonce")
 
     val details = for {
-      code <- EitherT.fromEither[IO](oidcAuthenticator.getCodeFromAuthResponse(request))
-      validToken <- oidcAuthenticator.oidcCallback(code, loginId)
-      userDetails <- EitherT.fromEither[IO](oidcAuthenticator.getUserFromClaims(validToken))
-      userCreate <- EitherT.right[ErrorResponse](processLoginWithDetails(userDetails))
+      expectedState <- EitherT.fromEither[IO](
+        request.session
+          .get("oidc_state")
+          .toRight(ErrorResponse(400, "Missing OIDC state"))
+      )
+
+      actualState <- EitherT.fromEither[IO](
+        request.getQueryString("state")
+          .toRight(ErrorResponse(400, "Missing OIDC state in callback"))
+      )
+
+      _ <- EitherT.fromEither[IO](
+        Either.cond(
+          expectedState == actualState,
+          (),
+          ErrorResponse(400, "Invalid OIDC state")
+        )
+      )
+
+      code <- EitherT.fromEither[IO](
+        oidcAuthenticator.getCodeFromAuthResponse(request, expectedState)
+      )
+
+      validToken <- oidcAuthenticator.oidcCallback(
+        code,
+        loginId,
+        expectedNonce
+      )
+
+      userDetails <- EitherT.fromEither[IO](
+        oidcAuthenticator.getUserFromClaims(validToken)
+      )
+
+      userCreate <- EitherT.right[ErrorResponse](
+        processLoginWithDetails(userDetails)
+      )
     } yield (userCreate, validToken)
 
     details.value

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -45,6 +45,8 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
   val mockOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   val enabledOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   enabledOidcAuthenticator.oidcEnabled.returns(true)
+  enabledOidcAuthenticator.generateState().returns("test-state")
+  enabledOidcAuthenticator.generateNonce().returns("test-nonce")
   enabledOidcAuthenticator.getCodeCall(anyString, anyString, anyString).returns(Uri("http://test.com"))
   enabledOidcAuthenticator.oidcLogoutUrl.returns("http://logout-test.com")
   enabledOidcAuthenticator.getValidUsernameFromToken(any[String]).returns(Some("test"))

--- a/modules/portal/test/controllers/FrontendControllerSpec.scala
+++ b/modules/portal/test/controllers/FrontendControllerSpec.scala
@@ -45,7 +45,7 @@ class FrontendControllerSpec extends Specification with Mockito with TestApplica
   val mockOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   val enabledOidcAuthenticator: OidcAuthenticator = mock[OidcAuthenticator]
   enabledOidcAuthenticator.oidcEnabled.returns(true)
-  enabledOidcAuthenticator.getCodeCall(anyString).returns(Uri("http://test.com"))
+  enabledOidcAuthenticator.getCodeCall(anyString, anyString, anyString).returns(Uri("http://test.com"))
   enabledOidcAuthenticator.oidcLogoutUrl.returns("http://logout-test.com")
   enabledOidcAuthenticator.getValidUsernameFromToken(any[String]).returns(Some("test"))
 

--- a/modules/portal/test/controllers/OidcAuthenticatorSpec.scala
+++ b/modules/portal/test/controllers/OidcAuthenticatorSpec.scala
@@ -59,14 +59,15 @@ class OidcAuthenticatorSpec extends Specification with Mockito {
 
   val goodToken: String =
     s"""{"username":"un",
-       |"firstname":"First",
-       |"lastname":"Last",
-       |"email":"test@test.com",
-       |"tid":"test-tenant-id",
-       |"aud":"test-client-id",
-       |"exp": $futureTime,
-       |"iat": $pastTime,
-       |"nbf": $pastTime}""".stripMargin
+      |"firstname":"First",
+      |"lastname":"Last",
+      |"email":"test@test.com",
+      |"tid":"test-tenant-id",
+      |"aud":"test-client-id",
+      |"nonce":"test-nonce",
+      |"exp": $futureTime,
+      |"iat": $pastTime,
+      |"nbf": $pastTime}""".stripMargin
 
   val jwtClaims: JWTClaimsSet = JWTClaimsSet.parse(goodToken)
 
@@ -92,7 +93,10 @@ class OidcAuthenticatorSpec extends Specification with Mockito {
   "OidcAuthenticator" should {
     "Initial code call" should {
       "properly generate the code call" in {
-        val codeCall = testOidcAuthenticator.getCodeCall("/abcd")
+        val state = "test-state"
+        val nonce = "test-nonce"
+
+        val codeCall = testOidcAuthenticator.getCodeCall("/abcd", state, nonce)
         val query = codeCall.queryString().get
 
         codeCall.toString must startWith("http://test.authorization.url")
@@ -100,33 +104,56 @@ class OidcAuthenticatorSpec extends Specification with Mockito {
         query must contain("response_type=code")
         query must contain("redirect_uri=http://localhost:9001/callback")
         query must contain("scope=openid+profile+email")
-        query must contain("nonce")
+        query must contain("state=test-state")
+        query must contain("nonce=test-nonce")
       }
       "properly handle code call response" in {
-        val request = FakeRequest("GET", "/callback?code=asdasdasdasd")
+        val request = FakeRequest("GET", "/callback?code=asdasdasdasd&state=test-state")
 
-        val out = testOidcAuthenticator.getCodeFromAuthResponse(request)
+        val out = testOidcAuthenticator.getCodeFromAuthResponse(request, "test-state")
         out must beRight(new AuthorizationCode("asdasdasdasd"))
       }
-      "fail if no code in code call response" in {
-        val request = FakeRequest("GET", "/callback?boo=asdasdasdasd")
+      "fail if state does not match" in {
+        val request =
+          FakeRequest("GET", "/callback?code=asdasdasdasd&state=wrong-state")
 
-        val out = testOidcAuthenticator.getCodeFromAuthResponse(request)
+        val out =
+          testOidcAuthenticator.getCodeFromAuthResponse(request, "test-state")
+
+        out must beLeft(
+          ErrorResponse(400, "Invalid OIDC state")
+        )
+      }
+      "fail if state is missing" in {
+        val request =
+          FakeRequest("GET", "/callback?code=asdasdasdasd")
+
+        val out =
+          testOidcAuthenticator.getCodeFromAuthResponse(request, "test-state")
+
+        out must beLeft(
+          ErrorResponse(400, "Invalid OIDC state")
+        )
+      }
+      "fail if no code in code call response" in {
+        val request = FakeRequest("GET", "/callback?boo=asdasdasdasd&state=test-state")
+
+        val out = testOidcAuthenticator.getCodeFromAuthResponse(request, "test-state")
         out must beLeft(ErrorResponse(500, "No code value in getCodeFromAuthResponse"))
       }
       "fail if there is some other parse error in the code response" in {
-        val request = FakeRequest("GET", "/callback?code=")
+        val request = FakeRequest("GET", "/callback?code=&state=test-state")
 
-        val out = testOidcAuthenticator.getCodeFromAuthResponse(request)
+        val out = testOidcAuthenticator.getCodeFromAuthResponse(request, "test-state")
         out must beLeft.like {
           case e: ErrorResponse => e.code == 500
         }
       }
       "fail if some other error in code call response" in {
         val request =
-          FakeRequest("GET", "/callback?error=invalid_request&error_description=something-bad")
+          FakeRequest("GET", "/callback?error=invalid_request&error_description=something-bad&state=test-state")
 
-        val out = testOidcAuthenticator.getCodeFromAuthResponse(request)
+        val out = testOidcAuthenticator.getCodeFromAuthResponse(request, "test-state")
         out must beLeft(ErrorResponse(302, "Sign in error: something-bad"))
       }
     }
@@ -229,6 +256,49 @@ class OidcAuthenticatorSpec extends Specification with Mockito {
 
         testOidcAuthenticator.getValidUsernameFromToken(tokenInfo) must beNone
       }
+      "fail if nonce is invalid" in {
+        val tokenInfo =
+          s"""{"username":"un",
+            |"tid":"test-tenant-id",
+            |"aud":"test-client-id",
+            |"firstname":"First",
+            |"lastname":"Last",
+            |"exp": $futureTime,
+            |"iat": $pastTime,
+            |"nbf": $pastTime,
+            |"nonce":"wrong-nonce",
+            |"email":"test@test.com"}""".stripMargin
+
+        testOidcAuthenticator.isValidIdToken(
+          JWTClaimsSet.parse(tokenInfo),
+          Some("test-nonce")
+        ) must beFalse
+      }
+
+      "fail if nonce is missing" in {
+        val tokenInfo =
+          s"""{"username":"un",
+            |"tid":"test-tenant-id",
+            |"aud":"test-client-id",
+            |"firstname":"First",
+            |"lastname":"Last",
+            |"exp": $futureTime,
+            |"iat": $pastTime,
+            |"nbf": $pastTime,
+            |"email":"test@test.com"}""".stripMargin
+
+        testOidcAuthenticator.isValidIdToken(
+          JWTClaimsSet.parse(tokenInfo),
+          Some("test-nonce")
+        ) must beFalse
+      }
+
+      "succeed if nonce matches" in {
+        testOidcAuthenticator.isValidIdToken(
+          jwtClaims,
+          Some("test-nonce")
+        ) must beTrue
+      }
     }
     "handleCallbackResponse" should {
       val unsignedTestKey = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
@@ -247,7 +317,31 @@ class OidcAuthenticatorSpec extends Specification with Mockito {
           """
         testResponse.setContent(body)
 
-        testOidcAuthenticator.handleCallbackResponse(testResponse) must beRight(jwtClaims)
+        testOidcAuthenticator.handleCallbackResponse(
+          testResponse,
+          Some("test-nonce")
+        ) must beRight(jwtClaims)
+      }
+      "fail with invalid nonce" in {
+        val testResponse = new HTTPResponse(200)
+        testResponse.setHeader("Content-Type", "application/json", "charset=utf-8")
+
+        val body =
+          s"""{
+              "access_token": "$unsignedTestKey",
+              "token_type": "Bearer",
+              "id_token": "$unsignedTestKey"
+              }
+          """
+
+        testResponse.setContent(body)
+
+        testOidcAuthenticator.handleCallbackResponse(
+          testResponse,
+          Some("wrong-nonce")
+        ) must beLeft(
+          ErrorResponse(500, "Invalid ID token response received from from OIDC provider")
+        )
       }
       "respond with errors if given" in {
         val testResponse = new HTTPResponse(400)


### PR DESCRIPTION
Fixes #.
VDNS-380

Changes in this pull request:

Description

- Fixed the OIDC authorization-code flow to prevent authentication CSRF / login CSRF by introducing validation of the OIDC state parameter.
- Previously the authorization request did not include a state parameter, and the callback accepted the authorization code without verifying that the callback belonged to the authentication flow initiated by the same browser session.

Fix

- Generate a cryptographically random state value when initiating the OIDC login.
- Store the generated state in the user's Play session before redirecting to the OIDC provider.
- Include the generated state in the OIDC authorization request.
- Retrieve the state returned by the OIDC provider during the callback.
- Compare the returned state with the value stored in the user's session.
- Reject the callback with Invalid OIDC state when the values do not match.
- Continue the authorization-code exchange only after successful state validation.

The callback flow now validates that the authorization response corresponds to the OIDC login initiated by the same user session, preventing an attacker from injecting their own authorization code into another user's browser session.

