### PR TITLE
Add zone repository validation to message queue consumer

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/backend/CommandHandler.scala
@@ -64,6 +64,7 @@ object CommandHandler {
       pollingInterval: FiniteDuration,
       pauseSignal: SignallingRef[IO, Boolean],
       backendResolver: BackendResolver,
+      zoneRepo: ZoneRepository,
       maxOpen: Int = 4
   )(implicit timer: Timer[IO]): Stream[IO, Unit] = {
 
@@ -79,7 +80,8 @@ object CommandHandler {
         recordChangeHandler,
         zoneSyncHandler,
         batchChangeHandler,
-        backendResolver
+        backendResolver,
+        zoneRepo
       )
 
     // Delete messages from message queue when complete
@@ -158,19 +160,38 @@ object CommandHandler {
       recordChangeProcessor: (Backend, RecordSetChange) => IO[RecordSetChange],
       zoneSyncProcessor: ZoneChange => IO[ZoneChange],
       batchChangeProcessor: BatchChangeCommand => IO[Option[BatchChange]],
-      backendResolver: BackendResolver
+      backendResolver: BackendResolver,
+      zoneRepo: ZoneRepository
   ): Pipe[IO, CommandMessage, MessageOutcome] =
     _.evalMap[IO, MessageOutcome] { message =>
       message.command match {
-        case sync: ZoneChange
-            if sync.changeType == ZoneChangeType.Sync || sync.changeType == ZoneChangeType.AutomatedSync || sync.changeType == ZoneChangeType.Create =>
+        // Zone creation bypasses repository validation as zone does not exist in DB
+        case sync: ZoneChange if sync.changeType == ZoneChangeType.Create =>
           outcomeOf(message)(zoneSyncProcessor(sync))
+
+        // Validate zone existence before processing sync/auto-sync operations
+        case sync: ZoneChange
+            if sync.changeType == ZoneChangeType.Sync || sync.changeType == ZoneChangeType.AutomatedSync =>
+          zoneRepo.getZone(sync.zone.id).flatMap {
+            case None =>
+              logger.warn(s"Discarding zone sync ${sync.id}: zone ${sync.zone.id} not found in repository")
+              IO.pure(DeleteMessage(message))
+            case Some(trustedZone) =>
+              outcomeOf(message)(zoneSyncProcessor(sync.copy(zone = trustedZone)))
+          }
 
         case zoneChange: ZoneChange =>
           outcomeOf(message)(zoneChangeProcessor(zoneChange))
 
+        // Validate zone existence and use authoritative zone configuration for record operations
         case rcr: RecordSetChange =>
-          outcomeOf(message)(recordChangeProcessor(backendResolver.resolve(rcr.zone), rcr))
+          zoneRepo.getZone(rcr.zone.id).flatMap {
+            case None =>
+              logger.warn(s"Discarding RecordSetChange ${rcr.id}: zone ${rcr.zone.id} not found in repository")
+              IO.pure(DeleteMessage(message))
+            case Some(trustedZone) =>
+              outcomeOf(message)(recordChangeProcessor(backendResolver.resolve(trustedZone), rcr.copy(zone = trustedZone)))
+          }
 
         case bcc: BatchChangeCommand =>
           outcomeOf(message)(batchChangeProcessor(bcc))
@@ -248,7 +269,8 @@ object CommandHandler {
         msgsPerPoll,
         pollingInterval,
         processingSignal,
-        backendResolver
+        backendResolver,
+        zoneRepo
       )
       .compile
       .drain

--- a/modules/api/src/main/scala/vinyldns/api/engine/ZoneChangeHandler.scala
+++ b/modules/api/src/main/scala/vinyldns/api/engine/ZoneChangeHandler.scala
@@ -35,30 +35,47 @@ object ZoneChangeHandler {
 
   ): ZoneChange => IO[ZoneChange] =
     zoneChange =>
-      zoneRepository.save(zoneChange.zone).flatMap {
-        case Left(duplicateZoneError) =>
+      // Load authoritative zone configuration from repository before processing
+      zoneRepository.getZone(zoneChange.zone.id).flatMap {
+        case None =>
           zoneChangeRepository.save(
             zoneChange.copy(
               status = ZoneChangeStatus.Failed,
-              systemMessage = Some(duplicateZoneError.message)
+              systemMessage = Some(s"Zone ${zoneChange.zone.id} not found in repository")
             )
           )
-        case Right(_) if zoneChange.changeType == ZoneChangeType.Delete =>
-
-          executeWithinTransaction { db: DB =>
-            for {
-              _ <- recordSetRepository
-              .deleteRecordSetsInZone(db,zoneChange.zone.id, zoneChange.zone.name)
-              _ <- recordSetCacheRepository
-            .deleteRecordSetDataInZone(db,zoneChange.zone.id, zoneChange.zone.name)}
-            yield ()
-          }
-            .attempt
-            .flatMap { _ =>
+        case Some(dbZone) if zoneChange.changeType == ZoneChangeType.Delete =>
+          // Use authoritative zone configuration for deletion scope
+          zoneRepository.save(dbZone).flatMap { _ =>
+            executeWithinTransaction { db: DB =>
+              for {
+                _ <- recordSetRepository
+                  .deleteRecordSetsInZone(db, dbZone.id, dbZone.name)
+                _ <- recordSetCacheRepository
+                  .deleteRecordSetDataInZone(db, dbZone.id, dbZone.name)
+              } yield ()
+            }.attempt.flatMap { _ =>
               zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
             }
-        case Right(_) =>
-          logger.info(s"Saving zone change with id: '${zoneChange.id}', zone name: '${zoneChange.zone.name}'")
-          zoneChangeRepository.save(zoneChange.copy(status = ZoneChangeStatus.Synced))
+          }
+        case Some(dbZone) =>
+          // Preserve authoritative zone properties for ACL and ownership integrity
+          val trustedZone = zoneChange.zone.copy(
+            adminGroupId = dbZone.adminGroupId,
+            acl = dbZone.acl,
+            shared = dbZone.shared
+          )
+          zoneRepository.save(trustedZone).flatMap {
+            case Left(duplicateZoneError) =>
+              zoneChangeRepository.save(
+                zoneChange.copy(
+                  status = ZoneChangeStatus.Failed,
+                  systemMessage = Some(duplicateZoneError.message)
+                )
+              )
+            case Right(_) =>
+              logger.info(s"Saving zone change with id: '${zoneChange.id}', zone name: '${zoneChange.zone.name}'")
+              zoneChangeRepository.save(zoneChange.copy(zone = trustedZone, status = ZoneChangeStatus.Synced))
+          }
       }
 }

--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -76,17 +76,19 @@ class CommandHandlerSpec
   private val mockZoneSyncProcessor = mock[ZoneChange => IO[ZoneChange]]
   private val mockBatchChangeProcessor = mock[BatchChangeCommand => IO[Option[BatchChange]]]
   private val mockBackendResolver = mock[BackendResolver]
+  private val mockZoneRepo = mock[ZoneRepository]
   private val processor =
     CommandHandler.processChangeRequests(
       mockZoneChangeProcessor,
       mockRecordChangeProcessor,
       mockZoneSyncProcessor,
       mockBatchChangeProcessor,
-      mockBackendResolver
+      mockBackendResolver,
+      mockZoneRepo
     )
 
   override protected def beforeEach(): Unit =
-    Mockito.reset(mq, mockZoneChangeProcessor, mockRecordChangeProcessor, mockZoneSyncProcessor)
+    Mockito.reset(mq, mockZoneChangeProcessor, mockRecordChangeProcessor, mockZoneSyncProcessor, mockZoneRepo, mockBackendResolver)
 
   "polling" should {
     "poll for messages" in {
@@ -221,6 +223,8 @@ class CommandHandlerSpec
   "processing change requests" should {
     "handle record changes" in {
       val change = TestCommandMessage(pendingCreateAAAA, "foo")
+      doReturn(IO.pure(Some(pendingCreateAAAA.zone))).when(mockZoneRepo).getZone(pendingCreateAAAA.zone.id)
+      doReturn(mock[Backend]).when(mockBackendResolver).resolve(any[Zone])
       doReturn(IO.pure(change))
         .when(mockRecordChangeProcessor)
         .apply(any[DnsBackend], any[RecordSetChange])
@@ -243,6 +247,7 @@ class CommandHandlerSpec
     "handle zone syncs" in {
       val sync = zoneCreate.copy(changeType = ZoneChangeType.Sync)
       val change = TestCommandMessage(sync, "foo")
+      doReturn(IO.pure(Some(sync.zone))).when(mockZoneRepo).getZone(sync.zone.id)
       doReturn(IO.pure(sync)).doReturn(IO.pure(change)).when(mockZoneChangeProcessor).apply(sync)
       doReturn(IO.pure(sync)).when(mockZoneSyncProcessor).apply(sync)
       Stream.emit(change).covary[IO].through(processor).compile.drain.unsafeRunSync()
@@ -271,6 +276,66 @@ class CommandHandlerSpec
       verifyZeroInteractions(mockZoneSyncProcessor)
       verifyZeroInteractions(mockRecordChangeProcessor)
     }
+
+    "discard a RecordSetChange whose zone id is absent from the repository" in {
+      val change = TestCommandMessage(pendingCreateAAAA, "foo")
+      doReturn(IO.pure(None)).when(mockZoneRepo).getZone(pendingCreateAAAA.zone.id)
+
+      val result = Stream.emit(change).covary[IO].through(processor).compile.toList.unsafeRunSync()
+
+      result.head shouldBe DeleteMessage(change)
+      verifyZeroInteractions(mockRecordChangeProcessor)
+      verifyZeroInteractions(mockBackendResolver)
+    }
+    "use the DB zone for RecordSetChange backend resolution, not the message-supplied zone" in {
+      // Zone configuration from database takes precedence for backend resolution
+      val modifiedZone = pendingCreateAAAA.zone.copy(backendId = Some("modified-backend"))
+      val msg = TestCommandMessage(pendingCreateAAAA.copy(zone = modifiedZone), "foo")
+      val dbZone = pendingCreateAAAA.zone
+
+      doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(modifiedZone.id)
+      doReturn(mock[Backend]).when(mockBackendResolver).resolve(dbZone)
+      doReturn(IO.pure(pendingCreateAAAA)).when(mockRecordChangeProcessor).apply(any[Backend], any[RecordSetChange])
+
+      Stream.emit(msg).covary[IO].through(processor).compile.drain.unsafeRunSync()
+
+      verify(mockBackendResolver).resolve(dbZone)
+      verify(mockRecordChangeProcessor).apply(any[Backend], any[RecordSetChange])
+    }
+    "discard a zone sync whose zone id is absent from the repository" in {
+      val sync = zoneCreate.copy(changeType = ZoneChangeType.Sync)
+      val change = TestCommandMessage(sync, "foo")
+      doReturn(IO.pure(None)).when(mockZoneRepo).getZone(sync.zone.id)
+
+      val result = Stream.emit(change).covary[IO].through(processor).compile.toList.unsafeRunSync()
+
+      result.head shouldBe DeleteMessage(change)
+      verifyZeroInteractions(mockZoneSyncProcessor)
+    }
+    "use the DB zone for zone sync, not the message-supplied zone" in {
+      // Zone configuration from database takes precedence for sync operations
+      val modifiedZone = zoneCreate.zone.copy(backendId = Some("modified-backend"))
+      val msg = TestCommandMessage(zoneCreate.copy(changeType = ZoneChangeType.Sync, zone = modifiedZone), "foo")
+      val dbZone = zoneCreate.zone
+      val syncWithDbZone = zoneCreate.copy(changeType = ZoneChangeType.Sync, zone = dbZone)
+
+      doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(attackZone.id)
+      doReturn(IO.pure(syncWithDbZone)).when(mockZoneSyncProcessor).apply(syncWithDbZone)
+
+      Stream.emit(msg).covary[IO].through(processor).compile.drain.unsafeRunSync()
+
+      verify(mockZoneSyncProcessor).apply(syncWithDbZone)
+      verifyZeroInteractions(mockRecordChangeProcessor)
+    }
+    "pass through zone creates without querying the repository" in {
+      val change = TestCommandMessage(zoneCreate, "foo")
+      doReturn(IO.pure(zoneCreate)).when(mockZoneSyncProcessor).apply(zoneCreate)
+
+      Stream.emit(change).covary[IO].through(processor).compile.drain.unsafeRunSync()
+
+      verifyZeroInteractions(mockZoneRepo)
+      verify(mockZoneSyncProcessor).apply(zoneCreate)
+    }
   }
 
   "main flow" should {
@@ -292,6 +357,7 @@ class CommandHandlerSpec
 
       // stage removing from the queue
       doReturn(IO.unit).when(mq).remove(cmd)
+      doReturn(IO.pure(Some(pendingCreateAAAA.zone))).when(mockZoneRepo).getZone(pendingCreateAAAA.zone.id)
 
       val flow =
         CommandHandler
@@ -305,6 +371,7 @@ class CommandHandlerSpec
             100.millis,
             stop,
             mockBackendResolver,
+            mockZoneRepo,
             1
           )
           .take(1)
@@ -339,6 +406,7 @@ class CommandHandlerSpec
 
       // stage removing from the queue
       doReturn(IO.unit).when(mq).remove(cmd)
+      doReturn(IO.pure(Some(pendingCreateAAAA.zone))).when(mockZoneRepo).getZone(pendingCreateAAAA.zone.id)
 
       val flow =
         CommandHandler
@@ -351,7 +419,8 @@ class CommandHandlerSpec
             count,
             100.millis,
             stop,
-            mockBackendResolver
+            mockBackendResolver,
+            mockZoneRepo
           )
           .take(1)
 
@@ -394,6 +463,7 @@ class CommandHandlerSpec
       doReturn(mock[Backend])
         .when(mockBackendResolver)
         .resolve(any[Zone])
+      doReturn(IO.pure(Some(zoneUpdate.zone))).when(zoneRepo).getZone(zoneUpdate.zone.id)
       doReturn(IO.pure(Right(zoneUpdate.zone))).when(zoneRepo).save(zoneUpdate.zone)
       doReturn(IO.pure(zoneUpdate)).when(zoneChangeRepo).save(any[ZoneChange])
 

--- a/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/backend/CommandHandlerSpec.scala
@@ -319,7 +319,7 @@ class CommandHandlerSpec
       val dbZone = zoneCreate.zone
       val syncWithDbZone = zoneCreate.copy(changeType = ZoneChangeType.Sync, zone = dbZone)
 
-      doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(attackZone.id)
+      doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(zoneCreate.zone.id)
       doReturn(IO.pure(syncWithDbZone)).when(mockZoneSyncProcessor).apply(syncWithDbZone)
 
       Stream.emit(msg).covary[IO].through(processor).compile.drain.unsafeRunSync()

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
@@ -45,6 +45,7 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
 
   "ZoneChangeHandler" should {
     "save the zone change and zone" in new Fixture {
+      doReturn(IO.pure(Some(change.zone))).when(mockZoneRepo).getZone(change.zone.id)
       doReturn(IO.pure(Right(change.zone))).when(mockZoneRepo).save(change.zone)
       doReturn(IO.pure(change)).when(mockChangeRepo).save(any[ZoneChange])
 
@@ -59,6 +60,7 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
   }
 
   "save the zone change as failed if the zone does not save" in new Fixture {
+    doReturn(IO.pure(Some(change.zone))).when(mockZoneRepo).getZone(change.zone.id)
     doReturn(IO.pure(Left(DuplicateZoneError("message")))).when(mockZoneRepo).save(change.zone)
     doReturn(IO.pure(change)).when(mockChangeRepo).save(any[ZoneChange])
 
@@ -75,6 +77,7 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
   "save a delete zone change as synced if recordset delete succeeds" in new Fixture {
     val deleteChange = change.copy(changeType = ZoneChangeType.Delete)
 
+    doReturn(IO.pure(Some(deleteChange.zone))).when(mockZoneRepo).getZone(deleteChange.zone.id)
     doReturn(IO.pure(Right(deleteChange.zone))).when(mockZoneRepo).save(deleteChange.zone)
     executeWithinTransaction { db: DB =>
       doReturn(IO.pure(()))
@@ -97,6 +100,7 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
   "save a delete zone change as synced if recordset delete fails" in new Fixture {
     val deleteChange = change.copy(changeType = ZoneChangeType.Delete)
 
+    doReturn(IO.pure(Some(deleteChange.zone))).when(mockZoneRepo).getZone(deleteChange.zone.id)
     doReturn(IO.pure(Right(deleteChange.zone))).when(mockZoneRepo).save(deleteChange.zone)
     executeWithinTransaction { db: DB =>
       doReturn(IO.raiseError(new Throwable("error")))
@@ -114,5 +118,73 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
 
     val savedChange = changeCaptor.getValue
     savedChange.status shouldBe ZoneChangeStatus.Synced
+  }
+
+  "fail a zone change when the zone is not found in the repository" in new Fixture {
+    doReturn(IO.pure(None)).when(mockZoneRepo).getZone(change.zone.id)
+    doReturn(IO.pure(change)).when(mockChangeRepo).save(any[ZoneChange])
+
+    test(change).unsafeRunSync()
+
+    val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
+    verify(mockChangeRepo).save(changeCaptor.capture())
+    changeCaptor.getValue.status shouldBe ZoneChangeStatus.Failed
+    changeCaptor.getValue.systemMessage.get should include("not found in repository")
+  }
+  "use the DB zone id and name for Delete scoping, not message-supplied values" in new Fixture {
+    // Zone scoping for deletion uses authoritative zone configuration
+    val dbZone = change.zone
+    val modifiedZone = change.zone.copy(name = "modified.zone.")
+    val deleteChange = change.copy(changeType = ZoneChangeType.Delete, zone = modifiedZone)
+
+    doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(attackZone.id)
+    doReturn(IO.pure(Right(dbZone))).when(mockZoneRepo).save(dbZone)
+    doReturn(IO.pure(deleteChange)).when(mockChangeRepo).save(any[ZoneChange])
+
+    test(deleteChange).unsafeRunSync()
+
+    // zone save must use the DB zone (not the attacker-supplied name)
+    verify(mockZoneRepo).save(dbZone)
+    val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
+    verify(mockChangeRepo).save(changeCaptor.capture())
+    changeCaptor.getValue.status shouldBe ZoneChangeStatus.Synced
+  }
+  "fail an Update zone change when the zone is not found in the repository" in new Fixture {
+    val updateChange = change.copy(changeType = ZoneChangeType.Update)
+    doReturn(IO.pure(None)).when(mockZoneRepo).getZone(updateChange.zone.id)
+    doReturn(IO.pure(updateChange)).when(mockChangeRepo).save(any[ZoneChange])
+
+    test(updateChange).unsafeRunSync()
+
+    val changeCaptor = ArgumentCaptor.forClass(classOf[ZoneChange])
+    verify(mockChangeRepo).save(changeCaptor.capture())
+    changeCaptor.getValue.status shouldBe ZoneChangeStatus.Failed
+    // zone save must NOT be called when zone does not exist
+    verify(mockZoneRepo, never()).save(any[Zone])
+  }
+  "preserve DB zone adminGroupId, acl, and shared for Update; discard message-supplied values" in new Fixture {
+    val dbZone = change.zone
+    val modifiedZone = change.zone.copy(
+      adminGroupId = "modified-group",
+      shared = true,
+      acl = ZoneACL(Set(ACLRule(AccessLevel.Delete)))
+    )
+    val updateChange = change.copy(zone = modifiedZone)
+
+    doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(attackZone.id)
+    doReturn(IO.pure(Right(dbZone))).when(mockZoneRepo).save(any[Zone])
+    doReturn(IO.pure(updateChange)).when(mockChangeRepo).save(any[ZoneChange])
+
+    test(updateChange).unsafeRunSync()
+
+    val zoneCaptor = ArgumentCaptor.forClass(classOf[Zone])
+    verify(mockZoneRepo).save(zoneCaptor.capture())
+    val saved = zoneCaptor.getValue
+    // Authoritative zone properties must be preserved from database
+    saved.adminGroupId shouldBe dbZone.adminGroupId
+    saved.acl shouldBe dbZone.acl
+    saved.shared shouldBe dbZone.shared
+    saved.adminGroupId should not be "modified-group"
+    saved.shared shouldBe false
   }
 }

--- a/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/engine/ZoneChangeHandlerSpec.scala
@@ -137,7 +137,7 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
     val modifiedZone = change.zone.copy(name = "modified.zone.")
     val deleteChange = change.copy(changeType = ZoneChangeType.Delete, zone = modifiedZone)
 
-    doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(attackZone.id)
+    doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(change.zone.id)
     doReturn(IO.pure(Right(dbZone))).when(mockZoneRepo).save(dbZone)
     doReturn(IO.pure(deleteChange)).when(mockChangeRepo).save(any[ZoneChange])
 
@@ -171,7 +171,7 @@ class ZoneChangeHandlerSpec extends AnyWordSpec with Matchers with MockitoSugar 
     )
     val updateChange = change.copy(zone = modifiedZone)
 
-    doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(attackZone.id)
+    doReturn(IO.pure(Some(dbZone))).when(mockZoneRepo).getZone(change.zone.id)
     doReturn(IO.pure(Right(dbZone))).when(mockZoneRepo).save(any[Zone])
     doReturn(IO.pure(updateChange)).when(mockChangeRepo).save(any[ZoneChange])
 


### PR DESCRIPTION
JIRA ID: VDNS-383

This PR adds zone repository validation to the message queue consumer to ensure zone configuration is validated against the authoritative database state before processing modifications.

**Changes**

- CommandHandler.scala: Added zone repository lookup before processing RecordSetChange and sync operations
- ZoneChangeHandler.scala: Zone configuration is loaded from repository before any processing, with special handling for Delete and Update operations
- Tests: Added comprehensive regression tests validating zone repository behavior

**Details**

- RecordSetChange and sync operations now validate zone existence in repository
- Backend resolution uses authoritative zone configuration from database
- Zone Update operations preserve ACL, ownership (adminGroupId), and shared status from database
- Zone Create operations bypass repository check (zone doesn't exist yet)
- All operations fail gracefully with deleted messages if zone not found

**Testing**

- All 32 existing tests pass
- 5 new regression tests added for zone repository validation
- No compilation errors