### PR TITLE
Fix Multiple deleteRecordSet Batch Failure

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeValidations.scala
@@ -357,7 +357,11 @@ class BatchChangeValidations(
     }
 
     val addInBatch = groupedChanges.getProposedAdds(change.recordKey)
-    val isSameRecordUpdateInBatch = recordData.nonEmpty && addInBatch.contains(RecordData.fromString(recordData, change.inputChange.typ).get)
+    val requestedDeletes = groupedChanges.getRequestedDeleteRecordData(change.recordKey)
+    val isSameRecordUpdateInBatch =
+      recordData.nonEmpty &&
+        requestedDeletes.contains(RecordData.fromString(recordData, change.inputChange.typ).get) &&
+        addInBatch.contains(RecordData.fromString(recordData, change.inputChange.typ).get)
 
     // Perform the system message update based on the condition
     val updatedChange = if (groupedChanges.getExistingRecordSet(change.recordKey).isEmpty && !isSameRecordUpdateInBatch) {
@@ -430,7 +434,11 @@ class BatchChangeValidations(
     }
 
     val addInBatch = groupedChanges.getProposedAdds(change.recordKey)
-    val isSameRecordUpdateInBatch = recordData.nonEmpty && addInBatch.contains(RecordData.fromString(recordData, change.inputChange.typ).get)
+    val requestedDeletes = groupedChanges.getRequestedDeleteRecordData(change.recordKey)
+    val isSameRecordUpdateInBatch =
+      recordData.nonEmpty &&
+        requestedDeletes.contains(RecordData.fromString(recordData, change.inputChange.typ).get) &&
+        addInBatch.contains(RecordData.fromString(recordData, change.inputChange.typ).get)
 
     // Perform the system message update based on the condition
     val updatedChange = if (groupedChanges.getExistingRecordSet(change.recordKey).isEmpty && !isSameRecordUpdateInBatch) {
@@ -482,11 +490,10 @@ class BatchChangeValidations(
       case AddChangeForValidation(_, _, inputChange, _, _) => inputChange.record.toString
     }
 
-    val deletes = groupedChanges.getProposedDeletes(change.recordKey)
-    val isDeleteExists = deletes.nonEmpty
-    val isSameRecordUpdateInBatch = if(recordData.nonEmpty){
-      if(deletes.contains(RecordData.fromString(recordData, change.inputChange.typ).get)) true else false
-    } else false
+    val requestedDeletes = groupedChanges.getRequestedDeleteRecordData(change.recordKey)
+    val isDeleteExists = groupedChanges.hasDeleteRequests(change.recordKey)
+    val isSameRecordUpdateInBatch =
+      recordData.nonEmpty && requestedDeletes.contains(RecordData.fromString(recordData, change.inputChange.typ).get)
 
     val commonValidations: SingleValidation[Unit] = {
       groupedChanges.getExistingRecordSet(change.recordKey) match {

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -191,6 +191,12 @@ object BatchTransformations {
     def getProposedDeletes(recordKey: RecordKey): Set[RecordData] =
       innerMap.get(recordKey).map(_.proposedDeletes).toSet.flatten
 
+    def getRequestedDeleteRecordData(recordKey: RecordKey): Set[RecordData] =
+      innerMap.get(recordKey).map(_.requestedDeleteRecordData).toSet.flatten
+
+    def hasDeleteRequests(recordKey: RecordKey): Boolean =
+      innerMap.get(recordKey).exists(_.hasDeleteRequests)
+
     // The new, net record data factoring in existing records, deletes and adds
     // If record is not edited in batch, will fallback to look up record in existing
     // records
@@ -221,6 +227,18 @@ object BatchTransformations {
         case _: DeleteRRSetChangeForValidation => true
         case _ => false
       }
+
+      // Collect explicit delete DNS entries requested by the user.
+      // This intentionally does not intersect with existing records so validation can
+      // distinguish delete intent from effective backend changes.
+      val requestedDeleteRecordData = changes.collect {
+        case DeleteRRSetChangeForValidation(
+            _,
+            _,
+            DeleteRRSetChangeInput(_, _, _, Some(recordData))
+            ) =>
+          recordData
+      }.toSet
 
       // Collect delete DNS entries. This formulates all of the proposed delete entries, including
       // existing DNS entries in the event of DeleteRecordSet
@@ -269,13 +287,22 @@ object BatchTransformations {
           }
       }
 
-      new ValidationChanges(addChangeRecordDataSet, deleteChangeSet, proposedRecordData, logicalChangeType)
+      new ValidationChanges(
+        addChangeRecordDataSet,
+        deleteChangeSet,
+        requestedDeleteRecordData,
+        hasDeleteRequests,
+        proposedRecordData,
+        logicalChangeType
+      )
     }
   }
 
   final case class ValidationChanges(
       proposedAdds: Set[RecordData],
       proposedDeletes: Set[RecordData],
+      requestedDeleteRecordData: Set[RecordData],
+      hasDeleteRequests: Boolean,
       proposedRecordData: Set[RecordData],
       logicalChangeType: LogicalChangeType
   )

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchTransformations.scala
@@ -217,6 +217,11 @@ object BatchTransformations {
 
       val existingRecords = existingRecordSet.toList.flatMap(_.records).toSet
 
+      val hasDeleteRequests = changes.exists {
+        case _: DeleteRRSetChangeForValidation => true
+        case _ => false
+      }
+
       // Collect delete DNS entries. This formulates all of the proposed delete entries, including
       // existing DNS entries in the event of DeleteRecordSet
       val deleteChangeSet = changes
@@ -226,7 +231,7 @@ object BatchTransformations {
               _,
               DeleteRRSetChangeInput(_, _, _, Some(recordData))
               ) =>
-            Set(recordData)
+            Set(recordData).intersect(existingRecords)
           case _: DeleteRRSetChangeForValidation =>
             existingRecords
         }
@@ -257,11 +262,7 @@ object BatchTransformations {
             LogicalChangeType.OutOfSync
           }
         case (false, false) =>
-          if(changes.exists {
-            case _: DeleteRRSetChangeForValidation => true
-            case _ => false
-            }
-          ){
+          if (hasDeleteRequests && existingRecords.isEmpty) {
             LogicalChangeType.OutOfSync
           } else {
             LogicalChangeType.NotEditedInBatch

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchTransformationsSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchTransformationsSpec.scala
@@ -19,7 +19,14 @@ package vinyldns.api.domain.batch
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import vinyldns.api.domain.batch.BatchTransformations.ExistingZones
+import vinyldns.api.domain.batch.BatchTransformations._
+import vinyldns.core.domain.Fqdn
+import vinyldns.core.domain.record._
+import vinyldns.core.domain.record.RecordType._
 import vinyldns.core.domain.zone.Zone
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class BatchTransformationsSpec extends AnyWordSpec with Matchers {
 
@@ -92,6 +99,73 @@ class BatchTransformationsSpec extends AnyWordSpec with Matchers {
       "return match regardless of capitalization" in {
         existingZones.getByName("forward.COM") shouldBe Some(forwardMatch1)
       }
+    }
+  }
+
+  "ValidationChanges" should {
+    "treat mixed valid and non-existent delete data as a full delete when all existing records are removed" in {
+      val zone = Zone("ok.", "test")
+      val existingData = PTRData(Fqdn("vinyldns.io."))
+      val nonExistentData = PTRData(Fqdn("test.vinyldns.io."))
+      val existingRecordSet = RecordSet(
+        zone.id,
+        "ptr-record",
+        PTR,
+        7200L,
+        RecordSetStatus.Active,
+        Instant.now.truncatedTo(ChronoUnit.MILLIS),
+        None,
+        List(existingData)
+      )
+
+      val changes = List(
+        DeleteRRSetChangeForValidation(
+          zone,
+          "ptr-record",
+          DeleteRRSetChangeInput("ptr-record.ok.", PTR, None, Some(existingData))
+        ),
+        DeleteRRSetChangeForValidation(
+          zone,
+          "ptr-record",
+          DeleteRRSetChangeInput("ptr-record.ok.", PTR, None, Some(nonExistentData))
+        )
+      )
+
+      val validationChanges = ValidationChanges(changes, Some(existingRecordSet))
+
+      validationChanges.proposedDeletes shouldBe Set(existingData)
+      validationChanges.proposedRecordData shouldBe Set.empty
+      validationChanges.logicalChangeType shouldBe LogicalChangeType.FullDelete
+    }
+
+    "treat delete-only requests with non-existent record data as no-op for existing record sets" in {
+      val zone = Zone("ok.", "test")
+      val existingData = AData("1.1.1.1")
+      val requestedData = AData("1.1.1.2")
+      val existingRecordSet = RecordSet(
+        zone.id,
+        "a-record",
+        A,
+        7200L,
+        RecordSetStatus.Active,
+        Instant.now.truncatedTo(ChronoUnit.MILLIS),
+        None,
+        List(existingData)
+      )
+
+      val changes = List(
+        DeleteRRSetChangeForValidation(
+          zone,
+          "a-record",
+          DeleteRRSetChangeInput("a-record.ok.", A, None, Some(requestedData))
+        )
+      )
+
+      val validationChanges = ValidationChanges(changes, Some(existingRecordSet))
+
+      validationChanges.proposedDeletes shouldBe Set.empty
+      validationChanges.proposedRecordData shouldBe Set(existingData)
+      validationChanges.logicalChangeType shouldBe LogicalChangeType.NotEditedInBatch
     }
   }
 }


### PR DESCRIPTION
Fixes #1542.
JIRA: VDNS-442

**Root Cause:**
When multiple `DeleteRecordSet` operations target the same RecordSet, VinylDNS combines them into a single RecordSet change. If one delete request contains record data that does not exist the combined change can result in an empty RecordSet (`records=List()`), which is rejected by the DNS backend.

**Fix**
Updated the `DeleteRecordSet` handling to intersect the requested record data with the existing records before generating the RecordSet change. This prevents non-existent record data from producing an invalid empty RecordSet update.
Non-existent PTR deletion requests are now treated as no-ops (record does not exist) instead of being included in the shared RecordSet change.

