### PR TITLE
Fix: Create service log files before API functional/Integration tests startup

### DIFF
--- a/test/api/functional/Dockerfile
+++ b/test/api/functional/Dockerfile
@@ -24,6 +24,9 @@ COPY quickstart/bind9/etc/named.conf.* /etc/bind/
 COPY quickstart/bind9/zones/ /var/bind/
 RUN named-checkconf
 
+# Create log files before startup to avoid tail race.
+RUN mkdir -p /localstack && touch /localstack/localstack.log /opt/vinyldns/vinyldns.log
+
 # Copy over the functional tests
 COPY  modules/api/src/test/functional /functional_test
 

--- a/test/api/integration/Dockerfile
+++ b/test/api/integration/Dockerfile
@@ -31,4 +31,7 @@ COPY quickstart/bind9/etc/named.conf.* /etc/bind/
 COPY quickstart/bind9/zones/ /var/bind/
 RUN named-checkconf
 
+# Create log file before startup to avoid tail race.
+RUN touch /opt/vinyldns/vinyldns.log
+
 ENV RUN_SERVICES="all"


### PR DESCRIPTION
VDNS-461

Fixes #1556.

**Problem**
API functional/integration tests were failing during service startup because the bootstrap script tails the LocalStack log file before LocalStack creates it:

tail: cannot open '/localstack/localstack.log' for reading: No such file or directory

This caused the bootstrap to exit and the tests to fail.

**Root Cause**

The LocalStack and VinylDNS log files were created by their respective services during startup. However the test bootstrap starts tail before the log producers have created the files resulting in a first-run race condition.

**Fix**

Created the required log directory and log files during the Docker image build.
This ensures the log files exist before the bootstrap starts tailing them, avoiding the missing-file race condition and allowing the API functional/integration tests to proceed successfully.
