### PR TITLE
Don't lock disabled service accounts during Graph API user sync

### DIFF
--- a/modules/docs/src/main/mdoc/operator/config-portal.md
+++ b/modules/docs/src/main/mdoc/operator/config-portal.md
@@ -215,6 +215,12 @@ user-sync {
     # The Graph API user attribute to match against VinylDNS usernames
     # Default: "onPremisesSamAccountName"
     username-attribute = "onPremisesSamAccountName"
+
+    # Optional. When set, disabled accounts whose "employeeType" equals this value
+    # are treated as service accounts and are NOT locked, since service accounts are
+    # commonly disabled for interactive sign-in while still in active use. Leave unset
+    # to lock every disabled account (default behavior).
+    # service-account-employee-type = "S"
   }
 }
 ```
@@ -442,6 +448,7 @@ user-sync {
   polling-interval-hours = 24
   graph-api {
     username-attribute = "onPremisesSamAccountName"
+    # service-account-employee-type = "S"  # optional; don't lock disabled service accounts
   }
 }
 

--- a/modules/docs/src/main/mdoc/operator/config-portal.md
+++ b/modules/docs/src/main/mdoc/operator/config-portal.md
@@ -219,7 +219,8 @@ user-sync {
     # Optional. When set, disabled accounts whose "employeeType" equals this value
     # are treated as service accounts and are NOT locked, since service accounts are
     # commonly disabled for interactive sign-in while still in active use. Leave unset
-    # to lock every disabled account (default behavior).
+    # to lock every disabled account (default behavior). The comparison is
+    # case-sensitive; surrounding whitespace is ignored.
     # service-account-employee-type = "S"
   }
 }

--- a/modules/portal/app/controllers/Settings.scala
+++ b/modules/portal/app/controllers/Settings.scala
@@ -69,6 +69,14 @@ class Settings(private val config: Configuration) {
     config.getOptional[String]("user-sync.graph-api.username-attribute")
       .getOrElse("onPremisesSamAccountName")
 
+  // Optional: employeeType value that marks a service account. When set, disabled
+  // accounts with this employeeType are NOT locked (they're often disabled for
+  // interactive sign-in but still in use). Unset = no carve-out (default behavior).
+  val graphApiServiceAccountEmployeeType: Option[String] =
+    config.getOptional[String]("user-sync.graph-api.service-account-employee-type")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
   val oidcEnabled: Boolean =
     config.getOptional[Boolean]("oidc.enabled").getOrElse(false)
 

--- a/modules/portal/app/controllers/UserSyncProvider.scala
+++ b/modules/portal/app/controllers/UserSyncProvider.scala
@@ -50,7 +50,8 @@ class GraphApiUserSyncProvider(
     tenantId: String,
     clientId: String,
     clientSecret: String,
-    usernameAttribute: String
+    usernameAttribute: String,
+    serviceAccountEmployeeType: Option[String] = None
 ) extends UserSyncProvider {
 
   private val logger = LoggerFactory.getLogger(classOf[GraphApiUserSyncProvider])
@@ -161,14 +162,27 @@ class GraphApiUserSyncProvider(
       Some(user)
     } else {
       val accountEnabled = (values.head \ "accountEnabled").asOpt[Boolean].getOrElse(true)
-      if (!accountEnabled) {
+      if (accountEnabled) {
+        None
+      } else if (isServiceAccount(values.head)) {
+        // Service accounts are frequently disabled for interactive sign-in in the
+        // directory while still in active use; don't lock them on that signal alone.
+        logger.info(
+          s"User ${user.userName} is disabled but has service-account employeeType; not marking as stale"
+        )
+        None
+      } else {
         logger.info(s"User ${user.userName} is disabled in Graph API, marking as stale")
         Some(user)
-      } else {
-        None
       }
     }
   }
+
+  // Only carve out service accounts when an employeeType marker is configured.
+  private[controllers] def isServiceAccount(userJson: JsValue): Boolean =
+    serviceAccountEmployeeType.exists { marker =>
+      (userJson \ "employeeType").asOpt[String].contains(marker)
+    }
 
   private[controllers] def escapeODataValue(value: String): String =
     value.replace("'", "''")
@@ -182,7 +196,10 @@ class GraphApiUserSyncProvider(
           s"$usernameAttribute eq '$escapedUsername'",
           "UTF-8"
         )
-        val select = java.net.URLEncoder.encode("accountEnabled", "UTF-8")
+        val selectFields =
+          if (serviceAccountEmployeeType.isDefined) "accountEnabled,employeeType"
+          else "accountEnabled"
+        val select = java.net.URLEncoder.encode(selectFields, "UTF-8")
         // $count=true + ConsistencyLevel: eventual are required for advanced query
         // properties like onPremisesSamAccountName, employeeId, etc.
         // See https://learn.microsoft.com/en-us/graph/aad-advanced-queries

--- a/modules/portal/app/controllers/UserSyncProvider.scala
+++ b/modules/portal/app/controllers/UserSyncProvider.scala
@@ -179,9 +179,10 @@ class GraphApiUserSyncProvider(
   }
 
   // Only carve out service accounts when an employeeType marker is configured.
+  // employeeType is free text in the directory, so trim it; match is case-sensitive.
   private[controllers] def isServiceAccount(userJson: JsValue): Boolean =
     serviceAccountEmployeeType.exists { marker =>
-      (userJson \ "employeeType").asOpt[String].contains(marker)
+      (userJson \ "employeeType").asOpt[String].map(_.trim).contains(marker)
     }
 
   private[controllers] def escapeODataValue(value: String): String =

--- a/modules/portal/app/modules/VinylDNSModule.scala
+++ b/modules/portal/app/modules/VinylDNSModule.scala
@@ -105,7 +105,8 @@ class VinylDNSModule(environment: Environment, configuration: Configuration)
           settings.oidcTenantId,
           settings.oidcClientId,
           settings.oidcSecret,
-          settings.graphApiUsernameAttribute
+          settings.graphApiUsernameAttribute,
+          settings.graphApiServiceAccountEmployeeType
         )
       case "ldap" =>
         new LdapUserSyncProvider(auth)

--- a/modules/portal/test/controllers/GraphApiUserSyncProviderSpec.scala
+++ b/modules/portal/test/controllers/GraphApiUserSyncProviderSpec.scala
@@ -204,6 +204,16 @@ class GraphApiUserSyncProviderSpec extends Specification with Mockito {
       provider.parseUserResponse(body, disabledUser) must beSome(disabledUser)
     }
 
+    "still lock a disabled account with a null employeeType" in {
+      val body = """{"value": [{"accountEnabled": false, "employeeType": null}]}"""
+      provider.parseUserResponse(body, disabledUser) must beSome(disabledUser)
+    }
+
+    "not lock a disabled account whose employeeType matches after trimming whitespace" in {
+      val body = """{"value": [{"accountEnabled": false, "employeeType": " S "}]}"""
+      provider.parseUserResponse(body, disabledUser) must beNone
+    }
+
     "still lock an account absent from the directory even if marker is configured" in {
       val body = """{"value": []}"""
       provider.parseUserResponse(body, missingUser) must beSome(missingUser)

--- a/modules/portal/test/controllers/GraphApiUserSyncProviderSpec.scala
+++ b/modules/portal/test/controllers/GraphApiUserSyncProviderSpec.scala
@@ -36,8 +36,15 @@ class GraphApiUserSyncProviderSpec extends Specification with Mockito {
     */
   class TestableGraphApiProvider(
       userResponses: Map[String, (Int, String)] = Map.empty,
-      tokenResponse: Either[Throwable, String] = Right("test-token")
-  ) extends GraphApiUserSyncProvider("test-tenant", "test-client", "test-secret", "onPremisesSamAccountName") {
+      tokenResponse: Either[Throwable, String] = Right("test-token"),
+      serviceAccountEmployeeType: Option[String] = None
+  ) extends GraphApiUserSyncProvider(
+        "test-tenant",
+        "test-client",
+        "test-secret",
+        "onPremisesSamAccountName",
+        serviceAccountEmployeeType
+      ) {
 
     override private[controllers] def getAccessToken(): IO[String] =
       tokenResponse match {
@@ -176,6 +183,36 @@ class GraphApiUserSyncProviderSpec extends Specification with Mockito {
     "default to enabled when accountEnabled field is missing" in {
       val body = """{"value": [{"displayName": "Test"}]}"""
       provider.parseUserResponse(body, testUser) must beNone
+    }
+  }
+
+  "parseUserResponse with service-account carve-out" should {
+    val provider = new TestableGraphApiProvider(serviceAccountEmployeeType = Some("S"))
+
+    "not lock a disabled account whose employeeType matches the marker" in {
+      val body = """{"value": [{"accountEnabled": false, "employeeType": "S"}]}"""
+      provider.parseUserResponse(body, disabledUser) must beNone
+    }
+
+    "still lock a disabled account whose employeeType differs" in {
+      val body = """{"value": [{"accountEnabled": false, "employeeType": "E"}]}"""
+      provider.parseUserResponse(body, disabledUser) must beSome(disabledUser)
+    }
+
+    "still lock a disabled account with no employeeType" in {
+      val body = """{"value": [{"accountEnabled": false}]}"""
+      provider.parseUserResponse(body, disabledUser) must beSome(disabledUser)
+    }
+
+    "still lock an account absent from the directory even if marker is configured" in {
+      val body = """{"value": []}"""
+      provider.parseUserResponse(body, missingUser) must beSome(missingUser)
+    }
+
+    "ignore employeeType entirely when no marker is configured" in {
+      val noMarker = new TestableGraphApiProvider()
+      val body = """{"value": [{"accountEnabled": false, "employeeType": "S"}]}"""
+      noMarker.parseUserResponse(body, disabledUser) must beSome(disabledUser)
     }
   }
 


### PR DESCRIPTION
VDNS-463

  ## Problem

  The Graph API user sync task locks any active user whose account is
  `accountEnabled=false` in Microsoft Entra. Service accounts are commonly
  disabled for interactive sign-in while still in active use (they
  authenticate non-interactively), so the task can flag live service
  accounts to be locked.

  ## Change

  Add an **optional** setting:

  user-sync.graph-api.service-account-employee-type = "S"

  When set, disabled accounts whose Graph `employeeType` equals the value are
  treated as service accounts and are **not** locked. `employeeType` is added
  to the Graph `$select` only when the setting is present.

  When **unset** (default), behavior and the Graph query are unchanged, so
  existing deployments are unaffected.

  ## Why `employeeType` rather than username patterns

  The `employeeType` attribute distinguishes service accounts from departed
  employees reliably, whereas username conventions do not. Some service
  accounts follow no naming convention, and some non-service accounts share a
  service-account-style prefix. Keying off the attribute avoids both
  false negatives and false positives that a name-based heuristic would hit.

  ## Behavior

  Only disabled accounts whose `employeeType` matches the configured marker
  are skipped. Accounts absent from the directory, and disabled accounts with
  a non-matching or missing `employeeType`, are still locked as before.

  ## Testing

  Added unit tests covering:
  - matching `employeeType` marker → not locked
  - non-matching / missing `employeeType` → locked
  - account absent from directory → locked regardless of the setting
  - no marker configured → prior behavior (any disabled account locked)

  ## Config docs

  `config-portal.md` documents the new optional setting.